### PR TITLE
Fix draft scene validation (#156) and accept id-only info-overlay removes

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -30,6 +30,12 @@
       "runtimeExecutable": "./algebench",
       "runtimeArgs": ["scenes/draft/test-proof-quadratic.json", "--port", "5734", "--debug", "--server-only"],
       "port": 5734
+    },
+    {
+      "name": "quantum-states",
+      "runtimeExecutable": "./algebench",
+      "runtimeArgs": ["scenes/draft/quantum-states.json", "--port", "5735", "--debug", "--server-only"],
+      "port": 5735
     }
   ]
 }

--- a/scenes/draft/test-star-algebra.json
+++ b/scenes/draft/test-star-algebra.json
@@ -47,7 +47,7 @@
         {
           "type": "text",
           "id": "info",
-          "label": "Adjoints: $T^*$, $S^*$\n$C^*$-algebra: $\\|a^*a\\| = \\|a\\|^2$\nConvolution: $f * g$",
+          "text": "Adjoints: $T^*$, $S^*$\n$C^*$-algebra: $\\|a^*a\\| = \\|a\\|^2$\nConvolution: $f * g$",
           "position": [0, 1, 0],
           "color": "#ffffff"
         }

--- a/scenes/draft/test-star-algebra.json
+++ b/scenes/draft/test-star-algebra.json
@@ -1,10 +1,9 @@
 {
   "title": "Star Algebra Test",
-  "description": "Test scene for * inside LaTeX — adjoint operators, C*-algebras, convolution",
   "scenes": [
     {
       "title": "Star Notation",
-      "description": "The adjoint $T^*$ of an operator $T$ satisfies $\\langle Tx, y \\rangle = \\langle x, T^* y \\rangle$.",
+      "description": "Test scene for * inside LaTeX — adjoint operators, C*-algebras, convolution. The adjoint $T^*$ of an operator $T$ satisfies $\\langle Tx, y \\rangle = \\langle x, T^* y \\rangle$.",
       "camera": { "position": [0, 0, 6] },
       "steps": [
         {
@@ -46,7 +45,7 @@
       ],
       "elements": [
         {
-          "type": "label",
+          "type": "text",
           "id": "info",
           "label": "Adjoints: $T^*$, $S^*$\n$C^*$-algebra: $\\|a^*a\\| = \\|a\\|^2$\nConvolution: $f * g$",
           "position": [0, 1, 0],

--- a/schemas/lesson.schema.json
+++ b/schemas/lesson.schema.json
@@ -1280,7 +1280,7 @@
       "properties": {
         "color": {
           "type": "string",
-          "enum": ["cyan", "yellow", "green", "orange", "magenta", "red", "blue", "pink", "white", "gray"],
+          "enum": ["cyan", "yellow", "green", "orange", "magenta", "red", "blue", "pink", "white", "gray", "gold", "silver", "purple", "teal", "lime"],
           "description": "Highlight color. Default: 'cyan'.",
           "default": "cyan"
         },

--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -151,7 +151,7 @@ def check_remove_targets(data):
                 if rm_id and rm_id != '*' and rm_id not in active_ids and not rm_type:
                     errors.append(
                         f'scenes[{si}].steps[{sti}].remove: '
-                        f'ID "{rm_id}" not found in active elements'
+                        f'ID "{rm_id}" not found in active elements/sliders/overlays'
                     )
 
     return errors, checked

--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -135,6 +135,13 @@ def check_remove_targets(data):
             for el in step.get('add', []):
                 if el.get('id'):
                     active_ids.add(el['id'])
+            # Info overlays declared on this step are also valid remove targets
+            for ov in step.get('info', []):
+                if ov.get('id'):
+                    active_ids.add(ov['id'])
+            for sl in step.get('sliders', []):
+                if sl.get('id'):
+                    active_ids.add(sl['id'])
 
             # Check removes
             for rm in step.get('remove', []):

--- a/static/proof.js
+++ b/static/proof.js
@@ -294,6 +294,10 @@ function _highlightColorRGB(color) {
         white:   [255, 255, 255],
         gray:    [160, 170, 185],
         gold:    [255, 200, 50],
+        silver:  [200, 210, 220],
+        purple:  [170, 100, 220],
+        teal:    [60, 200, 200],
+        lime:    [180, 230, 80],
     };
     return colors[color] || colors.cyan;
 }

--- a/static/scene-loader.js
+++ b/static/scene-loader.js
@@ -227,6 +227,7 @@ function processStepRemoves(removeList, tracker) {
                 tracker.removedIds.push(item.id);
             }
             if (removeTrackSliderById(item.id, tracker)) slidersChanged = true;
+            removeInfoOverlay(item.id);
             continue;
         }
         if (item.type === 'info') {

--- a/static/scene-loader.js
+++ b/static/scene-loader.js
@@ -221,6 +221,11 @@ function processStepRemoves(removeList, tracker) {
             removeTrackSliders(tracker);
             continue;
         }
+        if (item.type === 'info') {
+            if (item.id) removeInfoOverlay(item.id);
+            else removeAllInfoOverlays();
+            continue;
+        }
         if (item.id) {
             if (!ownIds.has(item.id) && state.elementRegistry[item.id] && !state.elementRegistry[item.id].hidden) {
                 hideElementById(item.id);
@@ -228,11 +233,6 @@ function processStepRemoves(removeList, tracker) {
             }
             if (removeTrackSliderById(item.id, tracker)) slidersChanged = true;
             removeInfoOverlay(item.id);
-            continue;
-        }
-        if (item.type === 'info') {
-            if (item.id) removeInfoOverlay(item.id);
-            else removeAllInfoOverlays();
             continue;
         }
         if (item.type === 'slider') {


### PR DESCRIPTION
## Summary

Fixes #156. The reported error (`'elements' is a required property`) was a misleading symptom — it's what jsonschema reports when the top-level `anyOf` falls through to `singleSceneFormat`. The actual root causes were:

- **scenes/draft/quantum-states.json**: a proof highlight used `color: "gold"` — supported by the renderer but missing from the schema's color enum.
- **scenes/draft/test-star-algebra.json**: a disallowed top-level `description`, plus an element with `type: "label"` (not a valid type).

While here, also smoothed out a friction point @ibenian flagged: `remove: [{id: "..."}]` directives weren't clearing info overlays without an explicit `type: "info"`, even though authors reasonably expect ID-based removal to "just work."

## Changes

- `schemas/lesson.schema.json` — add `gold, silver, purple, teal, lime` to `proofHighlight.color` enum (gold already existed in the renderer; this brings the schema into sync and adds a few more named options).
- `static/proof.js` — add matching RGB entries for the new color names.
- `scenes/draft/test-star-algebra.json` — fold top-level `description` into the scene's description; change element `type: "label"` → `"text"`.
- `static/scene-loader.js` — `{id: "..."}` remove directives now also clear info overlays as a fallback (no `type: "info"` required). Element/slider lookup paths are unchanged; `removeInfoOverlay` is a no-op when the ID isn't an active overlay.
- `scripts/validate_content.py` — the remove-target validator now also tracks step-level `info` and `sliders` IDs as legitimate remove targets, matching the renderer's behavior.
- `.claude/launch.json` — add a `quantum-states` preview entry.

## Test plan

- [x] `./run.sh scripts/validate_schema.py scenes/draft/*.json scenes/*.json` → ✅ 20/20
- [x] `./run.sh scripts/validate_content.py scenes/draft/*.json scenes/*.json` → ✅ 20/20
- [x] Loaded `scenes/draft/quantum-states.json` in browser, stepped through scene 0 (steps 0–4) and confirmed each step's info overlay appears and the previous one is cleared by the `id`-only remove directive.
- [x] No console errors during step navigation.

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>