### PR TITLE
security: scan {{...}} content templates for unsafe JS before load

### DIFF
--- a/scripts/audit_expressions.py
+++ b/scripts/audit_expressions.py
@@ -198,7 +198,7 @@ def classify_expression(expr, field_key, scene_unsafe):
         return 'unsafe_scene'
 
     if _JS_ONLY_RE.search(expr):
-        if field_key in _SCANNED_KEYS:
+        if field_key in _SCANNED_KEYS or field_key == 'content_template':
             return 'js_covered'
         return 'js_uncovered'
 

--- a/static/app.js
+++ b/static/app.js
@@ -4191,13 +4191,24 @@ function _scanSpecForUnsafeJs(spec) {
     // Only scan strings under known expression-bearing keys to avoid false positives
     // from natural-language text that contains 'let', '=>', 'return', etc.
     const EXPR_KEYS = new Set(['expr', 'x', 'y', 'z', 'expression', 'fx', 'fy', 'fz']);
+    const _TEMPLATE_RE = /\{\{([\s\S]*?)\}\}/g;
     function walk(obj, parentKey) {
         if (typeof obj === 'string') {
             return !!(parentKey && EXPR_KEYS.has(parentKey) && _JS_ONLY_RE.test(obj));
         }
         if (Array.isArray(obj)) return obj.some(item => walk(item, parentKey));
         if (obj && typeof obj === 'object') {
-            return Object.entries(obj).some(([k, v]) => walk(v, k));
+            return Object.entries(obj).some(([k, v]) => {
+                // Scan {{...}} expression blocks inside content strings
+                if (k === 'content' && typeof v === 'string') {
+                    let m;
+                    _TEMPLATE_RE.lastIndex = 0;
+                    while ((m = _TEMPLATE_RE.exec(v)) !== null) {
+                        if (_JS_ONLY_RE.test(m[1])) return true;
+                    }
+                }
+                return walk(v, k);
+            });
         }
         return false;
     }


### PR DESCRIPTION
## Summary

- Closes the trust-dialog bypass identified in #19 (Proposal 2 only)
- `_scanSpecForUnsafeJs` now extracts and tests every `{{...}}` block inside `content` strings against `_JS_ONLY_RE`
- `audit_expressions.py` marks `content_template` as a covered field, matching the new runtime behaviour

## Problem

`_scanSpecForUnsafeJs` only scanned fields in `EXPR_KEYS` (`expr`, `x`, `y`, `z`, etc.).  
A `content` string like `"{{new Function('return fetch(...)')()}}"` would load without ever showing the trust dialog.

## Relation to PR #19

PR #19 proposed two changes:

| Proposal | Decision |
|---|---|
| **Proposal 1** — add `toFixed`, `toPrecision`, etc. to `_JS_ONLY_RE` | ❌ Rejected — these built-ins are trusted and already registered in `_MATHJS_EXTENSIONS`; adding them to the regex would show spurious trust dialogs on legitimate scenes |
| **Proposal 2** — scan `{{...}}` templates in `_scanSpecForUnsafeJs` | ✅ Applied here |

Closing #19 as this PR covers the security-relevant fix.

## Verification

```
python scripts/audit_expressions.py
# ✅ All expression-bearing fields are covered by the sandbox / trust model.
# uncovered=0, exit 0
```

## Test plan

- [x] Load a scene with safe math in `content` templates (e.g. `{{x+1}}`) — no trust dialog
- [x] Load a scene with JS in a `content` template (e.g. `{{new Function('return 1')()}}`) — trust dialog fires
- [ ] `python scripts/audit_expressions.py` exits 0 with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)