### PR TITLE
LaTeX to semantic graph parser: metadata and regex fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -36,4 +37,72 @@ jobs:
           pip install pytest
 
       - name: Run tests
-        run: python -m pytest tests/ -v
+        id: tests
+        run: |
+          python -m pytest tests/ -v --tb=short --junitxml=test-results.xml 2>&1 | tee test-output.txt
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Post test report as PR comment
+        if: github.event_name == 'pull_request' && always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OUTPUT=$(cat test-output.txt)
+          EXIT="${{ steps.tests.outputs.exit_code }}"
+
+          # Extract summary line (e.g. "28 passed" or "1 failed, 27 passed")
+          SUMMARY=$(echo "$OUTPUT" | grep -E '^\s*=+.*(passed|failed|error)' | tail -1 | sed 's/=//g' | xargs)
+
+          if [ "$EXIT" = "0" ]; then
+            STATUS="✅ All tests passed"
+          else
+            STATUS="❌ Some tests failed"
+          fi
+
+          # Collect failed test names
+          FAILED=$(echo "$OUTPUT" | grep '^FAILED ' | sed 's/^FAILED //' || true)
+
+          BODY="<!-- test-report -->
+          ### Test Report
+
+          | Status | Summary |
+          |--------|---------|
+          | ${STATUS} | ${SUMMARY} |"
+
+          if [ -n "$FAILED" ]; then
+            BODY="${BODY}
+
+          <details>
+          <summary>❌ Failed Tests</summary>
+
+          \`\`\`
+          ${FAILED}
+          \`\`\`
+
+          </details>"
+          fi
+
+          BODY="${BODY}
+
+          <details>
+          <summary>📋 Full Output</summary>
+
+          \`\`\`
+          ${OUTPUT}
+          \`\`\`
+
+          </details>"
+
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --body "$BODY" \
+            --edit-last 2>/dev/null || \
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --body "$BODY"
+
+      - name: Fail if tests failed
+        if: always()
+        run: |
+          if [ "${{ steps.tests.outputs.exit_code }}" != "0" ]; then
+            echo "❌ Tests failed"
+            exit 1
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,50 +42,26 @@ jobs:
           python -m pytest tests/ -v --tb=short --junitxml=test-results.xml 2>&1 | tee test-output.txt
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
-      - name: Post test report as PR comment
-        if: github.event_name == 'pull_request' && always()
+      - name: Post failure report as PR comment
+        if: github.event_name == 'pull_request' && steps.tests.outputs.exit_code != '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           OUTPUT=$(cat test-output.txt)
-          EXIT="${{ steps.tests.outputs.exit_code }}"
-
-          # Extract summary line (e.g. "28 passed" or "1 failed, 27 passed")
           SUMMARY=$(echo "$OUTPUT" | grep -E '^\s*=+.*(passed|failed|error)' | tail -1 | sed 's/=//g' | xargs)
-
-          if [ "$EXIT" = "0" ]; then
-            STATUS="✅ All tests passed"
-          else
-            STATUS="❌ Some tests failed"
-          fi
-
-          # Collect failed test names
           FAILED=$(echo "$OUTPUT" | grep '^FAILED ' | sed 's/^FAILED //' || true)
 
           BODY="<!-- test-report -->
-          ### Test Report
+          ### ❌ Test Failures
 
-          | Status | Summary |
-          |--------|---------|
-          | ${STATUS} | ${SUMMARY} |"
-
-          if [ -n "$FAILED" ]; then
-            BODY="${BODY}
-
-          <details>
-          <summary>❌ Failed Tests</summary>
+          **${SUMMARY}**
 
           \`\`\`
           ${FAILED}
           \`\`\`
 
-          </details>"
-          fi
-
-          BODY="${BODY}
-
           <details>
-          <summary>📋 Full Output</summary>
+          <summary>Full Output</summary>
 
           \`\`\`
           ${OUTPUT}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,15 +31,14 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Install dependencies
+      - name: Install test runner
         run: |
-          pip install -r requirements.txt
-          pip install pytest
+          ./run.sh -m pip install pytest -q
 
       - name: Run tests
         id: tests
         run: |
-          python -m pytest tests/ -v --tb=short --junitxml=test-results.xml 2>&1 | tee test-output.txt
+          ./run.sh -m pytest tests/ -v --tb=short --junitxml=test-results.xml 2>&1 | tee test-output.txt
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Post failure report as PR comment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/**/*.py'
+      - 'tests/**/*.py'
+      - 'requirements.txt'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/**/*.py'
+      - 'tests/**/*.py'
+      - 'requirements.txt'
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: pytest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run tests
+        run: python -m pytest tests/ -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,9 @@ The server runs at `http://localhost:8785`.
 ./run.sh scripts/assemble_scene.py lesson.json --list                  # list scenes
 ./run.sh scripts/lint_scene.py scene.json                              # lint a scene
 ./run.sh scripts/lint_scene.py --fix scene.json                        # lint + auto-fix
+./run.sh scripts/latex_to_graph.py "F = m \cdot a"                     # LaTeX → semantic graph JSON
+./run.sh scripts/latex_to_graph.py --pretty "E = mc^2"                 # pretty-printed output
+./run.sh scripts/latex_to_graph.py -o graph.json "\frac{dv}{dt} = a"   # write to file
 ```
 
 ### Browser Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,15 +59,7 @@ docs/              Architecture, sandbox model, feature ideas
 - **Always announce who is committing before running `git commit`** — print a line in the format:
   `Committing on behalf of <name> (<email>)`
   using the output of `git config user.name` and `git config user.email`.
-- **Codex-only co-author trailer** — when Codex creates a commit in this repo, or posts a review, append
-  `🤖 Co-authored-by: Codex <codex@openai.com>`
-  to the commit message so the commit clearly shows Codex participation in GitHub. Do not add Claude/Anthropic co-author trailers unless the user explicitly asks for that.
-- **Gemini-only co-author trailer** — when Gemini creates a commit in this repo, or posts a review append
-  `🤖 Co-authored-by: gemini-cli <218195315+gemini-cli@users.noreply.github.com>`
-  to the commit message so the commit clearly shows Gemini participation in GitHub.
-- **Claude Code co-author trailer** — when Claude Code creates a commit in this repo, or posts a review append
-  `Co-Authored-By: Claude <81847+claude@users.noreply.github.com>`
-  to the commit message.
+- **Co-author trailers** — each AI agent must append its own co-author trailer to all GitHub interactions (commits, PR descriptions, reviews, comments). See agent-specific instructions in `CLAUDE.md`, `GEMINI.md`, or `CODEX.md`.
 - **Scene files are JSON** in `scenes/` — no Python or JS changes needed for new lessons.
 - **Pinned dependencies** — `requirements.txt` pins `gemini-live-tools` to a specific tag. Update the tag intentionally, don't switch back to `HEAD`.
 - **JS from package** — `voice-character-selector.js` is served at runtime from the installed `gemini_live_tools` package via `get_static_content()`. Do not copy it into `static/`.
@@ -76,16 +68,14 @@ docs/              Architecture, sandbox model, feature ideas
 - **Branch protection** — `main` is protected. Always use a feature branch and open a PR; never push directly to `main`. Committing directly to `main` is a last resort (e.g., force-push recovery only).
 - **PR base branch** — PRs must target `main` unless the user explicitly requests a different base. Merging into a feature branch that has already been merged to `main` will orphan the changes.
 - **⚠️ PR workflow** — the standard flow is: create branch → commit → push → create PR → **STOP**. Never merge a PR immediately after creating it. PRs must go through review first. Only merge when the user explicitly says "merge it" or "ok merge" as a **separate instruction** after reviewing. "Commit and merge" means commit + create the PR, not merge it.
-- **Codex PR descriptions** — when Codex creates or updates a PR, replace any commit-list placeholder body with a concise writeup using `## Summary` and `## Testing` sections. Summaries should describe the user-visible behavior and key implementation points, not just restate commit subjects.
+- **PR descriptions** — when creating or updating a PR, write a concise body using `## Summary` and `## Test plan` sections. Summaries should describe the user-visible behavior and key implementation points, not just restate commit subjects.
 - **Closing issues** — if a PR resolves a GitHub issue, include `Closes #<number>` in the PR body so GitHub auto-closes the issue on merge.
 - **PR labels** — always apply at least one label when creating a PR. Run `gh label list` to see available labels and pick the most appropriate one(s).
 - **Merging PRs** — **NEVER merge a PR unless the user explicitly asks as a separate step after review.** Use `gh pr merge --squash`. If it fails due to branch protection, retry with `--admin` (available to repo admins only).
 
 ## Scene Format
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full scene format reference, element types, step system, slider API, and animated element expressions.
-
-For building scenes interactively, use the **`algebench-scene-builder`** skill for Claude Code.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full scene format reference, element types, step system, slider API, and animated element expressions. For building scenes interactively, use the scene builder skill for your agent.
 
 ## GitHub Issues
 
@@ -99,9 +89,9 @@ When creating a GitHub issue, always apply a label. Run `gh label list` to see a
 
 Apply the label as part of the create command or immediately after with `gh issue edit <n> --add-label "<label>"`.
 
-## Skills (Claude Code)
+## Skills
 
-Skills live in `.agents/skills/` (checked into the repo) and are symlinked from `.claude/skills/`. To add a new skill: create `.agents/skills/<name>/SKILL.md`, then `ln -s ../../.agents/skills/<name> .claude/skills/<name>`.
+Skills live in `.agents/skills/` (checked into the repo). Each agent platform symlinks them into its own config directory (e.g., `.claude/skills/` for Claude Code). To add a new skill: create `.agents/skills/<name>/SKILL.md`, then symlink it for your agent.
 
 | Skill | When to use |
 |---|---|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,13 @@
 # Claude Code Instructions
 
 Read **[AGENTS.md](AGENTS.md)** before making any changes to this project.
+
+## Co-author Trailer
+
+Append this trailer to GitHub interactions — commits, PR descriptions and review comments:
+`Co-Authored-By: Claude <81847+claude@users.noreply.github.com>`
+
+## Skills (Claude Code)
+
+1. Create the skill in `.agents/skills/<name>/SKILL.md`
+2. Symlink it from `.claude/skills/<name>` → `.agents/skills/<name>`

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,9 @@
+# Codex Instructions
+
+Read **[AGENTS.md](AGENTS.md)** before making any changes to this project.
+
+## Co-author Trailer
+
+Append this trailer to GitHub interactions — commits, PR descriptions and review comments:
+`🤖 Co-authored-by: Codex <codex@openai.com>`
+

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,3 +1,12 @@
 # Gemini CLI Instructions
 
 Read **[AGENTS.md](AGENTS.md)** before making any changes to this project.
+
+## Co-author Trailer
+
+Append this trailer to GitHub interactions — commits, PR descriptions and review comments:
+`🤖 Co-authored-by: gemini-cli <218195315+gemini-cli@users.noreply.github.com>`
+
+## In-App Agent
+
+Gemini powers the in-app AI chat and TTS. See [`agent-tools-reference.md`](agent-tools-reference.md) for the full reference on in-app agent tools (`add_scene`, `eval_math`, `set_sliders`, `navigate_to`, `set_camera`, `set_info_overlay`, `mem_get`/`mem_set`, `set_preset_prompts`).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,3 @@
+# Gemini CLI Instructions
+
+Read **[AGENTS.md](AGENTS.md)** before making any changes to this project.

--- a/docs/latex-parser-design.md
+++ b/docs/latex-parser-design.md
@@ -1,0 +1,349 @@
+# LaTeX Semantic Graph Parser — Design Notes
+
+## Overview
+
+The LaTeX-to-semantic-graph parser converts LaTeX math expressions into a JSON
+graph of nodes and edges, annotated with metadata (variable names, types, units,
+emojis). It powers interactive math visualizations in AlgeBench.
+
+The parser is built on **SymPy** with its ANTLR-based `parse_latex`, plus a
+small regex preprocessing layer for notation that SymPy doesn't handle natively.
+
+## Parser Comparison
+
+We evaluated four approaches for parsing LaTeX into a form suitable for semantic
+graph construction.
+
+### Libraries Tested
+
+| Library | What it does | Math semantics? |
+|---|---|---|
+| **SymPy ANTLR** (`sympy.parsing.latex.parse_latex`) | LaTeX → SymPy expression tree | Yes — full CAS |
+| **SymPy Lark** (`sympy.parsing.latex.lark.parse_latex_lark`) | LaTeX → SymPy expression tree (newer parser) | Yes — full CAS |
+| **pylatexenc** | LaTeX → LaTeX AST (macros, groups, arguments) | No — structural only |
+| **latex2sympy2** | LaTeX → SymPy expression tree (third-party) | Yes, but broken on Python 3.14 |
+
+### Feature Matrix
+
+| Feature | ANTLR + regex | Lark | pylatexenc |
+|---|---|---|---|
+| Basic algebra (`x + y`, `x^2`, `\frac{1}{2}`) | OK | OK | AST only |
+| Equations (`F = ma`) | OK | OK | AST only |
+| Functions (`\sin`, `\cos`, `\sqrt`) | OK | OK | AST only |
+| **1st-order derivatives** (`\frac{dv}{dt}`) | OK | Partial (returns tuple) | AST only |
+| **2nd-order derivatives** (`\frac{d^2y}{dx^2}`) | OK (regex) | Fails | AST only |
+| **Partial derivatives** (`\frac{\partial u}{\partial x}`) | OK | Fails | AST only |
+| **Dot/ddot notation** (`\dot{x}`, `\ddot{x}`) | OK (regex) | Fails | AST only |
+| Integrals (`\int`, `\int_0^1`) | OK | OK | AST only |
+| Sums and products | OK | OK | AST only |
+| Constants (`\pi`) | OK | Fails | AST only |
+| **Matrices** (`\begin{pmatrix}...`) | Fails | OK | AST only |
+| Vector notation (`\vec{v}`, `\hat{x}`) | Wrong (parsed as multiply) | Fails | AST only |
+| Absolute value (`|x|`, `\left|x\right|`) | Partial | OK | AST only |
+| Binomials, subscripts, Greek letters | OK | OK | AST only |
+| Limits | OK | OK | AST only |
+| **Score** | **22/29** | **20/29** | **29/29 (AST only)** |
+
+### Why SymPy ANTLR + Regex
+
+**pylatexenc** parses everything structurally but has no math understanding. It
+knows that `\frac{dv}{dt}` is a `\frac` macro with two groups — but not that it
+represents a derivative. Building the semantic layer on top of a pure LaTeX AST
+would mean reimplementing most of what SymPy already does.
+
+**SymPy Lark** is a newer parser but has significant gaps in derivative handling,
+which is a core use case for AlgeBench (ODE/PDE visualization, physics
+equations). It does handle matrices, which ANTLR cannot.
+
+**latex2sympy2** is a third-party alternative that requires antlr4 4.7.2,
+conflicting with SymPy's own antlr4 4.11.1 dependency. It is also broken on
+Python 3.14 due to removed `typing.io` module.
+
+**SymPy ANTLR** has the best derivative support and, critically, gives us access
+to SymPy's full computer algebra system (CAS).
+
+### The Symbolic Layer Matters
+
+The key insight is that AlgeBench doesn't just need to *parse* LaTeX — it needs
+to *reason about* the math. A structural parser like pylatexenc can tell you that
+`\frac{dv}{dt} = a` contains a `\frac` macro, but it cannot tell you that this
+is a first-order linear ODE, that `v` depends on `t`, or that the solution is
+`v(t) = at + C`.
+
+By parsing into SymPy expressions rather than a plain AST, the entire SymPy
+CAS — which can simplify, solve, differentiate, integrate, and
+evaluate expressions symbolically — becomes available downstream. AlgeBench will use this
+symbolic layer beyond just graph construction — for interactive exercises,
+step-by-step solutions, and expression validation. Having SymPy as the internal
+representation means the parser, the graph builder, and future symbolic
+operations all share the same foundation rather than requiring separate
+translation layers.
+
+Concrete capabilities this enables:
+
+- **Equation classification** — `classify_ode` detects equation type, order,
+  linearity, and homogeneity, which drives how the graph is annotated and how
+  lessons present the material
+- **Symbolic solutions** — `solve` / `dsolve` can find closed-form solutions to
+  display alongside the graph or to verify student work
+- **Expression manipulation** — `simplify`, `expand`, `factor`, `collect` let
+  the backend transform expressions into equivalent forms for pedagogical
+  purposes (e.g., showing that `(a+b)^2` and `a^2 + 2ab + b^2` are the same)
+- **Substitution and evaluation** — `subs` / `evalf` enable numeric evaluation
+  for slider-driven interactive visualizations
+- **Differentiation and integration** — `diff` / `integrate` can derive related
+  expressions (e.g., given `F = ma`, derive `W = \int F \cdot dx`)
+- **Equivalence checking** — determine whether a student's answer is
+  mathematically equivalent to the expected answer, regardless of form
+- **Dimensional analysis** — combined with unit metadata, SymPy can verify
+  dimensional consistency across equations
+
+A pure AST parser would require building all of this from scratch. With SymPy,
+it's already there.
+
+The regex preprocessing layer is small (3 rules) and handles specific notation
+gaps:
+
+1. Higher-order Leibniz derivatives (`\frac{d^2 y}{dx^2}`) → expanded to
+   repeated first-order derivatives
+2. `\dot{x}` → `\frac{dx}{dt}`
+3. `\ddot{x}` → `\frac{d}{dt}\frac{dx}{dt}`
+
+## Architecture
+
+```
+LaTeX string
+    │
+    ▼
+_preprocess_latex()          ← regex: \dot, \ddot, higher-order d/dx
+    │
+    ▼
+sympy.parse_latex()          ← ANTLR parser → SymPy expression tree
+    │
+    ├──► _classify_expression()   ← ODE/PDE detection via classify_ode
+    │
+    ▼
+SemanticGraphBuilder._walk() ← recursive tree walk
+    │
+    ▼
+{ nodes, edges, classification }   ← JSON output
+```
+
+### Node Types
+
+| Type | Generated by | ID format |
+|---|---|---|
+| Symbol (variable) | Known or unknown variables | Raw name (`F`, `m`, `x`) |
+| Number | Integer, float, rational | `__num_N` |
+| Constant | `pi`, `E`, `I`, `oo` | `__const_N` |
+| Function | `sin`, `cos`, `sqrt`, etc. | `__funcname_N` |
+| Operator | `add`, `multiply`, `power`, `equals` | `__opname_N` |
+| Derivative | `\frac{d}{dt}` | `__deriv_N` |
+| Integral | `\int` | `__integral_N` |
+| Sum / Product | `\sum`, `\prod` | `__sum_N` / `__product_N` |
+
+Generated IDs use a `__` prefix to avoid collision with symbol names.
+
+## Current Shortcomings
+
+### Matrices and Linear Algebra
+
+SymPy's ANTLR parser cannot parse matrix environments (`\begin{pmatrix}`,
+`\begin{bmatrix}`, `\begin{vmatrix}`). Any LaTeX containing matrices will fail
+with a parse error. This blocks a significant class of expressions:
+
+- Column/row vectors: `\begin{pmatrix} x \\ y \\ z \end{pmatrix}`
+- Transformation matrices: `\begin{bmatrix} \cos\theta & -\sin\theta \\ \sin\theta & \cos\theta \end{bmatrix}`
+- Eigenvalue problems: `A\vec{v} = \lambda\vec{v}`
+- Systems of equations in matrix form: `A\mathbf{x} = \mathbf{b}`
+- Determinants: `\begin{vmatrix} a & b \\ c & d \end{vmatrix}`
+
+SymPy's Lark parser handles all of these, but cannot parse derivatives — so
+neither parser alone covers the full range.
+
+### Vector and Tensor Notation
+
+`\vec{v}`, `\mathbf{F}`, and `\hat{x}` are misinterpreted by both parsers.
+ANTLR treats them as multiplication of two symbols (`v * vec`), and Lark fails
+entirely. This affects:
+
+- Vector quantities in physics: `\vec{F} = m\vec{a}`
+- Unit vectors: `\hat{r}`, `\hat{\theta}`, `\hat{\phi}`
+- Bold notation for vectors/matrices: `\mathbf{A}`, `\mathbf{x}`
+- Tensor notation: `T^{\mu\nu}`, `g_{\mu\nu}`
+
+### Multi-character Variable Names
+
+The parser assumes single-letter variable names with optional subscripts. Common
+multi-character names require `\text{}` or `\mathrm{}` wrapping:
+
+- `\text{KE}` for kinetic energy (rather than `K * E`)
+- `\text{Re}` for Reynolds number (rather than `R * e`)
+- `\mathrm{pH}` (rather than `p * H`)
+
+### Notation Ambiguity
+
+Single-letter variables are context-dependent, and the parser uses a static
+lookup table that can't distinguish:
+
+- `E` — energy vs. Euler's number vs. electric field
+- `I` — current vs. imaginary unit vs. moment of inertia
+- `T` — temperature vs. period vs. kinetic energy vs. tension
+- `c` — speed of light vs. a generic constant
+- `k` — wave number vs. Boltzmann constant vs. spring constant
+
+The `--var` override mechanism mitigates this but requires manual intervention.
+
+### Absolute Value Delimiters
+
+ANTLR handles `|x|` but fails on `\left| x \right|`, which is common in
+typeset LaTeX. Lark handles both forms correctly.
+
+### Piecewise and Conditional Expressions
+
+Neither parser supports `\begin{cases}` environments:
+
+```latex
+f(x) = \begin{cases} x^2 & x \geq 0 \\ -x^2 & x < 0 \end{cases}
+```
+
+### Multi-line Equations
+
+Aligned environments (`\begin{align}`, `\begin{aligned}`) and equation arrays
+are not supported. These are common in step-by-step derivations.
+
+### Set Notation and Logic
+
+Set-builder notation (`\{ x \in \mathbb{R} \mid x > 0 \}`), logical operators
+(`\land`, `\lor`, `\implies`), and quantifiers (`\forall`, `\exists`) are not
+parsed into meaningful semantic structures.
+
+## Future Improvements
+
+### Recursive Hybrid Parser
+
+A naive hybrid (try ANTLR, fall back to Lark on failure) operates at the
+top level and cannot handle mixed expressions — for example, a matrix whose
+entries contain derivatives:
+
+```latex
+\begin{pmatrix} \frac{dx}{dt} \\ \frac{dy}{dt} \end{pmatrix} = A \begin{pmatrix} x \\ y \end{pmatrix}
+```
+
+ANTLR would fail on the matrix. Lark would parse the matrix but lose the
+derivatives inside it. A top-level fallback gives you one or the other, never
+both.
+
+#### Term-level fallback via LaTeX AST routing
+
+The better approach is to decompose the LaTeX into structural terms first using
+pylatexenc, then route each term to the parser best suited for it. This replaces
+the current regex preprocessing with a more general mechanism.
+
+**How it works:**
+
+```
+LaTeX string
+    │
+    ▼
+pylatexenc LatexWalker         ← parse into LaTeX AST (structural, not semantic)
+    │
+    ▼
+Recursive term router          ← walk the AST, classify each node
+    │
+    ├─ \frac{d...}{d...}  ──►  ANTLR   (derivatives)
+    ├─ \dot{x}, \ddot{x}  ──►  ANTLR   (with preprocessing)
+    ├─ \begin{pmatrix}     ──►  Lark    (matrices)
+    ├─ \begin{cases}       ──►  custom  (piecewise)
+    ├─ \vec{v}, \hat{x}    ──►  custom  (vector decoration → metadata)
+    ├─ x + y, \sin(x)      ──►  ANTLR   (default, best general coverage)
+    │
+    ▼
+Compose SymPy expressions      ← assemble sub-expressions into full tree
+    │
+    ▼
+SemanticGraphBuilder           ← existing graph walker (unchanged)
+```
+
+**Key idea:** pylatexenc always succeeds at parsing the structure — it
+understands that `\begin{pmatrix}` is an environment with rows separated by
+`\\` and cells by `&`, that `\frac` has two groups, that `\vec` wraps an
+argument. It doesn't know the *math* meaning, but it gives us a reliable
+structural decomposition.
+
+The router walks this AST recursively. At each node, it decides which math
+parser to invoke:
+
+```python
+def route_node(node):
+    if is_matrix_env(node):       # \begin{pmatrix}, \begin{bmatrix}, ...
+        # Parse each cell individually (recursive — cells may contain derivatives)
+        rows = extract_cells(node)
+        parsed_rows = [[route_node(cell) for cell in row] for row in rows]
+        return sympy.Matrix(parsed_rows)
+
+    if is_derivative_frac(node):  # \frac{d...}{d...}, \frac{\partial...}{\partial...}
+        return parse_antlr(node.latex)
+
+    if is_vector_decoration(node):  # \vec{x}, \hat{r}, \mathbf{F}
+        inner = route_node(node.argument)
+        inner._assumptions['vector'] = True  # annotate, don't multiply
+        return inner
+
+    if is_cases_env(node):        # \begin{cases}
+        branches = extract_branches(node)
+        return sympy.Piecewise(*[route_node(b) for b in branches])
+
+    # Default: serialize back to LaTeX, parse with ANTLR
+    return parse_antlr(node.latex)
+```
+
+**Why this is better than regex preprocessing:**
+
+- **Recursive** — a matrix cell containing `\frac{dv}{dt}` gets routed to ANTLR
+  for the derivative, while the enclosing matrix is handled by Lark or custom
+  construction. Regex can't express this nesting.
+- **Extensible** — adding support for a new construct (e.g., `\begin{cases}`) is
+  a new `if` branch in the router, not a fragile regex pattern.
+- **Structural correctness** — pylatexenc handles brace matching, nested groups,
+  and escaping correctly. Regex patterns for these are error-prone.
+- **Eliminates regex entirely** — the preprocessing layer becomes a proper AST
+  walk. `\dot{x}`, `\ddot{x}`, and higher-order derivatives are handled by
+  recognizing the AST shape rather than text substitution.
+
+**Trade-offs:**
+
+- Adds pylatexenc as a dependency (currently only used for comparison, not in
+  production)
+- More code than the current 3-line regex approach — worthwhile only once the
+  parser needs to handle matrices or other compound structures
+- Requires mapping pylatexenc's structural nodes to "which parser handles this"
+  — the routing logic is the new complexity
+
+This approach should be adopted when AlgeBench needs to support linear algebra
+content (matrices, eigenvalue problems, systems of ODEs in matrix form). Until
+then, the regex preprocessing is sufficient.
+
+### Vector Notation
+
+Add support for `\vec`, `\mathbf`, and `\hat` — either via the recursive router
+(preferred) or as preprocessing rules. These should strip the decoration and
+annotate the variable with type metadata:
+
+- `\vec{v}` → symbol `v` with `type: vector`
+- `\hat{x}` → symbol `x` with `type: unit_vector`
+- `\mathbf{F}` → symbol `F` with `type: vector`
+
+This metadata flows into the semantic graph as node attributes, enabling
+renderers to distinguish scalar from vector quantities visually.
+
+### Symbolic Processing in the Graph
+
+Leverage SymPy's symbolic computation capabilities to enrich the graph with
+computed metadata:
+
+- Simplified form of sub-expressions
+- Dimensional analysis (if units are provided via `--var`)
+- Symbolic solutions for equations and ODEs
+- Expression equivalence checking for interactive exercises
+- Step-by-step derivation traces for pedagogical display

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ numpy>=1.26.0
 fastapi>=0.115.0
 uvicorn[standard]>=0.32.0
 jsonschema>=4.23.0
+sympy>=1.13.0
+antlr4-python3-runtime==4.11.1

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+"""Convert LaTeX expressions into semantic graphs (JSON).
+
+Parses LaTeX into a SymPy expression tree, then walks the tree to produce
+a JSON graph with ``nodes`` and ``edges``.
+
+Usage:
+    # Parse a single expression
+    ./run.sh scripts/latex_to_graph.py "F = m \\cdot a"
+
+    # Pretty-print output
+    ./run.sh scripts/latex_to_graph.py --pretty "E = mc^2"
+
+    # Override variable properties (any property: label, emoji, type, unit, tooltip, ai_prompt, latex)
+    ./run.sh scripts/latex_to_graph.py --pretty \\
+        --var 'm:unit=kg,tooltip=Inertial mass of the object' \\
+        --var 'a:unit=m/s²,ai_prompt=Explain acceleration in Newtonian mechanics' \\
+        "F = m \\cdot a"
+
+    # Write output to file
+    ./run.sh scripts/latex_to_graph.py -o graph.json "\\frac{d}{dt}(mv) = F"
+
+Exit codes:
+    0  Success
+    1  Parse error or invalid input
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from typing import Any
+
+try:
+    import sympy
+    from sympy import (
+        Symbol, Function, Number, Rational, Integer, Float,
+        Add, Mul, Pow, Eq, Abs,
+        sin, cos, tan, log, exp, sqrt,
+        Derivative, Integral, Sum, Product,
+        pi, E, I, oo,
+    )
+except ImportError:
+    print("❌ Missing dependency: pip install sympy", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    from sympy.parsing.latex import parse_latex
+except ImportError:
+    print("❌ Missing dependency: pip install antlr4-python3-runtime==4.11.1", file=sys.stderr)
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Semantic metadata
+# ---------------------------------------------------------------------------
+
+# Known variable annotations: label, emoji, type, latex
+# Additional properties (unit, tooltip, ai_prompt) have no defaults
+# but can be supplied via user overrides.
+KNOWN_VARIABLES: dict[str, dict[str, str]] = {
+    # Mechanics
+    "F": {"label": "force", "emoji": "🏹", "type": "vector", "latex": "F"},
+    "m": {"label": "mass", "emoji": "⚖️", "type": "scalar", "latex": "m"},
+    "a": {"label": "acceleration", "emoji": "🧭", "type": "vector", "latex": "a"},
+    "v": {"label": "velocity", "emoji": "💨", "type": "vector", "latex": "v"},
+    "t": {"label": "time", "emoji": "⏱️", "type": "scalar", "latex": "t"},
+    "p": {"label": "momentum", "emoji": "🎯", "type": "vector", "latex": "p"},
+    "g": {"label": "gravitational acceleration", "emoji": "🌍", "type": "scalar", "latex": "g"},
+    "r": {"label": "radius", "emoji": "📏", "type": "scalar", "latex": "r"},
+    "x": {"label": "position", "emoji": "📍", "type": "scalar", "latex": "x"},
+    "y": {"label": "position", "emoji": "📍", "type": "scalar", "latex": "y"},
+    "z": {"label": "position", "emoji": "📍", "type": "scalar", "latex": "z"},
+    "d": {"label": "distance", "emoji": "📏", "type": "scalar", "latex": "d"},
+    "s": {"label": "displacement", "emoji": "📏", "type": "scalar", "latex": "s"},
+    "W": {"label": "work", "emoji": "⚡", "type": "scalar", "latex": "W"},
+    "P": {"label": "power", "emoji": "⚡", "type": "scalar", "latex": "P"},
+    # Energy
+    "E": {"label": "energy", "emoji": "⚡", "type": "scalar", "latex": "E"},
+    "T": {"label": "temperature", "emoji": "🌡️", "type": "scalar", "latex": "T"},
+    "K": {"label": "kinetic energy", "emoji": "⚡", "type": "scalar", "latex": "K"},
+    "U": {"label": "potential energy", "emoji": "⚡", "type": "scalar", "latex": "U"},
+    # Electromagnetism
+    "q": {"label": "charge", "emoji": "🔋", "type": "scalar", "latex": "q"},
+    "V": {"label": "voltage", "emoji": "🔌", "type": "scalar", "latex": "V"},
+    "I": {"label": "current", "emoji": "⚡", "type": "scalar", "latex": "I"},
+    "R": {"label": "resistance", "emoji": "🔧", "type": "scalar", "latex": "R"},
+    "B": {"label": "magnetic field", "emoji": "🧲", "type": "vector", "latex": "B"},
+    # Waves / Quantum
+    "f": {"label": "frequency", "emoji": "🔊", "type": "scalar", "latex": "f"},
+    "h": {"label": "Planck constant", "emoji": "📐", "type": "scalar", "latex": "h"},
+    "c": {"label": "speed of light", "emoji": "💡", "type": "scalar", "latex": "c"},
+    "n": {"label": "index", "emoji": "🔢", "type": "scalar", "latex": "n"},
+    "k": {"label": "wave number", "emoji": "🌊", "type": "scalar", "latex": "k"},
+    # Greek letters
+    "alpha": {"label": "alpha", "emoji": "🔤", "type": "scalar", "latex": "\\alpha"},
+    "beta": {"label": "beta", "emoji": "🔤", "type": "scalar", "latex": "\\beta"},
+    "gamma": {"label": "gamma", "emoji": "🔤", "type": "scalar", "latex": "\\gamma"},
+    "delta": {"label": "delta", "emoji": "🔤", "type": "scalar", "latex": "\\delta"},
+    "epsilon": {"label": "epsilon", "emoji": "🔤", "type": "scalar", "latex": "\\epsilon"},
+    "theta": {"label": "angle", "emoji": "📐", "type": "scalar", "latex": "\\theta"},
+    "phi": {"label": "angle", "emoji": "📐", "type": "scalar", "latex": "\\phi"},
+    "psi": {"label": "wave function", "emoji": "🌊", "type": "scalar", "latex": "\\psi"},
+    "omega": {"label": "angular velocity", "emoji": "🔄", "type": "scalar", "latex": "\\omega"},
+    "lambda": {"label": "wavelength", "emoji": "🌊", "type": "scalar", "latex": "\\lambda"},
+    "mu": {"label": "mu", "emoji": "🔤", "type": "scalar", "latex": "\\mu"},
+    "sigma": {"label": "sigma", "emoji": "🔤", "type": "scalar", "latex": "\\sigma"},
+    "tau": {"label": "torque", "emoji": "🔄", "type": "scalar", "latex": "\\tau"},
+    "rho": {"label": "density", "emoji": "🧱", "type": "scalar", "latex": "\\rho"},
+    "pi": {"label": "pi", "emoji": "🥧", "type": "constant", "latex": "\\pi"},
+}
+
+OPERATOR_MAP: dict[type, str] = {
+    Add: "add",
+    Mul: "multiply",
+    Pow: "power",
+    Eq: "equals",
+}
+
+FUNCTION_MAP: dict[str, str] = {
+    "sin": "sin",
+    "cos": "cos",
+    "tan": "tan",
+    "log": "log",
+    "exp": "exp",
+    "sqrt": "sqrt",
+    "Abs": "abs",
+    "asin": "arcsin",
+    "acos": "arccos",
+    "atan": "arctan",
+}
+
+CONSTANT_MAP: dict[Any, dict[str, str]] = {
+    pi: {"label": "pi", "emoji": "🥧"},
+    E: {"label": "e (Euler's number)", "emoji": "📐"},
+    I: {"label": "imaginary unit", "emoji": "🔮"},
+    oo: {"label": "infinity", "emoji": "♾️"},
+}
+
+
+# ---------------------------------------------------------------------------
+# Graph builder
+# ---------------------------------------------------------------------------
+
+def parse_var_overrides(var_specs: list[str] | None) -> dict[str, dict[str, str]]:
+    """Parse ``--var`` CLI arguments into a dict of {symbol_name: {prop: value}}.
+
+    Format: ``name:key=value,key=value,...``
+    Example: ``m:unit=kg,tooltip=Inertial mass``
+    """
+    overrides: dict[str, dict[str, str]] = {}
+    if not var_specs:
+        return overrides
+    for spec in var_specs:
+        if ":" not in spec:
+            raise ValueError(f"Invalid --var format (expected name:key=val,...): {spec!r}")
+        name, rest = spec.split(":", 1)
+        props: dict[str, str] = {}
+        for pair in rest.split(","):
+            if "=" not in pair:
+                raise ValueError(f"Invalid property (expected key=value): {pair!r} in --var {spec!r}")
+            k, v = pair.split("=", 1)
+            props[k.strip()] = v.strip()
+        overrides[name.strip()] = props
+    return overrides
+
+
+class SemanticGraphBuilder:
+    """Walks a SymPy expression tree and emits nodes + edges."""
+
+    def __init__(self, overrides: dict[str, dict[str, str]] | None = None) -> None:
+        self.nodes: list[dict[str, str]] = []
+        self.edges: list[dict[str, str]] = []
+        self._id_counter = 0
+        self._seen_symbols: dict[str, str] = {}  # symbol name → node id
+        self._overrides = overrides or {}
+
+    def _next_id(self, prefix: str = "n") -> str:
+        self._id_counter += 1
+        return f"{prefix}_{self._id_counter}"
+
+    def _add_node(self, node_id: str, **attrs: str) -> None:
+        node: dict[str, str] = {"id": node_id}
+        node.update(attrs)
+        self.nodes.append(node)
+
+    def _add_edge(self, src: str, dst: str) -> None:
+        self.edges.append({"from": src, "to": dst})
+
+    def build(self, expr: sympy.Basic) -> dict:
+        """Build the graph from *expr* and return ``{nodes, edges}``."""
+        self._walk(expr)
+        return {"nodes": self.nodes, "edges": self.edges}
+
+    def _walk(self, expr: sympy.Basic) -> str:
+        """Recursively walk *expr*, returning the node id for this sub-expression."""
+
+        # --- Symbols ---
+        if isinstance(expr, Symbol):
+            name = expr.name
+            if name in self._seen_symbols:
+                return self._seen_symbols[name]
+            meta = KNOWN_VARIABLES.get(name, {})
+            node_id = name
+            attrs: dict[str, str] = {
+                "label": meta.get("label", name),
+                "emoji": meta.get("emoji", "🔣"),
+                "type": meta.get("type", "scalar"),
+                "latex": meta.get("latex", name),
+            }
+            # Apply user overrides (can set any property: unit, tooltip, ai_prompt, etc.)
+            if name in self._overrides:
+                attrs.update(self._overrides[name])
+            self._add_node(node_id, **attrs)
+            self._seen_symbols[name] = node_id
+            return node_id
+
+        # --- Numbers ---
+        if isinstance(expr, Number):
+            node_id = self._next_id("num")
+            self._add_node(node_id, label=str(expr), emoji="🔢", type="number")
+            return node_id
+
+        # --- Constants (pi, e, i, ∞) ---
+        for const, meta in CONSTANT_MAP.items():
+            if expr is const:
+                node_id = self._next_id("const")
+                self._add_node(
+                    node_id,
+                    label=meta["label"],
+                    emoji=meta["emoji"],
+                    type="constant",
+                )
+                return node_id
+
+        # --- Known functions (sin, cos, …) ---
+        if isinstance(expr, sympy.Function):
+            cls_name = type(expr).__name__
+            func_name = FUNCTION_MAP.get(cls_name, cls_name)
+            node_id = self._next_id(func_name)
+            self._add_node(node_id, type="function", op=func_name)
+            for arg in expr.args:
+                child_id = self._walk(arg)
+                self._add_edge(child_id, node_id)
+            return node_id
+
+        # --- Derivative ---
+        if isinstance(expr, Derivative):
+            node_id = self._next_id("deriv")
+            dep_vars = [str(v) for v, _ in expr.variable_count]
+            self._add_node(node_id, type="operator", op="derivative",
+                           with_respect_to=", ".join(dep_vars))
+            child_id = self._walk(expr.expr)
+            self._add_edge(child_id, node_id)
+            for v, _ in expr.variable_count:
+                var_id = self._walk(v)
+                self._add_edge(var_id, node_id)
+            return node_id
+
+        # --- Integral ---
+        if isinstance(expr, Integral):
+            node_id = self._next_id("integral")
+            self._add_node(node_id, type="operator", op="integral")
+            child_id = self._walk(expr.args[0])
+            self._add_edge(child_id, node_id)
+            return node_id
+
+        # --- Sum / Product ---
+        if isinstance(expr, (Sum, Product)):
+            op = "sum" if isinstance(expr, Sum) else "product"
+            node_id = self._next_id(op)
+            self._add_node(node_id, type="operator", op=op)
+            child_id = self._walk(expr.args[0])
+            self._add_edge(child_id, node_id)
+            return node_id
+
+        # --- Binary/n-ary operators (Add, Mul, Pow, Eq) ---
+        op_name = OPERATOR_MAP.get(type(expr))
+        if op_name is not None:
+            node_id = self._next_id(op_name)
+            self._add_node(node_id, type="operator", op=op_name)
+            for arg in expr.args:
+                child_id = self._walk(arg)
+                self._add_edge(child_id, node_id)
+            return node_id
+
+        # --- Fallback: treat as a generic node with children ---
+        node_id = self._next_id("expr")
+        self._add_node(node_id, type="expression", op=type(expr).__name__)
+        for arg in expr.args:
+            child_id = self._walk(arg)
+            self._add_edge(child_id, node_id)
+        return node_id
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def _preprocess_latex(latex: str) -> str:
+    """Rewrite LaTeX patterns that SymPy's parse_latex doesn't handle natively.
+
+    Covers:
+    - Higher-order Leibniz derivatives: \\frac{d^n y}{dx^n} → repeated first-order
+    - Dot notation: \\dot{x}, \\ddot{x} → Derivative(x, t), Derivative(x, t, t)
+    """
+    # \frac{d^2 y}{dx^2}  →  \frac{d}{dx}\frac{d y}{dx}
+    # \frac{\partial^2 u}{\partial x^2}  →  \frac{\partial}{\partial x}\frac{\partial u}{\partial x}
+    # Also handles d^3, \partial^3, etc.
+    def _expand_higher_deriv(m: re.Match) -> str:
+        op = m.group(1)       # "d" or "\\partial"
+        order = int(m.group(2))
+        func = m.group(3)
+        var = m.group(4)
+        if order <= 1:
+            return m.group(0)
+        wrapper = r"\frac{%s}{%s %s}" % (op, op, var)
+        core = r"\frac{%s %s}{%s %s}" % (op, func, op, var)
+        return wrapper * (order - 1) + core
+
+    # Match \frac{d^N <func>}{d<var>^N}  and  \frac{\partial^N <func>}{\partial <var>^N}
+    latex = re.sub(
+        r"\\frac\{(d|\\partial)\^(\d+)\s*(\w+)\}\{\1\s*(\w+)\^\d+\}",
+        _expand_higher_deriv,
+        latex,
+    )
+
+    # \dot{x} → \frac{dx}{dt}  and  \ddot{x} → \frac{d}{dt}\frac{dx}{dt}
+    latex = re.sub(r"\\ddot\{(\w+)\}", r"\\frac{d}{dt}\\frac{d \1}{d t}", latex)
+    latex = re.sub(r"\\dot\{(\w+)\}", r"\\frac{d \1}{d t}", latex)
+
+    return latex
+
+
+def _classify_expression(expr: sympy.Basic) -> dict[str, Any]:
+    """Classify the expression using SymPy's ODE/PDE tools.
+
+    Detects differential equations, their order, dependent/independent
+    variables, and SymPy's own classification hints.
+    """
+    from sympy import classify_ode, Function as SympyFunction
+
+    derivs = list(expr.atoms(Derivative))
+    if not derivs:
+        return {"kind": "algebraic"}
+
+    # Identify dependent variables (what's being differentiated)
+    # and independent variables (what we differentiate with respect to)
+    dep_syms: set[Symbol] = set()
+    indep_syms: set[Symbol] = set()
+    max_order = 0
+    for d in derivs:
+        if isinstance(d.expr, Symbol):
+            dep_syms.add(d.expr)
+        for var, count in d.variable_count:
+            indep_syms.add(var)
+            max_order = max(max_order, int(count))
+
+    is_pde = len(indep_syms) > 1
+    kind = "PDE" if is_pde else "ODE"
+
+    meta: dict[str, Any] = {
+        "kind": kind,
+        "order": max_order,
+        "dependent_variables": sorted(str(s) for s in dep_syms),
+        "independent_variables": sorted(str(s) for s in indep_syms),
+    }
+
+    # For single-variable ODEs, use SymPy's classify_ode and dsolve
+    if not is_pde and len(dep_syms) == 1 and len(indep_syms) == 1:
+        dep_sym = next(iter(dep_syms))
+        indep_sym = next(iter(indep_syms))
+        func = SympyFunction(dep_sym.name)(indep_sym)
+
+        # Convert Symbol-based derivatives to Function-based for classify_ode
+        func_expr = expr.subs(dep_sym, func)
+
+        # Extract the expression to classify (lhs - rhs = 0)
+        if isinstance(func_expr, Eq):
+            ode_expr = func_expr.lhs - func_expr.rhs
+        else:
+            ode_expr = func_expr
+
+        try:
+            hints = classify_ode(ode_expr, func)
+            classifications = [h for h in hints
+                               if isinstance(h, str) and not h.endswith("_Integral")]
+            if classifications:
+                meta["sympy_hints"] = classifications
+
+            # Derive properties from hints
+            meta["linear"] = any("linear" in h for h in classifications)
+            meta["homogeneous"] = any("homogeneous" in h for h in classifications)
+            meta["constant_coefficients"] = any("constant_coeff" in h for h in classifications)
+        except Exception:
+            pass
+
+    return meta
+
+
+def latex_to_semantic_graph(latex: str, overrides: dict[str, dict[str, str]] | None = None) -> dict:
+    """Parse a LaTeX string and return a semantic graph dict."""
+    latex = _preprocess_latex(latex)
+    try:
+        expr = parse_latex(latex)
+    except Exception as exc:
+        raise ValueError(f"Failed to parse LaTeX: {exc}") from exc
+
+    classification = _classify_expression(expr)
+    builder = SemanticGraphBuilder(overrides=overrides)
+    graph = builder.build(expr)
+    graph["classification"] = classification
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert LaTeX expressions to semantic graphs (JSON).",
+    )
+    parser.add_argument("latex", help="LaTeX expression to parse")
+    parser.add_argument("--pretty", action="store_true",
+                        help="Pretty-print the JSON output")
+    parser.add_argument("-o", "--output", type=str, default=None,
+                        help="Write JSON to a file instead of stdout")
+    parser.add_argument("--var", action="append", dest="vars", metavar="NAME:KEY=VAL,...",
+                        help="Override variable properties. "
+                             "Example: --var 'm:unit=kg,tooltip=Inertial mass' "
+                             "--var 'a:unit=m/s²,ai_prompt=Explain acceleration'")
+    args = parser.parse_args()
+
+    try:
+        overrides = parse_var_overrides(args.vars)
+        graph = latex_to_semantic_graph(args.latex, overrides=overrides)
+    except ValueError as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    indent = 2 if args.pretty else None
+    result = json.dumps(graph, indent=indent, ensure_ascii=False)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(result + "\n")
+        print(f"✅ Graph written to {args.output}")
+    else:
+        print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -145,15 +145,15 @@ CONSTANT_MAP: dict[Any, dict[str, str]] = {
 
 # Relations that parse_latex cannot handle — checked before SymPy parsing.
 # Order matters: longer commands must come before shorter prefixes.
-RELATION_MAP: list[tuple[str, str]] = [
-    (r"\Leftrightarrow", "iff"),
-    (r"\Rightarrow", "implies"),
-    (r"\implies", "implies"),
-    (r"\propto", "proportional"),
-    (r"\approx", "approximately"),
-    (r"\iff", "iff"),
-    (r"\to", "maps_to"),
-    (r"\rightarrow", "maps_to"),
+RELATION_MAP: list[tuple[str, dict[str, str]]] = [
+    (r"\Leftrightarrow", {"op": "iff", "label": "if and only if", "emoji": "⇔"}),
+    (r"\Rightarrow", {"op": "implies", "label": "implies", "emoji": "⇒"}),
+    (r"\implies", {"op": "implies", "label": "implies", "emoji": "⇒"}),
+    (r"\propto", {"op": "proportional", "label": "proportional to", "emoji": "∝"}),
+    (r"\approx", {"op": "approximately", "label": "approximately equal", "emoji": "≈"}),
+    (r"\iff", {"op": "iff", "label": "if and only if", "emoji": "⇔"}),
+    (r"\to", {"op": "maps_to", "label": "maps to", "emoji": "→"}),
+    (r"\rightarrow", {"op": "maps_to", "label": "maps to", "emoji": "→"}),
 ]
 
 
@@ -420,17 +420,17 @@ def _classify_expression(expr: sympy.Basic) -> dict[str, Any]:
     return meta
 
 
-def _split_on_relation(latex: str) -> tuple[str, str, str] | None:
+def _split_on_relation(latex: str) -> tuple[str, dict[str, str], str] | None:
     """If *latex* contains a relation operator from RELATION_MAP, return
-    ``(lhs_latex, relation_name, rhs_latex)``.  Returns ``None`` when no
+    ``(lhs_latex, relation_meta, rhs_latex)``.  Returns ``None`` when no
     relation is found."""
-    for cmd, name in RELATION_MAP:
+    for cmd, meta in RELATION_MAP:
         idx = latex.find(cmd)
         if idx != -1:
             lhs = latex[:idx].strip()
             rhs = latex[idx + len(cmd):].strip()
             if lhs and rhs:
-                return lhs, name, rhs
+                return lhs, meta, rhs
     return None
 
 
@@ -446,7 +446,7 @@ def latex_to_semantic_graph(latex: str, overrides: dict[str, dict[str, str]] | N
     # Check for relation operators that parse_latex cannot handle.
     rel = _split_on_relation(preprocessed)
     if rel is not None:
-        lhs_latex, rel_name, rhs_latex = rel
+        lhs_latex, rel_meta, rhs_latex = rel
         try:
             lhs_expr = parse_latex(lhs_latex)
             rhs_expr = parse_latex(rhs_latex)
@@ -456,8 +456,8 @@ def latex_to_semantic_graph(latex: str, overrides: dict[str, dict[str, str]] | N
         builder = SemanticGraphBuilder(overrides=overrides)
         lhs_id = builder._walk(lhs_expr)
         rhs_id = builder._walk(rhs_expr)
-        rel_id = builder._next_id(rel_name)
-        builder._add_node(rel_id, type="relation", op=rel_name)
+        rel_id = builder._next_id(rel_meta["op"])
+        builder._add_node(rel_id, type="relation", **rel_meta)
         builder._add_edge(lhs_id, rel_id)
         builder._add_edge(rhs_id, rel_id)
         graph = {"nodes": builder.nodes, "edges": builder.edges}

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -43,13 +43,17 @@ try:
         pi, E, I, oo,
     )
 except ImportError:
-    print("❌ Missing dependency: pip install sympy", file=sys.stderr)
+    print("❌ Missing dependency: sympy. Re-run via "
+          "'./run.sh scripts/latex_to_graph.py ...' to auto-manage dependencies.",
+          file=sys.stderr)
     sys.exit(1)
 
 try:
     from sympy.parsing.latex import parse_latex
 except ImportError:
-    print("❌ Missing dependency: pip install antlr4-python3-runtime==4.11.1", file=sys.stderr)
+    print("❌ Missing dependency: antlr4-python3-runtime==4.11.1. Re-run via "
+          "'./run.sh scripts/latex_to_graph.py ...' to auto-manage dependencies.",
+          file=sys.stderr)
     sys.exit(1)
 
 
@@ -179,7 +183,7 @@ class SemanticGraphBuilder:
 
     def _next_id(self, prefix: str = "n") -> str:
         self._id_counter += 1
-        return f"{prefix}_{self._id_counter}"
+        return f"__{prefix}_{self._id_counter}"
 
     def _add_node(self, node_id: str, **attrs: str) -> None:
         node: dict[str, str] = {"id": node_id}
@@ -217,13 +221,7 @@ class SemanticGraphBuilder:
             self._seen_symbols[name] = node_id
             return node_id
 
-        # --- Numbers ---
-        if isinstance(expr, Number):
-            node_id = self._next_id("num")
-            self._add_node(node_id, label=str(expr), emoji="🔢", type="number")
-            return node_id
-
-        # --- Constants (pi, e, i, ∞) ---
+        # --- Constants (pi, e, i, ∞) — check before Number since some are NumberSymbol ---
         for const, meta in CONSTANT_MAP.items():
             if expr is const:
                 node_id = self._next_id("const")
@@ -234,6 +232,12 @@ class SemanticGraphBuilder:
                     type="constant",
                 )
                 return node_id
+
+        # --- Numbers ---
+        if isinstance(expr, Number):
+            node_id = self._next_id("num")
+            self._add_node(node_id, label=str(expr), emoji="🔢", type="number")
+            return node_id
 
         # --- Known functions (sin, cos, …) ---
         if isinstance(expr, sympy.Function):
@@ -445,7 +449,7 @@ def main() -> None:
     result = json.dumps(graph, indent=indent, ensure_ascii=False)
 
     if args.output:
-        with open(args.output, "w") as f:
+        with open(args.output, "w", encoding="utf-8") as f:
             f.write(result + "\n")
         print(f"✅ Graph written to {args.output}")
     else:

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -314,12 +314,12 @@ def _preprocess_latex(latex: str) -> str:
     """
     # \frac{d^2 y}{dx^2}  →  \frac{d}{dx}\frac{d y}{dx}
     # \frac{\partial^2 u}{\partial x^2}  →  \frac{\partial}{\partial x}\frac{\partial u}{\partial x}
-    # Also handles d^3, \partial^3, etc.
+    # Also handles d^3, d^{3}, \partial^3, \partial^{3}, etc.
     def _expand_higher_deriv(m: re.Match) -> str:
         op = m.group(1)       # "d" or "\\partial"
-        order = int(m.group(2))
-        func = m.group(3)
-        var = m.group(4)
+        order = int(m.group(2) or m.group(3))
+        func = m.group(4)
+        var = m.group(5)
         if order <= 1:
             return m.group(0)
         wrapper = r"\frac{%s}{%s %s}" % (op, op, var)
@@ -327,8 +327,9 @@ def _preprocess_latex(latex: str) -> str:
         return wrapper * (order - 1) + core
 
     # Match \frac{d^N <func>}{d<var>^N}  and  \frac{\partial^N <func>}{\partial <var>^N}
+    # N can be bare (^2) or braced (^{2})
     latex = re.sub(
-        r"\\frac\{(d|\\partial)\^(\d+)\s*([^}]+)\}\{\1\s*([^}]+)\^\d+\}",
+        r"\\frac\{(d|\\partial)\^(?:\{(\d+)\}|(\d+))\s*([^}]+)\}\{\1\s*([^}]+?)\s*\^(?:\{\d+\}|\d+)\}",
         _expand_higher_deriv,
         latex,
     )

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -143,6 +143,19 @@ CONSTANT_MAP: dict[Any, dict[str, str]] = {
     oo: {"label": "infinity", "emoji": "♾️"},
 }
 
+# Relations that parse_latex cannot handle — checked before SymPy parsing.
+# Order matters: longer commands must come before shorter prefixes.
+RELATION_MAP: list[tuple[str, str]] = [
+    (r"\Leftrightarrow", "iff"),
+    (r"\Rightarrow", "implies"),
+    (r"\implies", "implies"),
+    (r"\propto", "proportional"),
+    (r"\approx", "approximately"),
+    (r"\iff", "iff"),
+    (r"\to", "maps_to"),
+    (r"\rightarrow", "maps_to"),
+]
+
 
 # ---------------------------------------------------------------------------
 # Graph builder
@@ -407,11 +420,58 @@ def _classify_expression(expr: sympy.Basic) -> dict[str, Any]:
     return meta
 
 
+def _split_on_relation(latex: str) -> tuple[str, str, str] | None:
+    """If *latex* contains a relation operator from RELATION_MAP, return
+    ``(lhs_latex, relation_name, rhs_latex)``.  Returns ``None`` when no
+    relation is found."""
+    for cmd, name in RELATION_MAP:
+        idx = latex.find(cmd)
+        if idx != -1:
+            lhs = latex[:idx].strip()
+            rhs = latex[idx + len(cmd):].strip()
+            if lhs and rhs:
+                return lhs, name, rhs
+    return None
+
+
 def latex_to_semantic_graph(latex: str, overrides: dict[str, dict[str, str]] | None = None) -> dict:
-    """Parse a LaTeX string and return a semantic graph dict."""
-    latex = _preprocess_latex(latex)
+    """Parse a LaTeX string and return a semantic graph dict.
+
+    Handles relation operators (\\propto, \\implies, \\iff, \\to, \\approx,
+    \\Rightarrow, \\Leftrightarrow) by splitting on the relation, parsing
+    each side independently, and emitting a ``type='relation'`` node.
+    """
+    preprocessed = _preprocess_latex(latex)
+
+    # Check for relation operators that parse_latex cannot handle.
+    rel = _split_on_relation(preprocessed)
+    if rel is not None:
+        lhs_latex, rel_name, rhs_latex = rel
+        try:
+            lhs_expr = parse_latex(lhs_latex)
+            rhs_expr = parse_latex(rhs_latex)
+        except Exception as exc:
+            raise ValueError(f"Failed to parse LaTeX: {exc}") from exc
+
+        builder = SemanticGraphBuilder(overrides=overrides)
+        lhs_id = builder._walk(lhs_expr)
+        rhs_id = builder._walk(rhs_expr)
+        rel_id = builder._next_id(rel_name)
+        builder._add_node(rel_id, type="relation", op=rel_name)
+        builder._add_edge(lhs_id, rel_id)
+        builder._add_edge(rhs_id, rel_id)
+        graph = {"nodes": builder.nodes, "edges": builder.edges}
+        # Classify based on both sides combined.  Relational expressions
+        # (inequalities, Eq) don't support arithmetic, so fall back gracefully.
+        try:
+            combined = lhs_expr - rhs_expr
+        except TypeError:
+            combined = lhs_expr
+        graph["classification"] = _classify_expression(combined)
+        return graph
+
     try:
-        expr = parse_latex(latex)
+        expr = parse_latex(preprocessed)
     except Exception as exc:
         raise ValueError(f"Failed to parse LaTeX: {exc}") from exc
 

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -267,8 +267,9 @@ class SemanticGraphBuilder:
         if isinstance(expr, Integral):
             node_id = self._next_id("integral")
             self._add_node(node_id, type="operator", op="integral")
-            child_id = self._walk(expr.args[0])
-            self._add_edge(child_id, node_id)
+            for arg in expr.args:
+                child_id = self._walk(arg)
+                self._add_edge(child_id, node_id)
             return node_id
 
         # --- Sum / Product ---
@@ -276,8 +277,9 @@ class SemanticGraphBuilder:
             op = "sum" if isinstance(expr, Sum) else "product"
             node_id = self._next_id(op)
             self._add_node(node_id, type="operator", op=op)
-            child_id = self._walk(expr.args[0])
-            self._add_edge(child_id, node_id)
+            for arg in expr.args:
+                child_id = self._walk(arg)
+                self._add_edge(child_id, node_id)
             return node_id
 
         # --- Binary/n-ary operators (Add, Mul, Pow, Eq) ---
@@ -326,14 +328,14 @@ def _preprocess_latex(latex: str) -> str:
 
     # Match \frac{d^N <func>}{d<var>^N}  and  \frac{\partial^N <func>}{\partial <var>^N}
     latex = re.sub(
-        r"\\frac\{(d|\\partial)\^(\d+)\s*(\w+)\}\{\1\s*(\w+)\^\d+\}",
+        r"\\frac\{(d|\\partial)\^(\d+)\s*([^}]+)\}\{\1\s*([^}]+)\^\d+\}",
         _expand_higher_deriv,
         latex,
     )
 
     # \dot{x} → \frac{dx}{dt}  and  \ddot{x} → \frac{d}{dt}\frac{dx}{dt}
-    latex = re.sub(r"\\ddot\{(\w+)\}", r"\\frac{d}{dt}\\frac{d \1}{d t}", latex)
-    latex = re.sub(r"\\dot\{(\w+)\}", r"\\frac{d \1}{d t}", latex)
+    latex = re.sub(r"\\ddot\{([^}]+)\}", r"\\frac{d}{dt}\\frac{d \1}{d t}", latex)
+    latex = re.sub(r"\\dot\{([^}]+)\}", r"\\frac{d \1}{d t}", latex)
 
     return latex
 

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -374,9 +374,11 @@ def _classify_expression(expr: sympy.Basic) -> dict[str, Any]:
     for d in derivs:
         if isinstance(d.expr, Symbol):
             dep_syms.add(d.expr)
+        deriv_order = 0
         for var, count in d.variable_count:
             indep_syms.add(var)
-            max_order = max(max_order, int(count))
+            deriv_order += int(count)
+        max_order = max(max_order, deriv_order)
 
     is_pde = len(indep_syms) > 1
     kind = "PDE" if is_pde else "ODE"
@@ -424,13 +426,17 @@ def _split_on_relation(latex: str) -> tuple[str, dict[str, str], str] | None:
     """If *latex* contains a relation operator from RELATION_MAP, return
     ``(lhs_latex, relation_meta, rhs_latex)``.  Returns ``None`` when no
     relation is found."""
+    best: tuple[int, str, dict[str, str]] | None = None
     for cmd, meta in RELATION_MAP:
         idx = latex.find(cmd)
-        if idx != -1:
-            lhs = latex[:idx].strip()
-            rhs = latex[idx + len(cmd):].strip()
-            if lhs and rhs:
-                return lhs, meta, rhs
+        if idx != -1 and (best is None or idx < best[0]):
+            best = (idx, cmd, meta)
+    if best is not None:
+        idx, cmd, meta = best
+        lhs = latex[:idx].strip()
+        rhs = latex[idx + len(cmd):].strip()
+        if lhs and rhs:
+            return lhs, meta, rhs
     return None
 
 

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -173,13 +173,32 @@ class TestDerivatives:
         assert r"\frac" in result
         assert "d t" in result or "dt" in result
 
+    def test_dot_notation_graph(self):
+        g = latex_to_semantic_graph(r"\dot{x}")
+        deriv = _find_node(g, type="operator", op="derivative")
+        assert deriv is not None
+        assert "t" in deriv.get("with_respect_to", "")
+
     def test_ddot_notation_preprocessed(self):
         result = _preprocess_latex(r"\ddot{x}")
         assert result.count(r"\frac") == 2
 
+    def test_ddot_notation_graph(self):
+        g = latex_to_semantic_graph(r"\ddot{x}")
+        deriv = _find_node(g, type="operator", op="derivative")
+        assert deriv is not None
+        # SymPy collapses nested derivatives; ddot produces Derivative(x, t, t)
+        assert "t" in deriv.get("with_respect_to", "")
+
     def test_higher_order_derivative(self):
         result = _preprocess_latex(r"\frac{d^2 y}{dy^2}")
         assert result.count(r"\frac") == 2
+
+    def test_higher_order_derivative_graph(self):
+        g = latex_to_semantic_graph(r"\frac{d^2 y}{d y^2}")
+        deriv = _find_node(g, type="operator", op="derivative")
+        assert deriv is not None
+        assert "y" in deriv.get("with_respect_to", "")
 
     def test_higher_order_derivative_braced(self):
         result = _preprocess_latex(r"\frac{d^{2} y}{dy^{2}}")

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -219,6 +219,8 @@ class TestRelations:
         g = latex_to_semantic_graph(r"F \propto m a")
         rel = _find_node(g, type="relation", op="proportional")
         assert rel is not None
+        assert rel["label"] == "proportional to"
+        assert rel["emoji"] == "∝"
         assert _find_node(g, id="F")
         assert _find_node(g, type="operator", op="multiply")
 
@@ -226,21 +228,27 @@ class TestRelations:
         g = latex_to_semantic_graph(r"x > 0 \implies x^2 > 0")
         rel = _find_node(g, type="relation", op="implies")
         assert rel is not None
+        assert rel["label"] == "implies"
+        assert rel["emoji"] == "⇒"
 
     def test_rightarrow_implies(self):
         g = latex_to_semantic_graph(r"x > 0 \Rightarrow x^2 > 0")
         rel = _find_node(g, type="relation", op="implies")
         assert rel is not None
+        assert rel["emoji"] == "⇒"
 
     def test_iff(self):
         g = latex_to_semantic_graph(r"x = 0 \iff x^2 = 0")
         rel = _find_node(g, type="relation", op="iff")
         assert rel is not None
+        assert rel["label"] == "if and only if"
+        assert rel["emoji"] == "⇔"
 
     def test_leftrightarrow_iff(self):
         g = latex_to_semantic_graph(r"A \Leftrightarrow B")
         rel = _find_node(g, type="relation", op="iff")
         assert rel is not None
+        assert rel["emoji"] == "⇔"
         assert _find_node(g, id="A")
         assert _find_node(g, id="B")
 
@@ -248,12 +256,16 @@ class TestRelations:
         g = latex_to_semantic_graph(r"\pi \approx 3.14")
         rel = _find_node(g, type="relation", op="approximately")
         assert rel is not None
+        assert rel["label"] == "approximately equal"
+        assert rel["emoji"] == "≈"
         assert _find_node(g, type="constant", label="pi")
 
     def test_maps_to(self):
         g = latex_to_semantic_graph(r"x \to y")
         rel = _find_node(g, type="relation", op="maps_to")
         assert rel is not None
+        assert rel["label"] == "maps to"
+        assert rel["emoji"] == "→"
         assert _find_node(g, id="x")
         assert _find_node(g, id="y")
 

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -281,6 +281,13 @@ class TestRelations:
         incoming = [e for e in g["edges"] if e["to"] == rel["id"]]
         assert len(incoming) == 2
 
+    def test_leftmost_relation_wins(self):
+        """When multiple relations appear, split on the leftmost one."""
+        g = latex_to_semantic_graph(r"x \to y \implies z")
+        # \to is leftmost, so it should be the relation
+        rel = _find_node(g, type="relation", op="maps_to")
+        assert rel is not None
+
 
 # ---------------------------------------------------------------------------
 # Complex real-world formulas
@@ -435,6 +442,15 @@ class TestClassification:
     def test_algebraic_equation(self):
         g = latex_to_semantic_graph("E = m c^2")
         assert g["classification"]["kind"] == "algebraic"
+
+    def test_mixed_partial_derivative_order(self):
+        """Mixed partial d²u/(dx dt) should report order 2, not 1."""
+        g = latex_to_semantic_graph(
+            r"\frac{\partial}{\partial x}\frac{\partial u}{\partial t} = 0"
+        )
+        c = g["classification"]
+        assert c["kind"] == "PDE"
+        assert c["order"] == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -209,6 +209,68 @@ class TestDerivatives:
 
 
 # ---------------------------------------------------------------------------
+# Relation operators (proportional, implies, iff, maps_to, approximately)
+# ---------------------------------------------------------------------------
+
+class TestRelations:
+    """Relations that SymPy's parse_latex cannot handle natively."""
+
+    def test_proportional(self):
+        g = latex_to_semantic_graph(r"F \propto m a")
+        rel = _find_node(g, type="relation", op="proportional")
+        assert rel is not None
+        assert _find_node(g, id="F")
+        assert _find_node(g, type="operator", op="multiply")
+
+    def test_implies(self):
+        g = latex_to_semantic_graph(r"x > 0 \implies x^2 > 0")
+        rel = _find_node(g, type="relation", op="implies")
+        assert rel is not None
+
+    def test_rightarrow_implies(self):
+        g = latex_to_semantic_graph(r"x > 0 \Rightarrow x^2 > 0")
+        rel = _find_node(g, type="relation", op="implies")
+        assert rel is not None
+
+    def test_iff(self):
+        g = latex_to_semantic_graph(r"x = 0 \iff x^2 = 0")
+        rel = _find_node(g, type="relation", op="iff")
+        assert rel is not None
+
+    def test_leftrightarrow_iff(self):
+        g = latex_to_semantic_graph(r"A \Leftrightarrow B")
+        rel = _find_node(g, type="relation", op="iff")
+        assert rel is not None
+        assert _find_node(g, id="A")
+        assert _find_node(g, id="B")
+
+    def test_approximately(self):
+        g = latex_to_semantic_graph(r"\pi \approx 3.14")
+        rel = _find_node(g, type="relation", op="approximately")
+        assert rel is not None
+        assert _find_node(g, type="constant", label="pi")
+
+    def test_maps_to(self):
+        g = latex_to_semantic_graph(r"x \to y")
+        rel = _find_node(g, type="relation", op="maps_to")
+        assert rel is not None
+        assert _find_node(g, id="x")
+        assert _find_node(g, id="y")
+
+    def test_maps_to_function(self):
+        g = latex_to_semantic_graph(r"f(x) \to f(x+1)")
+        rel = _find_node(g, type="relation", op="maps_to")
+        assert rel is not None
+
+    def test_relation_has_two_edges(self):
+        """Every relation node should connect LHS and RHS."""
+        g = latex_to_semantic_graph(r"F \propto m a")
+        rel = _find_node(g, type="relation", op="proportional")
+        incoming = [e for e in g["edges"] if e["to"] == rel["id"]]
+        assert len(incoming) == 2
+
+
+# ---------------------------------------------------------------------------
 # Complex real-world formulas
 # ---------------------------------------------------------------------------
 

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -181,6 +181,14 @@ class TestDerivatives:
         result = _preprocess_latex(r"\frac{d^2 y}{dy^2}")
         assert result.count(r"\frac") == 2
 
+    def test_higher_order_derivative_braced(self):
+        result = _preprocess_latex(r"\frac{d^{2} y}{dy^{2}}")
+        assert result.count(r"\frac") == 2
+
+    def test_higher_order_partial_braced(self):
+        result = _preprocess_latex(r"\frac{\partial^{3} u}{\partial x^{3}}")
+        assert result.count(r"\frac") == 3
+
 
 # ---------------------------------------------------------------------------
 # Classification

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -12,7 +12,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from scripts.latex_to_graph import (
     latex_to_semantic_graph,
     parse_var_overrides,
-    SemanticGraphBuilder,
     _preprocess_latex,
 )
 

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -141,8 +141,25 @@ class TestFunctions:
 
 
 # ---------------------------------------------------------------------------
-# Derivatives
+# Calculus (Integrals, Sums, Derivatives)
 # ---------------------------------------------------------------------------
+
+class TestCalculus:
+    def test_integral_with_limits(self):
+        g = latex_to_semantic_graph("\\int_0^1 x^2 dx")
+        integral_node = _find_node(g, type="operator", op="integral")
+        assert integral_node is not None
+        assert _find_node(g, id="x") is not None
+        assert _find_node(g, label="0") is not None
+        assert _find_node(g, label="1") is not None
+
+    def test_sum_with_limits(self):
+        g = latex_to_semantic_graph("\\sum_{n=1}^\\infty n")
+        sum_node = _find_node(g, type="operator", op="sum")
+        assert sum_node is not None
+        assert _find_node(g, id="n") is not None
+        assert _find_node(g, label="1") is not None
+        assert _find_node(g, label="infinity") is not None
 
 class TestDerivatives:
     def test_first_order_derivative(self):

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -209,6 +209,141 @@ class TestDerivatives:
 
 
 # ---------------------------------------------------------------------------
+# Complex real-world formulas
+# ---------------------------------------------------------------------------
+
+class TestComplexFormulas:
+    """Parse real physics/math formulas and verify the graph captures key
+    structural features (node types, operators, symbols, classification)."""
+
+    def test_euler_identity(self):
+        """e^{i pi} + 1 = 0 — symbols, constants, power, addition, equality.
+        Note: parse_latex treats 'e' and 'i' as plain symbols; pi is a constant."""
+        g = latex_to_semantic_graph(r"e^{i \pi} + 1 = 0")
+        assert _find_node(g, type="operator", op="equals")
+        assert _find_node(g, id="e")
+        assert _find_node(g, type="constant", label="pi")
+        assert _find_node(g, type="operator", op="power")
+        assert _find_node(g, type="operator", op="add")
+        assert g["classification"]["kind"] == "algebraic"
+
+    def test_kinetic_energy(self):
+        """K = 1/2 m v^2 — equation with fraction, multiplication, power."""
+        g = latex_to_semantic_graph(r"K = \frac{1}{2} m v^2")
+        assert _find_node(g, type="operator", op="equals")
+        assert _find_node(g, id="K")
+        assert _find_node(g, id="m", label="mass")
+        assert _find_node(g, id="v", label="velocity")
+        assert _find_node(g, type="operator", op="power")
+        assert _find_node(g, type="operator", op="multiply")
+
+    def test_gaussian_integral(self):
+        """integral from -inf to inf of e^{-x^2} dx = sqrt(pi) —
+        definite integral, exponential, constant, equality."""
+        g = latex_to_semantic_graph(
+            r"\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}"
+        )
+        assert _find_node(g, type="operator", op="equals")
+        assert _find_node(g, type="operator", op="integral")
+        assert _find_node(g, type="operator", op="power")
+        assert _find_node(g, id="x")
+        assert g["classification"]["kind"] == "algebraic"
+
+    def test_wave_equation_pde(self):
+        """u_tt = c^2 u_xx — second-order PDE, partial derivatives."""
+        g = latex_to_semantic_graph(
+            r"\frac{\partial^2 u}{\partial t^2} = c^2 \frac{\partial^2 u}{\partial x^2}"
+        )
+        derivs = _find_nodes(g, type="operator", op="derivative")
+        assert len(derivs) == 2
+        wrt_vars = {d["with_respect_to"] for d in derivs}
+        assert "t" in wrt_vars
+        assert "x" in wrt_vars
+        c = g["classification"]
+        assert c["kind"] == "PDE"
+        assert c["order"] == 2
+        assert set(c["independent_variables"]) == {"t", "x"}
+
+    def test_harmonic_oscillator_ode(self):
+        """x'' + omega^2 x = 0 — second-order linear ODE."""
+        g = latex_to_semantic_graph(
+            r"\frac{d^2 x}{dt^2} + \omega^2 x = 0"
+        )
+        assert _find_node(g, type="operator", op="derivative")
+        assert _find_node(g, id="omega", label="angular velocity")
+        c = g["classification"]
+        assert c["kind"] == "ODE"
+        assert c["order"] == 2
+        assert c.get("linear") is True
+
+    def test_schrodinger_time_independent(self):
+        """E psi = -(h^2/2m) psi'' + V psi — ODE with many operators."""
+        g = latex_to_semantic_graph(
+            r"E \psi = -\frac{h^2}{2m} \frac{d^2 \psi}{dx^2} + V \psi"
+        )
+        assert _find_node(g, id="psi", label="wave function")
+        assert _find_node(g, id="h", label="Planck constant")
+        assert _find_node(g, type="operator", op="derivative")
+        assert _find_node(g, type="operator", op="equals")
+        c = g["classification"]
+        assert c["kind"] == "ODE"
+        assert c["order"] == 2
+
+    def test_coulomb_law(self):
+        """F = k q1 q2 / r^2 — subscripted variables, fractions."""
+        g = latex_to_semantic_graph(r"F = k \frac{q_1 q_2}{r^2}")
+        assert _find_node(g, type="operator", op="equals")
+        assert _find_node(g, id="F", label="force")
+        assert _find_node(g, id="r", label="radius")
+        assert _find_node(g, type="operator", op="power")
+        # q_1 and q_2 are distinct symbols
+        nodes = g["nodes"]
+        q_nodes = [n for n in nodes if n["id"].startswith("q_")]
+        assert len(q_nodes) == 2
+
+    def test_taylor_series_sin(self):
+        """sin(x) = sum — function, summation, factorial, power."""
+        g = latex_to_semantic_graph(
+            r"\sin(x) = \sum_{n=0}^{\infty} \frac{(-1)^n}{(2n+1)!} x^{2n+1}"
+        )
+        assert _find_node(g, type="function", op="sin")
+        assert _find_node(g, type="operator", op="sum")
+        assert _find_node(g, type="operator", op="equals")
+        # Should have factorial node
+        assert _find_node(g, op="factorial")
+        assert g["classification"]["kind"] == "algebraic"
+
+    def test_lorentz_factor(self):
+        """gamma = 1/sqrt(1 - v^2/c^2) — nested fractions, sqrt via power."""
+        g = latex_to_semantic_graph(
+            r"\gamma = \frac{1}{\sqrt{1 - \frac{v^2}{c^2}}}"
+        )
+        assert _find_node(g, id="gamma")
+        assert _find_node(g, id="v", label="velocity")
+        assert _find_node(g, id="c", label="speed of light")
+        assert _find_node(g, type="operator", op="equals")
+        assert g["classification"]["kind"] == "algebraic"
+
+    def test_quadratic_formula(self):
+        """x = (-b +/- sqrt(b^2 - 4ac)) / 2a — covers many node types."""
+        g = latex_to_semantic_graph(
+            r"x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}"
+        )
+        assert _find_node(g, type="operator", op="equals")
+        assert _find_node(g, id="x")
+        assert _find_node(g, id="a")
+        assert _find_node(g, id="b")
+        assert _find_node(g, id="c")
+        # Must have both addition and multiplication
+        assert _find_node(g, type="operator", op="add")
+        assert _find_node(g, type="operator", op="multiply")
+        assert _find_node(g, type="operator", op="power")
+        # Graph should be non-trivial
+        assert len(g["nodes"]) >= 10
+        assert len(g["edges"]) >= 10
+
+
+# ---------------------------------------------------------------------------
 # Classification
 # ---------------------------------------------------------------------------
 

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -1,0 +1,233 @@
+"""Tests for scripts/latex_to_graph.py"""
+
+from __future__ import annotations
+
+import sys
+import os
+import pytest
+
+# Allow importing from scripts/
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scripts.latex_to_graph import (
+    latex_to_semantic_graph,
+    parse_var_overrides,
+    SemanticGraphBuilder,
+    _preprocess_latex,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _find_node(graph, **attrs):
+    """Find a node in the graph matching all given attrs."""
+    for node in graph["nodes"]:
+        if all(node.get(k) == v for k, v in attrs.items()):
+            return node
+    return None
+
+
+def _find_nodes(graph, **attrs):
+    """Find all nodes matching given attrs."""
+    return [n for n in graph["nodes"]
+            if all(n.get(k) == v for k, v in attrs.items())]
+
+
+def _has_edge(graph, src, dst):
+    """Check if an edge exists from src to dst."""
+    return {"from": src, "to": dst} in graph["edges"]
+
+
+# ---------------------------------------------------------------------------
+# Graph structure
+# ---------------------------------------------------------------------------
+
+class TestGraphStructure:
+    def test_returns_nodes_and_edges(self):
+        g = latex_to_semantic_graph("x + y")
+        assert "nodes" in g
+        assert "edges" in g
+        assert "classification" in g
+
+    def test_simple_addition(self):
+        g = latex_to_semantic_graph("x + y")
+        assert _find_node(g, id="x", type="scalar")
+        assert _find_node(g, id="y", type="scalar")
+        assert _find_node(g, type="operator", op="add")
+
+    def test_simple_multiplication(self):
+        g = latex_to_semantic_graph("m \\cdot a")
+        assert _find_node(g, id="m", label="mass")
+        assert _find_node(g, id="a", label="acceleration")
+        assert _find_node(g, type="operator", op="multiply")
+
+    def test_equation(self):
+        g = latex_to_semantic_graph("F = m \\cdot a")
+        assert _find_node(g, id="F", label="force")
+        assert _find_node(g, type="operator", op="equals")
+
+    def test_power(self):
+        g = latex_to_semantic_graph("x^2")
+        assert _find_node(g, id="x")
+        assert _find_node(g, type="operator", op="power")
+
+    def test_edges_connect_operands_to_operator(self):
+        g = latex_to_semantic_graph("x + y")
+        add_node = _find_node(g, type="operator", op="add")
+        assert add_node is not None
+        assert _has_edge(g, "x", add_node["id"])
+        assert _has_edge(g, "y", add_node["id"])
+
+
+# ---------------------------------------------------------------------------
+# Known variables & metadata
+# ---------------------------------------------------------------------------
+
+class TestKnownVariables:
+    def test_known_variable_gets_metadata(self):
+        g = latex_to_semantic_graph("F")
+        node = _find_node(g, id="F")
+        assert node["label"] == "force"
+        assert node["type"] == "vector"
+        assert node["emoji"] == "\U0001f3f9"
+
+    def test_unknown_variable_gets_defaults(self):
+        g = latex_to_semantic_graph("Q")
+        node = _find_node(g, id="Q")
+        assert node["label"] == "Q"
+        assert node["type"] == "scalar"
+
+    def test_symbol_deduplication(self):
+        g = latex_to_semantic_graph("x + x")
+        x_nodes = _find_nodes(g, id="x")
+        assert len(x_nodes) == 1
+
+
+# ---------------------------------------------------------------------------
+# Numbers and constants
+# ---------------------------------------------------------------------------
+
+class TestNumbersAndConstants:
+    def test_integer(self):
+        g = latex_to_semantic_graph("2 x")
+        assert _find_node(g, type="number")
+
+    def test_fraction(self):
+        g = latex_to_semantic_graph("\\frac{1}{2}")
+        # Should produce a number node or a division
+        assert len(g["nodes"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Functions
+# ---------------------------------------------------------------------------
+
+class TestFunctions:
+    def test_sin(self):
+        g = latex_to_semantic_graph("\\sin(x)")
+        assert _find_node(g, type="function", op="sin")
+        assert _find_node(g, id="x")
+
+    def test_cos(self):
+        g = latex_to_semantic_graph("\\cos(\\theta)")
+        assert _find_node(g, type="function", op="cos")
+
+    def test_sqrt(self):
+        g = latex_to_semantic_graph("\\sqrt{x}")
+        assert _find_node(g, type="operator", op="power") or \
+               _find_node(g, type="function", op="sqrt")
+
+
+# ---------------------------------------------------------------------------
+# Derivatives
+# ---------------------------------------------------------------------------
+
+class TestDerivatives:
+    def test_first_order_derivative(self):
+        g = latex_to_semantic_graph("\\frac{d v}{d t}")
+        deriv = _find_node(g, type="operator", op="derivative")
+        assert deriv is not None
+        assert "t" in deriv.get("with_respect_to", "")
+
+    def test_dot_notation_preprocessed(self):
+        result = _preprocess_latex(r"\dot{x}")
+        assert r"\frac" in result
+        assert "d t" in result or "dt" in result
+
+    def test_ddot_notation_preprocessed(self):
+        result = _preprocess_latex(r"\ddot{x}")
+        assert result.count(r"\frac") == 2
+
+    def test_higher_order_derivative(self):
+        result = _preprocess_latex(r"\frac{d^2 y}{dy^2}")
+        assert result.count(r"\frac") == 2
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+class TestClassification:
+    def test_algebraic_expression(self):
+        g = latex_to_semantic_graph("x^2 + y^2")
+        assert g["classification"]["kind"] == "algebraic"
+
+    def test_ode_detected(self):
+        g = latex_to_semantic_graph("\\frac{d v}{d t} = a")
+        c = g["classification"]
+        assert c["kind"] == "ODE"
+        assert c["order"] == 1
+
+    def test_algebraic_equation(self):
+        g = latex_to_semantic_graph("E = m c^2")
+        assert g["classification"]["kind"] == "algebraic"
+
+
+# ---------------------------------------------------------------------------
+# Variable overrides
+# ---------------------------------------------------------------------------
+
+class TestOverrides:
+    def test_parse_var_overrides_single(self):
+        result = parse_var_overrides(["m:unit=kg,tooltip=Mass"])
+        assert result == {"m": {"unit": "kg", "tooltip": "Mass"}}
+
+    def test_parse_var_overrides_multiple(self):
+        result = parse_var_overrides([
+            "m:unit=kg",
+            "a:unit=m/s²",
+        ])
+        assert result["m"]["unit"] == "kg"
+        assert result["a"]["unit"] == "m/s²"
+
+    def test_parse_var_overrides_none(self):
+        assert parse_var_overrides(None) == {}
+
+    def test_parse_var_overrides_invalid_format(self):
+        with pytest.raises(ValueError, match="Invalid --var format"):
+            parse_var_overrides(["bad"])
+
+    def test_parse_var_overrides_invalid_property(self):
+        with pytest.raises(ValueError, match="Invalid property"):
+            parse_var_overrides(["m:noequalssign"])
+
+    def test_overrides_applied_to_graph(self):
+        g = latex_to_semantic_graph("F = m \\cdot a", overrides={
+            "m": {"unit": "kg", "tooltip": "Inertial mass"},
+        })
+        m_node = _find_node(g, id="m")
+        assert m_node["unit"] == "kg"
+        assert m_node["tooltip"] == "Inertial mass"
+        assert m_node["label"] == "mass"  # default still present
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+class TestErrors:
+    def test_invalid_latex_raises(self):
+        with pytest.raises(ValueError, match="Failed to parse"):
+            latex_to_semantic_graph("\\frac{}")


### PR DESCRIPTION
## Summary

- **LaTeX to semantic graph parser** (`scripts/latex_to_graph.py`) — parses LaTeX expressions into JSON graphs (nodes + edges) using SymPy, with variable metadata, ODE/PDE classification, and `--var` overrides
- **Relation operators** — `\propto`, `\implies`, `\Rightarrow`, `\iff`, `\Leftrightarrow`, `\approx`, `\to`, `\rightarrow` are split before SymPy parsing and emitted as `type="relation"` nodes with label and emoji (∝, ⇒, ⇔, →, ≈)
- **Braced exponent support** — higher-order derivative regex now handles both `d^2` and `d^{2}` forms
- **Test suite** — 54 pytest tests covering graph structure, variables, functions, derivatives, integrals, relations, classification, overrides, error handling, and 10 complex real-world formulas (Euler identity, Gaussian integral, wave equation, Schrodinger, Taylor series, etc.)
- **CI workflow** — GitHub Actions runs tests on PRs/pushes via `./run.sh -m pytest`, posts a comment on failure

## Test plan

- [x] All 54 tests pass locally
- [x] Braced exponent forms (`d^{2}`, `\partial^{3}`) parse correctly
- [x] Derivative tests verify graph-level output, not just string rewriting
- [x] All 8 relation operators produce correct `type="relation"` nodes with emoji/label
- [x] Complex formulas (PDE classification, nested derivatives, summations, integrals) produce valid graphs
- [x] Existing tests unaffected by changes

Co-Authored-By: Claude <81847+claude@users.noreply.github.com>