### PR TITLE
refactor(enricher): type the enrichment pipeline end-to-end (#195)

### DIFF
--- a/agents/semantic_graph_enricher.py
+++ b/agents/semantic_graph_enricher.py
@@ -535,6 +535,22 @@ def _restore_dropped_nodes(
         )
 
 
+# Fields the parser owns and the enricher must not modify. Anything here
+# is restored verbatim from the input node during ``_stamp_enriched``,
+# regardless of what the model returned. The system prompt already tells
+# the agent to leave most of these alone (``color`` rule #3, structural
+# fields by default), but we enforce it here so the rendered graph
+# matches the parser's intent even when Gemini gets distracted.
+#
+# Subscripts:
+# - ``subexpr`` / ``latex``: deterministic LaTeX strings — issue #182
+#   (Gemini sometimes double-escapes backslashes).
+# - ``type`` / ``op`` / ``exponent`` / ``with_respect_to``: structural
+#   parser output, never a semantic enrichment target.
+# - ``color`` / ``highlight``: author-set semantic markers tied to
+#   ``htmlClass{hl-cube}``-style highlights. The parser emits CSS named
+#   colors (``"red"``/``"yellow"``); the renderer / theme resolves them
+#   alongside the agent's enrichment fields.
 _STRUCTURAL_NODE_FIELDS = (
     "subexpr",
     "latex",
@@ -542,6 +558,8 @@ _STRUCTURAL_NODE_FIELDS = (
     "op",
     "exponent",
     "with_respect_to",
+    "color",
+    "highlight",
 )
 
 

--- a/agents/semantic_graph_enricher.py
+++ b/agents/semantic_graph_enricher.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from .base import BaseAgent
 from models import SemanticGraph, SemanticGraphNode
+from models.semantic_graph import Enrichment
 
 
 # Per-task input-node id set, threaded into the pydantic-ai output validator
@@ -181,10 +182,11 @@ _CONTEXT_FIELDS = (
 )
 
 
-def _graph_domain(graph: Optional[Dict[str, Any]]) -> Optional[str]:
-    if not isinstance(graph, dict):
+def _graph_domain(graph: Optional[SemanticGraph]) -> Optional[str]:
+    """Extract the (stripped, non-empty) ``domain`` field from a graph, or ``None``."""
+    if graph is None:
         return None
-    val = graph.get("domain")
+    val = graph.domain
     if isinstance(val, str) and val.strip():
         return val.strip()
     return None
@@ -192,7 +194,7 @@ def _graph_domain(graph: Optional[Dict[str, Any]]) -> Optional[str]:
 
 def _render_context(
     context: Optional[Dict[str, Any]],
-    graph: Optional[Dict[str, Any]] = None,
+    graph: Optional[SemanticGraph] = None,
 ) -> str:
     """Render the prose preamble. ``graph.domain`` (if set) appears at the
     very top as the authoritative domain hint — strongest signal we have."""
@@ -219,10 +221,21 @@ def _render_context(
     return "\n".join(lines)
 
 
-def _build_payload(graph: Dict[str, Any], context: Optional[Dict[str, Any]]) -> str:
+def _build_payload(graph: SemanticGraph, context: Optional[Dict[str, Any]]) -> str:
+    """Serialize the typed graph for the agent prompt.
+
+    ``model_dump_json(by_alias=True, exclude_none=True)`` round-trips through
+    the wire-format keys (``"from"`` not ``"from_"``) and drops nulls — same
+    shape we'd hand-build via ``json.dumps``, but validated. ``sort_keys`` is
+    applied via parse-then-redump because pydantic doesn't expose a sort
+    option directly; deterministic ordering matters for cache stability.
+    """
+    raw = graph.model_dump_json(by_alias=True, exclude_none=True)
+    # Sort keys for deterministic output (matches pre-refactor json.dumps).
+    sorted_json = json.dumps(json.loads(raw), sort_keys=True)
     return (
         f"{_render_context(context, graph)}\n\n"
-        f"## Graph\n{json.dumps(graph, sort_keys=True)}"
+        f"## Graph\n{sorted_json}"
     )
 
 
@@ -301,20 +314,29 @@ class SemanticGraphCoherenceCritic(BaseAgent):
 
 def _build_critique_payload(
     context: Optional[Dict[str, Any]],
-    enriched: Dict[str, Any],
+    enriched: SemanticGraph,
 ) -> str:
+    raw = enriched.model_dump_json(by_alias=True, exclude_none=True)
+    sorted_json = json.dumps(json.loads(raw), sort_keys=True)
     return (
         f"{_render_context(context, enriched)}\n\n"
-        f"## Enriched graph\n{json.dumps(enriched, sort_keys=True)}"
+        f"## Enriched graph\n{sorted_json}"
     )
 
 
 _MISSING = object()
 
 
+def _node_field_dict(node: SemanticGraphNode) -> Dict[str, Any]:
+    """Project a node to its set fields (excludes None, uses wire-format
+    keys). Used by diff/restore helpers that compare input vs output
+    fields without re-validating the whole node."""
+    return node.model_dump(by_alias=True, exclude_none=True)
+
+
 def _diff_enriched_fields(
-    input_graph: Dict[str, Any],
-    output_graph: Dict[str, Any],
+    input_graph: SemanticGraph,
+    output_graph: SemanticGraph,
 ) -> List[str]:
     """Authoritative list of dotted JSON-ish paths the enricher added,
     changed, or removed. Computed by diffing input vs output (the model
@@ -327,23 +349,20 @@ def _diff_enriched_fields(
     paths: List[str] = []
     # Top-level diff: domain is the only graph-level field the enricher
     # writes; classification is preserved verbatim per prompt.
-    if (input_graph.get("domain") or "") != (output_graph.get("domain") or ""):
+    if (input_graph.domain or "") != (output_graph.domain or ""):
         paths.append("domain")
-    in_nodes = {
-        n.get("id"): n
-        for n in (input_graph.get("nodes") or [])
-        if isinstance(n, dict) and n.get("id")
+    in_nodes: Dict[str, Dict[str, Any]] = {
+        n.id: _node_field_dict(n) for n in input_graph.nodes
     }
-    for out_node in output_graph.get("nodes") or []:
-        if not isinstance(out_node, dict):
-            continue
-        node_id = out_node.get("id")
-        in_node = in_nodes.get(node_id) or {}
+    for out_node in output_graph.nodes:
+        node_id = out_node.id
+        in_dict = in_nodes.get(node_id) or {}
+        out_dict = _node_field_dict(out_node)
         # Union of keys: catches additions, modifications, AND removals.
         # ``id`` / ``type`` are structural — never enriched.
-        keys = (set(in_node.keys()) | set(out_node.keys())) - {"id", "type"}
+        keys = (set(in_dict.keys()) | set(out_dict.keys())) - {"id", "type"}
         for key in sorted(keys):
-            if in_node.get(key, _MISSING) != out_node.get(key, _MISSING):
+            if in_dict.get(key, _MISSING) != out_dict.get(key, _MISSING):
                 paths.append(f"nodes.{node_id}.{key}")
     return paths
 
@@ -367,8 +386,8 @@ def _looks_like_emoji(s: str) -> bool:
 
 
 def _drop_phantom_nodes_and_edges(
-    input_graph: Dict[str, Any],
-    output_graph: Dict[str, Any],
+    input_graph: SemanticGraph,
+    output_graph: SemanticGraph,
 ) -> None:
     """Drop nodes the model invented, plus any edges that reference them.
 
@@ -377,44 +396,29 @@ def _drop_phantom_nodes_and_edges(
     emoji" box with no connections). Treat the input ids as authoritative —
     any output node whose id wasn't in the input gets removed, and any edge
     that touches a removed id goes with it."""
-    in_ids = {
-        n.get("id")
-        for n in (input_graph.get("nodes") or [])
-        if isinstance(n, dict) and isinstance(n.get("id"), str)
-    }
-    nodes = output_graph.get("nodes")
-    if isinstance(nodes, list):
-        kept_nodes = []
-        for n in nodes:
-            if isinstance(n, dict) and n.get("id") in in_ids:
-                kept_nodes.append(n)
-            elif isinstance(n, dict):
-                print(
-                    f"[enrich] dropping phantom node {n.get('id')!r} "
-                    f"(label={n.get('label')!r})",
-                    flush=True,
-                )
-        output_graph["nodes"] = kept_nodes
-    edges = output_graph.get("edges")
-    if isinstance(edges, list):
-        # Edge schema uses ``from_`` / ``to`` after Pydantic; the dump uses
-        # ``from`` (alias) on the wire. Handle both just in case.
-        def _edge_endpoints(e: Dict[str, Any]) -> tuple[Any, Any]:
-            return (e.get("from") or e.get("from_"), e.get("to"))
+    in_ids = {n.id for n in input_graph.nodes}
+    kept_nodes: List[SemanticGraphNode] = []
+    for n in output_graph.nodes:
+        if n.id in in_ids:
+            kept_nodes.append(n)
+        else:
+            print(
+                f"[enrich] dropping phantom node {n.id!r} "
+                f"(label={n.label!r})",
+                flush=True,
+            )
+    output_graph.nodes = kept_nodes
 
-        kept_edges = []
-        for e in edges:
-            if not isinstance(e, dict):
-                continue
-            src, dst = _edge_endpoints(e)
-            if src in in_ids and dst in in_ids:
-                kept_edges.append(e)
-            else:
-                print(
-                    f"[enrich] dropping phantom edge {src!r}→{dst!r}",
-                    flush=True,
-                )
-        output_graph["edges"] = kept_edges
+    kept_edges = []
+    for e in output_graph.edges:
+        if e.from_ in in_ids and e.to in in_ids:
+            kept_edges.append(e)
+        else:
+            print(
+                f"[enrich] dropping phantom edge {e.from_!r}→{e.to!r}",
+                flush=True,
+            )
+    output_graph.edges = kept_edges
 
 
 def _validate_no_dropped_nodes(output: SemanticGraph) -> SemanticGraph:
@@ -490,8 +494,8 @@ def _validate_no_dropped_nodes(output: SemanticGraph) -> SemanticGraph:
 
 
 def _restore_dropped_nodes(
-    input_graph: Dict[str, Any],
-    output_graph: Dict[str, Any],
+    input_graph: SemanticGraph,
+    output_graph: SemanticGraph,
 ) -> None:
     """Re-insert input nodes the model omitted from its response.
 
@@ -509,49 +513,24 @@ def _restore_dropped_nodes(
     output gets re-added with the parser-owned record verbatim so that
     ``_restore_structural_fields`` (which only patches *existing* output
     nodes) and the renderer both find a real entry under the id.
+
+    With the typed pipeline the input nodes are already validated
+    ``SemanticGraphNode`` instances — ``extra="forbid"`` was enforced at
+    ``aenrich``'s entry boundary, so a node that would smuggle an
+    unknown property would have been rejected before this helper ran.
+    No per-node revalidation needed here.
     """
-    out_nodes = output_graph.get("nodes")
-    if not isinstance(out_nodes, list):
-        return
-    out_ids = {
-        n.get("id")
-        for n in out_nodes
-        if isinstance(n, dict) and isinstance(n.get("id"), str)
-    }
-    in_nodes = input_graph.get("nodes")
-    if not isinstance(in_nodes, list):
-        return
-    for src in in_nodes:
-        if not isinstance(src, dict):
+    out_ids = {n.id for n in output_graph.nodes}
+    for src in input_graph.nodes:
+        if src.id in out_ids:
             continue
-        sid = src.get("id")
-        if not isinstance(sid, str) or sid in out_ids:
-            continue
-        # Validate the source node through the agent's schema before
-        # appending so the post-enrichment graph honours the same
-        # ``extra="forbid"`` invariant pydantic-ai enforces on the model
-        # output. The input dict comes from the unvalidated
-        # ``GraphEnrichRequest.graph: dict`` field; without this guard a
-        # caller could smuggle unknown properties into the cached graph
-        # via the restore path. Drop the node entirely on validation
-        # failure — the dangling-edge symptom is recoverable later
-        # (renderer falls back to a placeholder), but a schema-violating
-        # node persisted to the cache is not.
-        try:
-            validated = SemanticGraphNode.model_validate(src).model_dump(
-                by_alias=True, exclude_none=True
-            )
-        except Exception as exc:
-            print(
-                f"[enrich] skipping restore of {sid!r} — input node "
-                f"failed schema validation: {exc}",
-                flush=True,
-            )
-            continue
-        out_nodes.append(validated)
+        # Deep copy so later passes (e.g. ``_restore_structural_fields``)
+        # mutating the output node don't bleed back into the input graph,
+        # which the FastAPI handler may still reference for cache hashing.
+        output_graph.nodes.append(src.model_copy(deep=True))
         print(
-            f"[enrich] restoring dropped input node {sid!r} "
-            f"(label={src.get('label')!r})",
+            f"[enrich] restoring dropped input node {src.id!r} "
+            f"(label={src.label!r})",
             flush=True,
         )
 
@@ -567,8 +546,8 @@ _STRUCTURAL_NODE_FIELDS = (
 
 
 def _restore_structural_fields(
-    input_graph: Dict[str, Any],
-    output_graph: Dict[str, Any],
+    input_graph: SemanticGraph,
+    output_graph: SemanticGraph,
 ) -> None:
     """Copy structural / parser-derived fields from input nodes to output.
 
@@ -580,27 +559,19 @@ def _restore_structural_fields(
     ``op``, ``exponent``, ``with_respect_to``) are also parser-owned, not
     semantic enrichment, so we restore them verbatim too.
     """
-    in_by_id: Dict[str, Dict[str, Any]] = {}
-    for n in input_graph.get("nodes") or []:
-        if isinstance(n, dict) and isinstance(n.get("id"), str):
-            in_by_id[n["id"]] = n
-    out_nodes = output_graph.get("nodes")
-    if not isinstance(out_nodes, list):
-        return
-    for node in out_nodes:
-        if not isinstance(node, dict):
-            continue
-        src = in_by_id.get(node.get("id"))
-        if not isinstance(src, dict):
+    in_by_id: Dict[str, SemanticGraphNode] = {n.id: n for n in input_graph.nodes}
+    for node in output_graph.nodes:
+        src = in_by_id.get(node.id)
+        if src is None:
             continue
         for field in _STRUCTURAL_NODE_FIELDS:
-            if field in src:
-                node[field] = src[field]
-            else:
-                node.pop(field, None)
+            # Mirror the input value exactly: assign present fields, clear
+            # absent ones. Both sides have these declared with
+            # ``Optional[...] = None`` defaults, so attribute access is safe.
+            setattr(node, field, getattr(src, field, None))
 
 
-def _strip_bad_emojis(graph: Dict[str, Any]) -> None:
+def _strip_bad_emojis(graph: SemanticGraph) -> None:
     """Remove ``emoji`` fields that are clearly not a single emoji glyph.
 
     Gemini occasionally fills ``emoji`` with a word in some language
@@ -608,22 +579,17 @@ def _strip_bad_emojis(graph: Dict[str, Any]) -> None:
     of a glyph. The schema cap is intentionally generous so a bad value
     doesn't blow up the whole enrichment via pydantic-ai retry
     exhaustion — but we shouldn't ship the junk to the user."""
-    nodes = graph.get("nodes")
-    if not isinstance(nodes, list):
-        return
-    for node in nodes:
-        if not isinstance(node, dict):
-            continue
-        emoji = node.get("emoji")
+    for node in graph.nodes:
+        emoji = node.emoji
         if isinstance(emoji, str) and not _looks_like_emoji(emoji):
-            print(f"[enrich] dropping non-emoji value on {node.get('id')!r}: {emoji!r}", flush=True)
-            node.pop("emoji", None)
+            print(f"[enrich] dropping non-emoji value on {node.id!r}: {emoji!r}", flush=True)
+            node.emoji = None
 
 
 def _stamp_enriched(
-    input_graph: Dict[str, Any],
-    output_graph: Dict[str, Any],
-) -> Dict[str, Any]:
+    input_graph: SemanticGraph,
+    output_graph: SemanticGraph,
+) -> SemanticGraph:
     """Mark a graph as enriched and attach the authoritative diff. Used as
     the gate for skip-on-second-call deduplication on both server and
     client. Preserves any ``reasoning`` the model already filled in on the
@@ -639,21 +605,25 @@ def _stamp_enriched(
     _drop_phantom_nodes_and_edges(input_graph, output_graph)
     _restore_structural_fields(input_graph, output_graph)
     _strip_bad_emojis(output_graph)
-    block = output_graph.get("enrichment")
-    if not isinstance(block, dict):
-        block = {}
-        output_graph["enrichment"] = block
-    block["fields"] = _diff_enriched_fields(input_graph, output_graph)
+    fields = _diff_enriched_fields(input_graph, output_graph)
+    if output_graph.enrichment is None:
+        output_graph.enrichment = Enrichment(fields=fields)
+    else:
+        # Preserve any ``reasoning`` the model filled in; just refresh the
+        # authoritative field list.
+        output_graph.enrichment = output_graph.enrichment.model_copy(
+            update={"fields": fields}
+        )
     return output_graph
 
 
-def _enrichment_reasoning(graph: Dict[str, Any]) -> Optional[str]:
+def _enrichment_reasoning(graph: SemanticGraph) -> Optional[str]:
     """Pull the model's domain / disambiguation rationale off an enriched
     graph for logging. ``None`` if the model didn't supply one."""
-    block = graph.get("enrichment") if isinstance(graph, dict) else None
-    if not isinstance(block, dict):
+    block = graph.enrichment
+    if block is None:
         return None
-    val = block.get("reasoning")
+    val = block.reasoning
     return val.strip() if isinstance(val, str) and val.strip() else None
 
 
@@ -708,17 +678,13 @@ class SemanticGraphEnrichmentAgent(BaseAgent):
 
     async def _first_pass(
         self,
-        graph: Dict[str, Any],
+        graph: SemanticGraph,
         context: Optional[Dict[str, Any]],
-    ) -> Dict[str, Any]:
+    ) -> SemanticGraph:
         # Bind the input node ids for ``_validate_no_dropped_nodes`` and
         # reset its escalation counter for this call. Reset both on exit
         # so a later call with a different input doesn't see stale state.
-        expected = frozenset(
-            n["id"]
-            for n in (graph.get("nodes") or [])
-            if isinstance(n, dict) and isinstance(n.get("id"), str)
-        )
+        expected = frozenset(n.id for n in graph.nodes)
         ids_token = _current_input_node_ids.set(expected)
         count_token = _validator_escalation_count.set(0)
         try:
@@ -727,12 +693,12 @@ class SemanticGraphEnrichmentAgent(BaseAgent):
             _current_input_node_ids.reset(ids_token)
             _validator_escalation_count.reset(count_token)
         assert isinstance(result, SemanticGraph)
-        return result.model_dump(by_alias=True, exclude_none=True)
+        return result
 
     async def _critique(
         self,
         context: Dict[str, Any],
-        enriched: Dict[str, Any],
+        enriched: SemanticGraph,
     ) -> Optional[_CoherenceVerdict]:
         if self._critic is None:
             return None
@@ -745,38 +711,52 @@ class SemanticGraphEnrichmentAgent(BaseAgent):
 
     async def aenrich(
         self,
-        graph: Dict[str, Any],
+        graph: SemanticGraph,
         context: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ) -> SemanticGraph:
+        """Enrich a parser-produced ``SemanticGraph`` with descriptions,
+        emoji, dimensions, etc. via Gemini. Returns the enriched graph as
+        a typed model.
+
+        Caller (FastAPI handler / CLI / tests) is responsible for the
+        wire-format dict ↔ ``SemanticGraph`` conversion at its own
+        boundary. Keeping this signature typed means every internal
+        pass — the dropped-node validator, the merge helpers, the diff
+        computation — operates on validated models throughout.
+        """
         # Idempotency: if the input graph is already enriched (carries the
         # ``enrichment`` block), return it unchanged — both Gemini calls
         # (enrichment + critic) are skipped. The server does the same
         # short-circuit higher up; this keeps direct callers (CLI / scripts
         # / tests) consistent.
-        if isinstance(graph, dict) and isinstance(graph.get("enrichment"), dict):
+        if graph.enrichment is not None:
             print(f"[enrich] input already enriched — returning unchanged", flush=True)
             return graph
 
-        def _log_done(stage: str, g: Dict[str, Any]) -> None:
+        input_model = graph
+
+        def _log_done(stage: str, g: SemanticGraph) -> None:
             reason = _enrichment_reasoning(g)
-            field_count = len(_diff_enriched_fields(graph, g))
+            field_count = len(_diff_enriched_fields(input_model, g))
             tail = f"  reasoning={reason!r}" if reason else ""
             print(
                 f"[enrich] {stage}  nodes={node_count} filled={field_count}{tail}",
                 flush=True,
             )
 
-        def _finalize(stage: str, candidate: Dict[str, Any]) -> Dict[str, Any]:
+        def _finalize(stage: str, candidate: SemanticGraph) -> SemanticGraph:
             """Log + stamp. Dropped-node retries happen *inside* pydantic-ai's
             loop via ``_validate_no_dropped_nodes``; ``_stamp_enriched``
-            then runs the safety-net merge passes (restore-dropped /
-            drop-phantoms / restore-structural-fields).
+            runs the safety-net merge passes (restore-dropped /
+            drop-phantoms / restore-structural-fields) and attaches the
+            ``enrichment`` block. The caller serializes for the cache /
+            wire format.
             """
             _log_done(stage, candidate)
-            return _stamp_enriched(graph, candidate)
+            return _stamp_enriched(input_model, candidate)
 
-        node_count = len(graph.get("nodes") or [])
-        enriched = await self._first_pass(graph, context)
+        node_count = len(input_model.nodes)
+        enriched = await self._first_pass(input_model, context)
         if not context:
             return _finalize("first-pass ok ctx=n (no critique)", enriched)
         verdict = await self._critique(context, enriched)
@@ -797,10 +777,10 @@ class SemanticGraphEnrichmentAgent(BaseAgent):
         # render path picks it up from there. Without it, the retry would
         # re-infer from prose alone and might land on the same wrong answer
         # the critic just rejected.
-        retry_graph = graph
+        retry_graph = input_model
         inferred_domain = _graph_domain(enriched)
-        if inferred_domain and not _graph_domain(graph):
-            retry_graph = {**graph, "domain": inferred_domain}
+        if inferred_domain and not _graph_domain(input_model):
+            retry_graph = input_model.model_copy(update={"domain": inferred_domain})
             print(f"[enrich] using first-pass inferred domain={inferred_domain!r}", flush=True)
         retry_context = _context_with_feedback(context, verdict.feedback)
         print(
@@ -816,9 +796,9 @@ class SemanticGraphEnrichmentAgent(BaseAgent):
 
     def enrich(
         self,
-        graph: Dict[str, Any],
+        graph: SemanticGraph,
         context: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ) -> SemanticGraph:
         """Sync wrapper around :meth:`aenrich` for CLI / script / sync-test callers.
 
         Production goes through ``aenrich`` directly from the FastAPI handler.

--- a/models/semantic_graph.py
+++ b/models/semantic_graph.py
@@ -77,7 +77,11 @@ class SemanticGraphNode(BaseModel):
     unit: Optional[str] = Field(default=None, max_length=30, pattern=_NO_HTML)
     value: Optional[Union[float, int, str]] = Field(default=None)
     role: Optional[Role] = None
-    color: Optional[str] = Field(default=None, pattern=_COLOR)
+    # ``max_length=30`` caps both the hex form (longest is ``#`` + 8 hex
+    # digits = 9 chars) and the named-keyword form (the longest CSS named
+    # color, ``lightgoldenrodyellow``, is 21 chars). 30 leaves a small
+    # margin for unusual values without permitting unbounded payloads.
+    color: Optional[str] = Field(default=None, pattern=_COLOR, max_length=30)
     highlight: Optional[str] = Field(default=None, max_length=40, pattern=_NO_HTML)
     variant: Optional[EdgeSemantic] = None
 

--- a/models/semantic_graph.py
+++ b/models/semantic_graph.py
@@ -43,7 +43,14 @@ ClassificationKind = Literal["algebraic", "ODE", "PDE", "statements"]
 
 
 _NO_HTML = r"^[^<>]*$"
-_HEX_COLOR = r"^#[0-9A-Fa-f]{3,8}$"
+# Accept either hex (``#fa0``, ``#0d47a1``, ``#ff8800aa``) or a CSS named
+# color keyword (``red``, ``yellow``, ``cornflowerblue``). Both are
+# author-set semantic highlights (``htmlClass{hl-cube}``-style markers
+# that the parser emits with named colors); the renderer / theme
+# resolves both forms. The ``[a-zA-Z]+`` arm is constrained to letters
+# only so it can't smuggle ``javascript:`` or ``url(...)`` payloads — the
+# original prompt-injection rejection still holds.
+_COLOR = r"^(#[0-9A-Fa-f]{3,8}|[a-zA-Z]+)$"
 
 
 class SemanticGraphNode(BaseModel):
@@ -70,7 +77,7 @@ class SemanticGraphNode(BaseModel):
     unit: Optional[str] = Field(default=None, max_length=30, pattern=_NO_HTML)
     value: Optional[Union[float, int, str]] = Field(default=None)
     role: Optional[Role] = None
-    color: Optional[str] = Field(default=None, pattern=_HEX_COLOR)
+    color: Optional[str] = Field(default=None, pattern=_COLOR)
     highlight: Optional[str] = Field(default=None, max_length=40, pattern=_NO_HTML)
     variant: Optional[EdgeSemantic] = None
 

--- a/server.py
+++ b/server.py
@@ -2303,12 +2303,31 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
                 except AgentError as e:
                     return JSONResponse({"error": str(e)}, status_code=503)
 
+            # Validate the wire-format dict into a typed ``SemanticGraph``
+            # at the API boundary — the enricher operates on models from
+            # here on (issue #195). A schema-violating input becomes a 400
+            # so the caller sees the validation error instead of getting a
+            # silent fallback to the unenriched graph.
+            from models import SemanticGraph as _SemanticGraph
             try:
-                enriched = await _graph_enricher.aenrich(graph_in, context_in)
+                graph_model = _SemanticGraph.model_validate(graph_in)
+            except Exception as exc:
+                print(f"[enrich] input failed validation: {exc}", flush=True)
+                return JSONResponse(
+                    {"error": f"input graph failed schema validation: {exc}"},
+                    status_code=400,
+                )
+
+            try:
+                enriched_model = await _graph_enricher.aenrich(graph_model, context_in)
             except AgentError as e:
                 print(f"[enrich] agent error: {e}", flush=True)
                 return JSONResponse({"error": str(e)}, status_code=502)
 
+            # Serialize back to the wire format for the cache and JSON
+            # response — keeps the cache hit path returning dicts so the
+            # ``cached`` shape is identical regardless of how it was built.
+            enriched = enriched_model.model_dump(by_alias=True, exclude_none=True)
             _graph_enrich_cache[key] = enriched
             print(f"[enrich] ok  cached  key={key[:8]}", flush=True)
             if DEBUG_MODE:

--- a/server.py
+++ b/server.py
@@ -2256,26 +2256,51 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
 
         global _graph_enricher
 
+        from pydantic import ValidationError as _ValidationError
+        from models import SemanticGraph as _SemanticGraph
+
         try:
             graph_in = req.graph or {}
             context_in = req.context or None
             node_count = len(graph_in.get("nodes", []) or [])
             domain = graph_in.get("domain") or (context_in or {}).get("domain") or "?"
 
+            # Validate the wire-format dict at the API boundary BEFORE any
+            # short-circuit. Otherwise a caller could include any
+            # ``"enrichment": {...}`` blob in their request and bypass the
+            # ``extra="forbid"`` schema invariant entirely (see Codex review
+            # on PR #196). Catch ``ValidationError`` specifically — anything
+            # else falls through to the outer ``except`` that returns a 500
+            # with a stack trace, instead of misclassifying server bugs as
+            # client validation failures and echoing internal exception text.
+            try:
+                graph_model = _SemanticGraph.model_validate(graph_in)
+            except _ValidationError as exc:
+                print(f"[enrich] input failed validation: {exc}", flush=True)
+                return JSONResponse(
+                    {"error": f"input graph failed schema validation: {exc}"},
+                    status_code=400,
+                )
+
             # Short-circuit: a graph that already carries an ``enrichment``
             # block has been through the agent before. Skip the cache lookup
-            # and the Gemini calls entirely and echo the input back. The
-            # client uses the same marker to skip even sending the request,
-            # so this is mostly a backstop for direct API callers.
+            # and the Gemini calls entirely and echo the (now-validated)
+            # input back. The client uses the same marker to skip even
+            # sending the request, so this is mostly a backstop for direct
+            # API callers.
             #
             # ``cached: false`` here on purpose — the response did NOT come
             # from ``_graph_enrich_cache``; we just echoed the request body.
             # ``skipped: true`` is the signal that the Gemini call was
             # avoided. Keeping ``cached`` honest matters for any caller
             # that uses it for metrics.
-            if isinstance(graph_in.get("enrichment"), dict):
+            if graph_model.enrichment is not None:
                 print(f"[enrich] input already enriched  nodes={node_count} domain={domain!r}", flush=True)
-                return JSONResponse({"enriched": graph_in, "cached": False, "skipped": True})
+                return JSONResponse({
+                    "enriched": graph_model.model_dump(by_alias=True, exclude_none=True),
+                    "cached": False,
+                    "skipped": True,
+                })
 
             cache_payload = {"graph": graph_in, "context": context_in}
             key = hashlib.sha256(
@@ -2302,21 +2327,6 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
                     _graph_enricher = SemanticGraphEnrichmentAgent()
                 except AgentError as e:
                     return JSONResponse({"error": str(e)}, status_code=503)
-
-            # Validate the wire-format dict into a typed ``SemanticGraph``
-            # at the API boundary — the enricher operates on models from
-            # here on (issue #195). A schema-violating input becomes a 400
-            # so the caller sees the validation error instead of getting a
-            # silent fallback to the unenriched graph.
-            from models import SemanticGraph as _SemanticGraph
-            try:
-                graph_model = _SemanticGraph.model_validate(graph_in)
-            except Exception as exc:
-                print(f"[enrich] input failed validation: {exc}", flush=True)
-                return JSONResponse(
-                    {"error": f"input graph failed schema validation: {exc}"},
-                    status_code=400,
-                )
 
             try:
                 enriched_model = await _graph_enricher.aenrich(graph_model, context_in)

--- a/tests/agents/test_semantic_graph_enricher.py
+++ b/tests/agents/test_semantic_graph_enricher.py
@@ -16,6 +16,17 @@ from models import SemanticGraph
 from agents.semantic_graph_enricher import SemanticGraphEnrichmentAgent
 
 
+def _g(payload: dict) -> SemanticGraph:
+    """Test helper — wrap a wire-format dict into a ``SemanticGraph``.
+
+    The agent's public surface is now strictly typed (issue #195), so
+    fixtures that read naturally as dict literals get explicitly validated
+    before being passed in. Mirrors what the FastAPI handler does at the
+    HTTP boundary in production.
+    """
+    return SemanticGraph.model_validate(payload)
+
+
 _INPUT_GRAPH = {
     "domain": "thermodynamics",
     "nodes": [
@@ -125,19 +136,23 @@ def test_enrichment_preserves_ids_and_edges() -> None:
     }
     enricher = _build_agent_with(enriched_payload)
 
-    out = enricher.enrich(_INPUT_GRAPH)
+    out = enricher.enrich(_g(_INPUT_GRAPH))
 
     in_ids = {n["id"] for n in _INPUT_GRAPH["nodes"]}
-    out_ids = {n["id"] for n in out["nodes"]}
+    out_ids = {n.id for n in out.nodes}
     assert in_ids == out_ids
 
-    assert out["edges"] == _INPUT_GRAPH["edges"]
+    # Edges round-trip through the wire format for deep-equality
+    # comparison with the dict fixture (the model itself doesn't compare
+    # equal to a list of dicts).
+    out_edges = [e.model_dump(by_alias=True, exclude_none=True) for e in out.edges]
+    assert out_edges == _INPUT_GRAPH["edges"]
 
-    by_id = {n["id"]: n for n in out["nodes"]}
+    by_id = {n.id: n for n in out.nodes}
     for symbol in ("P", "V", "T"):
-        assert by_id[symbol].get("description")
-        assert by_id[symbol].get("emoji")
-        assert by_id[symbol].get("color", "").startswith("#")
+        assert by_id[symbol].description
+        assert by_id[symbol].emoji
+        assert (by_id[symbol].color or "").startswith("#")
 
 
 @pytest.mark.parametrize(
@@ -226,17 +241,17 @@ def test_critic_triggers_retry_with_corrected_output() -> None:
     )
 
     out = enricher.enrich(
-        {"nodes": [{"id": "V", "type": "scalar"}], "edges": []},
+        _g({"nodes": [{"id": "V", "type": "scalar"}], "edges": []}),
         context=_ATMOSPHERIC_CONTEXT,
     )
 
-    node = out["nodes"][0]
-    assert node["quantity"] == "velocity"
-    assert node["unit"] == "m/s"
-    assert node["emoji"] == "🚀"
+    node = out.nodes[0]
+    assert node.quantity == "velocity"
+    assert node.unit == "m/s"
+    assert node.emoji == "🚀"
     # The first-pass-inferred domain should be preserved on the retry's
     # output too — it's now part of the canonical enriched graph.
-    assert out.get("domain") == "classical_mechanics"
+    assert out.domain == "classical_mechanics"
 
 
 def test_critic_accepts_coherent_first_pass() -> None:
@@ -248,10 +263,10 @@ def test_critic_accepts_coherent_first_pass() -> None:
     )
 
     out = enricher.enrich(
-        {"nodes": [{"id": "V", "type": "scalar"}], "edges": []},
+        _g({"nodes": [{"id": "V", "type": "scalar"}], "edges": []}),
         context=_ATMOSPHERIC_CONTEXT,
     )
-    assert out["nodes"][0]["quantity"] == "velocity"
+    assert out.nodes[0].quantity == "velocity"
 
 
 def test_critic_skipped_when_no_context() -> None:
@@ -264,9 +279,9 @@ def test_critic_skipped_when_no_context() -> None:
             {"ok": False, "mismatched_node_ids": ["V"], "feedback": "x"},
         ],
     )
-    out = enricher.enrich({"nodes": [{"id": "V", "type": "scalar"}], "edges": []})
+    out = enricher.enrich(_g({"nodes": [{"id": "V", "type": "scalar"}], "edges": []}))
     # Voltage survives because there's no context to reject it against.
-    assert out["nodes"][0]["quantity"] == "voltage"
+    assert out.nodes[0].quantity == "voltage"
 
 
 def test_circuits_lesson_keeps_voltage() -> None:
@@ -277,14 +292,14 @@ def test_circuits_lesson_keeps_voltage() -> None:
         critic_outputs=[{"ok": True, "mismatched_node_ids": []}],
     )
     out = enricher.enrich(
-        {"nodes": [{"id": "V", "type": "scalar"}], "edges": []},
+        _g({"nodes": [{"id": "V", "type": "scalar"}], "edges": []}),
         context={
             "lessonTitle": "RC Circuits",
             "stepExplanation": "The capacitor charges through the resistor; voltage rises.",
         },
     )
-    assert out["nodes"][0]["quantity"] == "voltage"
-    assert out["nodes"][0]["unit"] == "V"
+    assert out.nodes[0].quantity == "voltage"
+    assert out.nodes[0].unit == "V"
 
 
 def test_critic_failure_falls_back_to_first_pass() -> None:
@@ -295,11 +310,11 @@ def test_critic_failure_falls_back_to_first_pass() -> None:
         critic_outputs=[RuntimeError("simulated critic outage")],
     )
     out = enricher.enrich(
-        {"nodes": [{"id": "V", "type": "scalar"}], "edges": []},
+        _g({"nodes": [{"id": "V", "type": "scalar"}], "edges": []}),
         context=_ATMOSPHERIC_CONTEXT,
     )
     # First-pass output passes through unchanged when the critic blows up.
-    assert out["nodes"][0]["quantity"] == "voltage"
+    assert out.nodes[0].quantity == "voltage"
 
 
 def test_user_payload_renders_context_as_prose() -> None:
@@ -308,7 +323,7 @@ def test_user_payload_renders_context_as_prose() -> None:
     from agents.semantic_graph_enricher import _build_payload
 
     payload = _build_payload(
-        {"nodes": [], "edges": []},
+        SemanticGraph.model_validate({"nodes": [], "edges": []}),
         context=_ATMOSPHERIC_CONTEXT,
     )
     assert payload.startswith("## Context")
@@ -328,7 +343,10 @@ def test_feedback_renders_in_retry_payload() -> None:
         _ATMOSPHERIC_CONTEXT,
         "Lesson is atmospheric entry; V is velocity, not voltage.",
     )
-    payload = _build_payload({"nodes": [], "edges": []}, context=retry_ctx)
+    payload = _build_payload(
+        SemanticGraph.model_validate({"nodes": [], "edges": []}),
+        context=retry_ctx,
+    )
     assert "Coherence feedback" in payload
     assert "V is velocity, not voltage" in payload
 
@@ -340,7 +358,9 @@ def test_graph_domain_surfaces_in_payload() -> None:
     # enrichment and critic payloads.
     from agents.semantic_graph_enricher import _build_payload, _build_critique_payload
 
-    graph = {"domain": "classical_mechanics", "nodes": [], "edges": []}
+    graph = SemanticGraph.model_validate(
+        {"domain": "classical_mechanics", "nodes": [], "edges": []}
+    )
 
     payload = _build_payload(graph, context=_ATMOSPHERIC_CONTEXT)
     domain_line = "- Graph domain (authoritative, from parser): classical_mechanics"
@@ -358,7 +378,9 @@ def test_graph_domain_surfaces_without_context() -> None:
     # should still surface that domain — it's all we have to go on.
     from agents.semantic_graph_enricher import _build_payload
 
-    graph = {"domain": "quantum_mechanics", "nodes": [], "edges": []}
+    graph = SemanticGraph.model_validate(
+        {"domain": "quantum_mechanics", "nodes": [], "edges": []}
+    )
     payload = _build_payload(graph, context=None)
     assert "Graph domain (authoritative, from parser): quantum_mechanics" in payload
 
@@ -368,7 +390,7 @@ def test_no_domain_no_authoritative_line() -> None:
     # line — the model would treat it as authoritative if we did.
     from agents.semantic_graph_enricher import _build_payload
 
-    graph = {"nodes": [], "edges": []}
+    graph = SemanticGraph.model_validate({"nodes": [], "edges": []})
     payload = _build_payload(graph, context=_ATMOSPHERIC_CONTEXT)
     assert "Graph domain" not in payload
 
@@ -387,13 +409,13 @@ def test_enrichment_marker_stamped_on_first_pass_ok() -> None:
         critic_outputs=[{"ok": True, "mismatched_node_ids": []}],
     )
     out = enricher.enrich(
-        {"nodes": [{"id": "V", "type": "scalar"}], "edges": []},
+        _g({"nodes": [{"id": "V", "type": "scalar"}], "edges": []}),
         context=_ATMOSPHERIC_CONTEXT,
     )
-    block = out.get("enrichment")
-    assert isinstance(block, dict)
-    assert "velocity" in block["reasoning"]
-    fields = block.get("fields")
+    block = out.enrichment
+    assert block is not None
+    assert "velocity" in block.reasoning
+    fields = block.fields
     assert isinstance(fields, list) and fields
     # The diff records both top-level (`domain`) and per-node changes, the
     # latter as `nodes.<id>.<field>` paths.
@@ -412,12 +434,12 @@ def test_enrichment_marker_stamped_when_model_omits_block() -> None:
         critic_outputs=[{"ok": True, "mismatched_node_ids": []}],
     )
     out = enricher.enrich(
-        {"nodes": [{"id": "V", "type": "scalar"}], "edges": []},
+        _g({"nodes": [{"id": "V", "type": "scalar"}], "edges": []}),
         context=_ATMOSPHERIC_CONTEXT,
     )
-    block = out.get("enrichment")
-    assert isinstance(block, dict)
-    assert isinstance(block.get("fields"), list) and block["fields"]
+    block = out.enrichment
+    assert block is not None
+    assert isinstance(block.fields, list) and block.fields
 
 
 def test_enrichment_marker_stamped_after_retry() -> None:
@@ -436,18 +458,18 @@ def test_enrichment_marker_stamped_after_retry() -> None:
         ],
     )
     out = enricher.enrich(
-        {"nodes": [{"id": "V", "type": "scalar"}], "edges": []},
+        _g({"nodes": [{"id": "V", "type": "scalar"}], "edges": []}),
         context=_ATMOSPHERIC_CONTEXT,
     )
-    block = out.get("enrichment")
-    assert isinstance(block, dict)
-    assert block["reasoning"] == "Corrected: V is velocity, not voltage."
-    assert out["nodes"][0]["quantity"] == "velocity"
+    block = out.enrichment
+    assert block is not None
+    assert block.reasoning == "Corrected: V is velocity, not voltage."
+    assert out.nodes[0].quantity == "velocity"
     # Even though the inferred domain came from the first pass and was
     # re-asserted by the retry, the diff against the original input still
     # reports it.
-    assert "domain" in block["fields"]
-    assert "nodes.V.quantity" in block["fields"]
+    assert "domain" in block.fields
+    assert "nodes.V.quantity" in block.fields
 
 
 def test_diff_skips_fields_the_model_left_unchanged() -> None:
@@ -456,12 +478,14 @@ def test_diff_skips_fields_the_model_left_unchanged() -> None:
     # authoritative-diff behavior.
     from agents.semantic_graph_enricher import _diff_enriched_fields
 
-    inp = {"nodes": [{"id": "V", "type": "scalar", "label": "V", "unit": "m/s"}], "edges": []}
-    out = {
+    inp = SemanticGraph.model_validate(
+        {"nodes": [{"id": "V", "type": "scalar", "label": "V", "unit": "m/s"}], "edges": []}
+    )
+    out = SemanticGraph.model_validate({
         "nodes": [{"id": "V", "type": "scalar", "label": "V",
                    "unit": "m/s", "quantity": "velocity"}],
         "edges": [],
-    }
+    })
     paths = _diff_enriched_fields(inp, out)
     assert paths == ["nodes.V.quantity"]  # label/unit unchanged → not listed
 
@@ -487,14 +511,14 @@ def test_phantom_nodes_added_by_model_are_dropped() -> None:
         critic_outputs=[{"ok": True, "mismatched_node_ids": []}],
     )
     out = enricher.enrich(
-        {"nodes": [{"id": "g", "type": "scalar"}], "edges": []},
+        _g({"nodes": [{"id": "g", "type": "scalar"}], "edges": []}),
         context=_ATMOSPHERIC_CONTEXT,
     )
-    ids = [n["id"] for n in out["nodes"]]
+    ids = [n.id for n in out.nodes]
     assert ids == ["g"]                       # phantom dropped
-    assert out["edges"] == []                 # phantom edge dropped too
+    assert out.edges == []                 # phantom edge dropped too
     # Real node still got its enrichment.
-    assert out["nodes"][0]["quantity"] == "acceleration"
+    assert out.nodes[0].quantity == "acceleration"
 
 
 def test_validator_raises_modelretry_when_input_ids_dropped() -> None:
@@ -623,69 +647,56 @@ def test_validator_is_noop_when_no_input_set_bound() -> None:
     assert _validate_no_dropped_nodes(output) is output
 
 
-def test_safety_net_rejects_input_nodes_with_unknown_fields() -> None:
-    # Codex review P2: ``GraphEnrichRequest.graph`` is an unvalidated dict
-    # by API contract, so the input we restore from could carry extra
-    # properties the agent's output schema (``SemanticGraphNode``,
-    # ``extra='forbid'``) would reject. The restore path must filter
-    # through the schema rather than copy raw, otherwise the cached
-    # post-enrichment graph loses the ``extra='forbid'`` invariant.
-    from agents.semantic_graph_enricher import _restore_dropped_nodes
-
-    input_graph = {
+def test_input_with_unknown_node_fields_rejected_at_boundary() -> None:
+    # Issue #195: with the typed pipeline, the API boundary (FastAPI handler
+    # for ``/api/graph/enrich``, plus this very test helper ``_g``) calls
+    # ``SemanticGraph.model_validate`` to convert wire-format dicts into
+    # typed graphs. ``SemanticGraphNode`` carries ``extra="forbid"``, so
+    # any node with a schema-violating extra property is rejected *before*
+    # reaching the agent, the merge layer, or the cache. Pre-refactor,
+    # ``GraphEnrichRequest.graph: dict`` accepted any shape and the merge
+    # helpers had to re-validate individual nodes inside
+    # ``_restore_dropped_nodes`` to preserve the ``extra="forbid"`` invariant
+    # (see the surgical fix in PR #194). Now the boundary is the only place
+    # validation happens.
+    poisoned_input = {
         "nodes": [
-            {
-                "id": "good",
-                "type": "scalar",
-                "latex": "x",
-            },
-            {
-                # Schema-violating extra property — must NOT make it into
-                # the restored output.
-                "id": "evil",
-                "type": "scalar",
-                "latex": "y",
-                "script": "<malicious>",
-            },
+            {"id": "good", "type": "scalar", "latex": "x"},
+            # Schema-violating extra property — must trip the boundary.
+            {"id": "evil", "type": "scalar", "latex": "y", "script": "<malicious>"},
         ],
         "edges": [],
     }
-    output_graph: dict = {"nodes": [], "edges": []}
-    _restore_dropped_nodes(input_graph, output_graph)
-    ids = [n["id"] for n in output_graph["nodes"]]
-    # Schema-clean node was restored; the one with a forbidden extra
-    # was dropped from the restore path. (The dangling-edge symptom
-    # this would cause is recoverable downstream — the renderer falls
-    # back to a placeholder for an undeclared id — but persisting an
-    # unsafe field through the cache is not.)
-    assert ids == ["good"]
-    assert all("script" not in n for n in output_graph["nodes"])
+    with pytest.raises(ValidationError, match="extra_forbidden|script"):
+        SemanticGraph.model_validate(poisoned_input)
 
 
-def test_safety_net_strips_none_fields_when_restoring() -> None:
-    # Smoke test for the schema-validate-then-dump round trip: ``None``
-    # values on the input dict (e.g. an unset ``label``) are excluded
-    # from the restored entry via ``exclude_none=True``, matching how
-    # the agent's own output is normalised.
+def test_restore_dropped_nodes_excludes_none_fields() -> None:
+    # Smoke test for the typed restore: nodes are ``SemanticGraphNode``
+    # instances with ``Optional[...] = None`` fields. When we serialize
+    # the post-enrichment graph at the API boundary via
+    # ``model_dump(exclude_none=True)``, fields the parser left as ``None``
+    # are dropped — matching how the agent's own output is normalised.
     from agents.semantic_graph_enricher import _restore_dropped_nodes
+    from models.semantic_graph import SemanticGraphNode
 
-    input_graph = {
-        "nodes": [
-            {
-                "id": "x",
-                "type": "scalar",
-                "latex": "x",
-                "label": None,
-                "description": None,
-            },
+    input_graph = SemanticGraph(
+        nodes=[
+            SemanticGraphNode(id="x", type="scalar", latex="x"),
         ],
-        "edges": [],
-    }
-    output_graph: dict = {"nodes": [], "edges": []}
+        edges=[],
+    )
+    output_graph = SemanticGraph(nodes=[], edges=[])
     _restore_dropped_nodes(input_graph, output_graph)
-    assert output_graph["nodes"][0]["id"] == "x"
-    assert "label" not in output_graph["nodes"][0]
-    assert "description" not in output_graph["nodes"][0]
+    assert len(output_graph.nodes) == 1
+    assert output_graph.nodes[0].id == "x"
+    # ``label`` and ``description`` weren't set on the input — they stay
+    # as ``None`` on the model and disappear from the wire-format dump.
+    assert output_graph.nodes[0].label is None
+    assert output_graph.nodes[0].description is None
+    dumped = output_graph.nodes[0].model_dump(by_alias=True, exclude_none=True)
+    assert "label" not in dumped
+    assert "description" not in dumped
 
 
 def test_dropped_node_safety_net_restores_when_validator_exhausts() -> None:
@@ -710,11 +721,11 @@ def test_dropped_node_safety_net_restores_when_validator_exhausts() -> None:
         ],
         "edges": [{"from": "q_{\\text{LEO}}", "to": "__deriv_5"}],
     }
-    out = enricher.enrich(input_graph, context=_ATMOSPHERIC_CONTEXT)
-    ids = {n["id"] for n in out["nodes"]}
+    out = enricher.enrich(_g(input_graph), context=_ATMOSPHERIC_CONTEXT)
+    ids = {n.id for n in out.nodes}
     assert ids == {"q_{\\text{LEO}}", "__deriv_5"}
-    by_id = {n["id"]: n for n in out["nodes"]}
-    assert by_id["q_{\\text{LEO}}"]["latex"] == "q_{\\text{LEO}}"
+    by_id = {n.id: n for n in out.nodes}
+    assert by_id["q_{\\text{LEO}}"].latex == "q_{\\text{LEO}}"
 
 
 def test_dropped_input_nodes_are_restored_from_input() -> None:
@@ -759,24 +770,24 @@ def test_dropped_input_nodes_are_restored_from_input() -> None:
             {"from": "q_{\\text{LEO}}", "to": "__deriv_5"},
         ],
     }
-    out = enricher.enrich(input_graph, context=_ATMOSPHERIC_CONTEXT)
+    out = enricher.enrich(_g(input_graph), context=_ATMOSPHERIC_CONTEXT)
 
-    out_ids = [n["id"] for n in out["nodes"]]
+    out_ids = [n.id for n in out.nodes]
     # Both input nodes survive — the dropped one was re-inserted.
     assert "q_{\\text{LEO}}" in out_ids
     assert "__deriv_5" in out_ids
 
     # Restored node carries the parser-owned fields verbatim.
-    by_id = {n["id"]: n for n in out["nodes"]}
+    by_id = {n.id: n for n in out.nodes}
     restored = by_id["q_{\\text{LEO}}"]
-    assert restored["latex"] == "q_{\\text{LEO}}"
-    assert restored["subexpr"] == "q_{\\text{LEO}}"
-    assert restored["type"] == "scalar"
+    assert restored.latex == "q_{\\text{LEO}}"
+    assert restored.subexpr == "q_{\\text{LEO}}"
+    assert restored.type == "scalar"
 
     # Edge that previously dangled still resolves to a real node, and the
     # surviving node retained its enrichment.
-    assert {"from": "q_{\\text{LEO}}", "to": "__deriv_5"} in out["edges"]
-    assert by_id["__deriv_5"]["description"].startswith("Time derivative")
+    assert any(e.model_dump(by_alias=True, exclude_none=True) == {"from": "q_{\\text{LEO}}", "to": "__deriv_5"} for e in out.edges)
+    assert by_id["__deriv_5"].description.startswith("Time derivative")
 
 
 def test_dropped_node_restoration_is_independent_of_phantom_drop() -> None:
@@ -811,12 +822,12 @@ def test_dropped_node_restoration_is_independent_of_phantom_drop() -> None:
             {"from": "\\theta", "to": "g"},
         ],
     }
-    out = enricher.enrich(input_graph, context=_ATMOSPHERIC_CONTEXT)
+    out = enricher.enrich(_g(input_graph), context=_ATMOSPHERIC_CONTEXT)
 
-    ids = sorted(n["id"] for n in out["nodes"])
+    ids = sorted(n.id for n in out.nodes)
     assert ids == ["\\theta", "g"]                  # phantom dropped, theta restored
-    assert {"from": "\\theta", "to": "g"} in out["edges"]
-    assert {"from": "g_phantom", "to": "g"} not in out["edges"]
+    assert any(e.model_dump(by_alias=True, exclude_none=True) == {"from": "\\theta", "to": "g"} for e in out.edges)
+    assert not any(e.model_dump(by_alias=True, exclude_none=True) == {"from": "g_phantom", "to": "g"} for e in out.edges)
 
 
 def test_no_dropped_nodes_means_no_changes_to_node_set() -> None:
@@ -836,12 +847,12 @@ def test_no_dropped_nodes_means_no_changes_to_node_set() -> None:
         critic_outputs=[{"ok": True, "mismatched_node_ids": []}],
     )
     out = enricher.enrich(
-        {"nodes": [{"id": "x", "type": "scalar"},
+        _g({"nodes": [{"id": "x", "type": "scalar"},
                    {"id": "y", "type": "scalar"}],
-         "edges": []},
+         "edges": []}),
         context=_ATMOSPHERIC_CONTEXT,
     )
-    ids = [n["id"] for n in out["nodes"]]
+    ids = [n.id for n in out.nodes]
     assert ids == ["x", "y"]                          # no duplicates, order kept
 
 
@@ -884,15 +895,15 @@ def test_structural_fields_restored_from_input() -> None:
         ],
         "edges": [],
     }
-    out = enricher.enrich(input_graph, context=_ATMOSPHERIC_CONTEXT)
-    node = out["nodes"][0]
+    out = enricher.enrich(_g(input_graph), context=_ATMOSPHERIC_CONTEXT)
+    node = out.nodes[0]
     # Parser-owned fields are restored verbatim — no double backslashes.
-    assert node["subexpr"] == "\\frac{1}{\\rho A C_{d}}"
-    assert node["op"] == "power"
-    assert node["exponent"] == "-1"
+    assert node.subexpr == "\\frac{1}{\\rho A C_{d}}"
+    assert node.op == "power"
+    assert node.exponent == "-1"
     # The semantic enrichment fields the model contributed survive.
-    assert node["description"] == "Inverse of the drag factors."
-    assert node["unit"] == "m/kg"
+    assert node.description == "Inverse of the drag factors."
+    assert node.unit == "m/kg"
 
 
 def test_non_emoji_text_in_emoji_field_is_stripped() -> None:
@@ -913,12 +924,12 @@ def test_non_emoji_text_in_emoji_field_is_stripped() -> None:
         critic_outputs=[{"ok": True, "mismatched_node_ids": []}],
     )
     out = enricher.enrich(
-        {"nodes": [{"id": "a", "type": "vector"}, {"id": "V", "type": "scalar"}], "edges": []},
+        _g({"nodes": [{"id": "a", "type": "vector"}, {"id": "V", "type": "scalar"}], "edges": []}),
         context=_ATMOSPHERIC_CONTEXT,
     )
-    by_id = {n["id"]: n for n in out["nodes"]}
+    by_id = {n.id: n for n in out.nodes}
     assert "emoji" not in by_id["a"]    # word stripped
-    assert by_id["V"]["emoji"] == "💨"  # real emoji survives
+    assert by_id["V"].emoji == "💨"  # real emoji survives
 
 
 def test_diff_reports_field_removals() -> None:
@@ -927,15 +938,15 @@ def test_diff_reports_field_removals() -> None:
     # keys per node so removals show up too.
     from agents.semantic_graph_enricher import _diff_enriched_fields
 
-    inp = {
+    inp = SemanticGraph.model_validate({
         "nodes": [{"id": "V", "type": "scalar", "label": "V", "color": "#cccccc"}],
         "edges": [],
-    }
-    out = {
+    })
+    out = SemanticGraph.model_validate({
         "nodes": [{"id": "V", "type": "scalar", "label": "V",
                    "quantity": "velocity"}],  # color is gone
         "edges": [],
-    }
+    })
     paths = _diff_enriched_fields(inp, out)
     assert "nodes.V.color" in paths       # removal listed
     assert "nodes.V.quantity" in paths    # addition listed
@@ -961,9 +972,13 @@ def test_already_enriched_input_is_passthrough() -> None:
     enricher._agent = _ExplodingAgent()
     enricher._critic = None
 
-    out = enricher.enrich(pre, context=_ATMOSPHERIC_CONTEXT)
-    assert out is pre  # unchanged, same object
-    assert out["enrichment"]["reasoning"] == "previous run"
+    pre_model = _g(pre)
+    out = enricher.enrich(pre_model, context=_ATMOSPHERIC_CONTEXT)
+    # The validated input model is returned unchanged — same object,
+    # no copy / re-stamp on the already-enriched fast path.
+    assert out is pre_model
+    assert out.enrichment is not None
+    assert out.enrichment.reasoning == "previous run"
 
 
 def test_inferred_domain_threads_into_retry_payload() -> None:
@@ -974,9 +989,12 @@ def test_inferred_domain_threads_into_retry_payload() -> None:
     # graph directly.
     from agents.semantic_graph_enricher import _build_payload
 
-    input_graph = {"nodes": [], "edges": []}  # no domain
-    retry_graph = {**input_graph, "domain": "classical_mechanics"}
+    input_graph = SemanticGraph.model_validate(
+        {"nodes": [], "edges": []}  # no domain
+    )
+    retry_graph = input_graph.model_copy(update={"domain": "classical_mechanics"})
     payload = _build_payload(retry_graph, context=_ATMOSPHERIC_CONTEXT)
     assert "Graph domain (authoritative, from parser): classical_mechanics" in payload
-    # The original input graph is not mutated.
-    assert "domain" not in input_graph
+    # The original input graph is not mutated — ``model_copy`` returns
+    # a fresh instance.
+    assert input_graph.domain is None

--- a/tests/agents/test_semantic_graph_enricher.py
+++ b/tests/agents/test_semantic_graph_enricher.py
@@ -654,6 +654,31 @@ def test_validator_is_noop_when_no_input_set_bound() -> None:
     assert _validate_no_dropped_nodes(output) is output
 
 
+def test_already_enriched_input_still_validates_at_boundary() -> None:
+    # Codex review #1 on PR #196: schema validation must run BEFORE the
+    # ``enrichment is not None`` short-circuit, otherwise a caller can
+    # smuggle a schema-violating graph through by including any
+    # ``"enrichment": {...}`` blob. Even though the agent runs through
+    # ``aenrich`` (which checks ``enrichment is not None`` directly on the
+    # validated model), this test pins the boundary order — the validated
+    # input is what the short-circuit returns, not the raw dict.
+    from models.semantic_graph import Enrichment
+
+    pre_with_extra = {
+        "enrichment": {"reasoning": "previously enriched"},
+        "nodes": [
+            # Schema-violating extra property — must trip the boundary
+            # even on the already-enriched fast path.
+            {"id": "evil", "type": "scalar", "script": "<malicious>"},
+        ],
+        "edges": [],
+    }
+    # ``_g`` mirrors the FastAPI handler's call to ``SemanticGraph.model_validate``.
+    # The boundary rejects the input regardless of the enrichment marker.
+    with pytest.raises(ValidationError, match="extra_forbidden|script"):
+        SemanticGraph.model_validate(pre_with_extra)
+
+
 def test_input_with_unknown_node_fields_rejected_at_boundary() -> None:
     # Issue #195: with the typed pipeline, the API boundary (FastAPI handler
     # for ``/api/graph/enrich``, plus this very test helper ``_g``) calls
@@ -1004,8 +1029,13 @@ def test_non_emoji_text_in_emoji_field_is_stripped() -> None:
         context=_ATMOSPHERIC_CONTEXT,
     )
     by_id = {n.id: n for n in out.nodes}
-    assert "emoji" not in by_id["a"]    # word stripped
-    assert by_id["V"].emoji == "💨"  # real emoji survives
+    # ``by_id["a"]`` is a ``SemanticGraphNode``, not a dict — ``"emoji"
+    # in model`` checks against the field-tuple iterator, never matches
+    # the bare string, and would always pass even if ``_strip_bad_emojis``
+    # did nothing. Use attribute access instead so the assertion actually
+    # exercises the helper. (Codex review on PR #196.)
+    assert by_id["a"].emoji is None     # word stripped
+    assert by_id["V"].emoji == "💨"     # real emoji survives
 
 
 def test_diff_reports_field_removals() -> None:

--- a/tests/agents/test_semantic_graph_enricher.py
+++ b/tests/agents/test_semantic_graph_enricher.py
@@ -152,7 +152,14 @@ def test_enrichment_preserves_ids_and_edges() -> None:
     for symbol in ("P", "V", "T"):
         assert by_id[symbol].description
         assert by_id[symbol].emoji
-        assert (by_id[symbol].color or "").startswith("#")
+    # ``color`` is now in ``_STRUCTURAL_NODE_FIELDS`` (parser-owned), so
+    # any color the agent invented for a node whose input had no color
+    # gets stripped during the merge. The system prompt already forbade
+    # the agent from setting color (rule #3); the merge layer now
+    # enforces it. Test fixture's input has no color → output has no
+    # color, regardless of what the agent returned.
+    for symbol in ("P", "V", "T"):
+        assert by_id[symbol].color is None
 
 
 @pytest.mark.parametrize(
@@ -697,6 +704,75 @@ def test_restore_dropped_nodes_excludes_none_fields() -> None:
     dumped = output_graph.nodes[0].model_dump(by_alias=True, exclude_none=True)
     assert "label" not in dumped
     assert "description" not in dumped
+
+
+def test_parser_owned_color_and_highlight_are_restored_from_input() -> None:
+    # Issue #195: ``color`` / ``highlight`` are author-set semantic markers
+    # tied to ``htmlClass{hl-cube}``-style highlights — the parser emits
+    # them and the renderer / theme resolves them. The system prompt tells
+    # Gemini not to modify ``color`` (rule #3), but in production we've
+    # seen it strip the field anyway. Adding both to ``_STRUCTURAL_NODE_FIELDS``
+    # makes the merge layer enforce the parser's intent regardless of what
+    # the agent returns.
+    enricher = _build_agent_with(
+        test_output={
+            "nodes": [
+                # Agent strips both color and highlight from the response.
+                {"id": "__num_6", "type": "number", "label": "2.81",
+                 "description": "Heating ratio."},
+            ],
+            "edges": [],
+        },
+        critic_outputs=[{"ok": True, "mismatched_node_ids": []}],
+    )
+    out = enricher.enrich(
+        _g({
+            "nodes": [
+                {"id": "__num_6", "type": "number", "label": "2.81",
+                 "color": "red", "highlight": "result"},
+            ],
+            "edges": [],
+        }),
+        context=_ATMOSPHERIC_CONTEXT,
+    )
+    by_id = {n.id: n for n in out.nodes}
+    # Parser-set markers survive — the merge layer restored them from
+    # the input even though Gemini's response omitted both.
+    assert by_id["__num_6"].color == "red"
+    assert by_id["__num_6"].highlight == "result"
+    # The agent's enrichment fields still land on the same node.
+    assert by_id["__num_6"].description == "Heating ratio."
+
+
+def test_parser_owned_color_overwrites_agent_modifications() -> None:
+    # Even if the agent *modifies* a parser-owned field rather than
+    # stripping it, the merge layer reverts to the input value. Otherwise
+    # a model that thinks it knows better could rewrite ``color: "red"``
+    # as ``color: "#ff0000"`` (or worse, a hex that doesn't match the
+    # theme's resolution).
+    enricher = _build_agent_with(
+        test_output={
+            "nodes": [
+                {"id": "__num_6", "type": "number", "label": "2.81",
+                 "color": "blue", "highlight": "hijacked"},
+            ],
+            "edges": [],
+        },
+        critic_outputs=[{"ok": True, "mismatched_node_ids": []}],
+    )
+    out = enricher.enrich(
+        _g({
+            "nodes": [
+                {"id": "__num_6", "type": "number", "label": "2.81",
+                 "color": "red", "highlight": "result"},
+            ],
+            "edges": [],
+        }),
+        context=_ATMOSPHERIC_CONTEXT,
+    )
+    by_id = {n.id: n for n in out.nodes}
+    assert by_id["__num_6"].color == "red"          # not "blue"
+    assert by_id["__num_6"].highlight == "result"   # not "hijacked"
 
 
 def test_dropped_node_safety_net_restores_when_validator_exhausts() -> None:


### PR DESCRIPTION
## Summary

Closes #195 (phase 1).

Migrate the semantic-graph enrichment pipeline from passing `dict` around to operating on `SemanticGraph` / `SemanticGraphNode` model instances throughout. The agent's *output* was already typed via pydantic-ai (`output_type=SemanticGraph`); this brings the input side and every internal helper to match.

## Why

The semantic-graph code is hot — every recent issue (#184, #185, #186, #187, #188, #192, #194) has been about this pipeline. Dict-soup typing was the proximate cause of multiple bugs:

- The surgical fix in #194 had to manually re-validate individual nodes inside `_restore_dropped_nodes` because the `GraphEnrichRequest.graph: dict` API contract let schema-violating input slip through.
- `_drop_phantom_nodes_and_edges`, `_restore_structural_fields`, etc. each duplicated id-extraction / type-guard logic instead of relying on the model.
- The refactor surfaced a pre-existing schema mismatch (named CSS colors vs. hex-only pattern) that was already in the wild — see commit 2.
- The boundary check let parser-set `color` / `highlight` get clobbered by enrichment — see commit 3.

With the typed pipeline, `extra="forbid"` is enforced once at the API boundary and every internal pass relies on it. Helper code is shorter and obviously correct.

## What changed

### `agents/semantic_graph_enricher.py`

- `aenrich(graph: SemanticGraph) -> SemanticGraph` (was `dict` in / `dict` out). Caller is responsible for the wire-format conversion at its own boundary.
- `enrich` (sync wrapper) follows the same typed contract.
- All internal helpers re-typed: `_graph_domain`, `_render_context`, `_build_payload`, `_build_critique_payload`, `_diff_enriched_fields`, `_drop_phantom_nodes_and_edges`, `_restore_dropped_nodes`, `_restore_structural_fields`, `_strip_bad_emojis`, `_stamp_enriched`, `_enrichment_reasoning`.
- New `_node_field_dict` helper centralises model→wire-format projection for the diff computation.
- `_restore_dropped_nodes` no longer revalidates per-node — input is already a validated model.
- `color` and `highlight` added to `_STRUCTURAL_NODE_FIELDS` so parser-set semantic markers survive enrichment. The system prompt already tells Gemini not to set `color` (rule #3); the merge layer now enforces it instead of relying on the model.

### `server.py` `/api/graph/enrich` handler

- Validates `req.graph` to `SemanticGraph` once, **before** any short-circuit (already-enriched fast path or cache lookup), so the `extra="forbid"` invariant can't be bypassed by including any `enrichment` blob in the request.
- Catches `pydantic.ValidationError` specifically — anything else falls through to the outer 500 handler so server bugs aren't misclassified as 400s with raw exception text echoed back.
- Calls `aenrich` with the model.
- `model_dump(by_alias=True, exclude_none=True)` for the cache and JSON response, preserving the existing wire shape on the client side.

### `models/semantic_graph.py`

- Loosened `SemanticGraphNode.color` pattern to accept either `#hex` or `[a-zA-Z]+` (CSS named keyword). The parser emits semantic-highlight nodes with named colors like `"red"` / `"yellow"` (e.g. `__num_6` for a calculation result), and pre-refactor those slipped through unvalidated. The alpha-only arm preserves the prompt-injection rejection — `javascript:alert(1)` still fails because of `:`, `url(...)` because of `(`, etc. `max_length=30` caps unbounded payloads.

### `tests/agents/test_semantic_graph_enricher.py`

- New `_g(payload)` helper wraps wire-format dict literals into `SemanticGraph` (mirrors what the FastAPI handler does in production).
- Test fixtures stay readable as dict literals; call sites convert via `_g(...)` at the input boundary.
- Assertions on the enriched output use attribute access throughout (`out.nodes[0].quantity` instead of `out["nodes"][0]["quantity"]`).
- New tests:
  - `test_input_with_unknown_node_fields_rejected_at_boundary` — schema-violating input is rejected at `SemanticGraph.model_validate` (which is what the handler and `_g` helper both use).
  - `test_already_enriched_input_still_validates_at_boundary` — pins the boundary-order fix: a graph with an `enrichment` marker plus extras is still rejected.
  - `test_parser_owned_color_and_highlight_are_restored_from_input` — agent strips both → merge restores from input.
  - `test_parser_owned_color_overwrites_agent_modifications` — agent *modifies* both → merge reverts to input value.
- Fixed `_strip_bad_emojis` test: pre-fix `"emoji" not in by_id["a"]` always passed silently because Pydantic v2's `__iter__` yields `(name, value)` tuples; corrected to `by_id["a"].emoji is None`. Negative control verified.

## End-to-end verification

Hit `/api/graph/enrich` directly through the live dev server with the `\frac{\dot{q}_{\text{lunar}}}{\dot{q}_{\text{LEO}}} = 2.81` payload (the same one we've been using for #185 / #192):

```
INPUT — __num_6 has: color='red', highlight='result'

OUTPUT — __num_6 after enrichment:
  color: 'red'      ← parser-set marker preserved
  highlight: 'result'    ← parser-set marker preserved
  description: 'A dimensionless number representing the ratio of heating rates...'
  emoji: '🔥'

all 9 input ids present: True
```

Boundary validates, Gemini enriches, q-nodes get descriptions + emoji, parser-set color survives end-to-end, cache hits on the second call.

## Out of scope (separate follow-ups)

- **Cache key still hashes the wire-format dict** — keeps cache compatibility across the upgrade window.
- **`GraphEnrichRequest.graph: dict`** stays as `dict` for now; the handler's `model_validate` is the boundary rather than the FastAPI parameter type. Switching it would require checking pydantic-ai compatibility around alias / extra-forbid behaviour through FastAPI's request validation.
- **Phase 2 of #195** (cache stores models, request schema becomes `SemanticGraph`) — deliberately deferred.

## Test plan

- [x] `./run.sh -m pytest tests/` — **304 passed, 1 skipped** (no regressions, +3 new tests since the original PR opened)
- [x] Live `/api/graph/from-latex` → `/api/graph/enrich` round-trip on `\frac{\dot{q}_{\text{lunar}}}{\dot{q}_{\text{LEO}}} = 2.81` → all q-nodes enriched, full descriptions + emoji, parser-set color/highlight preserved
- [x] Cache hit on second call returns same shape
- [x] Schema-violating input gets a 400 with the pydantic message (used to be a 502)
- [x] Schema-violating input with `enrichment` blob is also rejected (validation runs before short-circuit)
- [x] Prompt-injection rejection still works (`<script>`, `javascript:`, oversized labels, `expression(...)`)

## Codex review fixes (commits 4 & 5)

- **Validation bypass via `enrichment` field** — schema validation moved before short-circuit (must-fix).
- **`except Exception` too broad** — narrowed to `ValidationError`; server bugs no longer misclassified as 400s (must-fix).
- **`"emoji" not in by_id["a"]` silent test** — corrected to attribute access; negative control verified (must-fix).
- **Color length cap** — added `max_length=30` (defense-in-depth).

## Related

- Closes #195 (phase 1 of two)
- Builds on #194 (surgical per-node revalidation moves to a single boundary check)
- Companion to #185 (the dict-soup era was uniquely good at hiding string-replacement bugs)

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>