### PR TITLE
feat(graph): AI Ask buttons on semantic graph nodes (#171)

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -54,7 +54,7 @@ function setPresetPrompts(prompts) {
         const btn = document.createElement('button');
         btn.className = 'preset-prompt-btn';
         btn.textContent = text;
-        btn.title = text + '\n\nClick to send · ⌘-click to edit';
+        btn.title = text + '\n\nClick to send · ⌘/Ctrl-click to edit';
         btn.addEventListener('click', (e) => {
             if (e.metaKey || e.ctrlKey) {
                 const input = document.getElementById('chat-input');

--- a/static/chat.js
+++ b/static/chat.js
@@ -54,9 +54,9 @@ function setPresetPrompts(prompts) {
         const btn = document.createElement('button');
         btn.className = 'preset-prompt-btn';
         btn.textContent = text;
-        btn.title = text + '\n\nClick to send · Shift+click to edit';
+        btn.title = text + '\n\nClick to send · ⌘-click to edit';
         btn.addEventListener('click', (e) => {
-            if (e.shiftKey) {
+            if (e.metaKey || e.ctrlKey) {
                 const input = document.getElementById('chat-input');
                 if (input) {
                     input.value = text;

--- a/static/graph-panel/graph-panel.css
+++ b/static/graph-panel/graph-panel.css
@@ -83,11 +83,16 @@
 .graph-panel-info .gp-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 0.5rem;
 }
 .graph-panel-info .gp-header h3 {
   margin: 0;
+  flex: 1;
+}
+.graph-panel-info .gp-header .gp-close {
+  position: static;
+  top: auto;
+  right: auto;
 }
 .graph-panel-info .graph-panel-ai-btn {
   opacity: 1;

--- a/static/graph-panel/graph-panel.css
+++ b/static/graph-panel/graph-panel.css
@@ -80,6 +80,26 @@
   border-left: 3px solid rgba(128, 128, 128, 0.3);
 }
 
+.graph-panel-info .gp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+.graph-panel-info .gp-header h3 {
+  margin: 0;
+}
+.graph-panel-info .graph-panel-ai-btn {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.graph-node-ai-btn {
+  width: 22px;
+  height: 22px;
+  transition: opacity 0.12s ease;
+}
+
 /* Transition for highlight/dim */
 svg .node,
 svg .edgePath,

--- a/static/graph-panel/graph-panel.js
+++ b/static/graph-panel/graph-panel.js
@@ -15,6 +15,8 @@
  *   setTimeout(() => gp.attach(), 1000);
  */
 
+import { makeAiAskButton } from "/labels.js";
+
 const PANEL_FIELDS = [
   ["label", "Label"],
   ["type", "Type"],
@@ -45,8 +47,23 @@ export class SemanticGraphPanel {
 
     this.tooltip = opts.tooltip || this._createTooltip();
     this.panel = opts.panel || this._createPanel();
+    if (!this.panel.querySelector(".graph-panel-ai-btn")) {
+      this._ensurePanelHeader(this.panel);
+      this._injectPanelAskButton(this.panel);
+    }
     this._activeNode = null;
     this._handlers = [];
+    this._nodeAskBtn = null;
+  }
+
+  _ensurePanelHeader(panelEl) {
+    if (panelEl.querySelector(".gp-header")) return;
+    const h3 = panelEl.querySelector("h3");
+    if (!h3) return;
+    const header = document.createElement("div");
+    header.className = "gp-header";
+    h3.replaceWith(header);
+    header.appendChild(h3);
   }
 
   /* ------------------------------------------------------------------ */
@@ -92,14 +109,52 @@ export class SemanticGraphPanel {
     el.className = "graph-panel-info";
     el.innerHTML =
       '<button class="gp-close">&times;</button>' +
-      '<h3>Node Details</h3>' +
+      '<div class="gp-header"><h3>Node Details</h3></div>' +
       '<div class="gp-symbol"></div>' +
       '<div class="gp-fields"></div>';
     el.querySelector(".gp-close").addEventListener("click", () => {
       el.classList.remove("open");
     });
+    this._injectPanelAskButton(el);
     document.body.appendChild(el);
     return el;
+  }
+
+  _injectPanelAskButton(panelEl) {
+    const header = panelEl.querySelector(".gp-header") || panelEl;
+    const btn = makeAiAskButton(
+      "ai-ask-btn graph-panel-ai-btn",
+      "Ask AI about this node",
+      () => this._buildNodeAskMessage(this._activeNode),
+    );
+    header.appendChild(btn);
+    this._panelAskBtn = btn;
+  }
+
+  _buildNodeAskMessage(nodeId) {
+    if (!nodeId) return "Explain this graph node.";
+    const data = this._nodeData[nodeId] || {};
+    const subexpr = this._subexprs[nodeId];
+    const lines = ["Explain this semantic graph node:"];
+    if (data.label) lines.push(`Label: ${data.label}`);
+    if (data.type) lines.push(`Type: ${data.type}`);
+    if (data.role) lines.push(`Role: ${data.role}`);
+    if (data.quantity) lines.push(`Quantity: ${data.quantity}`);
+    if (data.dimension) lines.push(`Dimension: ${data.dimension}`);
+    if (data.unit) lines.push(`Unit: ${data.unit}`);
+    if (data.value !== undefined) lines.push(`Value: ${data.value}`);
+    if (data.op) lines.push(`Operation: ${data.op}`);
+    if (subexpr) lines.push(`Expression: $${subexpr}$`);
+    if (data.description) lines.push(`Description: ${data.description}`);
+    const incoming = [];
+    const outgoing = [];
+    for (const [src, dst] of this._edges) {
+      if (dst === nodeId && src !== nodeId) incoming.push(src);
+      if (src === nodeId && dst !== nodeId) outgoing.push(dst);
+    }
+    if (incoming.length) lines.push(`Incoming: ${incoming.join(", ")}`);
+    if (outgoing.length) lines.push(`Outgoing: ${outgoing.join(", ")}`);
+    return lines.join("\n");
   }
 
   /* ------------------------------------------------------------------ */
@@ -234,9 +289,56 @@ export class SemanticGraphPanel {
   /* Attach / detach                                                    */
   /* ------------------------------------------------------------------ */
 
+  _ensureNodeAskBtn() {
+    if (this._nodeAskBtn) return this._nodeAskBtn;
+    const btn = makeAiAskButton(
+      "ai-ask-btn graph-node-ai-btn",
+      "Ask AI about this node",
+      () => this._buildNodeAskMessage(this._hoveredAskNodeId || this._activeNode),
+    );
+    btn.style.position = "fixed";
+    btn.style.opacity = "0";
+    btn.style.pointerEvents = "none";
+    btn.style.zIndex = "950";
+    btn.addEventListener("mouseenter", () => this._cancelNodeAskHide());
+    btn.addEventListener("mouseleave", () => this._hideNodeAskBtn());
+    document.body.appendChild(btn);
+    this._nodeAskBtn = btn;
+    return btn;
+  }
+
+  _showNodeAskBtnFor(nodeEl) {
+    const btn = this._ensureNodeAskBtn();
+    this._cancelNodeAskHide();
+    const r = nodeEl.getBoundingClientRect();
+    btn.style.left = (r.right - 6) + "px";
+    btn.style.top = (r.top - 10) + "px";
+    btn.style.opacity = "1";
+    btn.style.pointerEvents = "auto";
+  }
+
+  _cancelNodeAskHide() {
+    if (this._nodeAskHideTimer) {
+      clearTimeout(this._nodeAskHideTimer);
+      this._nodeAskHideTimer = null;
+    }
+  }
+
+  _hideNodeAskBtn() {
+    if (!this._nodeAskBtn) return;
+    const btn = this._nodeAskBtn;
+    this._cancelNodeAskHide();
+    this._nodeAskHideTimer = setTimeout(() => {
+      btn.style.opacity = "0";
+      btn.style.pointerEvents = "none";
+    }, 220);
+  }
+
   attach() {
     const svg = this.container.querySelector("svg");
     if (!svg) return;
+
+    this._askNodeEls = [];
 
     svg.querySelectorAll(".node").forEach(el => {
       const id = el.id.replace(/^flowchart-/, "").replace(/-\d+$/, "");
@@ -268,6 +370,7 @@ export class SemanticGraphPanel {
           this._activeNode = null;
           this._clearHighlight();
           this.panel.classList.remove("open");
+          this._hideNodeAskBtn();
         } else {
           this._activeNode = id;
           this._highlight(id);
@@ -277,6 +380,10 @@ export class SemanticGraphPanel {
       };
       el.addEventListener("click", onClick);
       this._handlers.push([el, "click", onClick]);
+
+      // Track this node for the global pointer-tracking ask-button logic.
+      this._askNodeEls = this._askNodeEls || [];
+      this._askNodeEls.push({ id, el });
     });
 
     const onDocClick = (e) => {
@@ -293,10 +400,53 @@ export class SemanticGraphPanel {
       this._activeNode = null;
       this._clearHighlight();
       this.panel.classList.remove("open");
+      this._hideNodeAskBtn();
       this._emitSelectionChange();
     };
     document.addEventListener("click", onDocClick);
     this._handlers.push([document, "click", onDocClick]);
+
+    // Global pointer tracker for the ask button — robust to gaps between a
+    // node and the floating button when nodes are large or shapes are wide.
+    const onPointerMove = (e) => {
+      const x = e.clientX;
+      const y = e.clientY;
+      const btn = this._nodeAskBtn;
+      if (btn) {
+        const br = btn.getBoundingClientRect();
+        const padded = (r, pad) => x >= r.left - pad && x <= r.right + pad
+          && y >= r.top - pad && y <= r.bottom + pad;
+        if (btn.style.opacity === "1" && padded(br, 12)) {
+          this._cancelNodeAskHide();
+          return;
+        }
+      }
+      let bestEl = null;
+      let bestId = null;
+      let bestDist = Infinity;
+      for (const { id, el } of this._askNodeEls || []) {
+        const op = el.style.opacity;
+        if (op && parseFloat(op) < 0.9) continue;
+        const r = el.getBoundingClientRect();
+        const padX = 24;
+        const padY = 18;
+        if (x >= r.left - padX && x <= r.right + padX
+            && y >= r.top - padY && y <= r.bottom + padY) {
+          const cx = (r.left + r.right) / 2;
+          const cy = (r.top + r.bottom) / 2;
+          const d = Math.hypot(x - cx, y - cy);
+          if (d < bestDist) { bestDist = d; bestEl = el; bestId = id; }
+        }
+      }
+      if (bestEl) {
+        this._hoveredAskNodeId = bestId;
+        this._showNodeAskBtnFor(bestEl);
+      } else {
+        this._hideNodeAskBtn();
+      }
+    };
+    document.addEventListener("pointermove", onPointerMove);
+    this._handlers.push([document, "pointermove", onPointerMove]);
   }
 
   /**
@@ -360,6 +510,8 @@ export class SemanticGraphPanel {
     this._handlers = [];
     if (this.tooltip.parentNode) this.tooltip.remove();
     if (this.panel.parentNode) this.panel.remove();
+    if (this._nodeAskBtn && this._nodeAskBtn.parentNode) this._nodeAskBtn.remove();
+    this._nodeAskBtn = null;
   }
 
   /* ------------------------------------------------------------------ */

--- a/static/graph-panel/graph-panel.js
+++ b/static/graph-panel/graph-panel.js
@@ -64,6 +64,11 @@ export class SemanticGraphPanel {
     header.className = "gp-header";
     h3.replaceWith(header);
     header.appendChild(h3);
+    // Re-parent the close button into the header so it shares the flex
+    // layout instead of sitting on top of (and visually colliding with)
+    // the AI Ask button.
+    const close = panelEl.querySelector(".gp-close");
+    if (close) header.appendChild(close);
   }
 
   /* ------------------------------------------------------------------ */
@@ -108,8 +113,8 @@ export class SemanticGraphPanel {
     const el = document.createElement("div");
     el.className = "graph-panel-info";
     el.innerHTML =
-      '<button class="gp-close">&times;</button>' +
-      '<div class="gp-header"><h3>Node Details</h3></div>' +
+      '<div class="gp-header"><h3>Node Details</h3>' +
+      '<button class="gp-close">&times;</button></div>' +
       '<div class="gp-symbol"></div>' +
       '<div class="gp-fields"></div>';
     el.querySelector(".gp-close").addEventListener("click", () => {
@@ -127,7 +132,9 @@ export class SemanticGraphPanel {
       "Ask AI about this node",
       () => this._buildNodeAskMessage(this._activeNode),
     );
-    header.appendChild(btn);
+    const close = header.querySelector(".gp-close");
+    if (close) header.insertBefore(btn, close);
+    else header.appendChild(btn);
     this._panelAskBtn = btn;
   }
 

--- a/static/labels.js
+++ b/static/labels.js
@@ -266,13 +266,23 @@ export function openChatPanel() {
 export function makeAiAskButton(className, title, getMessage) {
     const btn = document.createElement('button');
     btn.className = className;
-    btn.title = title;
+    btn.title = title + '\n\nClick to send · ⌘-click to edit';
     btn.innerHTML = AI_SPARKLE_SVG;
     btn.addEventListener('click', (e) => {
         e.stopPropagation();
-        if (typeof sendChatMessage !== 'function') return;
+        const message = getMessage();
         openChatPanel();
-        sendChatMessage(getMessage());
+        if (e.metaKey || e.ctrlKey) {
+            const input = document.getElementById('chat-input');
+            if (input) {
+                input.value = message;
+                input.focus();
+                input.dispatchEvent(new Event('input'));
+            }
+            return;
+        }
+        if (typeof sendChatMessage !== 'function') return;
+        sendChatMessage(message);
     });
     return btn;
 }

--- a/static/labels.js
+++ b/static/labels.js
@@ -266,7 +266,7 @@ export function openChatPanel() {
 export function makeAiAskButton(className, title, getMessage) {
     const btn = document.createElement('button');
     btn.className = className;
-    btn.title = title + '\n\nClick to send · ⌘-click to edit';
+    btn.title = title + '\n\nClick to send · ⌘/Ctrl-click to edit';
     btn.innerHTML = AI_SPARKLE_SVG;
     btn.addEventListener('click', (e) => {
         e.stopPropagation();


### PR DESCRIPTION
## Summary

Adds AI Ask buttons to the semantic graph and unifies how all AI Ask buttons handle modifier keys.

### Semantic graph (closes #171)

- **Persistent button** in the Node Details panel header — always visible while the panel is open. Click sends the selected node's context (label, type, role, expression, description, neighbors) to the AI chat.
- **Floating button** that appears on hover of any non-dimmed node and tracks that node's top-right corner. Uses a global pointer tracker with generous padding around both the node and the button, so moving the cursor from a large node onto the floating button doesn't snap it away mid-click.
- `.gp-close` was moved into the new flex `.gp-header` so the close button shares the layout with the AI Ask button instead of overlapping it via absolute positioning.

### ⌘/Ctrl-click to edit (applies to every AI Ask button)

Holding ⌘ (or Ctrl) on any AI Ask button now **stages** the generated message into the chat input and focuses it, instead of sending. Plain click is unchanged.

- Centralized in `makeAiAskButton` so it propagates to proof steps, proof goal, doc/scene content, and the new graph buttons.
- Preset prompts now also use ⌘/Ctrl (was Shift) for consistency.
- Tooltip on every button reads: *Click to send · ⌘/Ctrl-click to edit*.

## Test plan

- [ ] Open a proof step with a semantic graph
- [ ] Verify the Node Details panel shows an AI Ask button next to the title; clicking it opens the chat with node context
- [ ] Hover graph nodes — floating AI button appears at the hovered node's top-right corner
- [ ] Move the cursor from a large node onto the floating button — it stays visible and clicks register
- [ ] Select a node, hover dimmed (non-upstream) nodes — button does NOT appear
- [ ] ⌘/Ctrl-click a graph AI button — message is staged in chat input, not sent
- [ ] ⌘/Ctrl-click a proof step / doc / scene-description AI button — same behavior
- [ ] ⌘/Ctrl-click a preset prompt — staged into input (was Shift before)
- [ ] Plain click on any of the above still sends
- [ ] In standalone panel mode, the close button and AI Ask button do not overlap

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>