### PR TITLE
feat: general labelExpr for animated elements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,6 +198,7 @@ Use the built-in scenes in `scenes/` as reference — `eigenvalues.json` and `ma
 - Use `"remove": ["*"]` to clear all elements in a step
 - Sliders: add `"sliders": [{"id": "t", "label": "t", "min": 0, "max": 1, "value": 0.5}]`
 - Animated sliders: add `"animate": true, "duration": 2000` to a slider def
+- Dynamic labels: add `"labelExpr": "'Value: ' + toFixed(x*100, 1) + '%'"` to any animated element — the label text updates each frame based on slider values and time
 
 ---
 

--- a/scenes/orbital-flight-simulation.json
+++ b/scenes/orbital-flight-simulation.json
@@ -1097,8 +1097,7 @@
               "color": "#ff5d73",
               "width": 12.8,
               "arrowScale": 1.2,
-              "labelShowAltitude": true,
-              "labelAltitudePrecision": 1,
+              "labelExpr": "concat(\"h=\", toFixed(max(0, sqrt(orbitX(t,0)^2 + orbitY(t,0)^2 + 80^2) - Rp), 1), \" km\")",
               "label": "rocket"
             },
             {
@@ -1558,8 +1557,7 @@
               "color": "#ffd166",
               "width": 12.8,
               "arrowScale": 1.2,
-              "labelShowAltitude": true,
-              "labelAltitudePrecision": 1,
+              "labelExpr": "concat(\"h=\", toFixed(max(0, sqrt(orbitX(t,1)^2 + orbitY(t,1)^2 + 80^2) - Rp), 1), \" km\")",
               "label": "powered rocket"
             },
             {
@@ -2111,8 +2109,7 @@
               "color": "#ffd166",
               "width": 12,
               "arrowScale": 1.2,
-              "labelShowAltitude": true,
-              "labelAltitudePrecision": 1,
+              "labelExpr": "concat(\"h=\", toFixed(max(0, sqrt(orbitX(t,2)^2 + orbitY(t,2)^2 + 80^2) - Rp), 1), \" km\")",
               "label": "guided rocket"
             },
             {

--- a/static/expr.js
+++ b/static/expr.js
@@ -15,6 +15,7 @@ const _mathjs = math.create(math.all);
 // (_EXPR_HELPERS), so both evaluators always stay consistent.
 const _MATHJS_EXTENSIONS = {
     toFixed: (val, decimals) => Number(val).toFixed(Number(decimals)),
+    concat: (...args) => args.map(a => String(a)).join(''),
     // bar(value, width=20) — Unicode block progress bar, e.g. bar(0.4) → "████████░░░░░░░░░░░░"
     bar: (val, w = 20) => {
         const n = Math.round(Math.max(0, Math.min(1, Number(val))) * Number(w));

--- a/static/labels.js
+++ b/static/labels.js
@@ -56,11 +56,11 @@ export function renderKaTeX(text, displayMode) {
             }).join('');
         } else if (seg.startsWith('$$')) {
             const tex = seg.slice(2, -2);
-            try { return katex.renderToString(tex, { throwOnError: false, displayMode: true }); }
+            try { return katex.renderToString(tex, { throwOnError: false, strict: false, displayMode: true }); }
             catch(e) { return escapeHtml(seg); }
         } else {
             const tex = seg.slice(1, -1);
-            try { return katex.renderToString(tex, { throwOnError: false, displayMode: false }); }
+            try { return katex.renderToString(tex, { throwOnError: false, strict: false, displayMode: false }); }
             catch(e) { return escapeHtml(seg); }
         }
     }).join('');
@@ -85,7 +85,7 @@ export function renderMarkdown(md) {
     html = html.replace(/%%MATH_BLOCK_(\d+)%%/g, (m, idx) => {
         const block = mathBlocks[parseInt(idx)];
         try {
-            return katex.renderToString(block.tex, { throwOnError: false, displayMode: block.display });
+            return katex.renderToString(block.tex, { throwOnError: false, strict: false, displayMode: block.display });
         } catch(e) { return block.tex; }
     });
 

--- a/static/objects/animated-curve.js
+++ b/static/objects/animated-curve.js
@@ -1,5 +1,5 @@
 import { state } from '/state.js';
-import { parseColor } from '/labels.js';
+import { parseColor, addLabel3D, renderKaTeX } from '/labels.js';
 import { compileExpr, evalExpr } from '/expr.js';
 import { dataToWorld } from '/coords.js';
 import { resolveLineWidth } from '/camera.js';
@@ -10,6 +10,11 @@ export function renderAnimatedCurve(el, view) {
     const opacityRaw = el.opacity != null ? el.opacity : 1;
     const opacityExpr = typeof opacityRaw === 'string' ? compileExpr(opacityRaw) : null;
     const lineOpacity = opacityExpr ? evalExpr(opacityExpr, 0) : Number(opacityRaw);
+    const label = el.label;
+    const labelExprString = (typeof el.labelExpr === 'string' && el.labelExpr.trim()) ? el.labelExpr.trim() : null;
+    const labelOffset = (Array.isArray(el.labelOffset) && el.labelOffset.length === 3)
+        ? [Number(el.labelOffset[0]) || 0, Number(el.labelOffset[1]) || 0, Number(el.labelOffset[2]) || 0]
+        : [0, 0.3, 0];
     const samples = el.samples || 200;
 
     let rangeLExpr = null, rangeRExpr = null;
@@ -65,6 +70,25 @@ export function renderAnimatedCurve(el, view) {
     });
     curveEntry.node = curveNode;
     state.lineNodes.push(curveEntry);
+
+    // Label
+    let labelExprFn = null;
+    if (labelExprString) {
+        try { labelExprFn = compileExpr(labelExprString); } catch (err) { console.warn('animated_curve labelExpr compile error:', err); }
+    }
+
+    let labelEl = null;
+    if (label || labelExprFn) {
+        const mid = initPts[Math.floor(initPts.length / 2)] || [0, 0, 0];
+        labelEl = addLabel3D(label || '', [mid[0] + labelOffset[0], mid[1] + labelOffset[1], mid[2] + labelOffset[2]], color);
+        if (labelExprFn) {
+            try {
+                const txt = String(evalExpr(labelExprFn, 0));
+                labelEl.el.innerHTML = renderKaTeX(txt, false);
+                labelEl._lastDynamicText = txt;
+            } catch (_e) {}
+        }
+    }
 
     // Fill regions
     const fillRegions = Array.isArray(el.fill_regions) ? el.fill_regions : [];
@@ -254,6 +278,21 @@ export function renderAnimatedCurve(el, view) {
             try {
                 const pts = buildCurvePoints(tSec);
                 curveData.set('data', pts);
+                if (labelEl) {
+                    const mid = pts[Math.floor(pts.length / 2)] || [0, 0, 0];
+                    labelEl.dataPos[0] = mid[0] + labelOffset[0];
+                    labelEl.dataPos[1] = mid[1] + labelOffset[1];
+                    labelEl.dataPos[2] = mid[2] + labelOffset[2];
+                    if (labelExprFn) {
+                        try {
+                            const txt = String(evalExpr(labelExprFn, tSec));
+                            if (labelEl._lastDynamicText !== txt) {
+                                labelEl.el.innerHTML = renderKaTeX(txt, false);
+                                labelEl._lastDynamicText = txt;
+                            }
+                        } catch (_e) {}
+                    }
+                }
                 if (opacityExpr) {
                     curveNode.set('opacity', evalExpr(opacityExpr, tSec) * (state.displayParams.lineOpacity || 1));
                 }

--- a/static/objects/animated-cylinder.js
+++ b/static/objects/animated-cylinder.js
@@ -1,5 +1,5 @@
 import { state } from '/state.js';
-import { parseColor, addLabel3D } from '/labels.js';
+import { parseColor, addLabel3D, renderKaTeX } from '/labels.js';
 import { compileExpr, evalExpr } from '/expr.js';
 import { _resolveCylinderDataEndpoints, _setCylinderTransformFromData } from '/objects/cylinder.js';
 
@@ -9,6 +9,7 @@ export function renderAnimatedCylinder(el, view) {
     const radialSegments = el.radialSegments || 32;
     const openEnded = !!el.openEnded;
     const label = el.label;
+    const labelExprString = (typeof el.labelExpr === 'string' && el.labelExpr.trim()) ? el.labelExpr.trim() : null;
     const radius = (typeof el.radius === 'number') ? el.radius : 1;
     const radiusExpr = (typeof el.radiusExpr === 'string')
         ? el.radiusExpr
@@ -75,10 +76,22 @@ export function renderAnimatedCylinder(el, view) {
     state.three.scene.add(mesh);
     state.planeMeshes.push(mesh);
 
+    let labelExprFn = null;
+    if (labelExprString) {
+        try { labelExprFn = compileExpr(labelExprString); } catch (err) { console.warn('animated_cylinder labelExpr compile error:', err); }
+    }
+
     let labelEl = null;
-    if (label) {
+    if (label || labelExprFn) {
         const mid = [(initFrom[0] + initTo[0]) / 2, (initFrom[1] + initTo[1]) / 2, (initFrom[2] + initTo[2]) / 2];
-        labelEl = addLabel3D(label, mid, color);
+        labelEl = addLabel3D(label || '', mid, color);
+        if (labelExprFn) {
+            try {
+                const txt = String(evalExpr(labelExprFn, 0));
+                labelEl.el.innerHTML = renderKaTeX(txt, false);
+                labelEl._lastDynamicText = txt;
+            } catch (_e) {}
+        }
     }
 
     const animState = { stopped: false };
@@ -117,6 +130,15 @@ export function renderAnimatedCylinder(el, view) {
                 labelEl.dataPos[0] = (fromData[0] + toData[0]) / 2;
                 labelEl.dataPos[1] = (fromData[1] + toData[1]) / 2;
                 labelEl.dataPos[2] = (fromData[2] + toData[2]) / 2;
+                if (labelExprFn) {
+                    try {
+                        const txt = String(evalExpr(labelExprFn, tSec));
+                        if (labelEl._lastDynamicText !== txt) {
+                            labelEl.el.innerHTML = renderKaTeX(txt, false);
+                            labelEl._lastDynamicText = txt;
+                        }
+                    } catch (_e) {}
+                }
             }
         },
     });

--- a/static/objects/animated-line.js
+++ b/static/objects/animated-line.js
@@ -1,5 +1,5 @@
 import { state } from '/state.js';
-import { parseColor, addLabel3D } from '/labels.js';
+import { parseColor, addLabel3D, renderKaTeX } from '/labels.js';
 import { compileExpr, evalExpr } from '/expr.js';
 import { resolveLineWidth, getAbstractWidthScale } from '/camera.js';
 
@@ -9,6 +9,7 @@ export function renderAnimatedLine(el, view) {
     const opacity = (el.opacity !== undefined) ? Number(el.opacity) : 1;
     const baseOpacity = Math.max(0, Math.min(1, Number.isFinite(opacity) ? opacity : 1));
     const label = el.label;
+    const labelExprString = (typeof el.labelExpr === 'string' && el.labelExpr.trim()) ? el.labelExpr.trim() : null;
     const pointExprs = el.points;
 
     if (!Array.isArray(pointExprs) || pointExprs.length < 2) return null;
@@ -41,10 +42,22 @@ export function renderAnimatedLine(el, view) {
     lineEntry.node = lineNode;
     state.lineNodes.push(lineEntry);
 
+    let labelExprFn = null;
+    if (labelExprString) {
+        try { labelExprFn = compileExpr(labelExprString); } catch (err) { console.warn('animated_line labelExpr compile error:', err); }
+    }
+
     let labelEl = null;
-    if (label) {
+    if (label || labelExprFn) {
         const mid = currentPoints[Math.floor(currentPoints.length / 2)];
-        labelEl = addLabel3D(label, mid, color);
+        labelEl = addLabel3D(label || '', mid, color);
+        if (labelExprFn) {
+            try {
+                const txt = String(evalExpr(labelExprFn, 0));
+                labelEl.el.innerHTML = renderKaTeX(txt, false);
+                labelEl._lastDynamicText = txt;
+            } catch (_e) {}
+        }
     }
 
     const animState = { stopped: false };
@@ -73,6 +86,15 @@ export function renderAnimatedLine(el, view) {
                     labelEl.dataPos[0] = mid[0];
                     labelEl.dataPos[1] = mid[1] + 0.3;
                     labelEl.dataPos[2] = mid[2];
+                    if (labelExprFn) {
+                        try {
+                            const txt = String(evalExpr(labelExprFn, tSec));
+                            if (labelEl._lastDynamicText !== txt) {
+                                labelEl.el.innerHTML = renderKaTeX(txt, false);
+                                labelEl._lastDynamicText = txt;
+                            }
+                        } catch (_e) {}
+                    }
                 }
             } catch(err) { /* keep last frame */ }
         },

--- a/static/objects/animated-point.js
+++ b/static/objects/animated-point.js
@@ -1,5 +1,5 @@
 import { state } from '/state.js';
-import { parseColor, addLabel3D } from '/labels.js';
+import { parseColor, addLabel3D, renderKaTeX } from '/labels.js';
 import { compileExpr, evalExpr } from '/expr.js';
 import { dataToWorld, dataLenToWorld } from '/coords.js';
 
@@ -10,6 +10,7 @@ export function renderAnimatedPoint(el, view) {
     const exprStrings = el.expr || el.positionExpr || el.toExpr
         || (Array.isArray(el.position) && el.position.length === 3 ? el.position.map(v => String(v)) : null);
     const visibleExprString = (typeof el.visibleExpr === 'string' && el.visibleExpr.trim()) ? el.visibleExpr.trim() : null;
+    const labelExprString = (typeof el.labelExpr === 'string' && el.labelExpr.trim()) ? el.labelExpr.trim() : null;
 
     if (!Array.isArray(exprStrings) || exprStrings.length !== 3) return null;
 
@@ -40,9 +41,22 @@ export function renderAnimatedPoint(el, view) {
     state.three.scene.add(mesh);
     state.planeMeshes.push(mesh);
 
+    let labelExprFn = null;
+    if (labelExprString) {
+        try { labelExprFn = compileExpr(labelExprString); } catch (err) { console.warn('animated_point labelExpr compile error:', err); }
+    }
+
     let labelEl = null;
-    if (label) {
-        labelEl = addLabel3D(label, [initPos[0], initPos[1], initPos[2] + 0.3], color);
+    if (label || labelExprFn) {
+        const initText = label || '';
+        labelEl = addLabel3D(initText, [initPos[0], initPos[1], initPos[2] + 0.3], color);
+        if (labelExprFn) {
+            try {
+                const txt = String(evalExpr(labelExprFn, 0));
+                labelEl.el.innerHTML = renderKaTeX(txt, false);
+                labelEl._lastDynamicText = txt;
+            } catch (_e) {}
+        }
     }
 
     const animState = { stopped: false };
@@ -95,6 +109,15 @@ export function renderAnimatedPoint(el, view) {
                 labelEl.dataPos[1] = p[1];
                 labelEl.dataPos[2] = p[2] + 0.3;
                 labelEl.forceHidden = !isVisible;
+                if (labelExprFn) {
+                    try {
+                        const txt = String(evalExpr(labelExprFn, tSec));
+                        if (labelEl._lastDynamicText !== txt) {
+                            labelEl.el.innerHTML = renderKaTeX(txt, false);
+                            labelEl._lastDynamicText = txt;
+                        }
+                    } catch (_e) {}
+                }
             }
         },
     });

--- a/static/objects/animated-polygon.js
+++ b/static/objects/animated-polygon.js
@@ -1,5 +1,5 @@
 import { state } from '/state.js';
-import { parseColor, addLabel3D } from '/labels.js';
+import { parseColor, addLabel3D, renderKaTeX } from '/labels.js';
 import { compileExpr, evalExpr } from '/expr.js';
 import { dataToWorld, dataLenToWorld } from '/coords.js';
 
@@ -57,6 +57,7 @@ export function renderAnimatedPolygon(el, view) {
     const opacity = opacityExpr ? 0.3 : opacityRaw;
     const thickness = el.thickness || 0.02;
     const label = el.label;
+    const labelExprString = (typeof el.labelExpr === 'string' && el.labelExpr.trim()) ? el.labelExpr.trim() : null;
     const sh = el.shader || {};
 
     const animState = { stopped: false };
@@ -267,12 +268,24 @@ export function renderAnimatedPolygon(el, view) {
         });
     }
 
+    let labelExprFn = null;
+    if (labelExprString) {
+        try { labelExprFn = compileExpr(labelExprString); } catch (err) { console.warn('animated_polygon labelExpr compile error:', err); }
+    }
+
     let labelEl = null;
-    if (label) {
+    if (label || labelExprFn) {
         const cx = currentDataVerts.reduce((s, v) => s + v[0], 0) / currentDataVerts.length;
         const cy = currentDataVerts.reduce((s, v) => s + v[1], 0) / currentDataVerts.length;
         const cz = currentDataVerts.reduce((s, v) => s + v[2], 0) / currentDataVerts.length;
-        labelEl = addLabel3D(label, [cx, cy, cz], color);
+        labelEl = addLabel3D(label || '', [cx, cy, cz], color);
+        if (labelExprFn) {
+            try {
+                const txt = String(evalExpr(labelExprFn, 0));
+                labelEl.el.innerHTML = renderKaTeX(txt, false);
+                labelEl._lastDynamicText = txt;
+            } catch (_e) {}
+        }
     }
 
     state.activeAnimExprs.push(animExprEntry);
@@ -307,6 +320,15 @@ export function renderAnimatedPolygon(el, view) {
                     labelEl.dataPos[0] = verts.reduce((s, v) => s + v[0], 0) / verts.length;
                     labelEl.dataPos[1] = verts.reduce((s, v) => s + v[1], 0) / verts.length + 0.3;
                     labelEl.dataPos[2] = verts.reduce((s, v) => s + v[2], 0) / verts.length;
+                    if (labelExprFn) {
+                        try {
+                            const txt = String(evalExpr(labelExprFn, tSec));
+                            if (labelEl._lastDynamicText !== txt) {
+                                labelEl.el.innerHTML = renderKaTeX(txt, false);
+                                labelEl._lastDynamicText = txt;
+                            }
+                        } catch (_e) {}
+                    }
                 }
             } catch(err) { /* keep last frame */ }
         },

--- a/static/objects/animated-vector.js
+++ b/static/objects/animated-vector.js
@@ -24,8 +24,7 @@ export function renderAnimatedVector(el, view) {
         || (Array.isArray(el.to) && el.to.length === 3 ? el.to.map(v => String(v)) : null);
     const fromExprStrings = el.fromExpr;
     const visibleExprString = (typeof el.visibleExpr === 'string' && el.visibleExpr.trim()) ? el.visibleExpr.trim() : null;
-    const labelShowAltitude = !!el.labelShowAltitude;
-    const labelAltitudePrecision = Number.isFinite(el.labelAltitudePrecision) ? Math.max(0, Math.floor(el.labelAltitudePrecision)) : 1;
+    const labelExprString = (typeof el.labelExpr === 'string' && el.labelExpr.trim()) ? el.labelExpr.trim() : null;
     const trailOpts = el.trail;
     const hasExplicitWidth = (typeof el.width === 'number' && isFinite(el.width));
     const widthScale = hasExplicitWidth ? Math.max(0.01, el.width) : 1.3;
@@ -235,14 +234,26 @@ export function renderAnimatedVector(el, view) {
     }
 
     // Label
+    let labelExprFn = null;
+    if (labelExprString) {
+        try { labelExprFn = compileExpr(labelExprString); } catch (err) { console.warn('animated_vector labelExpr compile error:', err); }
+    }
+
     let labelEl = null;
-    if (label) {
+    if (label || labelExprFn) {
         const labelPos = el.labelPosition || [
             (initFrom[0] + initTo[0]) / 2 + labelOffset[0],
             (initFrom[1] + initTo[1]) / 2 + labelOffset[1],
             (initFrom[2] + initTo[2]) / 2 + labelOffset[2]
         ];
-        labelEl = addLabel3D(label, labelPos, color);
+        labelEl = addLabel3D(label || '', labelPos, color);
+        if (labelExprFn) {
+            try {
+                const txt = String(evalExpr(labelExprFn, 0));
+                labelEl.el.innerHTML = renderKaTeX(txt, false);
+                labelEl._lastDynamicText = txt;
+            } catch (_e) {}
+        }
     }
 
     // Compiled expr functions
@@ -365,15 +376,14 @@ export function renderAnimatedVector(el, view) {
                 labelEl.dataPos[1] = (cf[1] + ct[1]) / 2 + labelOffset[1];
                 labelEl.dataPos[2] = (cf[2] + ct[2]) / 2 + labelOffset[2];
                 labelEl.forceHidden = false;
-                if (labelShowAltitude) {
-                    const rr = Math.sqrt(cf[0] * cf[0] + cf[1] * cf[1] + cf[2] * cf[2]);
-                    const RpVal = state.sceneSliders.Rp ? Number(state.sceneSliders.Rp.value) : 0;
-                    const alt = Math.max(0, rr - RpVal);
-                    const txt = `h=${alt.toFixed(labelAltitudePrecision)} km`;
-                    if (labelEl._lastDynamicText !== txt) {
-                        labelEl.el.innerHTML = renderKaTeX(txt, false);
-                        labelEl._lastDynamicText = txt;
-                    }
+                if (labelExprFn) {
+                    try {
+                        const txt = String(evalExpr(labelExprFn, tSec));
+                        if (labelEl._lastDynamicText !== txt) {
+                            labelEl.el.innerHTML = renderKaTeX(txt, false);
+                            labelEl._lastDynamicText = txt;
+                        }
+                    } catch (_e) {}
                 }
             }
 


### PR DESCRIPTION
## Summary

- Adds `labelExpr` field to all 6 animated element types (`animated_point`, `animated_line`, `animated_polygon`, `animated_cylinder`, `animated_vector`, `animated_curve`) — evaluates a math.js expression each frame and updates label text via `renderKaTeX` with DOM caching
- Adds `concat()` helper to the expression sandbox for string building in math.js (which doesn't support `+` on strings)
- Removes hardcoded `labelShowAltitude` from animated-vector.js; migrates orbital flight scene to use `labelExpr` with `concat()`
- Silences KaTeX strict-mode console warnings (`strict: false`)
- Documents `labelExpr` in CONTRIBUTING.md

### Usage
```json
{
  "type": "animated_point",
  "expr": ["prev*5", "10.8", "0.1"],
  "labelExpr": "concat(\"Disease (\", toFixed(prev*100, 1), \"%)\") "
}
```

## Test plan

- [x] Orbital flight scene shows dynamic `h=X km` altitude labels
- [ ] Verify labelExpr works on animated_point, animated_polygon, animated_line
- [x] Verify static `label` still works when `labelExpr` is absent
- [x] Verify `labelExpr` without `label` creates a label automatically

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)