### PR TITLE
docs: cross-link all project documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,9 +203,14 @@ Use the built-in scenes in `scenes/` as reference — `eigenvalues.json` and `ma
 
 ## Ideas and Roadmap
 
-If you are looking for inspiration, or want a sense of the technical directions the project is considering, see [`docs/feature-ideas.md`](docs/feature-ideas.md). It is a living document covering everything from AI pedagogy and new domain libraries to visualization element types, scene architecture, and longer-shot experimental ideas.
+If you are looking for inspiration, or want a sense of the directions the project is considering:
 
-Nothing in that document is committed to — it is a collection of seeds. If something there resonates with your interests or expertise, that is a good signal that a contribution in that area would be genuinely useful rather than speculative.
+- **[docs/feature-ideas.md](docs/feature-ideas.md)** — Platform and UX feature ideas: AI pedagogy, visualization element types, scene architecture, and longer-shot experimental ideas.
+- **[docs/lesson-ideas.md](docs/lesson-ideas.md)** — Lesson concepts and content proposals: probability & statistics, machine learning, calculus, linear algebra, physics, complex analysis, and more.
+
+Nothing in those documents is committed to — they are collections of seeds. If something there resonates with your interests or expertise, that is a good signal that a contribution in that area would be genuinely useful rather than speculative.
+
+For system architecture and technical reference, see [docs/architecture.md](docs/architecture.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for how to add scenes, voice characters, 
 
 ## Roadmap
 
-See [docs/feature-ideas.md](docs/feature-ideas.md) for a collection of technical directions and creative ideas under consideration.
+See [docs/feature-ideas.md](docs/feature-ideas.md) for technical directions and creative ideas under consideration, and [docs/lesson-ideas.md](docs/lesson-ideas.md) for lesson concepts and content proposals.
 
 ## Documentation
 
@@ -76,6 +76,7 @@ See [docs/feature-ideas.md](docs/feature-ideas.md) for a collection of technical
 - [docs/sandbox-model.md](docs/sandbox-model.md) — Expression evaluation, trust model, security boundary
 - [docs/sandboxing-plan.md](docs/sandboxing-plan.md) — Implementation status and backend sandboxing roadmap
 - [docs/feature-ideas.md](docs/feature-ideas.md) — Roadmap ideas and creative directions
+- [docs/lesson-ideas.md](docs/lesson-ideas.md) — Lesson concepts across probability, ML, calculus, physics, and more
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,10 +3,12 @@
 > Technical documentation for contributors and maintainers.
 
 **Related docs:**
-- [README](../README.md) — Project overview and quick start
+- [../README.md](../README.md) — Project overview and quick start
+- [../CONTRIBUTING.md](../CONTRIBUTING.md) — How to contribute scenes, characters, and more
 - [sandbox-model.md](sandbox-model.md) — Expression evaluation, trust model, security boundary
 - [sandboxing-plan.md](sandboxing-plan.md) — Implementation status and backend sandboxing roadmap
 - [feature-ideas.md](feature-ideas.md) — Roadmap ideas and creative directions
+- [lesson-ideas.md](lesson-ideas.md) — Lesson concepts and content proposals
 
 ---
 

--- a/docs/feature-ideas.md
+++ b/docs/feature-ideas.md
@@ -4,6 +4,12 @@ A living document of technical directions and creative ideas for making AlgeBenc
 distinctive AI-guided math exploration tool. Nothing here is committed to — these are
 seeds for discussion and experimentation.
 
+**See also:**
+- [lesson-ideas.md](lesson-ideas.md) — Lesson concepts and content proposals
+- [architecture.md](architecture.md) — System architecture and technical reference
+- [../CONTRIBUTING.md](../CONTRIBUTING.md) — How to contribute scenes, characters, and more
+- [../README.md](../README.md) — Project overview and quick start
+
 ---
 
 ## 1. AI Pedagogy

--- a/docs/lesson-ideas.md
+++ b/docs/lesson-ideas.md
@@ -4,7 +4,11 @@ A living document of lesson concepts and content ideas for AlgeBench. Each entry
 describes a potential multi-scene lesson or domain library — specific mathematical
 content rather than platform features.
 
-See also: [feature-ideas.md](feature-ideas.md) for platform and UX feature ideas.
+**See also:**
+- [feature-ideas.md](feature-ideas.md) — Platform and UX feature ideas
+- [architecture.md](architecture.md) — System architecture and technical reference
+- [../CONTRIBUTING.md](../CONTRIBUTING.md) — How to contribute scenes, characters, and more
+- [../README.md](../README.md) — Project overview and quick start
 
 ---
 


### PR DESCRIPTION
## Summary
- Added cross-links between README, CONTRIBUTING, feature-ideas, lesson-ideas, and architecture docs
- Each doc now has a "See also" section pointing to all related docs for easy navigation
- Added lesson-ideas.md to README's Documentation and Roadmap sections

## Test plan
- [x] Verify all relative links resolve correctly on GitHub
- [x] Check that no existing links were broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)