### PR TITLE
fix(graph): stop re.sub from interpreting \t in \text subscripts (#185)

### DIFF
--- a/server.py
+++ b/server.py
@@ -376,6 +376,23 @@ def _normalize_frac_derivatives(latex: str) -> str:
 _ORDER_TO_ACCENT: dict[int, str] = {1: "dot", 2: "ddot", 3: "dddot", 4: "ddddot"}
 
 
+def _re_sub_literal(pattern: str, replacement: str, text: str) -> str:
+    """``re.sub`` variant that treats *replacement* as a literal string.
+
+    Plain ``re.sub(pattern, replacement_str, text)`` interprets backslash
+    escapes in the replacement: ``\\t`` becomes TAB, ``\\n`` becomes
+    newline, ``\\1``/``\\g<name>`` become back-references, etc. That is a
+    footgun for any code that builds replacement strings out of LaTeX
+    (``\\text{...}``, ``\\dot{...}``, ``\\frac{...}``), where backslashes
+    are content rather than syntax. Wrapping the replacement in a callable
+    bypasses the mini-language entirely — the return value is written
+    verbatim. Use this whenever the replacement is built from non-trivial
+    data; reserve plain ``re.sub`` with a string replacement for the cases
+    where ``\\1`` / ``\\g<name>`` back-references are *intended*.
+    """
+    return re.sub(pattern, lambda _m, r=replacement: r, text)
+
+
 def _restore_dot_notation(
     latex: str,
     dotted_vars: dict[str, int],
@@ -408,8 +425,13 @@ def _restore_dot_notation(
                 rf"\\frac\{{d\^\{{{order}\}}\}}"
                 rf"\{{d\s*t\^\{{{order}\}}\}}\s*{escaped_var}"
             ]
+        # The replacement embeds raw LaTeX (``var`` may contain
+        # ``\text{...}``); use ``_re_sub_literal`` so backslash escapes in
+        # the replacement string aren't interpreted by ``re.sub`` (e.g.
+        # ``\t`` of ``\text`` → TAB). See the helper's docstring.
+        replacement = f"\\{accent}{{{var}}}"
         for pattern in patterns:
-            latex = re.sub(pattern, rf"\\{accent}{{{var}}}", latex)
+            latex = _re_sub_literal(pattern, replacement, latex)
     return latex
 
 

--- a/tests/test_dot_notation_restore.py
+++ b/tests/test_dot_notation_restore.py
@@ -1,0 +1,146 @@
+"""Regression tests for ``server._restore_dot_notation`` and the underlying
+``_re_sub_literal`` helper.
+
+These cover issue #185: when the variable being differentiated carries a
+``\\text{...}`` subscript (or any other LaTeX command starting with a
+backslash-letter that re.sub's replacement-string mini-language would
+interpret), the result must contain the *literal* LaTeX, never the C-style
+escape (``\\t`` → TAB, ``\\n`` → newline, etc.).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from server import _re_sub_literal, _restore_dot_notation, _derive_semantic_graph  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helper: _re_sub_literal — the general guard
+# ---------------------------------------------------------------------------
+
+class TestReSubLiteral:
+    """Verify the helper bypasses re.sub's replacement mini-language for
+    every backslash escape that's a known footgun, not just ``\\t``."""
+
+    def test_text_subscript_does_not_become_tab(self):
+        out = _re_sub_literal(r"XXX", r"q_{\text{LEO}}", "XXX")
+        assert "\t" not in out
+        assert out == r"q_{\text{LEO}}"
+
+    def test_newline_escape_preserved_literally(self):
+        out = _re_sub_literal(r"XXX", r"\nu", "XXX")
+        assert "\n" not in out
+        assert out == r"\nu"
+
+    def test_carriage_return_escape_preserved_literally(self):
+        out = _re_sub_literal(r"XXX", r"\rho", "XXX")
+        assert "\r" not in out
+        assert out == r"\rho"
+
+    def test_back_reference_not_interpreted(self):
+        # ``\1`` would normally be the first capture group's contents.
+        out = _re_sub_literal(r"X(Y)X", r"\1", "XYX")
+        assert out == r"\1"
+
+    def test_double_backslash_not_collapsed(self):
+        # Plain re.sub collapses ``\\\\`` to ``\\``; the literal helper does not.
+        out = _re_sub_literal(r"XXX", r"\\dot{x}", "XXX")
+        assert out == r"\\dot{x}"
+
+    def test_no_match_returns_text_unchanged(self):
+        assert _re_sub_literal(r"XXX", r"\dot{x}", "abc") == "abc"
+
+
+# ---------------------------------------------------------------------------
+# Direct: _restore_dot_notation — the original site
+# ---------------------------------------------------------------------------
+
+class TestRestoreDotNotation:
+    """Drive the function with the exact LaTeX shapes SymPy emits, for the
+    variable forms that triggered #185."""
+
+    def test_text_subscript_round_trips_without_tab(self):
+        # SymPy canonical form for d/dt of ``q_{\text{LEO}}``.
+        sympy_form = r"\frac{d}{d t} q_{\text{LEO}}"
+        out = _restore_dot_notation(sympy_form, {r"q_{\text{LEO}}": 1})
+        assert "\t" not in out
+        # Restored to ``\dot{q_{\text{LEO}}}`` — single backslash before each
+        # LaTeX command, ``\text{...}`` intact inside the subscript.
+        assert out == r"\dot{q_{\text{LEO}}}"
+
+    def test_rewritten_form_also_restored(self):
+        # The d-on-numerator shape that survives in equals-node subexprs.
+        sympy_form = r"\frac{d q_{\text{lunar}}}{d t}"
+        out = _restore_dot_notation(sympy_form, {r"q_{\text{lunar}}": 1})
+        assert "\t" not in out
+        assert out == r"\dot{q_{\text{lunar}}}"
+
+    def test_second_order_text_subscript(self):
+        sympy_form = r"\frac{d^{2}}{d t^{2}} x_{\text{cm}}"
+        out = _restore_dot_notation(sympy_form, {r"x_{\text{cm}}": 2})
+        assert "\t" not in out
+        assert out == r"\ddot{x_{\text{cm}}}"
+
+    def test_plain_variable_still_restored(self):
+        # Sanity: the no-subscript case must still work.
+        out = _restore_dot_notation(r"\frac{d}{d t} x", {"x": 1})
+        assert out == r"\dot{x}"
+
+    def test_multiple_dotted_vars_in_one_pass(self):
+        sympy_form = (
+            r"\frac{\frac{d q_{\text{lunar}}}{d t}}"
+            r"{\frac{d q_{\text{LEO}}}{d t}}"
+        )
+        out = _restore_dot_notation(
+            sympy_form,
+            {r"q_{\text{lunar}}": 1, r"q_{\text{LEO}}": 1},
+        )
+        assert "\t" not in out
+        assert r"\dot{q_{\text{lunar}}}" in out
+        assert r"\dot{q_{\text{LEO}}}" in out
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the original repro from issue #185
+# ---------------------------------------------------------------------------
+
+class TestIssue185Repro:
+    """The exact repro from issue #185. Builds the semantic graph for the
+    user-facing LaTeX and asserts no node's ``subexpr`` carries a literal
+    TAB byte."""
+
+    LATEX = r"\frac{\dot{q}_{\text{lunar}}}{\dot{q}_{\text{LEO}}} = 2.81"
+
+    def test_no_subexpr_carries_a_tab(self):
+        g = _derive_semantic_graph(self.LATEX)
+        for node in g["nodes"]:
+            sub = node.get("subexpr", "")
+            assert "\t" not in sub, (
+                f"Node {node.get('id')!r} subexpr still has TAB: {sub!r}"
+            )
+
+    def test_q_label_nodes_render_text_command_literally(self):
+        g = _derive_semantic_graph(self.LATEX)
+        # Both label nodes must keep ``\text{...}`` intact.
+        ids = {node["id"] for node in g["nodes"]}
+        assert r"q_{\text{lunar}}" in ids
+        assert r"q_{\text{LEO}}" in ids
+
+    def test_dotted_subexprs_use_dot_command(self):
+        g = _derive_semantic_graph(self.LATEX)
+        # The deriv-operator nodes' subexprs should contain ``\dot{...}``
+        # with the original ``\text{...}`` subscript fully preserved.
+        deriv_subs = [
+            node.get("subexpr", "")
+            for node in g["nodes"]
+            if node.get("id", "").startswith("__deriv_")
+        ]
+        assert deriv_subs, "expected at least one __deriv_* node"
+        for sub in deriv_subs:
+            assert r"\dot{" in sub
+            assert r"\text{" in sub
+            assert "\t" not in sub


### PR DESCRIPTION
## Summary

Closes #185.

`_restore_dot_notation` was rebuilding `\dot{X}` / `\ddot{X}` from SymPy's `\frac{d X}{d t}` output via `re.sub(pattern, rf"\\{accent}{{{var}}}", text)`. The replacement was a *string*, so re.sub's mini-language ran on it: when `var` carried `\text{...}` (e.g. `q_{\text{LEO}}`), the `\t` of `\text` was rewritten as a literal **TAB (0x09)** and the user-visible LaTeX became `\dot{q_{<TAB>ext{LEO}}}` — KaTeX then rendered the surviving `ext{LEO}` as `extLEO`.

## Why

The bug isn't accent-specific — *any* backslash escape that re.sub's replacement-string mini-language recognises is a footgun when the replacement is built from LaTeX. `\t` was the loud one (`\text{...}` is everywhere), but `\n` / `\r` / `\1` / `\g<name>` / `\\` would all hit the same trap.

## What changed

- New `_re_sub_literal(pattern, replacement, text)` helper that wraps the replacement in a callable, bypassing re.sub's escape mini-language entirely. Returns the replacement verbatim — `\t`, `\n`, `\r`, `\1` etc. are all left intact.
- `_restore_dot_notation` now goes through `_re_sub_literal`, with the replacement built via a non-raw f-string (`f"\\{accent}{{{var}}}"`) so the single-backslash form arrives at the helper untouched.
- Helper docstring spells out when future callers should prefer it over plain `re.sub` (i.e. whenever the replacement is built from non-trivial data — reserve plain `re.sub` for cases where `\1` / `\g<name>` back-references are *intended*).

Grep confirmed `_restore_dot_notation` was the only currently-vulnerable call site in the Python tree.

## Repro

```python
from server import _derive_semantic_graph
g = _derive_semantic_graph(
    r'\frac{\dot{q}_{\text{lunar}}}{\dot{q}_{\text{LEO}}} = 2.81'
)
# before: 5 of 9 nodes' subexprs contain TAB bytes
# after:  every subexpr is clean (\dot{q_{\text{lunar}}}, etc.)
```

End-to-end verified in the atmospheric-entry-physics lesson, *Aerodynamic Heating and the Bow Shock → Stagnation Point Heating* proof, V³ penalty step. Pre-fix the floating step card showed `q̇_{extlunar} / q̇_{extLEO}`; post-fix it shows `\dot{q}_{\text{lunar}} / \dot{q}_{\text{LEO}}` correctly. (The remaining sanitized-id labels visible on q nodes after enrichment are a separate bug — filed as #192.)

## Tests

New `tests/test_dot_notation_restore.py` — 14 cases across three classes:

- **`TestReSubLiteral`** (6) — guards the helper itself for `\t`, `\n`, `\r`, back-references, double backslash, and no-match passthrough.
- **`TestRestoreDotNotation`** (5) — drives the function directly with SymPy canonical/rewritten shapes, second-order accents, plain vars, and multi-var passes.
- **`TestIssue185Repro`** (3) — end-to-end through `_derive_semantic_graph` with the LaTeX from the issue's repro.

**Negative control verified:** when I temporarily reinstated the buggy `re.sub(..., rf"\\{accent}...", ...)` call, 6 of the 14 tests failed in the right places. Restoring the fix → all 14 green.

## Test plan

- [x] `./run.sh -m pytest tests/test_dot_notation_restore.py -v` — 14 passed
- [x] `./run.sh -m pytest tests/` — 291 passed, 1 skipped (was 277/1 before; +14 new)
- [x] Manual UI check in atmospheric-entry-physics lesson, V³ penalty step → equation card renders correctly
- [x] Negative control: revert call site → 6 expected failures; restore → 14 green

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>