### PR TITLE
fix(graph): tooltip renders \rho_0 as ρ₀ instead of plain text (#197)

### DIFF
--- a/docs/latex-parser-design.md
+++ b/docs/latex-parser-design.md
@@ -148,6 +148,207 @@ SemanticGraphBuilder._walk() ← recursive tree walk
 
 Generated IDs use a `__` prefix to avoid collision with symbol names.
 
+### Node Display Fields: `latex` vs `subexpr`
+
+Each node carries up to two LaTeX-bearing fields, which look redundant on a
+leaf symbol but are not interchangeable:
+
+| Field | Domain | Set on | Source |
+|---|---|---|---|
+| `latex` | LaTeX for *this node's name* | Leaf symbols (and override placeholders) | Reconstructed from input via `_latex_commands` |
+| `subexpr` | LaTeX for *the entire sub-expression rooted at this node* | Every node | Either raw input LaTeX (root, relations, override placeholders) or `_subexpr_ordered` (everything else) |
+
+For a leaf like `\rho_0`, the two collapse to the same string. For a compound
+node — a `Mul`, `Pow`, function, equation root — `subexpr` is bigger than any
+single symbol's `latex` and is the only field that exists.
+
+Frontend consumers pick whichever fits:
+
+- **Mermaid node body** (the green circle): uses `label` if the enricher set
+  one, else `latex`.
+- **Node Details panel title**: prefers `latex`, falls back to `subexpr`.
+- **Hover tooltip**: uses `subexpr` unconditionally — no fallback.
+
+The fields must therefore *agree* on a leaf symbol, even though they're
+populated by different code paths. See "SymPy Round-Trip and `_latex_commands`"
+below for why agreement isn't automatic and what keeps them in sync.
+
+### SymPy Round-Trip and `_latex_commands`
+
+SymPy's `parse_latex` → SymPy expression tree → `sympy.latex` round-trip is
+**lossy for symbol names that came from LaTeX macros** (`\rho`, `\beta`,
+`\hat{n}`, etc.).
+
+The chain:
+
+1. Author writes `\rho_0`.
+2. `parse_latex` normalizes the subscript and produces `Symbol("rho_{0}")`
+   — a Symbol whose `.name` is the literal six-character string `rho_{0}`,
+   braces and all. The backslash is gone; the macro is now an identifier.
+3. `sympy.latex(Symbol("rho_{0}"))` returns the bare string `"rho_{0}"`.
+   SymPy's printer recognizes Greek-letter names by matching the raw name
+   against a fixed table (`alpha`, `beta`, `rho`, …) and splits subscripts
+   on the *digit suffix* form (`alpha_0` → `\alpha_{0}`). Neither matches
+   the *brace-included* form `parse_latex` emits, so the backslash is not
+   restored. The name is printed verbatim.
+
+The two halves of SymPy's own round-trip don't agree on canonical naming.
+That's the seam where the backslash falls out.
+
+We don't fix this inside SymPy. Instead, the parser does its **own
+pre-parse scan** of the original LaTeX source and builds a `_latex_commands:
+dict[str, str]` map of every backslash macro it sees, mapping the SymPy-style
+identifier name to its original LaTeX command (`{"rho": "\\rho", "beta":
+"\\beta", ...}`). This is built by `_extract_latex_commands` *before* SymPy
+parses anything.
+
+When the builder needs LaTeX for a Symbol, the helper `_symbol_latex(name)`
+consults this map:
+
+1. Direct hit: `name in _latex_commands` → use the command.
+2. Subscript hit: split on `_`, look up the base (`rho_{0}` → `rho` →
+   `\rho`), reattach the subscript suffix (`\rho_{0}`).
+3. Leibniz-d hit: `drho` → `\mathrm{d}\rho` (handles SymPy's habit of
+   merging `d\rho` into a single identifier).
+4. None of the above: use the raw name (e.g. `x`, `m`, `Cd` — plain
+   variables that have no LaTeX form to recover).
+
+`_symbol_latex` is shared by both `_walk_inner` (which sets the node's
+`latex` field) and `_subexpr_ordered` (which sets `subexpr`), so the two
+fields are guaranteed to agree on a leaf. **They diverge whenever
+`_subexpr_ordered` falls through to `sympy.latex(expr)` on a non-Symbol
+sub-tree** — at which point the round-trip leak reappears inside compound
+`subexpr` strings (e.g. `\frac{H rho_{0}}{...}` instead of `\frac{H
+\rho_{0}}{...}`). That's a known residual issue: the leak is contained to
+compound nodes' `subexpr` fields and doesn't affect any node's `latex`.
+
+#### Why not just prepend `\` to every Symbol name?
+
+The set of valid LaTeX commands is a fixed, finite vocabulary; symbol names
+are arbitrary strings chosen by the lesson author. There's no rule saying
+"any name is a macro." `Symbol("x")` → `\x` is a KaTeX error. We need to
+distinguish `rho` (a real macro) from `mass` (a plain variable), and the
+only reliable signal is whether the original input contained `\rho`. That's
+exactly what `_latex_commands` records.
+
+#### Why not subclass `Symbol` to carry the original LaTeX?
+
+Tried mentally; not worth it. SymPy `Symbol` uses `__slots__` and is
+interned (`Symbol("x") is Symbol("x")` returns `True`), so you can't attach
+attributes directly. A `TaggedSymbol(Symbol)` subclass works, but
+`TaggedSymbol("rho") != Symbol("rho")`, which breaks SymPy internals,
+`parse_latex` output (which always returns plain `Symbol`), and any code
+path that compares against bare `Symbol`. An external map keyed by name —
+which is what `_latex_commands` is — gives us the same "extra info attached
+to a Symbol" semantics without fighting interning or equality.
+
+## Graph Enrichment via Pydantic AI
+
+The parser produces a structurally-correct graph but deliberately leaves
+**semantic** fields blank: `label`, `emoji`, `quantity`, `dimension`, `unit`,
+`description`, `role`. Hardcoding those in the parser was tried and
+abandoned — a symbol named `F` is "force" in mechanics, "free energy" in
+thermodynamics, and "field strength" in electromagnetism. There's no
+domain-free correct answer.
+
+Enrichment is therefore a **second pass**, performed by a Gemini model
+behind a [`pydantic-ai`](https://ai.pydantic.dev) wrapper, with the lesson
+context as input.
+
+### Pipeline
+
+```
+Parser graph (structural only)
+    │
+    ▼
+SemanticGraphEnrichmentAgent.arun(graph + context)   ← Gemini 2.5 Pro
+    │      └── pydantic-ai validates output against SemanticGraph schema
+    │           and retries up to max_retries=2 on validation failure
+    ▼
+Enriched graph (label, emoji, quantity, unit, description, …)
+    │
+    ▼
+SemanticGraphCoherenceCritic.arun(context + enriched)  ← Gemini 2.5 Pro
+    │      └── verdict: ok? mismatched_node_ids? feedback?
+    ▼
+   ok ─────────────► return enriched
+   mismatch ──────► fold critic feedback into context, re-run enricher once
+```
+
+Both agents inherit from a thin `BaseAgent` ([agents/base.py](../agents/base.py))
+that owns the `pydantic_ai.Agent` instance, model selection (env-overridable
+via `GEMINI_MODEL`), retry budget, and the `AgentError` failure boundary.
+Subclasses just declare four class attributes — `name`, `system_prompt`,
+`result_type` (a Pydantic model), `model` — and call `arun(input_data)`.
+
+### Why pydantic-ai
+
+The agent loop has to enforce **two** invariants on the model's output:
+
+1. **Schema correctness** — the response must parse as the
+   `SemanticGraphNode` Pydantic model (capped string lengths, regex on
+   color/no-HTML fields, enum values for `role` and `EdgeSemantic`, etc.).
+2. **Structural preservation** — the enricher must return the *same set of
+   node ids and edges* as the input. It's editing fields, not redesigning
+   the graph.
+
+`pydantic-ai` gives us (1) for free: it validates each model response against
+`SemanticGraph` and, on `ValidationError`, sends the validator's complaint
+back to the model as a follow-up message, asking for a corrected response.
+We get up to `max_retries=2` of self-correction without writing any of the
+"please fix this field" prompt logic ourselves.
+
+For (2), we register a custom **output validator** with pydantic-ai
+(`_validate_no_dropped_nodes`, [agents/semantic_graph_enricher.py:424](../agents/semantic_graph_enricher.py#L424))
+that raises `pydantic_ai.ModelRetry` when input ids are missing from the
+output. Same retry loop, same budget — pydantic-ai treats our validator's
+`ModelRetry` exactly like a schema failure. Issue [#192](https://github.com/ibenian/algebench/issues/192)
+documents the failure mode this guards against (Gemini occasionally drops
+small variable nodes during enrichment).
+
+A small set of **post-validation cleanups** ([agents/semantic_graph_enricher.py:543](../agents/semantic_graph_enricher.py#L543))
+runs after pydantic-ai succeeds — they handle quirks too narrow to retry on
+(double-escaped backslashes in JSON-mode output, foreign-language words
+mistakenly placed in the `emoji` field, etc.). Anything that *should* trigger
+a retry stays in the validator path; anything that's just cosmetic gets
+quietly fixed.
+
+### The coherence critic
+
+Schema-valid enrichment is not the same as *correct* enrichment. Gemini
+will happily annotate a node `V` as "voltage" in an atmospheric-entry lesson
+where `V` is velocity. Both are well-formed; only one matches the lesson.
+
+`SemanticGraphCoherenceCritic` is a separate `BaseAgent` whose `result_type`
+is `_CoherenceVerdict { ok, mismatched_node_ids, feedback }`. After every
+enrichment, we hand it the lesson context plus the enriched graph and ask:
+*does any node's claimed physical quantity belong to a different physical
+domain than the lesson?* The prompt explicitly instructs it to be
+conservative — only flag clear cross-domain contradictions, not stylistic
+issues.
+
+If the critic returns `ok = false`, we fold its `feedback` string into the
+enrichment context and re-run the enricher once. The re-run sees the
+critic's note and typically picks the right reading on the second pass.
+
+We avoid hand-coded keyword tables (e.g. "if context mentions 'velocity',
+reject 'voltage'") deliberately — the critic generalizes to any domain the
+model can reason about, which is far broader than any list we could
+maintain.
+
+### What pydantic-ai is *not* doing here
+
+- **Tool use / function calling**: the enricher takes the graph as input
+  and returns the graph as output. There are no tools registered.
+- **Multi-turn conversation**: each enrichment is a single
+  `agent.run(prompt)`. The retry loop is internal to one call; there's no
+  user-visible chat history.
+- **Streaming**: the result is a structured object, not free text. We need
+  the whole thing before we can validate or render.
+
+The pydantic-ai value-add is narrow but exactly right for this shape of
+problem: *take a typed input, return a typed output, retry until valid*.
+
 ## Current Shortcomings
 
 ### Matrices and Linear Algebra

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -322,6 +322,31 @@ class SemanticGraphBuilder:
         """Return the position of *sym_name* in the original LaTeX."""
         return self._symbol_order.get(sym_name, len(self._original_latex))
 
+    def _symbol_latex(self, name: str) -> str | None:
+        """LaTeX form for a Symbol *name*, applying the same Greek-letter
+        and Leibniz-differential reconstruction as ``_walk_inner``.
+
+        Returns ``None`` when the bare name carries no LaTeX command (so
+        the caller can fall back to ``sympy.latex``). SymPy's own
+        ``latex()`` doesn't know that the Symbol named ``rho_{0}`` came
+        from ``\\rho_0`` — so without this, ``subexpr`` ends up as
+        ``rho_{0}`` while ``latex`` is ``\\rho_{0}``, and KaTeX renders
+        the tooltip as plain text instead of ρ₀.
+        """
+        if name in self._latex_commands:
+            return self._latex_commands[name]
+        if "_" in name:
+            base = name.split("_")[0]
+            if base in self._latex_commands:
+                return self._latex_commands[base] + name[len(base):]
+        if (
+            len(name) > 1
+            and name[0] == "d"
+            and name[1:] in self._latex_commands
+        ):
+            return r"\mathrm{d}" + self._latex_commands[name[1:]]
+        return None
+
     def _subexpr_ordered(self, expr: sympy.Basic) -> str:
         """Like ``sympy.latex(expr)`` but with terms in authorial order."""
         # Atomic placeholder symbols (compound symbols and \text{...})
@@ -332,6 +357,9 @@ class SemanticGraphBuilder:
             if name in self._overrides and self._overrides[name].get("latex"):
                 if name.startswith("Theta_{") or name.startswith("Xi_{"):
                     return self._overrides[name]["latex"]
+            sym_latex = self._symbol_latex(name)
+            if sym_latex is not None:
+                return sym_latex
         if not self._original_latex:
             return sympy.latex(expr)
 
@@ -457,24 +485,11 @@ class SemanticGraphBuilder:
                 return self._seen_symbols[name]
             meta = KNOWN_VARIABLES.get(name, {})
             node_id = name
-            latex_fallback = self._latex_commands.get(name)
-            if latex_fallback is None:
-                base = name.split("_")[0] if "_" in name else None
-                if base and base in self._latex_commands:
-                    suffix = name[len(base):]
-                    latex_fallback = self._latex_commands[base] + suffix
-                elif (
-                    len(name) > 1
-                    and name[0] == "d"
-                    and name[1:] in self._latex_commands
-                ):
-                    # Leibniz differential: SymPy's parse_latex merges `d\rho`
-                    # into a single symbol `drho` (losing the macro). Emit
-                    # `\mathrm{d}\rho` — upright d per ISO 80000-2 — so KaTeX
-                    # renders `dρ` instead of the literal identifier `drho`.
-                    latex_fallback = r"\mathrm{d}" + self._latex_commands[name[1:]]
-                else:
-                    latex_fallback = name
+            # Leibniz differential note: SymPy's parse_latex merges `d\rho`
+            # into a single symbol `drho` (losing the macro). The helper
+            # emits `\mathrm{d}\rho` — upright d per ISO 80000-2 — so KaTeX
+            # renders `dρ` instead of the literal identifier `drho`.
+            latex_fallback = self._symbol_latex(name) or name
             # Parser emits structural fields only — ``type`` (scalar /
             # vector / constant) and ``latex`` (Greek-letter command etc.).
             # All semantic metadata (label, emoji, quantity, dimension,

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -115,6 +115,16 @@ class TestKnownVariables:
         x_nodes = _find_nodes(g, id="x")
         assert len(x_nodes) == 1
 
+    def test_subscripted_greek_subexpr_keeps_latex_command(self):
+        # Regression for gh-197: hover tooltip rendered \rho_0 as plain
+        # text "rho_0" because the node's `subexpr` came straight from
+        # `sympy.latex(Symbol("rho_{0}"))`, which drops the backslash.
+        # The subexpr must carry the same LaTeX command as `latex`.
+        g = latex_to_semantic_graph(r"\rho_0 + 1")
+        node = _find_node(g, id="rho_{0}")
+        assert node["latex"] == r"\rho_{0}"
+        assert node["subexpr"] == r"\rho_{0}"
+
 
 # ---------------------------------------------------------------------------
 # Numbers and constants

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -125,6 +125,28 @@ class TestKnownVariables:
         assert node["latex"] == r"\rho_{0}"
         assert node["subexpr"] == r"\rho_{0}"
 
+    def test_compound_mul_subexpr_recovers_greek_command(self):
+        # Regression for gh-197: a non-root Mul containing a Greek-named
+        # Symbol must propagate the backslash through `_subexpr_ordered`'s
+        # per-factor recursion. Pre-fix, factors fell through to
+        # `sympy.latex(Symbol("rho_{0}"))` and joined the compound string
+        # as bare `rho_{0}`. The Mul must not be the root — root nodes
+        # get `subexpr` from the original input verbatim, masking the bug.
+        g = latex_to_semantic_graph(r"\rho_0 V + 1")
+        muls = _find_nodes(g, type="operator", op="multiply")
+        assert muls
+        sub = muls[0].get("subexpr", "")
+        assert r"\rho_{0}" in sub, sub
+        assert "rho_{0}" not in sub.replace(r"\rho_{0}", ""), sub
+
+    def test_non_greek_subscripted_symbol_not_falsely_prefixed(self):
+        # Negative case: `x_0` is a plain ASCII variable, not a LaTeX
+        # macro. `_symbol_latex` must NOT invent a `\x` command for it.
+        g = latex_to_semantic_graph(r"x_0 + 1")
+        node = _find_node(g, id="x_{0}")
+        assert node["latex"] == "x_{0}"
+        assert node["subexpr"] == "x_{0}"
+
 
 # ---------------------------------------------------------------------------
 # Numbers and constants


### PR DESCRIPTION
## Summary

- Fix the hover tooltip for Greek-name leaf nodes (e.g. `\rho_0`) so it renders as ρ₀ instead of the plain string `rho_0`.
- Document the SymPy round-trip leak that caused this, the `_latex_commands` recovery mechanism, and the pydantic-ai enrichment pipeline.

## Why

The semantic graph node body and Node Details panel render a node's `latex` field via KaTeX, but the **hover tooltip** renders `subexpr`. For a leaf symbol parsed from `\rho_0`, those two fields were allowed to diverge:

- `latex` was reconstructed from the original input via the `_latex_commands` map → `\rho_{0}` ✅
- `subexpr` came straight from `sympy.latex(Symbol("rho_{0}"))`, which returns the bare string `rho_{0}` ❌

The two halves of SymPy's own round-trip don't agree on canonical naming — `parse_latex(r"\rho_0")` produces `Symbol("rho_{0}")` (literal braces in the name), and `sympy.latex` doesn't recognize the brace-included form as a Greek macro. KaTeX then rendered the tooltip as italic plain text.

## What changed

**`scripts/latex_to_graph.py`** — extracted a shared `_symbol_latex(name)` helper that applies the same Greek-letter and Leibniz-differential reconstruction logic used elsewhere. Both `_walk_inner` (sets `latex`) and `_subexpr_ordered` (sets `subexpr`) now call it, so the two fields are guaranteed to agree on a leaf symbol.

**`tests/test_latex_to_graph.py`** — added a regression test asserting both fields equal `\rho_{0}` for input `\rho_0 + 1`.

**`docs/latex-parser-design.md`** — three new sections documenting the architecture:
- *Node Display Fields: `latex` vs `subexpr`* — table of which UI surface reads which field.
- *SymPy Round-Trip and `_latex_commands`* — explains the lossy round-trip, the pre-parse regex scan, and FAQ subsections on why we don't just prepend `\` and why subclassing `Symbol` doesn't pay off.
- *Graph Enrichment via Pydantic AI* — pipeline diagram, what pydantic-ai gives us (schema validation + retry, `ModelRetry`-raising output validator from #192), and what it deliberately doesn't do.

## Known residual

The fix closes the leak for **leaf** symbols. Compound `subexpr` strings (e.g. inside an `__exp_15` node) can still leak bare `rho_{0}` because `_subexpr_ordered` falls through to `sympy.latex(expr)` for `Pow`/`Function` sub-trees, which renders the whole sub-expression through SymPy's printer in one go. That's a separate, narrower leak — flagged for a follow-up.

## Test plan

- [x] `pytest tests/` — 305 passed, 1 skipped (no regressions)
- [x] New regression test `test_subscripted_greek_subexpr_keeps_latex_command` covers the exact `\rho_0` scenario from the issue
- [ ] Manual verification: open the Trajectory and the Entry Corridor → G-Load Profile and Peak Altitude → step 2 → hover the ρ₀ node → tooltip should render as ρ₀

Closes #197.

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>