### PR TITLE
chore: bump gemini-live-tools to v0.1.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gemini-live-tools @ git+https://github.com/ibenian/gemini-live-tools.git@v0.1.11#subdirectory=python
+gemini-live-tools @ git+https://github.com/ibenian/gemini-live-tools.git@v0.1.12#subdirectory=python
 google-genai>=1.27.0
 numpy>=1.26.0
 fastapi>=0.115.0


### PR DESCRIPTION
## Summary

- Bumps `gemini-live-tools` from v0.1.11 to v0.1.12 in `requirements.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)