### PR TITLE
fix: harden TTS message button state handling

### DIFF
--- a/.agents/skills/debug-chrome/SKILL.md
+++ b/.agents/skills/debug-chrome/SKILL.md
@@ -1,0 +1,92 @@
+# Debug AlgeBench in Chrome
+
+Launch AlgeBench (if not already running), open it in Chrome via browser tools, and interactively debug the UI.
+
+---
+
+## Usage
+
+```
+/debug-chrome [stop|restart]
+```
+
+- `/debug-chrome` — ensure the app is running and open it in Chrome
+- `/debug-chrome stop` — kill the running server
+- `/debug-chrome restart` — kill and relaunch the server
+
+---
+
+## Steps
+
+### 1. Check if the server is already running
+
+```bash
+curl -s -o /dev/null -w '%{http_code}' http://localhost:8785/
+```
+
+- If HTTP 200 → server is running, skip to step 3.
+- If connection refused or non-200 → server is not running, go to step 2.
+- If the user passed `stop`, go to step 5.
+- If the user passed `restart`, go to step 5 first, then step 2.
+
+### 2. Launch the server
+
+Run in background:
+
+```bash
+./algebench scenes/test/test-proof-quadratic.json --debug --server-only &
+```
+
+Wait a few seconds, then verify it's up:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}' http://localhost:8785/
+```
+
+If still not responding, check if the port is different:
+
+```bash
+grep 'DEFAULT_PORT' server.py
+```
+
+Adjust the URL accordingly.
+
+### 3. Open in Chrome
+
+Use the Chrome browser tools:
+
+1. `tabs_context_mcp` with `createIfEmpty: true`
+2. Create a new tab or reuse an existing one
+3. Navigate to `http://localhost:8785`
+4. Click the **Chat** tab to access AI chat and TTS controls
+
+### 4. Debug interactively
+
+Now use Chrome tools (screenshot, javascript_tool, read_console_messages, read_page, etc.) to debug whatever the user needs.
+
+- **Check console errors**: `read_console_messages` with `onlyErrors: true`
+- **Inspect state**: `javascript_tool` to query JS variables and DOM
+- **Take screenshots**: `computer` with `action: screenshot`
+- **Click elements**: `computer` with `action: left_click`
+
+**Important**: `chat.js` variables like `activeSpeakBtn`, `ttsRequestId`, `ttsPlayer` are script-scoped (not ES modules), so they ARE accessible from `javascript_tool`. If a variable is not accessible, check if it was declared inside a function closure.
+
+### 5. Stop the server
+
+Find and kill the process:
+
+```bash
+lsof -ti :8785 | xargs kill 2>/dev/null || true
+```
+
+Verify it's stopped:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}' http://localhost:8785/ 2>/dev/null || echo 'stopped'
+```
+
+### Notes
+
+- The server auto-reloads static files (JS/CSS/HTML) on each request — no restart needed for frontend changes.
+- **Restart is needed** when Python files (server.py, agent_tools.py) change.
+- Use `--debug` flag for verbose server logging.

--- a/.claude/skills/debug-chrome
+++ b/.claude/skills/debug-chrome
@@ -1,0 +1,1 @@
+../../.agents/skills/debug-chrome

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@ AlgeBench is an interactive 3D math visualizer built on MathBox / Three.js, with
 
 The server runs at `http://localhost:8785`.
 
+### Browser Testing
+
+When you need to test the UI in a browser (e.g. debugging TTS, buttons, styles), navigate to `http://localhost:8785` using the Chrome browser tools. Switch to the **Chat** tab to interact with the AI chat and TTS controls. If the page doesn't load, find the actual port with `grep DEFAULT_PORT server.py`.
+
 ## Project Structure
 
 ```
@@ -48,11 +52,11 @@ docs/              Architecture, sandbox model, feature ideas
 - **Security** — path traversal and XSS vulnerabilities were previously fixed. Be careful with user-supplied paths in the server and anything that renders untrusted expressions.
 - **Branch protection** — `main` is protected. Always use a feature branch and open a PR; never push directly to `main`. Committing directly to `main` is a last resort (e.g., force-push recovery only).
 - **PR base branch** — PRs must target `main` unless the user explicitly requests a different base. Merging into a feature branch that has already been merged to `main` will orphan the changes.
-- **PR workflow** — the standard flow is: create branch → commit → push → create PR → **stop and wait for the user to review**. Never merge a PR unless the user explicitly asks (e.g., "merge it", "ok merge"). Creating a PR without a review step defeats its purpose.
+- **⚠️ PR workflow** — the standard flow is: create branch → commit → push → create PR → **STOP**. Never merge a PR immediately after creating it. PRs must go through review first. Only merge when the user explicitly says "merge it" or "ok merge" as a **separate instruction** after reviewing. "Commit and merge" means commit + create the PR, not merge it.
 - **Codex PR descriptions** — when Codex creates or updates a PR, replace any commit-list placeholder body with a concise writeup using `## Summary` and `## Testing` sections. Summaries should describe the user-visible behavior and key implementation points, not just restate commit subjects.
 - **Closing issues** — if a PR resolves a GitHub issue, include `Closes #<number>` in the PR body so GitHub auto-closes the issue on merge.
 - **PR labels** — always apply at least one label when creating a PR. Run `gh label list` to see available labels and pick the most appropriate one(s).
-- **Merging PRs** — only merge when the user explicitly asks. Use `gh pr merge --merge`. If it fails due to branch protection, retry with `--admin` (available to repo admins only).
+- **Merging PRs** — **NEVER merge a PR unless the user explicitly asks as a separate step after review.** Use `gh pr merge --squash`. If it fails due to branch protection, retry with `--admin` (available to repo admins only).
 
 ## Scene Format
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ Skills live in `.agents/skills/` (checked into the repo) and are symlinked from 
 | `algebench-release` | Tag a new release on main |
 | `algebench-scene-builder` | Build or edit scene JSON files interactively |
 | `audit-expressions` | Audit expression sandbox coverage before merging scene changes |
+| `debug-chrome` | Launch AlgeBench and debug the UI in Chrome |
 | `update-glt` | Update gemini-live-tools — install from a PR branch, version tag, or latest release |
 | `version-bump` | Bump the version number |
 

--- a/server.py
+++ b/server.py
@@ -783,7 +783,8 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
                    tts_parallelism=None, tts_min_buffer=None, tts_min_sentence_chars=None,
                    tts_min_sentence_chars_growth=None, tts_chunk_timeout=None,
                    tts_max_retries=None, tts_retry_delay=None, tts_style=None,
-                   tts_live=True, tts_output_file=None, tts_realtime=False):
+                   tts_live=True, tts_output_file=None, tts_realtime=False,
+                   server_only=False):
     """Serve the AlgeBench viewer and optionally open in browser."""
     global DEBUG_MODE
     DEBUG_MODE = debug
@@ -1175,6 +1176,9 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
         }
         print(json.dumps(result, indent=2))
         sys.stdout.flush()
+    elif server_only:
+        print(f"AlgeBench server running at {url}")
+        print(f"\nPress 'q' or Ctrl+C to stop the server")
     else:
         webbrowser.open(url)
         print(f"Opened AlgeBench in browser")
@@ -1274,6 +1278,8 @@ Examples:
                         help='Buffer full sentences before playback instead of realtime streaming')
     parser.add_argument('--tts-realtime', '-rt', action='store_true', default=False,
                         help='(deprecated, no-op) Realtime streaming is now the default; this flag will be removed in a future release')
+    parser.add_argument('--server-only', action='store_true', default=False,
+                        help='Start the server without opening a browser window')
 
     args = parser.parse_args()
 
@@ -1333,6 +1339,7 @@ Examples:
         tts_live=args.tts_live,
         tts_output_file=args.tts_output_file,
         tts_realtime=not args.tts_buffered,
+        server_only=args.server_only,
     )
 
 

--- a/server.py
+++ b/server.py
@@ -1188,7 +1188,10 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
             "pid": os.getpid()
         }
         print(json.dumps(result, indent=2))
-        sys.stdout.flush()
+        try:
+            sys.stdout.flush()
+        except (BrokenPipeError, OSError):
+            pass
     elif server_only:
         print(f"AlgeBench server running at {url}")
         print(f"\nPress 'q' or Ctrl+C to stop the server")

--- a/server.py
+++ b/server.py
@@ -13,6 +13,7 @@ import json
 import os
 import asyncio
 import webbrowser
+import builtins
 from pathlib import Path
 import threading
 import time
@@ -56,6 +57,18 @@ style_css_path  = static_dir / "style.css"
 # Cleared on server start; agents control what's stored via store_as param.
 # ---------------------------------------------------------------------------
 _agent_memory: dict = {}
+
+
+def print(*args, **kwargs):
+    """Best-effort logging: detached stdout/stderr should not break request handling."""
+    try:
+        return builtins.print(*args, **kwargs)
+    except BrokenPipeError:
+        return None
+    except OSError as e:
+        if getattr(e, "errno", None) == 32:
+            return None
+        raise
 
 
 def _memory_summary(key: str, value) -> str:

--- a/static/chat.js
+++ b/static/chat.js
@@ -657,25 +657,21 @@ function addChatMessage(role, content, toolCalls) {
         speakBtn.innerHTML = SVG_SPEAKER;
 
         const setBtnState = (state) => {
-            speakBtn.classList.remove('active', 'paused', 'loading', 'idle');
+            speakBtn.classList.remove('active', 'loading', 'idle');
             if (state) speakBtn.classList.add(state);
             else speakBtn.classList.add('idle');
-            msgDiv.classList.remove('tts-speaking', 'tts-loading', 'tts-paused');
+            msgDiv.classList.remove('tts-speaking', 'tts-loading');
             if (state === 'active') msgDiv.classList.add('tts-speaking');
             if (state === 'loading') msgDiv.classList.add('tts-loading');
-            if (state === 'paused') msgDiv.classList.add('tts-paused');
             if (state === 'loading') {
                 speakBtn.textContent = '...';
                 speakBtn.title = 'Loading audio (click to cancel)';
             } else if (state === 'active') {
                 speakBtn.innerHTML = SVG_SPEAKER;
-                speakBtn.title = 'Playing (click to pause, double-click to restart)';
-            } else if (state === 'paused') {
-                speakBtn.innerHTML = SVG_SPEAKER;
-                speakBtn.title = 'Paused (click to resume, double-click to restart)';
+                speakBtn.title = 'Playing (click to stop, double-click to restart)';
             } else {
                 speakBtn.innerHTML = SVG_SPEAKER;
-                speakBtn.title = 'Read aloud (click to play, double-click to restart)';
+                speakBtn.title = 'Read aloud (click to play)';
             }
         };
 

--- a/static/chat.js
+++ b/static/chat.js
@@ -1130,21 +1130,21 @@ async function speakText(text, { explicit = false } = {}) {
                 mode: (selectedTtsMode === 'silent') ? 'perform' : (selectedTtsMode || 'read'),
             }),
         });
+        if (!response.ok || ttsRequestId !== myId) return;
+
+        ttsHasOutputFile = response.headers.get('X-TTS-Has-Output-File') === '1';
+
+        // Delegate all audio decoding and playback to TTSAudioPlayer
+        await player.playStreamWithAbort(response, abort);
+
+        // Show download button if server saved audio to file
+        if (ttsRequestId === myId && ttsHasOutputFile && myDownloadBtn) {
+            myDownloadBtn.style.display = 'flex';
+        }
     } catch (err) {
         return;
-    }
-
-    if (!response.ok || ttsRequestId !== myId) return;
-
-    ttsHasOutputFile = response.headers.get('X-TTS-Has-Output-File') === '1';
-
-    // Delegate all audio decoding and playback to TTSAudioPlayer
-    await player.playStreamWithAbort(response, abort);
-    if (ttsAbortController === abort) ttsAbortController = null;
-
-    // Show download button if server saved audio to file
-    if (ttsRequestId === myId && ttsHasOutputFile && myDownloadBtn) {
-        myDownloadBtn.style.display = 'flex';
+    } finally {
+        if (ttsAbortController === abort) ttsAbortController = null;
     }
 }
 

--- a/static/chat.js
+++ b/static/chat.js
@@ -1072,14 +1072,21 @@ window.algebenchSpeakText = function(text, onEnd) {
 
     const startTime = Date.now();
     let hasStarted = false;
+    let sawNonIdle = false;
     const poll = setInterval(() => {
         if (ttsRequestId !== expectedId) {
             clearInterval(poll); onEnd(); return;
         }
         const p = _ensureTTSPlayer();
+        if (p && p._state !== 'idle') sawNonIdle = true;
         if (p && p.isPlaying()) hasStarted = true;
         // Only trigger onEnd after playback has actually started then stopped
         if (hasStarted && p && !p.isPlaying()) {
+            clearInterval(poll); onEnd(); return;
+        }
+        // Abort/error path: request became active, but the player returned to idle
+        // before any audio started, so the button should reset immediately.
+        if (!hasStarted && sawNonIdle && p && p._state === 'idle') {
             clearInterval(poll); onEnd(); return;
         }
         if (Date.now() - startTime > 60000) {

--- a/static/chat.js
+++ b/static/chat.js
@@ -986,6 +986,7 @@ let ttsRequestId = 0;         // Monotonic counter — invalidates stale streams
 let ttsPausedByUser = false;
 let ttsPlayer = null;         // TTSAudioPlayer instance (lazy-init)
 let ttsHasOutputFile = false;
+let ttsAbortController = null; // AbortController for the active fetch stream
 
 function _ensureTTSPlayer() {
     if (!ttsPlayer && window.GeminiTTSPlayer) {
@@ -1056,6 +1057,7 @@ window.algebenchStopTTS = function() {
     ++ttsRequestId;
     ttsPausedByUser = false;
     ttsHasOutputFile = false;
+    if (ttsAbortController) { ttsAbortController.abort(); ttsAbortController = null; }
     const p = _ensureTTSPlayer();
     if (p) p.stop();
 };
@@ -1069,12 +1071,15 @@ window.algebenchSpeakText = function(text, onEnd) {
     if (typeof onEnd !== 'function') return;
 
     const startTime = Date.now();
+    let hasStarted = false;
     const poll = setInterval(() => {
         if (ttsRequestId !== expectedId) {
             clearInterval(poll); onEnd(); return;
         }
         const p = _ensureTTSPlayer();
-        if (p && !p.isPlaying()) {
+        if (p && p.isPlaying()) hasStarted = true;
+        // Only trigger onEnd after playback has actually started then stopped
+        if (hasStarted && p && !p.isPlaying()) {
             clearInterval(poll); onEnd(); return;
         }
         if (Date.now() - startTime > 60000) {
@@ -1106,7 +1111,9 @@ async function speakText(text, { explicit = false } = {}) {
     const player = _ensureTTSPlayer();
     if (!player) return;
 
+    if (ttsAbortController) { ttsAbortController.abort(); ttsAbortController = null; }
     const abort = new AbortController();
+    ttsAbortController = abort;
     let response;
     try {
         response = await fetch('/api/tts/stream', {
@@ -1130,6 +1137,7 @@ async function speakText(text, { explicit = false } = {}) {
 
     // Delegate all audio decoding and playback to TTSAudioPlayer
     await player.playStreamWithAbort(response, abort);
+    if (ttsAbortController === abort) ttsAbortController = null;
 
     // Show download button if server saved audio to file
     if (ttsRequestId === myId && ttsHasOutputFile && myDownloadBtn) {

--- a/static/style.css
+++ b/static/style.css
@@ -2596,12 +2596,6 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     animation: speak-ring 1.2s ease-out infinite;
     pointer-events: none;
 }
-.msg-speak-btn.paused {
-    color: rgba(170, 178, 196, 0.9) !important;
-    background: rgba(45, 52, 72, 0.34);
-    border-color: rgba(110, 122, 156, 0.45);
-    opacity: 1 !important;
-}
 @keyframes speak-pulse {
     0%, 100% { box-shadow: 0 0 0 0 rgba(100, 160, 255, 0.28); transform: scale(1); }
     50%      { box-shadow: 0 0 0 5px rgba(100, 160, 255, 0.0); transform: scale(1.06); }
@@ -2638,12 +2632,8 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 .chat-msg.tts-loading .msg-body {
     border-color: rgba(120, 145, 220, 0.4);
 }
-.chat-msg.tts-paused .msg-body {
-    border-color: rgba(95, 180, 135, 0.45);
-}
 .chat-msg.tts-speaking .msg-speak-btn,
-.chat-msg.tts-loading .msg-speak-btn,
-.chat-msg.tts-paused .msg-speak-btn {
+.chat-msg.tts-loading .msg-speak-btn {
     color: #c6d8ff;
     border-color: rgba(120, 140, 230, 0.45);
 }


### PR DESCRIPTION
## Summary
- fix the message speak button so cancel/restart during pre-playback loading resets promptly instead of getting stuck
- simplify the message-button UI state machine to the three states it actually supports: idle, loading, and active
- harden server logging so detached stdout/stderr does not turn `/api/chat` requests into `500 [Errno 32] Broken pipe`

Supersedes #85.

## Testing
- manually verified the speak button in the browser: play, stop during loading, stop during playback, restart, and fast stop/replay sequences
- restarted the patched server and verified `POST /api/chat` returns `200` instead of a broken-pipe `500`
