### PR TITLE
docs(agents): require syncing main before creating a feature branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ docs/              Architecture, sandbox model, feature ideas
 - **JS from package** — `voice-character-selector.js` is served at runtime from the installed `gemini_live_tools` package via `get_static_content()`. Do not copy it into `static/`.
 - **`.venv` is local** — recreate with `rm -rf .venv && ./algebench` if broken.
 - **Security** — path traversal and XSS vulnerabilities were previously fixed. Be careful with user-supplied paths in the server and anything that renders untrusted expressions.
+- **Sync `main` before branching.** Run `git fetch origin && git checkout main && git pull --ff-only origin main` *before* `git checkout -b <feature>`. Branching off a stale `main` invites needless rebases and merge conflicts later.
 - **Always create a feature branch before starting work on an issue.** Create the branch immediately — before making any code changes — so all work is tracked from the start.
 - **Branch protection** — `main` is protected. Always use a feature branch and open a PR; never push directly to `main`. Committing directly to `main` is a last resort (e.g., force-push recovery only).
 - **PR base branch** — PRs must target `main` unless the user explicitly requests a different base. Merging into a feature branch that has already been merged to `main` will orphan the changes.


### PR DESCRIPTION
## Summary
- Adds an explicit bullet to `AGENTS.md`: fetch `origin` and fast-forward `main` *before* `git checkout -b <feature>`.
- Closes the workflow gap behind a recent slip where a feature branch got created without first syncing `main`.

## Test plan
- [x] Read the new bullet in `AGENTS.md` Key Conventions; verify wording matches the existing tone.

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>