### PR TITLE
feat: make realtime TTS the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,15 @@ AlgeBench supports three TTS configurations, each with different trade-offs:
 | `--tts-parallelism` | 3 | Max concurrent sentence synthesis (1–4) |
 | `--tts-min-buffer` | 30.0 | Seconds of audio to buffer before playback |
 | `--tts-min-sentence-chars` | 100 | Merge short sentences up to this char count |
+| `--tts-output-file out.wav` | — | Save audio to WAV file (auto-enables buffered mode) |
 
 **Common options** (all modes):
 
 | Flag | Description |
 |------|-------------|
 | `--tts-style "..."` | Additional style guidance (e.g. "speak slowly") |
-| `--tts-output-file out.wav` | Save audio to WAV file |
+
+`--no-tts-live` and `--tts-output-file` automatically enable buffered mode when used without `--tts-buffered`.
 
 ---
 

--- a/server.py
+++ b/server.py
@@ -1262,17 +1262,32 @@ Examples:
                         help='Save all TTS audio to this WAV file in addition to playing')
     parser.add_argument('--tts-buffered', action='store_true', default=False,
                         help='Buffer full sentences before playback instead of realtime streaming')
-    parser.add_argument('--tts-realtime', '-rt', action='store_true', default=True,
-                        help='(default) Use realtime Live API streaming for lowest latency TTS')
+    parser.add_argument('--tts-realtime', '-rt', action='store_true', default=False,
+                        help='(deprecated, no-op) Realtime streaming is now the default; this flag will be removed in a future release')
 
     args = parser.parse_args()
 
-    # Warn if buffered-only flags are used without --tts-buffered
+    # Auto-enable buffered mode when flags require it
+    if not args.tts_buffered:
+        if not args.tts_live:
+            args.tts_buffered = True
+            print("ℹ️  --no-tts-live requires buffered mode; enabling --tts-buffered automatically.",
+                  file=sys.stderr)
+        elif args.tts_output_file:
+            args.tts_buffered = True
+            print("ℹ️  --tts-output-file requires buffered mode; enabling --tts-buffered automatically.",
+                  file=sys.stderr)
+
+    # Warn if buffered-only tuning flags are used without --tts-buffered
     if not args.tts_buffered:
         buffered_only = ['--tts-parallelism', '--tts-min-buffer',
                          '--tts-min-sentence-chars', '--tts-min-sentence-chars-growth',
                          '--tts-chunk-timeout', '--tts-max-retries', '--tts-retry-delay']
-        used = [f for f in buffered_only if f in sys.argv]
+        used = [
+            f
+            for f in buffered_only
+            if any(arg == f or arg.startswith(f + '=') for arg in sys.argv)
+        ]
         if used:
             print(f"⚠️  Warning: {', '.join(used)} only apply in buffered mode (--tts-buffered). "
                   f"Ignoring in realtime mode.", file=sys.stderr)


### PR DESCRIPTION
## Summary

- Realtime streaming TTS is now the default (was opt-in via `--tts-realtime` / `-rt`)
- Adds `--tts-buffered` flag to opt back into the legacy buffered mode (sentences synthesized and buffered before playback)
- `-rt` flag kept for backwards compatibility (no-op since realtime is now default)

## Test plan

- [x] Verify `./algebench` uses realtime TTS by default
- [x] Verify `./algebench --tts-buffered` falls back to buffered sentence mode
- [x] Verify `-rt` still works without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)