### PR TITLE
Fix numeric literal corruption in semantic graph labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ docs/              Architecture, sandbox model, feature ideas
 - **JS from package** — `voice-character-selector.js` is served at runtime from the installed `gemini_live_tools` package via `get_static_content()`. Do not copy it into `static/`.
 - **`.venv` is local** — recreate with `rm -rf .venv && ./algebench` if broken.
 - **Security** — path traversal and XSS vulnerabilities were previously fixed. Be careful with user-supplied paths in the server and anything that renders untrusted expressions.
+- **Always create a feature branch before starting work on an issue.** Create the branch immediately — before making any code changes — so all work is tracked from the start.
 - **Branch protection** — `main` is protected. Always use a feature branch and open a PR; never push directly to `main`. Committing directly to `main` is a last resort (e.g., force-push recovery only).
 - **PR base branch** — PRs must target `main` unless the user explicitly requests a different base. Merging into a feature branch that has already been merged to `main` will orphan the changes.
 - **⚠️ PR workflow** — the standard flow is: create branch → commit → push → create PR → **STOP**. Never merge a PR immediately after creating it. PRs must go through review first. Only merge when the user explicitly says "merge it" or "ok merge" as a **separate instruction** after reviewing. "Commit and merge" means commit + create the PR, not merge it.

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -377,7 +377,11 @@ class SemanticGraphBuilder:
                     return "-" + s
                 inner = Mul(*rest)
                 return "-" + self._subexpr_ordered(inner)
-            factors = list(expr.as_ordered_factors())
+            # Use ``expr.args`` instead of ``as_ordered_factors()`` so
+            # negative coefficients stay unified (e.g. ``Integer(-122)``
+            # remains one token instead of being split into ``-1 * 122``
+            # which renders as ``-1122`` after LaTeX juxtaposition).
+            factors = list(expr.args)
             factors.sort(key=lambda f: self._original_position(
                 str(f.args[0]) if isinstance(f, Pow) else str(f)
             ))
@@ -483,7 +487,10 @@ class SemanticGraphBuilder:
         # --- Numbers ---
         if isinstance(expr, Number):
             node_id = self._next_id("num")
-            self._add_node(node_id, label=str(expr), emoji="🔢", type="number")
+            # ``str(Float("7.2"))`` returns ``"7.20000000000000"`` (SymPy's
+            # default 15-digit printer); ``sympy.latex`` trims trailing zeros
+            # and also emits ``\frac{}`` for rationals, which KaTeX renders.
+            self._add_node(node_id, label=sympy.latex(expr), emoji="🔢", type="number")
             return node_id
 
         # --- Known functions (sin, cos, …) ---

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -288,6 +288,13 @@ class SemanticGraphBuilder:
         self._original_latex = original_latex or ""
         self._symbol_order = self._build_symbol_order()
 
+    @staticmethod
+    def _fmt_number(expr: sympy.Basic) -> str:
+        """Plain-text label for a numeric expression, without SymPy precision noise."""
+        if isinstance(expr, sympy.Float):
+            return sympy.latex(expr)
+        return str(expr)
+
     def _next_id(self, prefix: str = "n") -> str:
         self._id_counter += 1
         return f"__{prefix}_{self._id_counter}"
@@ -487,10 +494,7 @@ class SemanticGraphBuilder:
         # --- Numbers ---
         if isinstance(expr, Number):
             node_id = self._next_id("num")
-            # ``str(Float("7.2"))`` returns ``"7.20000000000000"`` (SymPy's
-            # default 15-digit printer); ``sympy.latex`` trims trailing zeros
-            # and also emits ``\frac{}`` for rationals, which KaTeX renders.
-            self._add_node(node_id, label=sympy.latex(expr), emoji="🔢", type="number")
+            self._add_node(node_id, label=self._fmt_number(expr), emoji="🔢", type="number")
             return node_id
 
         # --- Known functions (sin, cos, …) ---
@@ -543,7 +547,7 @@ class SemanticGraphBuilder:
         # --- Power with literal exponent — absorb the number into the node ---
         if isinstance(expr, Pow) and isinstance(expr.args[1], Number):
             exponent = expr.args[1]
-            exp_val = str(exponent)
+            exp_val = self._fmt_number(exponent)
             node_id = self._next_id("power")
             self._add_node(node_id, type="operator", op="power", exponent=exp_val)
             base_id = self._walk(expr.args[0])
@@ -573,7 +577,7 @@ class SemanticGraphBuilder:
         ):
             node_id = self._next_id("power")
             self._add_node(
-                node_id, type="operator", op="power", exponent=str(expr.args[1])
+                node_id, type="operator", op="power", exponent=self._fmt_number(expr.args[1])
             )
             base_id = self._walk(expr.args[0])
             self._add_edge(base_id, node_id)

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -143,6 +143,13 @@ class TestNumbersAndConstants:
         assert mul is not None
         assert "-1 122" not in mul.get("subexpr", "")
 
+    def test_float_exponent_no_precision_noise(self):
+        """Regression: x^{7.2} exponent was '7.20000000000000' (gh-145)."""
+        g = latex_to_semantic_graph("x^{7.2}")
+        pw = _find_node(g, type="operator", op="power")
+        assert pw is not None
+        assert pw["exponent"] == "7.2"
+
 
 # ---------------------------------------------------------------------------
 # Functions

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -118,6 +118,31 @@ class TestNumbersAndConstants:
         # Should produce a number node or a division
         assert len(g["nodes"]) > 0
 
+    def test_float_label_no_precision_noise(self):
+        """Regression: Float(7.2) label was '7.20000000000000' (gh-145)."""
+        g = latex_to_semantic_graph("7.2 x")
+        num = _find_node(g, type="number")
+        assert num is not None
+        assert num["label"] == "7.2"
+
+    def test_negative_integer_label_preserved(self):
+        """Regression: -122 label should stay '-122', not be split (gh-145)."""
+        g = latex_to_semantic_graph("-122")
+        num = _find_node(g, type="number", label="-122")
+        assert num is not None
+
+    def test_negative_fraction_subexpr_no_digit_concat(self):
+        """Regression: -122/7.2 multiply subexpr was '-1 122 ...' (gh-145).
+
+        When SymPy's as_ordered_factors splits Integer(-122) into -1*122,
+        the LaTeX join produces '-1122' visually.  The fix uses expr.args
+        which keeps -122 unified.
+        """
+        g = latex_to_semantic_graph(r"e^{-122/7.2}")
+        mul = _find_node(g, type="operator", op="multiply")
+        assert mul is not None
+        assert "-1 122" not in mul.get("subexpr", "")
+
 
 # ---------------------------------------------------------------------------
 # Functions


### PR DESCRIPTION
## Summary

Fixes two bugs where numeric values displayed incorrectly in semantic graph tooltips and node labels:

- **Integer corruption (`-122` → `-1122`)**: SymPy's `as_ordered_factors()` splits `Integer(-122)` into `[-1, 122]`. After joining with spaces, KaTeX renders the adjacent digits as `-1122`. Fixed by using `expr.args` which keeps negative coefficients as a single token.
- **Float precision noise (`7.2` → `7.20000000000000`)**: `str(Float("7.2"))` dumps SymPy's internal 15-digit representation. Fixed by using `sympy.latex(expr)` which trims trailing zeros.

Also adds a convention to AGENTS.md requiring feature branches before starting work on issues.

Closes #145

## Test plan

- [x] 3 new regression tests added for float precision, negative integer labels, and digit-concatenation in subexpr
- [x] Full test suite passes (192 tests)
- [x] Manual verification with the exact LaTeX from the issue (`e^{-122/7.2}`)
- [x] Visual check in UI: atmospheric-entry-physics.json, Allen-Eggers Step 7

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>