### PR TITLE
fix(enricher): restore parser-owned LaTeX fields so Gemini can't mangle subexpr

### DIFF
--- a/agents/semantic_graph_enricher.py
+++ b/agents/semantic_graph_enricher.py
@@ -394,6 +394,50 @@ def _drop_phantom_nodes_and_edges(
         output_graph["edges"] = kept_edges
 
 
+_STRUCTURAL_NODE_FIELDS = (
+    "subexpr",
+    "latex",
+    "type",
+    "op",
+    "exponent",
+    "with_respect_to",
+)
+
+
+def _restore_structural_fields(
+    input_graph: Dict[str, Any],
+    output_graph: Dict[str, Any],
+) -> None:
+    """Copy structural / parser-derived fields from input nodes to output.
+
+    ``subexpr`` and ``latex`` are deterministic LaTeX strings produced by
+    ``scripts/latex_to_graph.py`` — the enricher should never rewrite them.
+    Gemini in JSON mode occasionally double-escapes backslashes (e.g.
+    ``\\frac`` → ``\\\\frac``), which mangles the rendered tooltip and chat
+    expression display (issue #182). Other structural fields (``type``,
+    ``op``, ``exponent``, ``with_respect_to``) are also parser-owned, not
+    semantic enrichment, so we restore them verbatim too.
+    """
+    in_by_id: Dict[str, Dict[str, Any]] = {}
+    for n in input_graph.get("nodes") or []:
+        if isinstance(n, dict) and isinstance(n.get("id"), str):
+            in_by_id[n["id"]] = n
+    out_nodes = output_graph.get("nodes")
+    if not isinstance(out_nodes, list):
+        return
+    for node in out_nodes:
+        if not isinstance(node, dict):
+            continue
+        src = in_by_id.get(node.get("id"))
+        if not isinstance(src, dict):
+            continue
+        for field in _STRUCTURAL_NODE_FIELDS:
+            if field in src:
+                node[field] = src[field]
+            else:
+                node.pop(field, None)
+
+
 def _strip_bad_emojis(graph: Dict[str, Any]) -> None:
     """Remove ``emoji`` fields that are clearly not a single emoji glyph.
 
@@ -423,6 +467,7 @@ def _stamp_enriched(
     client. Preserves any ``reasoning`` the model already filled in on the
     ``enrichment`` block. Mutates and returns ``output_graph``."""
     _drop_phantom_nodes_and_edges(input_graph, output_graph)
+    _restore_structural_fields(input_graph, output_graph)
     _strip_bad_emojis(output_graph)
     block = output_graph.get("enrichment")
     if not isinstance(block, dict):

--- a/tests/agents/test_semantic_graph_enricher.py
+++ b/tests/agents/test_semantic_graph_enricher.py
@@ -497,6 +497,56 @@ def test_phantom_nodes_added_by_model_are_dropped() -> None:
     assert out["nodes"][0]["quantity"] == "acceleration"
 
 
+def test_structural_fields_restored_from_input(monkeypatch) -> None:
+    # Gemini in JSON mode occasionally double-escapes backslashes in
+    # ``subexpr`` (``\frac`` → ``\\frac``), which breaks the rendered
+    # tooltip and chat "Expression:" line — both feed the value to
+    # KaTeX, where ``\\`` is a line break and the rest renders as raw
+    # letters. Issue #182. Structural fields (``subexpr``, ``latex``,
+    # ``type``, ``op``, ``exponent``, ``with_respect_to``) are
+    # parser-derived and must be restored verbatim from the input.
+    enricher = _build_agent_with(
+        test_output={
+            "nodes": [
+                {
+                    "id": "__power_7",
+                    "type": "operator",
+                    "op": "power",
+                    "exponent": "-1",
+                    # Mangled by the model:
+                    "subexpr": "\\\\frac{1}{\\\\rho A C_{d}}",
+                    "description": "Inverse of the drag factors.",
+                    "dimension": "M⁻¹·L",
+                    "unit": "m/kg",
+                },
+            ],
+            "edges": [],
+        },
+        critic_outputs=[{"ok": True, "mismatched_node_ids": []}],
+    )
+    input_graph = {
+        "nodes": [
+            {
+                "id": "__power_7",
+                "type": "operator",
+                "op": "power",
+                "exponent": "-1",
+                "subexpr": "\\frac{1}{\\rho A C_{d}}",
+            },
+        ],
+        "edges": [],
+    }
+    out = enricher.enrich(input_graph, context=_ATMOSPHERIC_CONTEXT)
+    node = out["nodes"][0]
+    # Parser-owned fields are restored verbatim — no double backslashes.
+    assert node["subexpr"] == "\\frac{1}{\\rho A C_{d}}"
+    assert node["op"] == "power"
+    assert node["exponent"] == "-1"
+    # The semantic enrichment fields the model contributed survive.
+    assert node["description"] == "Inverse of the drag factors."
+    assert node["unit"] == "m/kg"
+
+
 def test_non_emoji_text_in_emoji_field_is_stripped() -> None:
     # Gemini sometimes returns a word in the `emoji` field by mistake
     # (e.g. "ускорение" / "acceleration"). The schema cap is generous so

--- a/tests/agents/test_semantic_graph_enricher.py
+++ b/tests/agents/test_semantic_graph_enricher.py
@@ -497,7 +497,7 @@ def test_phantom_nodes_added_by_model_are_dropped() -> None:
     assert out["nodes"][0]["quantity"] == "acceleration"
 
 
-def test_structural_fields_restored_from_input(monkeypatch) -> None:
+def test_structural_fields_restored_from_input() -> None:
     # Gemini in JSON mode occasionally double-escapes backslashes in
     # ``subexpr`` (``\frac`` → ``\\frac``), which breaks the rendered
     # tooltip and chat "Expression:" line — both feed the value to


### PR DESCRIPTION
## Summary
- Gemini's structured-JSON output occasionally double-escaped backslashes in the ``subexpr`` field (``\frac`` → ``\\frac``), so KaTeX rendered the graph node tooltip and chat *Expression:* line as raw italic letters (``frac1rhoAC_d``) instead of the proper $\frac{1}{\rho A C_d}$ fraction.
- New ``_restore_structural_fields`` step in ``_stamp_enriched`` overwrites six parser-owned fields (``subexpr``, ``latex``, ``type``, ``op``, ``exponent``, ``with_respect_to``) on each output node from the matching input node, by id. The model can no longer corrupt these by construction.
- Regression test feeds the exact bug pattern and asserts the input's clean value is restored while enrichment fields (``description``, ``unit``) survive.
- All 26 ``test_semantic_graph_enricher.py`` tests pass.

Verified end-to-end on the atmospheric-entry lesson (Splashdown Dynamics → Solve for Terminal Velocity, node ``__power_7``):
- ``/api/graph/enrich`` returns ``subexpr: "\\frac{1}{\\rho A C_{d}}"`` (clean).
- Mermaid node tooltip renders the proper fraction (KaTeX MathML annotation matches ``\frac{1}{\rho A C_{d}}``).
- Chat *Ask AI* message renders ``Expression: $\frac{1}{\rho A C_{d}}$`` as a fraction.

The in-memory ``_graph_enrich_cache`` resets on server restart, so cached mangled enrichments will refresh naturally on deploy.

Closes #182

## Test plan
- [ ] ``./run.sh -m pytest tests/agents/test_semantic_graph_enricher.py`` — 26 passing.
- [ ] Open the atmospheric-entry lesson, navigate to *Splashdown Dynamics → Solve for Terminal Velocity*, hover the ``__power_7`` node — tooltip shows the fraction $\frac{1}{\rho A C_d}$ rendered, not raw letters.
- [ ] Click the node, click the *Ask AI* button — the message body renders ``Expression: $\frac{1}{\rho A C_{d}}$`` as a fraction.

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>