### PR TITLE
fix: TTS play/stop button sync with player state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@ AlgeBench is an interactive 3D math visualizer built on MathBox / Three.js, with
 
 The server runs at `http://localhost:8785`.
 
+### Browser Testing
+
+When you need to test the UI in a browser (e.g. debugging TTS, buttons, styles), navigate to `http://localhost:8785` using the Chrome browser tools. Switch to the **Chat** tab to interact with the AI chat and TTS controls. If the page doesn't load, find the actual port with `grep DEFAULT_PORT server.py`.
+
 ## Project Structure
 
 ```
@@ -48,11 +52,11 @@ docs/              Architecture, sandbox model, feature ideas
 - **Security** — path traversal and XSS vulnerabilities were previously fixed. Be careful with user-supplied paths in the server and anything that renders untrusted expressions.
 - **Branch protection** — `main` is protected. Always use a feature branch and open a PR; never push directly to `main`. Committing directly to `main` is a last resort (e.g., force-push recovery only).
 - **PR base branch** — PRs must target `main` unless the user explicitly requests a different base. Merging into a feature branch that has already been merged to `main` will orphan the changes.
-- **PR workflow** — the standard flow is: create branch → commit → push → create PR → **stop and wait for the user to review**. Never merge a PR unless the user explicitly asks (e.g., "merge it", "ok merge"). Creating a PR without a review step defeats its purpose.
+- **⚠️ PR workflow** — the standard flow is: create branch → commit → push → create PR → **STOP**. Never merge a PR immediately after creating it. PRs must go through review first. Only merge when the user explicitly says "merge it" or "ok merge" as a **separate instruction** after reviewing. "Commit and merge" means commit + create the PR, not merge it.
 - **Codex PR descriptions** — when Codex creates or updates a PR, replace any commit-list placeholder body with a concise writeup using `## Summary` and `## Testing` sections. Summaries should describe the user-visible behavior and key implementation points, not just restate commit subjects.
 - **Closing issues** — if a PR resolves a GitHub issue, include `Closes #<number>` in the PR body so GitHub auto-closes the issue on merge.
 - **PR labels** — always apply at least one label when creating a PR. Run `gh label list` to see available labels and pick the most appropriate one(s).
-- **Merging PRs** — only merge when the user explicitly asks. Use `gh pr merge --merge`. If it fails due to branch protection, retry with `--admin` (available to repo admins only).
+- **Merging PRs** — **NEVER merge a PR unless the user explicitly asks as a separate step after review.** Use `gh pr merge --squash`. If it fails due to branch protection, retry with `--admin` (available to repo admins only).
 
 ## Scene Format
 

--- a/static/chat.js
+++ b/static/chat.js
@@ -986,6 +986,7 @@ let ttsRequestId = 0;         // Monotonic counter — invalidates stale streams
 let ttsPausedByUser = false;
 let ttsPlayer = null;         // TTSAudioPlayer instance (lazy-init)
 let ttsHasOutputFile = false;
+let ttsAbortController = null; // AbortController for the active fetch stream
 
 function _ensureTTSPlayer() {
     if (!ttsPlayer && window.GeminiTTSPlayer) {
@@ -1056,6 +1057,7 @@ window.algebenchStopTTS = function() {
     ++ttsRequestId;
     ttsPausedByUser = false;
     ttsHasOutputFile = false;
+    if (ttsAbortController) { ttsAbortController.abort(); ttsAbortController = null; }
     const p = _ensureTTSPlayer();
     if (p) p.stop();
 };
@@ -1069,12 +1071,15 @@ window.algebenchSpeakText = function(text, onEnd) {
     if (typeof onEnd !== 'function') return;
 
     const startTime = Date.now();
+    let hasStarted = false;
     const poll = setInterval(() => {
         if (ttsRequestId !== expectedId) {
             clearInterval(poll); onEnd(); return;
         }
         const p = _ensureTTSPlayer();
-        if (p && !p.isPlaying()) {
+        if (p && p.isPlaying()) hasStarted = true;
+        // Only trigger onEnd after playback has actually started then stopped
+        if (hasStarted && p && !p.isPlaying()) {
             clearInterval(poll); onEnd(); return;
         }
         if (Date.now() - startTime > 60000) {
@@ -1106,7 +1111,9 @@ async function speakText(text, { explicit = false } = {}) {
     const player = _ensureTTSPlayer();
     if (!player) return;
 
+    if (ttsAbortController) { ttsAbortController.abort(); ttsAbortController = null; }
     const abort = new AbortController();
+    ttsAbortController = abort;
     let response;
     try {
         response = await fetch('/api/tts/stream', {
@@ -1130,6 +1137,7 @@ async function speakText(text, { explicit = false } = {}) {
 
     // Delegate all audio decoding and playback to TTSAudioPlayer
     await player.playStreamWithAbort(response, abort);
+    if (ttsAbortController === abort) ttsAbortController = null;
 
     // Show download button if server saved audio to file
     if (ttsRequestId === myId && ttsHasOutputFile && myDownloadBtn) {


### PR DESCRIPTION
## Summary
- Fix TTS speak button getting stuck in idle while audio plays — the completion poll fired before playback started, causing premature reset
- Abort the fetch stream when stopping TTS so the player does not restart from incoming data
- Strengthen PR review workflow in AGENTS.md and add browser testing instructions

Superseded by #86, which carries the TTS fix forward and includes the follow-up state-machine cleanup and server-side broken-pipe fix.

## Test plan
- [x] Open Chat tab, let auto-play TTS start in Perform mode — button should show active (highlighted)
- [x] Click the speak button while playing — audio stops immediately, button returns to idle
- [x] Click speak button again — TTS restarts from beginning
- [x] Double-click speak button — restarts playback
