### PR TITLE
Harden /objects/ path handler against traversal

### DIFF
--- a/server.py
+++ b/server.py
@@ -2096,7 +2096,7 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
         """
         objects_root = (static_dir / "objects").resolve()
         try:
-            path = (static_dir / "objects" / filename).resolve()
+            path = (objects_root / filename).resolve()
             path.relative_to(objects_root)
         except (OSError, ValueError):
             return Response(status_code=404)

--- a/server.py
+++ b/server.py
@@ -2086,10 +2086,21 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
 
     @fastapp.get("/objects/{filename:path}")
     async def get_objects_js(filename: str):
-        """Serve ES module files from static/objects/ subdirectory."""
-        safe = filename.replace('..', '').lstrip('/')
-        path = static_dir / "objects" / safe
-        if not path.is_file() or not path.suffix == '.js':
+        """Serve ES module files from static/objects/ subdirectory.
+
+        Resolves the requested path and confirms it's still inside
+        ``static/objects`` before opening anything — this blocks
+        ``../`` traversal, encoded dot variants, absolute paths, and
+        symlinks escaping the subtree. Matches the pattern used by
+        ``/graph-panel/{path:path}``.
+        """
+        objects_root = (static_dir / "objects").resolve()
+        try:
+            path = (static_dir / "objects" / filename).resolve()
+            path.relative_to(objects_root)
+        except (OSError, ValueError):
+            return Response(status_code=404)
+        if not path.is_file() or path.suffix != '.js':
             return Response(status_code=404)
         with open(path, 'r') as f:
             js = f.read()


### PR DESCRIPTION
## Summary

- Replace the brittle `filename.replace('..', '').lstrip('/')` sanitizer in the `/objects/` route with a `Path.resolve()` + `relative_to()` containment check, matching the working pattern already used by `/graph-panel/{path:path}`.
- The old string strip was defeated by encoded dot variants (`%2e%2e`), by URL-decoded `..` reintroduced after the strip, and by symlinks escaping the subtree.
- The `.js` suffix check is kept as defense in depth.

Closes #130

## Test plan

- [x] `./run.sh -m pytest tests/` — 193 passed
- [ ] Manual smoke: request a legitimate static module (e.g. `/objects/<existing>.js`) — served with 200
- [ ] Manual smoke: request a traversal attempt (e.g. `/objects/../server.py`, `/objects/%2e%2e/server.py`) — returns 404

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>