### PR TITLE
fix: reduce console noise and add CTX popup refresh button

### DIFF
--- a/agent_tools.py
+++ b/agent_tools.py
@@ -448,6 +448,8 @@ def build_system_prompt(context, agent_memory=None):
     for s in sections:
         if f"## {s}" in prompt_text:
             included.append(s)
-    print(f"   📋 System prompt sections: {', '.join(included)} ({len(prompt_text)} chars)")
+    import server as _srv
+    if getattr(_srv, 'DEBUG_MODE', False):
+        print(f"   📋 System prompt sections: {', '.join(included)} ({len(prompt_text)} chars)")
 
     return prompt_text

--- a/static/chat.js
+++ b/static/chat.js
@@ -1388,7 +1388,7 @@ function logContextIfChanged() {
         rt.sliders ? `${Object.keys(rt.sliders).length} sliders` : null,
         rt.activeTab || null,
     ].filter(Boolean).join(', ');
-    console.log('%c🤖 Chat context updated: %c' +
+    if (window.DEBUG_MODE) console.log('%c🤖 Chat context updated: %c' +
         `scene=[${sceneParts}] runtime=[${rtParts}] (${json.length} chars)`,
         'color: #8888ff; font-weight: bold', 'color: #ccc');
 }
@@ -1398,8 +1398,6 @@ let _contextPollId = null;
 function startContextPolling() {
     if (_contextPollId) return;
     _contextPollId = setInterval(logContextIfChanged, 1000);
-    // Also log immediately
-    setTimeout(logContextIfChanged, 500);
 }
 
 // ----- Welcome Message -----

--- a/static/index.html
+++ b/static/index.html
@@ -210,6 +210,7 @@
         <div id="context-popup-header">
             <span>Prompt Context</span>
             <div id="context-popup-actions">
+                <button id="context-popup-refresh" title="Refresh context">&#x21bb;</button>
                 <button id="context-popup-toggle" title="Collapse or expand text pane">&#9776;</button>
                 <button id="context-popup-copy" title="Copy system prompt">Copy</button>
                 <button id="context-popup-close">&times;</button>

--- a/static/json-browser.js
+++ b/static/json-browser.js
@@ -1174,6 +1174,7 @@ export function setupContextStatusPopup() {
             meta.textContent = 'Refreshing live prompt context…';
             try {
                 await loadPromptContext();
+                console.log(`%c📋 Prompt context refreshed%c (${currentPromptText.length} chars)`, 'color: #aa88ff; font-weight: bold', 'color: #ccc');
             } catch (err) {
                 body.innerHTML = '';
                 const empty = document.createElement('div');
@@ -1314,12 +1315,13 @@ export function setupContextStatusPopup() {
     }
 
     body.addEventListener('scroll', syncActiveSectionFromScroll);
-    window.addEventListener('algebench-context-changed', () => {
-        scheduleContextRefresh('context-changed');
-    });
     window.algebenchRefreshPromptContext = (reason = 'manual') => {
         scheduleContextRefresh(reason);
     };
+    const refreshBtn = document.getElementById('context-popup-refresh');
+    if (refreshBtn) {
+        refreshBtn.addEventListener('click', () => scheduleContextRefresh('manual'));
+    }
 
     pill.classList.remove('hidden');
     {
@@ -1344,6 +1346,7 @@ export function setupContextStatusPopup() {
         meta.textContent = 'Fetching live prompt context…';
         try {
             await loadPromptContext();
+            console.log(`%c📋 Prompt context loaded%c (${currentPromptText.length} chars)`, 'color: #aa88ff; font-weight: bold', 'color: #ccc');
         } catch (err) {
             body.innerHTML = '';
             const empty = document.createElement('div');

--- a/static/style.css
+++ b/static/style.css
@@ -1376,6 +1376,7 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     align-items: center;
     gap: 8px;
 }
+#context-popup-refresh,
 #context-popup-toggle,
 #context-popup-copy {
     border: 1px solid rgba(170, 140, 255, 0.32);


### PR DESCRIPTION
## Summary

- Gate chat context poll log and server-side system prompt log behind `--debug` mode
- Remove auto-refresh of CTX popup on context-changed events (was firing every second)
- Add manual refresh button (↻) to CTX popup header
- Log prompt context on open and manual refresh only

## Test plan

- [x] No context update logs in browser console without `--debug`
- [x] No system prompt logs in server terminal without `--debug`
- [x] CTX popup refresh button works and logs on click
- [x] CTX popup loads context on open

🤖 Generated with [Claude Code](https://claude.com/claude-code)