### PR TITLE
fix(graph): persist enrichment to step before bailing on navigate (#188)

### DIFF
--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -918,16 +918,15 @@ function _runEnrichmentFetch(graph, keyAtFetch, stepAtFetch) {
         const enriched = data && data.enriched;
         if (!enriched || !Array.isArray(enriched.nodes)) return;
 
-        // Mark the original graph too, so if the user navigates away and back
-        // we don't refetch — the response is cached server-side anyway, but
-        // skipping the round trip is cheaper.
+        // Persist the enriched graph onto the step regardless of current focus
+        // — otherwise navigating away mid-fetch silently drops the response.
+        markEnriched(enriched);
+        if (stepAtFetch && stepAtFetch.semanticGraph) {
+            stepAtFetch.semanticGraph.graph = enriched;
+        }
         markEnriched(graph);
 
-        const nowStep = currentProofStep();
-        if (nowStep !== stepAtFetch) return;
-        if (!nowStep || !nowStep.semanticGraph) return;
-        markEnriched(enriched);
-        nowStep.semanticGraph.graph = enriched;
+        if (currentProofStep() !== stepAtFetch) return;
         // Force re-render so the enriched fields propagate through Mermaid
         // and the side panel.
         _currentSemanticKey = null;


### PR DESCRIPTION
Fixes #188.

## Summary

When the user dwelled on a proof step long enough to trigger Gemini enrichment, then navigated away before the fetch resolved, the enriched response was silently dropped. Returning to the step showed the unenriched graph forever — and because the original graph object had been flagged \`__enriched\`, no retry ever fired.

## Root cause

In \`_runEnrichmentFetch\` ([static/graph-view.js](static/graph-view.js)), the response handler ran \`markEnriched(graph)\` *before* the focus check, then bailed if the user had moved on — so the original graph was flagged as enriched but the enriched data was never written to the step.

## Fix (option 1 from the issue)

Write the enriched graph onto \`stepAtFetch.semanticGraph.graph\` regardless of current focus, then mark both objects as enriched, then re-render only when the user is still on the originating step. The data now reaches the step even if the user navigated away mid-fetch — and the in-memory state matches the server-side cache, so revisits show the enriched form.

## Test plan

- [ ] Open a lesson with proof steps that need enrichment (e.g. \`scenes/draft/atmospheric-entry-physics.json\` → Splashdown Impact Loads → Average acceleration).
- [ ] Land on a step where the "Enriching graph…" indicator appears, then quickly navigate to another step before the fetch returns.
- [ ] Wait for the indicator to clear, navigate back: node descriptions / emojis / units should now be populated.
- [ ] Steps where the user stays put still re-render correctly with enrichment.

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>