### PR TITLE
feat: serve voice-character-selector.js from gemini-live-tools package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ venv/
 .env
 *.wav
 *.m4a
-static/gemini-live-tools/
 settings.local.json
 
 # Override global gitignore to include project-level agent skill definitions

--- a/algebench
+++ b/algebench
@@ -4,34 +4,16 @@
 DIR="$(cd "$(dirname "$0")" && pwd)"
 VENV="$DIR/.venv"
 
-SYNC_JS=0
-JS_DEST="$DIR/static/gemini-live-tools/js/voice-character-selector.js"
-
 if [ "$1" = "--update" ]; then
     shift
     echo "Updating dependencies..."
     "$VENV/bin/pip" install --upgrade -r "$DIR/requirements.txt"
     "$VENV/bin/pip" install --force-reinstall --no-deps "gemini-live-tools @ git+https://github.com/ibenian/gemini-live-tools.git#subdirectory=python"
     echo "✓ Update complete"
-    SYNC_JS=1
 elif [ ! -d "$VENV" ]; then
     echo "Setting up virtual environment (first run only)..."
     python3 -m venv "$VENV"
     "$VENV/bin/pip" install -r "$DIR/requirements.txt"
-    SYNC_JS=1
-elif [ ! -f "$JS_DEST" ]; then
-    SYNC_JS=1
-fi
-
-if [ "$SYNC_JS" = "1" ]; then
-    JS_SRC=$("$VENV/bin/python3" -c "import gemini_live_tools, pathlib; print(pathlib.Path(gemini_live_tools.__file__).parent / 'static' / 'voice-character-selector.js')" 2>/dev/null)
-    if [ -f "$JS_SRC" ]; then
-        mkdir -p "$DIR/static/gemini-live-tools/js"
-        cp "$JS_SRC" "$JS_DEST"
-        echo "✓ voice-character-selector.js synced from gemini-live-tools"
-    else
-        echo "⚠ Could not locate voice-character-selector.js in gemini-live-tools package"
-    fi
 fi
 
 exec "$VENV/bin/python3" "$DIR/server.py" "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-gemini-live-tools @ git+https://github.com/ibenian/gemini-live-tools.git#subdirectory=python
+gemini-live-tools @ git+https://github.com/ibenian/gemini-live-tools.git@v0.1.2#subdirectory=python
 google-genai>=1.27.0
 numpy>=1.26.0

--- a/server.py
+++ b/server.py
@@ -31,9 +31,10 @@ script_dir = Path(__file__).parent.resolve()
 scenes_dir = script_dir / "scenes"
 
 try:
-    from gemini_live_tools import GeminiLiveAPI, pcm_to_wav_bytes
+    from gemini_live_tools import GeminiLiveAPI, pcm_to_wav_bytes, get_static_content as _glt_static
     TTS_AVAILABLE = True
 except ImportError:
+    _glt_static = None
     TTS_AVAILABLE = False
 static_dir   = script_dir / "static"
 app_js_path  = static_dir / "app.js"
@@ -800,19 +801,17 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
                 self.wfile.write(js.encode('utf-8'))
 
             elif path == '/gemini-live-tools/js/voice-character-selector.js':
-                shared_js_path = static_dir / "gemini-live-tools" / "js" / "voice-character-selector.js"
-                if not shared_js_path.exists():
-                    print("⚠ voice-character-selector.js not found — run ./algebench --update")
-                    self.send_response(404)
-                    self.end_headers()
-                else:
-                    with open(shared_js_path, 'r') as f:
-                        js = f.read()
+                try:
+                    js = _glt_static('voice-character-selector.js')
                     self.send_response(200)
                     self.send_header('Content-Type', 'application/javascript')
                     self.send_header('Cache-Control', 'no-cache, no-store, must-revalidate')
                     self.end_headers()
                     self.wfile.write(js.encode('utf-8'))
+                except Exception:
+                    print("⚠ voice-character-selector.js not found in gemini-live-tools package")
+                    self.send_response(404)
+                    self.end_headers()
 
             elif path == '/style.css':
                 self.send_response(200)


### PR DESCRIPTION
## Summary
- Removes local static file copy of `voice-character-selector.js` — no longer synced to `static/gemini-live-tools/js/` at install time
- Serves the JS directly from the installed `gemini_live_tools` package at runtime via `get_static_content()`
- Pins `gemini-live-tools` to `v0.1.2` in `requirements.txt`

## Test plan
- [x] Run `./algebench` and verify the voice character selector loads in the browser
- [x] Confirm `GET /gemini-live-tools/js/voice-character-selector.js` returns 200 with correct JS content
- [x] Verify no `static/gemini-live-tools/` directory is created on fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)