### PR TITLE
Add { } button to open JSON browser at current semantic graph

### DIFF
--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -925,7 +925,6 @@ function currentSemanticGraphJsonPath() {
 
     let proofPath = null;
     if (entry.level === 'file') {
-        if (singleSceneRoot) return null;
         proofPath = containerToPath(lesson.proof, 'proof', entry.proof);
     } else if (entry.level === 'scene') {
         if (singleSceneRoot) {

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -902,6 +902,88 @@ function currentProofStep() {
     return entry.proof.steps[i];
 }
 
+// Build the dotted JSON path from ``state.lessonSpec`` root to the
+// ``semanticGraph`` of the currently displayed proof step, or ``null`` when
+// the path cannot be determined. Handles single-scene-as-root lessons (no
+// ``scenes`` wrapper) and single-vs-array ``proof`` fields at every level.
+function currentSemanticGraphJsonPath() {
+    const lesson = state.lessonSpec;
+    const entry = state.proofSpec && state.proofSpec[state.proofActiveIndex];
+    const stepIdx = state.proofStepIndex;
+    if (!lesson || !entry || stepIdx < 0) return null;
+
+    const singleSceneRoot = !lesson.scenes && !!lesson.elements;
+
+    function containerToPath(container, basePath, needle) {
+        if (!container) return null;
+        if (Array.isArray(container)) {
+            const i = container.indexOf(needle);
+            return i === -1 ? null : `${basePath}[${i}]`;
+        }
+        return container === needle ? basePath : null;
+    }
+
+    let proofPath = null;
+    if (entry.level === 'file') {
+        if (singleSceneRoot) return null;
+        proofPath = containerToPath(lesson.proof, 'proof', entry.proof);
+    } else if (entry.level === 'scene') {
+        if (singleSceneRoot) {
+            proofPath = containerToPath(lesson.proof, 'proof', entry.proof);
+        } else {
+            const scene = lesson.scenes && lesson.scenes[entry.sceneIndex];
+            proofPath = containerToPath(
+                scene && scene.proof,
+                `scenes[${entry.sceneIndex}].proof`,
+                entry.proof,
+            );
+        }
+    } else if (entry.level === 'step') {
+        if (singleSceneRoot) {
+            const step = lesson.steps && lesson.steps[entry.stepIndex];
+            proofPath = containerToPath(
+                step && step.proof,
+                `steps[${entry.stepIndex}].proof`,
+                entry.proof,
+            );
+        } else {
+            const step = lesson.scenes &&
+                lesson.scenes[entry.sceneIndex] &&
+                lesson.scenes[entry.sceneIndex].steps &&
+                lesson.scenes[entry.sceneIndex].steps[entry.stepIndex];
+            proofPath = containerToPath(
+                step && step.proof,
+                `scenes[${entry.sceneIndex}].steps[${entry.stepIndex}].proof`,
+                entry.proof,
+            );
+        }
+    }
+
+    if (!proofPath) return null;
+    return `${proofPath}.steps[${stepIdx}].semanticGraph`;
+}
+
+function updateShowJsonButtonState() {
+    const btn = document.getElementById('graph-show-json');
+    if (!btn) return;
+    const step = currentProofStep();
+    const hasGraph = !!(step && step.semanticGraph && step.semanticGraph.graph);
+    btn.disabled = !hasGraph;
+}
+
+function setupShowJsonButton() {
+    const btn = document.getElementById('graph-show-json');
+    if (!btn) return;
+    btn.addEventListener('click', () => {
+        const path = currentSemanticGraphJsonPath();
+        if (!path || typeof window.algebenchOpenJsonBrowserAtPath !== 'function') {
+            return;
+        }
+        window.algebenchOpenJsonBrowserAtPath(path);
+    });
+    updateShowJsonButtonState();
+}
+
 function stableStepKey(step) {
     return `${state.proofActiveIndex}:${state.proofStepIndex}:${step.id || ''}`;
 }
@@ -933,6 +1015,7 @@ function escapeHtml(s) {
 
 function onStepChange() {
     updateTreeHighlight();
+    updateShowJsonButtonState();
     if (isGraphModeActive()) renderCurrentStepGraph();
 }
 
@@ -1134,6 +1217,7 @@ function init() {
     setupDockTabs();
     setupGraphControls();
     setupZoomControls();
+    setupShowJsonButton();
     setupControlsOverflowWatcher();
     window.addEventListener('algebench:stepchange', onStepChange);
     window.addEventListener('algebench:proofload', onProofLoad);

--- a/static/index.html
+++ b/static/index.html
@@ -84,6 +84,7 @@
                     </select>
                 </div>
                 <div id="graph-controls-right" class="graph-controls">
+                    <button id="graph-show-json" class="graph-ctrl-btn" title="Show semantic graph in JSON browser" aria-label="Show semantic graph JSON" disabled>{ }</button>
                     <div id="graph-zoom-controls">
                         <button id="graph-zoom-out" class="graph-ctrl-btn" title="Zoom out" aria-label="Zoom out">&minus;</button>
                         <span id="graph-zoom-level" class="graph-ctrl-label" aria-live="polite">100%</span>

--- a/static/json-browser.js
+++ b/static/json-browser.js
@@ -620,6 +620,20 @@ export function setupJsonViewer() {
         if (select) selectJsonLine(line);
     }
 
+    // Open the overlay (rebuilding JSON + tree if it was hidden) and navigate
+    // to ``path``. If the overlay is already open, just navigate. Returns
+    // ``true`` when ``path`` resolved to a known line, ``false`` otherwise.
+    // After the btn click rebuilds the tree synchronously, navigation can
+    // run immediately — ``_pathLineMap`` and the DOM tree items are already
+    // populated. Layout measurements during the scroll happen on the next
+    // frame anyway.
+    window.algebenchOpenJsonBrowserAtPath = function(path) {
+        if (overlay.classList.contains('hidden')) btn.click();
+        if (_pathLineMap[path] === undefined) return false;
+        syncJsonFromTreeClick(path, { select: true });
+        return true;
+    };
+
     // Wire up tree clicks (delegated)
     if (treePanel) {
         treePanel.addEventListener('click', e => {

--- a/static/json-browser.js
+++ b/static/json-browser.js
@@ -620,15 +620,10 @@ export function setupJsonViewer() {
         if (select) selectJsonLine(line);
     }
 
-    // Open the overlay (rebuilding JSON + tree if it was hidden) and navigate
-    // to ``path``. If the overlay is already open, just navigate. Returns
-    // ``true`` when ``path`` resolved to a known line, ``false`` otherwise.
-    // After the btn click rebuilds the tree synchronously, navigation can
-    // run immediately — ``_pathLineMap`` and the DOM tree items are already
-    // populated. Layout measurements during the scroll happen on the next
-    // frame anyway.
+    // Rebuild the JSON overlay from the current lessonSpec and navigate to
+    // ``path``. Returns ``true`` when the path resolved, ``false`` otherwise.
     window.algebenchOpenJsonBrowserAtPath = function(path) {
-        if (overlay.classList.contains('hidden')) btn.click();
+        btn.click(); // always rebuild from current lessonSpec and ensure overlay is visible
         if (_pathLineMap[path] === undefined) return false;
         syncJsonFromTreeClick(path, { select: true });
         return true;


### PR DESCRIPTION
Closes #157

## Summary

- Adds a `{ }` button to the semantic graph panel controls that opens the JSON browser overlay and navigates directly to the `semanticGraph` node for the current proof step
- Exposes `window.algebenchOpenJsonBrowserAtPath(path)` from the JSON browser closure so other components can programmatically open and navigate to a specific JSON path
- Builds the correct dotted JSON path for all proof location variants: file-level, scene-level, and step-level proofs; single object vs array `proof` fields; single-scene-as-root lessons

## Changed files

- **static/index.html** — Added the `{ }` button in `#graph-controls-right`
- **static/graph-view.js** — Added `currentSemanticGraphJsonPath()` path builder, button setup/state management, and wired into `onStepChange()` and `init()`
- **static/json-browser.js** — Exposed `algebenchOpenJsonBrowserAtPath` window global that opens the overlay and navigates to a path

## Test plan

- [x] 226 existing tests pass
- [x] Button appears disabled when no semantic graph exists for the current step
- [x] Button enables when navigating to a step with a semantic graph
- [x] Clicking the button opens the JSON browser at the correct `semanticGraph` path
- [x] Button state updates correctly when stepping through proof steps
- [x] Works with single-scene-as-root lessons

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>