### PR TITLE
Improve left and right panel visuals

### DIFF
--- a/static/context-browser.js
+++ b/static/context-browser.js
@@ -16,12 +16,14 @@ export function buildSceneTree(spec) {
     if (!spec || !spec.scenes) return;
 
     spec.scenes.forEach((scene, i) => {
+        const sceneTitle = scene.title || ('Scene ' + (i + 1));
         const sceneDiv = document.createElement('div');
         sceneDiv.className = 'tree-scene';
         sceneDiv.dataset.sceneIdx = i;
 
         const header = document.createElement('div');
         header.className = 'tree-scene-header';
+        header.title = sceneTitle;
 
         const arrow = document.createElement('span');
         arrow.className = 'tree-scene-arrow';
@@ -29,7 +31,8 @@ export function buildSceneTree(spec) {
         header.appendChild(arrow);
 
         const title = document.createElement('span');
-        title.innerHTML = renderKaTeX(scene.title || ('Scene ' + (i + 1)), false);
+        title.innerHTML = renderKaTeX(sceneTitle, false);
+        title.title = sceneTitle;
         header.appendChild(title);
 
         header.addEventListener('click', (e) => {
@@ -49,11 +52,13 @@ export function buildSceneTree(spec) {
             stepsDiv.className = 'tree-steps';
 
             scene.steps.forEach((step, j) => {
+                const stepTitle = step.title || ('Step ' + (j + 1));
                 const stepDiv = document.createElement('div');
                 stepDiv.className = 'tree-step';
                 stepDiv.dataset.sceneIdx = i;
                 stepDiv.dataset.stepIdx = j;
-                stepDiv.innerHTML = renderKaTeX(step.title || ('Step ' + (j + 1)), false);
+                stepDiv.title = stepTitle;
+                stepDiv.innerHTML = renderKaTeX(stepTitle, false);
                 stepDiv.addEventListener('click', () => { if (_navigateFn) _navigateFn(i, j); });
                 stepsDiv.appendChild(stepDiv);
             });

--- a/static/index.html
+++ b/static/index.html
@@ -49,6 +49,9 @@
         <div id="scene-dock">
             <div id="scene-dock-toggle" title="Scene tree (T)">&#9776;</div>
             <div id="scene-dock-panel">
+                <div id="scene-dock-header">
+                    <div id="scene-dock-title">Scenes</div>
+                </div>
                 <div id="scene-tree"></div>
             </div>
         </div>

--- a/static/labels.js
+++ b/static/labels.js
@@ -223,7 +223,7 @@ export function injectAskButtons(contentEl) {
         }
         const lastEl = el.lastElementChild;
         if (lastEl && lastEl.classList && lastEl.classList.contains('katex-display')) {
-            const mathRow = document.createElement('div');
+            const mathRow = document.createElement('span');
             mathRow.className = 'doc-ai-math-row';
             btn.classList.add('ai-ask-btn--math-side');
             lastEl.replaceWith(mathRow);

--- a/static/labels.js
+++ b/static/labels.js
@@ -223,7 +223,13 @@ export function injectAskButtons(contentEl) {
         }
         const lastEl = el.lastElementChild;
         if (lastEl && lastEl.classList && lastEl.classList.contains('katex-display')) {
-            btn.classList.add('ai-ask-btn--after-block');
+            const mathRow = document.createElement('div');
+            mathRow.className = 'doc-ai-math-row';
+            btn.classList.add('ai-ask-btn--math-side');
+            lastEl.replaceWith(mathRow);
+            mathRow.appendChild(lastEl);
+            mathRow.appendChild(btn);
+            return;
         }
         el.appendChild(btn);
     });

--- a/static/style.css
+++ b/static/style.css
@@ -1911,8 +1911,10 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 /* Tab Content */
 .tab-content { display: none; flex: 1; overflow: hidden; flex-direction: column; }
 .tab-content.active { display: flex; }
-#tab-doc {
-    overflow-y: auto;
+#tab-doc.active {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
     background:
         linear-gradient(180deg, rgba(18, 20, 40, 0.96) 0%, rgba(13, 15, 30, 0.99) 100%);
 }
@@ -2132,6 +2134,9 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     padding: 12px 14px;
     border-bottom: 1px solid rgba(116, 132, 255, 0.08);
     flex-shrink: 0;
+    position: sticky;
+    top: 0;
+    z-index: 2;
     background:
         linear-gradient(180deg, rgba(23, 25, 49, 0.96), rgba(16, 18, 39, 0.88));
 }
@@ -2166,6 +2171,9 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 }
 
 #explanation-content {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
     padding: 22px 16px 28px;
     color: rgba(219, 224, 245, 0.96);
     text-wrap: pretty;

--- a/static/style.css
+++ b/static/style.css
@@ -2058,7 +2058,7 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     cursor: pointer;
 }
 #ttsVolumeSlider::-moz-range-track {
-    height: 3px;
+    height: 4px;
     border-radius: 2px;
     background: rgba(137, 150, 255, 0.3);
 }

--- a/static/style.css
+++ b/static/style.css
@@ -2213,6 +2213,55 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     padding-left: 24px;
 }
 #explanation-content li { margin-bottom: 7px; }
+#explanation-content table {
+    width: 100%;
+    max-width: 42rem;
+    margin: 0 auto 22px;
+    border-collapse: separate;
+    border-spacing: 0;
+    background: rgba(21, 24, 46, 0.82);
+    border: 1px solid rgba(112, 126, 211, 0.14);
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow:
+        0 12px 26px rgba(6, 9, 24, 0.18),
+        inset 0 1px 0 rgba(255, 255, 255, 0.02);
+}
+#explanation-content thead th {
+    padding: 14px 16px 12px;
+    text-align: left;
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: rgba(241, 245, 255, 0.96);
+    background: rgba(34, 39, 74, 0.92);
+    border-bottom: 1px solid rgba(122, 137, 224, 0.16);
+}
+#explanation-content tbody td {
+    padding: 14px 16px;
+    vertical-align: top;
+    font-size: 0.98rem;
+    line-height: 1.65;
+    color: rgba(218, 223, 242, 0.92);
+    border-bottom: 1px solid rgba(112, 126, 211, 0.1);
+}
+#explanation-content tbody tr:last-child td {
+    border-bottom: none;
+}
+#explanation-content tbody tr:nth-child(even) td {
+    background: rgba(29, 33, 61, 0.38);
+}
+#explanation-content th:first-child,
+#explanation-content td:first-child {
+    width: 22%;
+    white-space: nowrap;
+}
+#explanation-content th:nth-child(2),
+#explanation-content td:nth-child(2) {
+    width: 30%;
+}
+#explanation-content table .katex {
+    font-size: 0.9em;
+}
 #explanation-content strong { color: #f5f7ff; }
 #explanation-content em { color: rgba(206, 211, 235, 0.9); }
 #explanation-content code {

--- a/static/style.css
+++ b/static/style.css
@@ -1911,32 +1911,42 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 /* Tab Content */
 .tab-content { display: none; flex: 1; overflow: hidden; flex-direction: column; }
 .tab-content.active { display: flex; }
-#tab-doc { overflow-y: auto; }
+#tab-doc {
+    overflow-y: auto;
+    background:
+        linear-gradient(180deg, rgba(18, 20, 40, 0.96) 0%, rgba(13, 15, 30, 0.99) 100%);
+}
 #tab-chat { display: none; flex-direction: column; }
 #tab-chat.active { display: flex; }
 #chat-tts-controls {
     display: flex;
-    gap: 6px;
+    gap: 8px;
     align-items: center;
-    padding: 8px 10px;
-    border-bottom: 1px solid rgba(100, 100, 255, 0.1);
-    background: rgba(10, 10, 28, 0.4);
+    flex-wrap: wrap;
+    padding: 10px 14px 12px;
+    border-bottom: 1px solid rgba(116, 132, 255, 0.08);
+    background:
+        linear-gradient(180deg, rgba(23, 25, 49, 0.96), rgba(16, 18, 39, 0.88));
     flex-shrink: 0;
 }
 .chat-control-btn {
-    padding: 4px 10px;
-    background: rgba(30, 30, 65, 0.7);
-    border: 1px solid rgba(100, 100, 255, 0.2);
-    border-radius: 4px;
-    color: rgba(170, 170, 215, 0.9);
+    min-height: 34px;
+    padding: 6px 12px;
+    background: rgba(44, 47, 83, 0.82);
+    border: 1px solid rgba(118, 132, 238, 0.18);
+    border-radius: 10px;
+    color: rgba(214, 220, 255, 0.88);
     font-size: 0.76em;
+    font-weight: 600;
     cursor: pointer;
-    transition: background 0.15s, color 0.15s, border-color 0.15s;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
+    transition: background 0.15s, color 0.15s, border-color 0.15s, transform 0.15s;
 }
 .chat-control-btn:hover {
-    background: rgba(50, 50, 100, 0.85);
-    color: #e0e0ff;
-    border-color: rgba(140, 140, 255, 0.4);
+    background: rgba(57, 61, 102, 0.92);
+    color: #f3f5ff;
+    border-color: rgba(150, 168, 255, 0.3);
+    transform: translateY(-1px);
 }
 .tts-volume-icon {
     font-size: 14px;
@@ -1949,10 +1959,10 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 #ttsVolumeSlider {
     -webkit-appearance: none;
     appearance: none;
-    width: 56px;
-    height: 3px;
+    width: 72px;
+    height: 4px;
     border-radius: 2px;
-    background: rgba(140, 140, 255, 0.35);
+    background: rgba(137, 150, 255, 0.3);
     cursor: pointer;
     opacity: 0.7;
     transition: opacity 0.2s;
@@ -1963,29 +1973,29 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     width: 12px;
     height: 12px;
     border-radius: 50%;
-    background: rgba(140, 140, 255, 0.8);
-    box-shadow: 0 0 4px rgba(100, 100, 255, 0.5);
+    background: rgba(180, 191, 255, 0.95);
+    box-shadow: 0 0 0 3px rgba(120, 136, 255, 0.18);
     border: none;
     cursor: pointer;
     transition: transform 0.15s, box-shadow 0.15s;
 }
 #ttsVolumeSlider::-webkit-slider-thumb:hover {
     transform: scale(1.3);
-    box-shadow: 0 0 8px rgba(100, 100, 255, 0.7);
+    box-shadow: 0 0 0 5px rgba(120, 136, 255, 0.24);
 }
 #ttsVolumeSlider::-moz-range-thumb {
     width: 12px;
     height: 12px;
     border-radius: 50%;
-    background: rgba(140, 140, 255, 0.8);
-    box-shadow: 0 0 4px rgba(100, 100, 255, 0.5);
+    background: rgba(180, 191, 255, 0.95);
+    box-shadow: 0 0 0 3px rgba(120, 136, 255, 0.18);
     border: none;
     cursor: pointer;
 }
 #ttsVolumeSlider::-moz-range-track {
     height: 3px;
     border-radius: 2px;
-    background: rgba(140, 140, 255, 0.35);
+    background: rgba(137, 150, 255, 0.3);
 }
 .style-picker { position: relative; }
 .style-btn { max-width: 185px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -2100,42 +2110,55 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     box-shadow: 0 0 6px rgba(120, 140, 255, 0.35);
 }
 .ai-ask-btn svg { pointer-events: none; }
-/* Button after a block element (e.g. display math): right-align on its own line */
-.ai-ask-btn.ai-ask-btn--after-block {
-    display: block;
-    margin-left: auto;
-    margin-top: 4px;
+.doc-ai-math-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 18px 0 20px;
+}
+.ai-ask-btn.ai-ask-btn--math-side {
+    width: 22px;
+    height: 22px;
+    margin-left: 0;
+    top: 0;
+    flex-shrink: 0;
+    align-self: center;
 }
 
 /* Doc Toolbar (Speak / Commentate) */
 #doc-toolbar {
     display: flex;
-    gap: 6px;
-    padding: 8px 10px;
-    border-bottom: 1px solid rgba(100, 100, 255, 0.1);
+    gap: 8px;
+    padding: 12px 14px;
+    border-bottom: 1px solid rgba(116, 132, 255, 0.08);
     flex-shrink: 0;
-    background: rgba(10, 10, 28, 0.4);
+    background:
+        linear-gradient(180deg, rgba(23, 25, 49, 0.96), rgba(16, 18, 39, 0.88));
 }
 #doc-toolbar button {
-    padding: 4px 10px;
-    background: rgba(30, 30, 65, 0.7);
-    border: 1px solid rgba(100, 100, 255, 0.2);
-    border-radius: 4px;
-    color: rgba(170, 170, 215, 0.85);
+    min-height: 34px;
+    padding: 6px 12px;
+    background: rgba(44, 47, 83, 0.82);
+    border: 1px solid rgba(118, 132, 238, 0.18);
+    border-radius: 10px;
+    color: rgba(214, 220, 255, 0.88);
     font-size: 0.76em;
+    font-weight: 600;
     cursor: pointer;
-    transition: background 0.15s, color 0.15s, border-color 0.15s;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
+    transition: background 0.15s, color 0.15s, border-color 0.15s, transform 0.15s;
     white-space: nowrap;
 }
 #doc-toolbar button:hover:not(:disabled) {
-    background: rgba(50, 50, 100, 0.85);
-    color: #e0e0ff;
-    border-color: rgba(140, 140, 255, 0.4);
+    background: rgba(57, 61, 102, 0.92);
+    color: #f3f5ff;
+    border-color: rgba(150, 168, 255, 0.3);
+    transform: translateY(-1px);
 }
 #doc-toolbar button.active {
-    background: rgba(70, 70, 150, 0.85);
-    border-color: rgba(140, 160, 255, 0.6);
-    color: #c8d0ff;
+    background: rgba(98, 111, 197, 0.88);
+    border-color: rgba(171, 184, 255, 0.36);
+    color: #f9fbff;
 }
 #doc-toolbar button:disabled {
     opacity: 0.45;
@@ -2143,81 +2166,108 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 }
 
 #explanation-content {
-    padding: 24px 20px;
+    padding: 22px 16px 28px;
+    color: rgba(219, 224, 245, 0.96);
+    text-wrap: pretty;
+}
+#explanation-content > * {
+    max-width: 42rem;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 #explanation-content h1 {
-    font-size: 20px;
-    font-weight: 600;
-    color: #ffffff;
-    margin: 0 0 12px 0;
-    line-height: 1.3;
+    font-size: 1.95rem;
+    font-weight: 700;
+    color: #fbfcff;
+    margin: 0 0 14px 0;
+    line-height: 1.15;
+    letter-spacing: -0.03em;
 }
 #explanation-content h2 {
-    font-size: 17px;
+    font-size: 1.15rem;
     font-weight: 600;
-    color: #b0c0ff;
-    margin: 20px 0 8px 0;
-    line-height: 1.3;
+    color: rgba(180, 198, 255, 0.96);
+    margin: 28px 0 10px 0;
+    line-height: 1.25;
+    letter-spacing: -0.01em;
 }
 #explanation-content h3 {
-    font-size: 15px;
+    font-size: 0.96rem;
     font-weight: 600;
-    color: #c0b0ff;
-    margin: 16px 0 6px 0;
+    color: rgba(204, 189, 255, 0.92);
+    margin: 22px 0 8px 0;
     line-height: 1.3;
 }
 #explanation-content p {
-    font-size: 14px;
-    line-height: 1.7;
-    color: #d0d0d0;
-    margin: 0 0 12px 0;
+    font-size: 0.98rem;
+    line-height: 1.78;
+    color: rgba(218, 223, 242, 0.92);
+    margin: 0 0 15px 0;
 }
 #explanation-content ul, #explanation-content ol {
-    font-size: 14px;
-    line-height: 1.7;
-    color: #d0d0d0;
-    margin: 0 0 12px 0;
-    padding-left: 20px;
+    font-size: 0.98rem;
+    line-height: 1.78;
+    color: rgba(218, 223, 242, 0.92);
+    margin: 0 0 15px 0;
+    padding-left: 24px;
 }
-#explanation-content li { margin-bottom: 4px; }
-#explanation-content strong { color: #e0e0ff; }
-#explanation-content em { color: #c8c8e0; }
+#explanation-content li { margin-bottom: 7px; }
+#explanation-content strong { color: #f5f7ff; }
+#explanation-content em { color: rgba(206, 211, 235, 0.9); }
 #explanation-content code {
-    background: rgba(40, 40, 80, 0.6);
-    padding: 2px 5px;
-    border-radius: 3px;
+    background: rgba(53, 59, 102, 0.78);
+    padding: 3px 7px;
+    border-radius: 7px;
     font-family: 'SF Mono', 'Fira Code', monospace;
     font-size: 0.88em;
-    color: #c0c0ff;
+    color: #dde2ff;
 }
 #explanation-content pre {
-    background: rgba(10, 10, 30, 0.8);
-    border: 1px solid rgba(100, 100, 255, 0.1);
-    border-radius: 6px;
-    padding: 12px;
-    margin: 0 0 12px 0;
+    background: linear-gradient(180deg, rgba(20, 23, 45, 0.96), rgba(14, 16, 31, 0.98));
+    border: 1px solid rgba(110, 124, 210, 0.12);
+    border-radius: 16px;
+    padding: 16px 18px;
+    margin: 0 0 18px 0;
     overflow-x: auto;
+    box-shadow:
+        0 12px 26px rgba(6, 9, 24, 0.18),
+        inset 0 1px 0 rgba(255, 255, 255, 0.02);
 }
 #explanation-content pre code {
     background: none;
     padding: 0;
     font-size: 13px;
+    color: rgba(223, 228, 248, 0.92);
 }
 #explanation-content blockquote {
-    border-left: 3px solid rgba(100, 120, 255, 0.4);
-    padding: 8px 14px;
-    margin: 0 0 12px 0;
-    color: #b0b0d0;
-    font-style: italic;
+    border-left: 4px solid rgba(105, 183, 255, 0.72);
+    padding: 12px 16px;
+    margin: 0 0 18px 0;
+    color: rgba(193, 203, 236, 0.9);
+    background: linear-gradient(180deg, rgba(29, 39, 72, 0.9), rgba(22, 30, 56, 0.92));
+    border-radius: 0 14px 14px 0;
+    font-style: normal;
 }
 #explanation-content hr {
     border: none;
-    border-top: 1px solid rgba(100, 100, 255, 0.15);
-    margin: 16px 0;
+    border-top: 1px solid rgba(116, 132, 255, 0.12);
+    margin: 24px 0;
 }
-#explanation-content .katex { color: #e0d0ff; font-size: 0.92em; }
-#explanation-content .katex-display { margin: 12px 0; overflow: hidden; }
+#explanation-content .katex { color: #ece0ff; font-size: 0.95em; }
+#explanation-content .katex-display {
+    margin: 18px 0 20px;
+    overflow: hidden;
+    padding: 18px 16px;
+    background: rgba(19, 22, 42, 0.68);
+    border: 1px solid rgba(109, 123, 202, 0.1);
+    border-radius: 14px;
+}
+#explanation-content .doc-ai-math-row .katex-display {
+    flex: 1;
+    min-width: 0;
+    margin: 0;
+}
 
 /* Step Caption Overlay */
 #step-caption {
@@ -2487,16 +2537,18 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 #chat-messages {
     flex: 1;
     overflow-y: auto;
-    padding: 12px;
+    padding: 18px 16px 14px;
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 14px;
+    background:
+        linear-gradient(180deg, rgba(16, 18, 39, 0.94) 0%, rgba(15, 16, 34, 0.97) 100%);
 }
 
 /* Chat Messages */
 .chat-msg {
     display: flex;
-    gap: 8px;
+    gap: 10px;
     align-items: flex-start;
     animation: chatFadeIn 0.2s ease;
 }
@@ -2506,32 +2558,42 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 }
 .msg-avatar {
     flex-shrink: 0;
-    width: 28px;
-    height: 28px;
+    width: 32px;
+    height: 32px;
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 14px;
+    font-size: 15px;
     border-radius: 50%;
-    background: rgba(40, 40, 80, 0.5);
+    background: linear-gradient(180deg, rgba(65, 71, 116, 0.95), rgba(38, 42, 75, 0.92));
+    border: 1px solid rgba(129, 141, 235, 0.14);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
-.chat-msg.user .msg-avatar { background: rgba(60, 60, 120, 0.5); }
+.chat-msg.user .msg-avatar {
+    background: linear-gradient(180deg, rgba(74, 88, 158, 0.95), rgba(49, 58, 112, 0.92));
+}
 .msg-body {
     flex: 1;
     font-size: 13px;
-    line-height: 1.6;
-    color: #d0d0e0;
+    line-height: 1.65;
+    color: rgba(221, 225, 244, 0.95);
     min-width: 0;
     overflow-wrap: break-word;
 }
 .chat-msg.user .msg-body {
-    background: rgba(60, 60, 140, 0.2);
-    border-radius: 10px 10px 2px 10px;
-    padding: 8px 12px;
-    color: #e0e0f0;
+    background: linear-gradient(180deg, rgba(47, 53, 107, 0.88), rgba(35, 39, 81, 0.9));
+    border: 1px solid rgba(118, 136, 246, 0.18);
+    border-radius: 16px 16px 6px 16px;
+    padding: 11px 14px;
+    color: rgba(240, 243, 255, 0.96);
+    box-shadow: 0 10px 26px rgba(4, 8, 24, 0.2);
 }
 .chat-msg.assistant .msg-body {
-    padding: 2px 0;
+    padding: 10px 14px 11px;
+    background: rgba(23, 26, 50, 0.7);
+    border: 1px solid rgba(110, 124, 210, 0.08);
+    border-radius: 16px 16px 16px 6px;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.015);
 }
 /* Markdown inside chat messages */
 .msg-body p { margin: 0 0 8px 0; }
@@ -2539,13 +2601,13 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 .msg-body ul, .msg-body ol { margin: 4px 0 8px 0; padding-left: 18px; }
 .msg-body li { margin-bottom: 2px; }
 .msg-body code {
-    background: rgba(40, 40, 80, 0.6);
-    padding: 1px 4px;
-    border-radius: 3px;
+    background: rgba(54, 60, 103, 0.78);
+    padding: 2px 6px;
+    border-radius: 6px;
     font-size: 0.9em;
-    color: #c0c0ff;
+    color: #d9deff;
 }
-.msg-body strong { color: #e0e0ff; }
+.msg-body strong { color: #f4f6ff; }
 .msg-body .katex { color: #e0d0ff; font-size: 0.92em; }
 
 /* Per-message speak button */
@@ -2710,17 +2772,21 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 
 /* Tool Call Chips */
 .chat-tool-call {
-    margin-left: 36px;
-    padding: 4px 10px;
-    background: rgba(40, 60, 100, 0.2);
-    border: 1px solid rgba(100, 140, 200, 0.15);
-    border-radius: 6px;
+    margin-left: 42px;
+    padding: 8px 12px;
+    background: rgba(22, 29, 54, 0.9);
+    border: 1px solid rgba(103, 125, 198, 0.16);
+    border-radius: 12px;
     font-size: 0.78em;
-    color: rgba(160, 180, 220, 0.8);
+    color: rgba(190, 202, 235, 0.86);
     cursor: pointer;
-    transition: background 0.15s;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+    transition: background 0.15s, border-color 0.15s;
 }
-.chat-tool-call:hover { background: rgba(40, 60, 100, 0.35); }
+.chat-tool-call:hover {
+    background: rgba(28, 36, 66, 0.95);
+    border-color: rgba(123, 149, 226, 0.24);
+}
 .tool-call-summary { line-height: 1.5; }
 .tool-call-details {
     margin-top: 4px;
@@ -2737,19 +2803,20 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 #preset-prompts {
     display: flex;
     flex-wrap: wrap;
-    gap: 6px;
-    padding: 6px 10px 4px;
-    border-top: 1px solid rgba(255,255,255,0.06);
+    gap: 8px;
+    padding: 12px 14px 8px;
+    border-top: 1px solid rgba(116, 132, 255, 0.08);
+    background: rgba(14, 16, 34, 0.82);
 }
 #preset-prompts.hidden { display: none; }
 
 .preset-prompt-btn {
-    background: rgba(80, 130, 220, 0.12);
-    border: 1px solid rgba(100, 160, 255, 0.28);
-    border-radius: 14px;
-    padding: 4px 12px;
+    background: rgba(41, 52, 95, 0.82);
+    border: 1px solid rgba(117, 143, 234, 0.24);
+    border-radius: 999px;
+    padding: 7px 14px;
     font-size: 12px;
-    color: rgba(160, 200, 255, 0.9);
+    color: rgba(197, 216, 255, 0.92);
     cursor: pointer;
     transition: background 0.15s, border-color 0.15s, color 0.15s;
     white-space: nowrap;
@@ -2759,53 +2826,65 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     font-family: inherit;
 }
 .preset-prompt-btn:hover {
-    background: rgba(80, 130, 220, 0.25);
-    border-color: rgba(100, 160, 255, 0.55);
-    color: rgba(200, 225, 255, 1);
+    background: rgba(54, 68, 119, 0.92);
+    border-color: rgba(143, 171, 255, 0.4);
+    color: rgba(240, 245, 255, 1);
 }
 /* Chat Input Area */
 #chat-input-area {
     display: flex;
     gap: 8px;
-    padding: 10px 12px;
-    border-top: 1px solid rgba(100, 100, 255, 0.12);
-    background: rgba(10, 10, 30, 0.4);
+    padding: 14px;
+    border-top: 1px solid rgba(116, 132, 255, 0.08);
+    background:
+        linear-gradient(180deg, rgba(15, 17, 34, 0.96), rgba(11, 13, 26, 0.98));
     flex-shrink: 0;
     align-items: flex-end;
 }
 #chat-input {
     flex: 1;
-    background: rgba(30, 30, 60, 0.6);
-    border: 1px solid rgba(100, 100, 255, 0.2);
-    border-radius: 8px;
-    padding: 8px 12px;
-    color: #e0e0f0;
+    background: rgba(24, 27, 53, 0.95);
+    border: 1px solid rgba(118, 132, 235, 0.18);
+    border-radius: 16px;
+    padding: 12px 15px;
+    color: #eef1ff;
     font-size: 13px;
     font-family: inherit;
     resize: none;
     outline: none;
     max-height: 120px;
     line-height: 1.5;
-    transition: border-color 0.2s;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
+    transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
 }
-#chat-input:focus { border-color: rgba(140, 160, 255, 0.5); }
-#chat-input::placeholder { color: rgba(140, 140, 180, 0.5); }
+#chat-input:focus {
+    border-color: rgba(149, 165, 255, 0.42);
+    box-shadow: 0 0 0 3px rgba(98, 115, 224, 0.16);
+    background: rgba(27, 31, 59, 0.98);
+}
+#chat-input::placeholder { color: rgba(154, 161, 196, 0.58); }
 #chat-send {
-    background: rgba(80, 80, 200, 0.3);
-    border: 1px solid rgba(100, 100, 255, 0.3);
-    border-radius: 8px;
-    color: #b0b8ff;
-    width: 36px;
-    height: 36px;
+    background: linear-gradient(180deg, rgba(104, 118, 255, 0.92), rgba(73, 90, 223, 0.92));
+    border: 1px solid rgba(144, 160, 255, 0.34);
+    border-radius: 14px;
+    color: #f8f9ff;
+    width: 44px;
+    height: 44px;
     cursor: pointer;
     font-size: 16px;
     display: flex;
     align-items: center;
     justify-content: center;
+    box-shadow: 0 10px 24px rgba(45, 61, 176, 0.34);
     transition: all 0.15s;
     flex-shrink: 0;
 }
-#chat-send:hover { background: rgba(80, 80, 200, 0.5); color: #fff; }
+#chat-send:hover {
+    background: linear-gradient(180deg, rgba(121, 135, 255, 0.98), rgba(86, 104, 235, 0.96));
+    color: #fff;
+    transform: translateY(-1px);
+    box-shadow: 0 14px 28px rgba(53, 70, 195, 0.4);
+}
 
 /* ============================================================
    Proof Panel (inside chat tab, split vertically)
@@ -2820,10 +2899,17 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 #proof-panel {
     display: flex;
     flex-direction: column;
-    border-bottom: 1px solid rgba(100, 100, 255, 0.15);
+    margin: 0 12px 10px;
+    border: 1px solid rgba(117, 132, 228, 0.12);
+    border-radius: 18px;
     overflow: hidden;
     flex-shrink: 0;
     max-height: 60%;
+    background:
+        linear-gradient(180deg, rgba(25, 28, 56, 0.98), rgba(18, 20, 43, 0.97));
+    box-shadow:
+        0 14px 30px rgba(4, 7, 22, 0.22),
+        inset 0 1px 0 rgba(255, 255, 255, 0.03);
 }
 #proof-panel.hidden { display: none; }
 
@@ -2831,11 +2917,11 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 6px 10px;
-    background: rgba(10, 10, 28, 0.5);
-    border-bottom: 1px solid rgba(100, 100, 255, 0.1);
+    padding: 11px 14px;
+    background: rgba(21, 24, 48, 0.92);
+    border-bottom: 1px solid rgba(118, 132, 228, 0.1);
     flex-shrink: 0;
-    gap: 6px;
+    gap: 10px;
 }
 
 #proof-panel-tabs {
@@ -2843,23 +2929,24 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     gap: 4px;
 }
 .proof-tab {
-    padding: 3px 10px;
+    padding: 7px 12px;
     background: transparent;
     border: 1px solid transparent;
-    border-radius: 4px;
-    color: rgba(150, 150, 200, 0.7);
+    border-radius: 999px;
+    color: rgba(177, 184, 224, 0.78);
     font-size: 0.72em;
+    font-weight: 600;
     cursor: pointer;
     transition: all 0.15s;
 }
 .proof-tab:hover {
-    color: rgba(200, 200, 240, 0.9);
-    background: rgba(40, 40, 80, 0.4);
+    color: rgba(233, 238, 255, 0.95);
+    background: rgba(49, 55, 97, 0.62);
 }
 .proof-tab.active {
-    color: #c8d0ff;
-    background: rgba(50, 50, 110, 0.6);
-    border-color: rgba(100, 100, 255, 0.25);
+    color: #f0f3ff;
+    background: rgba(69, 77, 128, 0.82);
+    border-color: rgba(145, 160, 255, 0.22);
 }
 
 #proof-panel-controls {
@@ -2868,46 +2955,50 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     align-items: center;
 }
 .proof-ctrl-btn {
-    padding: 3px 8px;
-    background: rgba(30, 30, 65, 0.7);
-    border: 1px solid rgba(100, 100, 255, 0.2);
-    border-radius: 4px;
-    color: rgba(170, 170, 215, 0.85);
+    min-height: 32px;
+    padding: 5px 10px;
+    background: rgba(44, 48, 84, 0.82);
+    border: 1px solid rgba(118, 132, 238, 0.18);
+    border-radius: 10px;
+    color: rgba(214, 220, 255, 0.84);
     font-size: 0.72em;
+    font-weight: 600;
     cursor: pointer;
     transition: all 0.15s;
 }
 .proof-ctrl-btn:hover {
-    background: rgba(50, 50, 100, 0.85);
-    color: #e0e0ff;
-    border-color: rgba(140, 140, 255, 0.4);
+    background: rgba(57, 61, 102, 0.92);
+    color: #eef2ff;
+    border-color: rgba(150, 168, 255, 0.3);
 }
 .proof-ctrl-btn.active {
-    background: rgba(70, 70, 150, 0.85);
-    border-color: rgba(140, 160, 255, 0.6);
-    color: #c8d0ff;
+    background: rgba(98, 111, 197, 0.88);
+    border-color: rgba(171, 184, 255, 0.36);
+    color: #f9fbff;
 }
 
-.proof-tab-content { display: none; overflow-y: auto; flex: 1; padding: 8px 10px; }
+.proof-tab-content { display: none; overflow-y: auto; flex: 1; padding: 14px; }
 .proof-tab-content.active { display: block; }
 
 /* Proof goal */
 .proof-goal {
     position: relative;
-    padding: 8px 10px;
-    margin-bottom: 8px;
-    border-left: 3px solid rgba(100, 180, 255, 0.5);
-    background: rgba(30, 40, 70, 0.4);
-    border-radius: 0 4px 4px 0;
+    padding: 12px 14px;
+    margin-bottom: 14px;
+    border-left: 4px solid rgba(104, 180, 255, 0.72);
+    background: linear-gradient(180deg, rgba(31, 42, 77, 0.9), rgba(23, 31, 59, 0.92));
+    border-radius: 0 14px 14px 0;
     font-size: 0.88em;
-    color: rgba(200, 210, 240, 0.95);
+    color: rgba(232, 238, 255, 0.96);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
 }
 .proof-goal-label {
-    font-size: 0.7em;
+    font-size: 0.66em;
     text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: rgba(140, 160, 220, 0.7);
-    margin-bottom: 4px;
+    letter-spacing: 0.12em;
+    color: rgba(151, 171, 231, 0.74);
+    margin-bottom: 8px;
+    font-weight: 700;
 }
 .proof-goal-row {
     display: flex;
@@ -2930,17 +3021,18 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 
 /* Proof section header (file / scene / step level) */
 .proof-section {
-    margin-bottom: 10px;
+    margin-bottom: 14px;
 }
 .proof-section-header {
     display: flex;
     align-items: center;
     gap: 6px;
-    padding: 4px 0;
+    padding: 2px 2px 8px;
     cursor: pointer;
-    color: rgba(160, 170, 220, 0.8);
-    font-size: 0.76em;
+    color: rgba(178, 186, 227, 0.84);
+    font-size: 0.74em;
     font-weight: 600;
+    letter-spacing: 0.02em;
     user-select: none;
 }
 .proof-section-header:hover { color: #c8d0ff; }
@@ -2959,14 +3051,14 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 
 /* Proof technique badge */
 .proof-technique-badge {
-    font-size: 0.8em;
-    font-weight: 500;
+    font-size: 0.72em;
+    font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.03em;
-    padding: 1px 6px;
-    border-radius: 3px;
-    background: rgba(100, 80, 160, 0.35);
-    color: rgba(180, 160, 240, 0.9);
+    letter-spacing: 0.08em;
+    padding: 4px 8px;
+    border-radius: 999px;
+    background: rgba(117, 90, 52, 0.78);
+    color: rgba(242, 216, 149, 0.96);
     white-space: nowrap;
 }
 .proof-technique-badge.technique-contradiction { background: rgba(160, 60, 60, 0.35); color: rgba(240, 150, 150, 0.9); }
@@ -2981,12 +3073,14 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 /* Proof step card */
 .proof-step {
     position: relative;
-    padding: 8px 10px;
-    margin-bottom: 6px;
-    border-left: 3px solid rgba(80, 80, 160, 0.4);
-    border-radius: 0 4px 4px 0;
-    background: rgba(20, 20, 45, 0.3);
+    padding: 14px 16px 12px;
+    margin-bottom: 10px;
+    border-left: 4px solid rgba(100, 114, 210, 0.58);
+    border-radius: 0 16px 16px 0;
+    background: linear-gradient(180deg, rgba(31, 34, 68, 0.92), rgba(24, 27, 55, 0.95));
+    border-top: 1px solid rgba(255, 255, 255, 0.03);
     cursor: pointer;
+    box-shadow: 0 10px 24px rgba(7, 10, 24, 0.16);
     transition: all 0.15s;
 }
 .proof-step-math-row {
@@ -3007,12 +3101,15 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     flex-shrink: 0;
 }
 .proof-step:hover {
-    background: rgba(30, 30, 60, 0.5);
-    border-left-color: rgba(100, 100, 200, 0.6);
+    background: linear-gradient(180deg, rgba(36, 40, 78, 0.95), rgba(28, 31, 63, 0.97));
+    border-left-color: rgba(129, 146, 243, 0.7);
 }
 .proof-step.active {
-    background: rgba(35, 35, 75, 0.6);
-    border-left-color: rgba(100, 160, 255, 0.8);
+    background: linear-gradient(180deg, rgba(43, 48, 92, 0.98), rgba(33, 38, 71, 0.98));
+    border-left-color: rgba(111, 181, 255, 0.86);
+    box-shadow:
+        0 14px 28px rgba(10, 15, 34, 0.22),
+        0 0 0 1px rgba(111, 181, 255, 0.08);
 }
 .proof-step.dimmed {
     opacity: 0.4;
@@ -3023,22 +3120,23 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 .proof-step-header {
     display: flex;
     align-items: center;
-    gap: 6px;
-    margin-bottom: 4px;
+    gap: 8px;
+    margin-bottom: 8px;
 }
 .proof-step-number {
-    font-size: 0.68em;
-    color: rgba(140, 140, 200, 0.6);
-    min-width: 18px;
+    font-size: 0.74em;
+    color: rgba(142, 151, 211, 0.76);
+    min-width: 22px;
 }
 .proof-step-type {
-    font-size: 0.62em;
+    font-size: 0.6em;
     text-transform: uppercase;
-    letter-spacing: 0.04em;
-    padding: 1px 5px;
-    border-radius: 3px;
-    background: rgba(60, 60, 120, 0.4);
-    color: rgba(160, 170, 220, 0.8);
+    letter-spacing: 0.12em;
+    padding: 4px 8px;
+    border-radius: 999px;
+    background: rgba(72, 84, 146, 0.44);
+    color: rgba(187, 199, 247, 0.92);
+    font-weight: 700;
 }
 .proof-step-type.type-given { background: rgba(60, 100, 140, 0.4); color: rgba(130, 190, 230, 0.9); }
 .proof-step-type.type-conclusion { background: rgba(50, 120, 70, 0.4); color: rgba(120, 220, 150, 0.9); }
@@ -3046,25 +3144,26 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 .proof-step-status { min-width: 14px; font-size: 0.72em; }
 
 .proof-step-label {
-    font-size: 0.82em;
+    font-size: 0.98em;
     font-weight: 600;
-    color: rgba(200, 210, 240, 0.95);
+    color: rgba(240, 244, 255, 0.97);
 }
 
 .proof-step-math {
-    padding: 6px 8px;
-    margin: 6px 0;
-    background: rgba(15, 15, 35, 0.5);
-    border-radius: 4px;
+    padding: 20px 18px;
+    margin: 10px 0 12px;
+    background: rgba(18, 20, 42, 0.78);
+    border: 1px solid rgba(114, 129, 208, 0.08);
+    border-radius: 12px;
     overflow-x: auto;
 }
-.proof-step-math .katex { font-size: 1.05em; }
+.proof-step-math .katex { font-size: 1.12em; }
 
 .proof-step-justification {
-    font-size: 0.76em;
+    font-size: 0.74em;
     font-style: italic;
-    color: rgba(160, 170, 210, 0.7);
-    margin: 4px 0;
+    color: rgba(168, 177, 214, 0.72);
+    margin: 6px 0;
 }
 .proof-step-justification::before {
     content: '\25B8 ';
@@ -3072,26 +3171,26 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 }
 
 .proof-step-explanation {
-    font-size: 0.78em;
-    color: rgba(180, 185, 220, 0.8);
-    margin: 4px 0;
-    line-height: 1.45;
+    font-size: 0.84em;
+    color: rgba(198, 204, 230, 0.88);
+    margin: 8px 0 0;
+    line-height: 1.55;
 }
 
 /* Proof tags */
 .proof-step-tags {
     display: flex;
-    gap: 4px;
+    gap: 6px;
     flex-wrap: wrap;
-    margin-top: 4px;
+    margin-top: 10px;
 }
 .proof-tag {
-    font-size: 0.62em;
-    padding: 1px 6px;
-    border-radius: 8px;
-    background: rgba(60, 60, 120, 0.35);
-    color: rgba(150, 160, 210, 0.75);
-    border: 1px solid rgba(80, 80, 160, 0.25);
+    font-size: 0.64em;
+    padding: 4px 8px;
+    border-radius: 999px;
+    background: rgba(56, 62, 108, 0.72);
+    color: rgba(183, 192, 230, 0.82);
+    border: 1px solid rgba(97, 108, 173, 0.22);
 }
 
 /* Proof AI ask buttons */
@@ -3125,12 +3224,12 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 /* Highlight annotation (shown on click) */
 .proof-hl-annotation {
     font-size: 0.74em;
-    color: rgba(190, 200, 230, 0.85);
-    padding: 4px 8px 4px 10px;
-    margin: 3px 0;
-    border-left: 2px solid rgba(100, 200, 255, 0.5);
-    background: rgba(30, 40, 65, 0.4);
-    border-radius: 0 4px 4px 0;
+    color: rgba(207, 216, 240, 0.9);
+    padding: 8px 10px 8px 12px;
+    margin: 6px 0 0;
+    border-left: 3px solid rgba(100, 200, 255, 0.5);
+    background: rgba(34, 43, 73, 0.74);
+    border-radius: 0 12px 12px 0;
     display: flex;
     align-items: center;
     gap: 6px;
@@ -3157,9 +3256,9 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     align-items: center;
     justify-content: center;
     gap: 10px;
-    padding: 6px 10px;
-    border-top: 1px solid rgba(100, 100, 255, 0.1);
-    background: rgba(10, 10, 28, 0.4);
+    padding: 12px 14px;
+    border-top: 1px solid rgba(118, 132, 228, 0.08);
+    background: rgba(18, 20, 40, 0.9);
     flex-shrink: 0;
 }
 #proof-nav .nav-btn {
@@ -3173,9 +3272,9 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     pointer-events: none;
 }
 #proof-counter {
-    font-size: 0.72em;
-    color: rgba(150, 160, 210, 0.7);
-    min-width: 80px;
+    font-size: 0.74em;
+    color: rgba(186, 194, 231, 0.8);
+    min-width: 96px;
     text-align: center;
 }
 
@@ -3183,12 +3282,13 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 #proof-resize-handle {
     height: 5px;
     cursor: ns-resize;
-    background: rgba(80, 80, 180, 0.15);
+    margin: 0 12px;
+    background: rgba(96, 108, 193, 0.12);
     flex-shrink: 0;
     transition: background 0.15s;
 }
 #proof-resize-handle:hover {
-    background: rgba(100, 100, 220, 0.35);
+    background: rgba(118, 132, 230, 0.28);
 }
 #proof-resize-handle.hidden { display: none; }
 

--- a/static/style.css
+++ b/static/style.css
@@ -1657,71 +1657,104 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 #scene-dock {
     display: none;
     flex-shrink: 0;
+    position: relative;
 }
 #scene-dock.visible {
     display: flex;
 }
 #scene-dock-toggle {
-    width: 36px;
-    background: rgba(15, 15, 35, 0.95);
-    border-right: 1px solid rgba(100, 100, 255, 0.15);
+    width: 42px;
+    background:
+        linear-gradient(180deg, rgba(20, 22, 42, 0.96), rgba(13, 15, 31, 0.98));
+    border-right: 1px solid rgba(112, 124, 214, 0.12);
     display: flex;
     align-items: flex-start;
     justify-content: center;
-    padding-top: 12px;
+    padding-top: 14px;
     cursor: pointer;
-    color: rgba(180, 180, 220, 0.8);
-    font-size: 18px;
+    color: rgba(192, 199, 235, 0.82);
+    font-size: 17px;
     user-select: none;
-    transition: color 0.2s, background 0.2s;
+    transition: color 0.2s, background 0.2s, border-color 0.2s;
     flex-shrink: 0;
 }
 #scene-dock-toggle:hover {
-    color: rgba(200, 200, 255, 1);
-    background: rgba(25, 25, 50, 0.95);
+    color: rgba(242, 245, 255, 1);
+    background:
+        linear-gradient(180deg, rgba(28, 31, 58, 0.98), rgba(18, 21, 41, 0.99));
+    border-right-color: rgba(140, 156, 248, 0.2);
 }
 #scene-dock-toggle.active {
-    color: rgba(140, 160, 255, 1);
+    color: rgba(163, 177, 255, 0.98);
 }
 #scene-dock-panel {
     width: 0;
     overflow: hidden;
-    background: rgba(15, 15, 35, 0.95);
-    border-right: 1px solid rgba(100, 100, 255, 0.15);
+    background:
+        linear-gradient(180deg, rgba(19, 21, 41, 0.98), rgba(13, 15, 29, 0.99));
+    border-right: 1px solid rgba(112, 124, 214, 0.12);
     display: flex;
     flex-direction: column;
     transition: width 0.2s ease;
     flex-shrink: 0;
+    box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.02);
 }
 #scene-dock-panel.open {
-    width: 220px;
+    width: 260px;
+}
+#scene-dock-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 16px 10px;
+    border-bottom: 1px solid rgba(112, 124, 214, 0.08);
+    flex-shrink: 0;
+}
+#scene-dock-title {
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: rgba(176, 186, 229, 0.72);
 }
 #scene-tree {
     flex: 1;
     overflow-y: auto;
-    padding: 8px 0;
+    padding: 10px 10px 14px;
 }
 .tree-scene {
     cursor: pointer;
     user-select: none;
+    margin-bottom: 8px;
 }
 .tree-scene-header {
     display: flex;
     align-items: center;
-    gap: 4px;
-    padding: 6px 10px;
+    gap: 8px;
+    padding: 10px 12px;
     font-size: 0.82em;
     font-weight: 600;
-    color: #c0c0e0;
-    transition: background 0.15s, color 0.15s;
+    color: rgba(208, 214, 241, 0.86);
+    border: 1px solid rgba(108, 121, 198, 0.08);
+    border-radius: 14px;
+    background: rgba(29, 33, 60, 0.54);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
+    transition: background 0.15s, color 0.15s, border-color 0.15s, transform 0.15s;
 }
 .tree-scene-header:hover {
-    background: rgba(80, 80, 200, 0.2);
+    background: rgba(39, 44, 78, 0.78);
     color: #fff;
+    border-color: rgba(130, 145, 233, 0.14);
+    transform: translateY(-1px);
 }
 .tree-scene.active > .tree-scene-header {
     color: #fff;
-    background: rgba(80, 80, 200, 0.3);
+    background:
+        linear-gradient(180deg, rgba(58, 66, 120, 0.88), rgba(43, 49, 98, 0.88));
+    border-color: rgba(149, 164, 255, 0.2);
+    box-shadow:
+        0 10px 22px rgba(7, 10, 26, 0.18),
+        inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 .tree-scene-arrow {
     font-size: 10px;
@@ -1729,44 +1762,49 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     text-align: center;
     transition: transform 0.15s;
     flex-shrink: 0;
-    color: rgba(160, 160, 220, 0.6);
+    color: rgba(163, 172, 220, 0.64);
 }
 .tree-scene.expanded > .tree-scene-header > .tree-scene-arrow {
     transform: rotate(90deg);
 }
 .tree-steps {
     display: none;
-    padding-left: 18px;
+    margin-top: 6px;
+    padding: 4px 0 2px 16px;
+    border-left: 1px solid rgba(96, 108, 183, 0.16);
+    margin-left: 14px;
 }
 .tree-scene.expanded > .tree-steps {
     display: block;
 }
 .tree-step {
-    padding: 4px 10px 4px 12px;
+    padding: 7px 10px 7px 12px;
     font-size: 0.78em;
-    color: #a0a0c0;
+    color: rgba(176, 183, 216, 0.82);
     cursor: pointer;
     border-left: 2px solid transparent;
+    border-radius: 0 10px 10px 0;
     transition: all 0.15s;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 }
 .tree-step:hover {
-    background: rgba(80, 80, 200, 0.15);
-    color: #d0d0ff;
+    background: rgba(54, 60, 107, 0.44);
+    color: rgba(228, 232, 255, 0.96);
 }
 .tree-step.active {
     color: #fff;
-    border-left-color: rgba(140, 160, 255, 0.8);
-    background: rgba(80, 80, 200, 0.25);
+    border-left-color: rgba(150, 173, 255, 0.84);
+    background:
+        linear-gradient(180deg, rgba(53, 62, 121, 0.72), rgba(42, 49, 96, 0.68));
 }
 .tree-step.visited {
-    color: #b0b0d0;
+    color: rgba(190, 196, 223, 0.86);
 }
 .tree-step.visited::before {
     content: '\2713 ';
-    color: rgba(100, 200, 100, 0.6);
+    color: rgba(111, 214, 146, 0.7);
     font-size: 0.85em;
 }
 .tree-scene-header .katex,

--- a/static/style.css
+++ b/static/style.css
@@ -1924,12 +1924,13 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     display: flex;
     gap: 8px;
     align-items: center;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     padding: 10px 14px 12px;
     border-bottom: 1px solid rgba(116, 132, 255, 0.08);
     background:
         linear-gradient(180deg, rgba(23, 25, 49, 0.96), rgba(16, 18, 39, 0.88));
     flex-shrink: 0;
+    overflow-x: auto;
 }
 .chat-control-btn {
     min-height: 34px;
@@ -1943,6 +1944,30 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     cursor: pointer;
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
     transition: background 0.15s, color 0.15s, border-color 0.15s, transform 0.15s;
+}
+.style-picker {
+    position: relative;
+    flex: 1 1 0;
+    min-width: 0;
+}
+.style-btn {
+    width: 100%;
+    max-width: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+#chatVoiceSelect {
+    flex: 0 1 82px;
+    min-width: 82px;
+}
+#chatTtsModeSelect {
+    flex: 0 1 92px;
+    min-width: 92px;
+}
+#proof-toggle-btn {
+    flex: 0 0 auto;
+    white-space: nowrap;
 }
 .chat-control-btn:hover {
     background: rgba(57, 61, 102, 0.92);
@@ -1999,8 +2024,6 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     border-radius: 2px;
     background: rgba(137, 150, 255, 0.3);
 }
-.style-picker { position: relative; }
-.style-btn { max-width: 185px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .style-palette {
     position: fixed;
     top: 0;


### PR DESCRIPTION
## Summary
- refresh the right-side Doc, Chat, and Proof panels with cleaner surfaces, stronger hierarchy, and improved spacing
- improve Doc rendering with better code, block math, markdown table, and pinned-toolbar behavior
- refresh the left scene dock styling, add full-title tooltips for tree items, and tune chat-toolbar control widths to keep the Proof button on one line

## Testing
- manual UI review in the app across the Doc, Chat, Proof, and scene-dock panels
- verified Doc/Chat tab switching after pinning the Doc toolbar
- verified display-math AI button alignment and markdown table readability in the Doc tab