### PR TITLE
Rewrite README landing to lead with value and audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,22 @@
 # AlgeBench
 
-Interactive 3D math visualizer built on [MathBox](https://github.com/unconed/mathbox) / [Three.js](https://github.com/mrdoob/three.js), with AI chat and narrated lessons — powered by [Gemini](https://deepmind.google/technologies/gemini/). Expressions evaluated via [math.js](https://github.com/josdejong/mathjs).
+**Math you can rotate, pause, and ask questions to.**
+
+Interactive 3D lessons with a live AI narrator. Spin up a scene, listen to it explain itself, then interrupt and ask *why* — the narrator answers in real time and the visualization responds.
+
+**Made for:** self-taught learners, students, and educators who think math makes more sense when you can see it move.
+
+![AlgeBench screenshot](docs/rotating-space-habitat.png)
 
 ```
 algebench eigenvalues.json
 ```
 
-![AlgeBench screenshot](docs/rotating-space-habitat.png)
+Built on [MathBox](https://github.com/unconed/mathbox) / [Three.js](https://github.com/mrdoob/three.js), powered by [Gemini](https://deepmind.google/technologies/gemini/), expressions via [math.js](https://github.com/josdejong/mathjs).
 
 ---
 
-## Demo Videos
+## See it in action
 
 **YouTube Channel:** [youtube.com/@AlgeBench](https://www.youtube.com/@AlgeBench)
 


### PR DESCRIPTION
## Summary
- Lead with a punchy tagline and one-sentence description of the live interaction loop — narrate, interrupt, ask *why*.
- Add an explicit "Made for" line (self-taught learners, students, educators) so visitors self-identify fast.
- Move the screenshot above the tech-stack line; demote MathBox / Three.js / Gemini / math.js to a single credit line.
- Rename "Demo Videos" → "See it in action".

## Why
GitHub visitors decide in the first ~15 seconds. The old opening led with the tech stack; the new one leads with what it does and who it's for.

## Test plan
- [ ] Render README on GitHub and confirm tagline, description, audience line, screenshot, and credits appear above the fold.

Co-Authored-By: Claude <81847+claude@users.noreply.github.com>