### PR TITLE
docs: add Codex PR description guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ docs/              Architecture, sandbox model, feature ideas
 - **`.venv` is local** — recreate with `rm -rf .venv && ./algebench` if broken.
 - **Security** — path traversal and XSS vulnerabilities were previously fixed. Be careful with user-supplied paths in the server and anything that renders untrusted expressions.
 - **Branch protection** — `main` is protected. Always use a feature branch and open a PR; never push directly to `main`.
+- **Codex PR descriptions** — when Codex creates or updates a PR, replace any commit-list placeholder body with a concise writeup using `## Summary` and `## Testing` sections. Summaries should describe the user-visible behavior and key implementation points, not just restate commit subjects.
 - **Merging PRs** — always use `gh pr merge --squash --admin` to bypass branch protection checks.
 
 ## Scene Format


### PR DESCRIPTION
## Summary
- add a Codex-specific instruction in `AGENTS.md` requiring PR descriptions to use `## Summary` and `## Testing` instead of a raw commit list
- clarify that PR summaries should describe user-visible behavior and key implementation points, not just restate commit subjects

## Testing
- not run: documentation-only change
