### PR TITLE
chore: bump gemini-live-tools to v0.1.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gemini-live-tools @ git+https://github.com/ibenian/gemini-live-tools.git@v0.1.14#subdirectory=python
+gemini-live-tools @ git+https://github.com/ibenian/gemini-live-tools.git@v0.1.15#subdirectory=python
 google-genai>=1.27.0
 numpy>=1.26.0
 fastapi>=0.115.0


### PR DESCRIPTION
## Summary
- Bump `gemini-live-tools` dependency from v0.1.14 to v0.1.15

## Test plan
- [x] Verify app starts successfully with updated dependency
- [x] Test Gemini Live tools functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)