### PR TITLE
feat: animated_curve element with fill_regions

### DIFF
--- a/scenes/test/test-animated-curve.json
+++ b/scenes/test/test-animated-curve.json
@@ -407,69 +407,6 @@
               "position": "top-left"
             }
           ]
-        },
-        {
-          "title": "Sloped x-boundaries — rightOf and leftOf with x",
-          "description": "`rightOf` and `leftOf` accept `x` in scope, so the x-boundary can be any expression of `x` — including a line `m * x + b`. Here the fill is clipped between two parallel sloped lines: `rightOf: \"m * x + b\"` (left edge) and `leftOf: \"m * x + b + W\"` (right edge, shifted by `W`). Two `animated_line` elements mark the boundary lines. Drag `m` to tilt, `b` to translate, `W` to widen the stripe.",
-          "remove": [
-            { "id": "cos-line5" }, { "id": "sin-fill5" },
-            { "id": "vbound-left" }, { "id": "vbound-right" },
-            { "id": "hbound-top" }, { "id": "hbound-bot" }
-          ],
-          "add": [
-            {
-              "id": "curve9",
-              "type": "animated_curve",
-              "expr": "A * sin(x + phi)",
-              "range": [-4, 4],
-              "samples": 200,
-              "color": "#44ccff",
-              "width": 2.5,
-              "opacity": 0.9,
-              "fill_regions": [
-                {
-                  "id": "sloped-stripe",
-                  "color": "#88ffcc",
-                  "opacity": 0.45,
-                  "rightOf": "m * x + b",
-                  "leftOf": "m * x + b + W",
-                  "outlineWidth": 1.5,
-                  "outlineColor": "#44ffaa",
-                  "outlineOpacity": 0.8
-                }
-              ]
-            },
-            {
-              "id": "line-left",
-              "type": "animated_line",
-              "points": [["-4", "m * (-4) + b", "0"], ["4", "m * 4 + b", "0"]],
-              "color": "#ffdd44",
-              "width": 1.5,
-              "opacity": 0.7
-            },
-            {
-              "id": "line-right",
-              "type": "animated_line",
-              "points": [["-4", "m * (-4) + b + W", "0"], ["4", "m * 4 + b + W", "0"]],
-              "color": "#ffdd44",
-              "width": 1.5,
-              "opacity": 0.7
-            }
-          ],
-          "sliders": [
-            { "id": "A",   "label": "$A$ (amplitude)", "min": 0.1, "max": 2,    "step": 0.1,  "default": 1 },
-            { "id": "phi", "label": "$\\varphi$ (phase)", "min": -3.14, "max": 3.14, "step": 0.1, "default": 0 },
-            { "id": "m",   "label": "$m$ (slope)",     "min": -2,  "max": 2,    "step": 0.1,  "default": 0.5 },
-            { "id": "b",   "label": "$b$ (offset)",    "min": -3,  "max": 3,    "step": 0.1,  "default": -1 },
-            { "id": "W",   "label": "$W$ (width)",     "min": 0.1, "max": 4,    "step": 0.1,  "default": 2 }
-          ],
-          "info": [
-            {
-              "id": "info9",
-              "content": "Fill where ${{toFixed(m,2)}}x + {{toFixed(b,2)}} \\leq x \\leq {{toFixed(m,2)}}x + {{toFixed(b+W,2)}}$ \\quad stripe width $W = {{toFixed(W,1)}}$",
-              "position": "top-left"
-            }
-          ]
         }
       ]
     }

--- a/static/app.js
+++ b/static/app.js
@@ -3622,6 +3622,8 @@ function renderAnimatedCurve(el, view) {
 
     function updateFillMesh(entry, tSec, pts) {
         const { cAbove, cBelow, cRightOf, cLeftOf, fillAttr, fillGeom } = entry;
+        const rightOfX = cRightOf ? evalExpr(cRightOf, tSec) : null; // fill where x >= rightOfX
+        const leftOfX  = cLeftOf  ? evalExpr(cLeftOf,  tSec) : null; // fill where x <= leftOfX
         const floats = fillAttr.array;
         let idx = 0;
 
@@ -3629,14 +3631,8 @@ function renderAnimatedCurve(el, view) {
             const x0 = pts[i][0],   x1 = pts[i + 1][0];
             const cy0 = pts[i][1],  cy1 = pts[i + 1][1];
 
-            // rightOf/leftOf evaluated per-sample with x in scope (supports "m * x + b")
-            const rightOf0 = cRightOf ? evalBound(cRightOf, x0, tSec) : null;
-            const rightOf1 = cRightOf ? evalBound(cRightOf, x1, tSec) : null;
-            const leftOf0  = cLeftOf  ? evalBound(cLeftOf,  x0, tSec) : null;
-            const leftOf1  = cLeftOf  ? evalBound(cLeftOf,  x1, tSec) : null;
-
-            if (rightOf0 != null && x1 < rightOf0 && x1 < rightOf1) continue;
-            if (leftOf0  != null && x0 > leftOf0  && x0 > leftOf1)  continue;
+            if (rightOfX != null && x1 < rightOfX) continue; // quad fully left of rightOf bound
+            if (leftOfX  != null && x0 > leftOfX)  continue; // quad fully right of leftOf bound
 
             // Evaluate per-sample boundaries (supports x-dependent exprs like "cos(x)-1")
             const aboveY0 = cAbove ? evalBound(cAbove, x0, tSec) : null;
@@ -3689,15 +3685,15 @@ function renderAnimatedCurve(el, view) {
     // Traces: top side left→right, right vertical cap, bottom side right→left, left vertical cap, closure.
     function buildOutlinePts(entry, tSec, pts) {
         const { cAbove, cBelow, cRightOf, cLeftOf } = entry;
+        const rightOfX = cRightOf ? evalExpr(cRightOf, tSec) : null;
+        const leftOfX  = cLeftOf  ? evalExpr(cLeftOf,  tSec) : null;
 
         // Collect samples within the x membership bounds
         const clipped = [];
         for (const p of pts) {
             const x = p[0], cy = p[1];
-            const rightOfV = cRightOf ? evalBound(cRightOf, x, tSec) : null;
-            const leftOfV  = cLeftOf  ? evalBound(cLeftOf,  x, tSec) : null;
-            if (rightOfV != null && x < rightOfV - 1e-9) continue;
-            if (leftOfV  != null && x > leftOfV  + 1e-9) continue;
+            if (rightOfX != null && x < rightOfX - 1e-9) continue;
+            if (leftOfX  != null && x > leftOfX  + 1e-9) continue;
             let topY, botY;
             if (cAbove != null && cBelow != null) {
                 // Band fill: outline spans between the two expressions directly


### PR DESCRIPTION
## Summary

- Adds `animated_curve` element to `app.js`: a live `y = f(x)` curve driven by slider expressions, with optional `fill_regions` for shaded areas
- `fill_regions` support four membership conditions: `above`, `below`, `rightOf`, `leftOf`
- **Band fill mode**: when both `above` and `below` are set in one region, fills directly between the two expressions — no curve boundary — enabling all four constraints simultaneously with `max`/`min` composition
- Outline support per fill region (`outlineWidth`, `outlineColor`, `outlineOpacity`) draws the full perimeter as a MathBox line
- Test scene (`scenes/test/test-animated-curve.json`) with 7 progressive steps and full markdown reference doc

## Steps in test scene
1. Basic curve, no fill
2. Fill above/below x-axis (two regions)
3. Definite integral shading with `rightOf`/`leftOf` + outline
4. Fill between two curves (`above: "cos(x)-C"` with x-dependent expression)
5. Both above and below fill regions simultaneously
6. Vertical boundary lines with `rightOf`/`leftOf` + `animated_line` markers
7. All four constraints: `above: max(cos, bot)`, `below: min(sin, top)`, `rightOf: L`, `leftOf: R` — two complementary band fills tile the `[bot, top]` band, split at curve intersections

## Test plan
- [x] Load `test-animated-curve.json`, step through all 7 steps
- [x] Step 3: drag L/R sliders, verify fill clips; drag outline sliders
- [x] Step 4: drag A/phi/B/psi/C, verify fill between two curves updates
- [x] Step 7: drag top/bot sliders — horizontal limits visibly constrain the fill; drag L/R for x-clipping; verify blue/red regions split at every curve crossing

🤖 Generated with [Claude Code](https://claude.com/claude-code)