### PR TITLE
fix(graph): sanitize node IDs starting with non-letters (#177)

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -2,8 +2,18 @@
 
 Read **[AGENTS.md](AGENTS.md)** before making any changes to this project.
 
+## UI Testing
+
+When testing the UI, always start AlgeBench with:
+
+```bash
+./algebench <filepath> --server-only --debug --port 8785
+```
+
+Then open `http://localhost:8785` in the in-app browser. The `--server-only`
+flag prevents the launcher from opening a second browser window outside Codex.
+
 ## Co-author Trailer
 
 Append this trailer to GitHub interactions — commits, PR descriptions and review comments:
 `🤖 Co-authored-by: Codex <codex@openai.com>`
-

--- a/scripts/graph_to_mermaid.py
+++ b/scripts/graph_to_mermaid.py
@@ -345,10 +345,12 @@ def _format_label(
 # ---------------------------------------------------------------------------
 
 def _sanitize_id(node_id: str) -> str:
-    """Make a node ID safe for Mermaid (no special chars)."""
-    out = node_id
+    """Make a node ID safe for Mermaid (no special chars or numeric start)."""
+    out = str(node_id)
     for ch in "-. {}()*":
         out = out.replace(ch, "_")
+    if not out or not re.match(r"^[A-Za-z_]", out):
+        out = f"n_{out}"
     return out
 
 

--- a/static/graph-panel/graph-panel.js
+++ b/static/graph-panel/graph-panel.js
@@ -526,8 +526,9 @@ export class SemanticGraphPanel {
   /* ------------------------------------------------------------------ */
 
   static sanitizeId(nodeId) {
-    let out = nodeId;
+    let out = String(nodeId);
     for (const ch of "-. {}()*") out = out.replaceAll(ch, "_");
+    if (!out || !/^[A-Za-z_]/.test(out)) out = `n_${out}`;
     return out;
   }
 }

--- a/tests/test_graph_to_mermaid.py
+++ b/tests/test_graph_to_mermaid.py
@@ -148,6 +148,12 @@ class TestSanitizeId:
     def test_dots(self):
         assert _sanitize_id("node.1") == "node_1"
 
+    def test_numeric_scientific_notation_like_id_gets_prefixed(self):
+        assert _sanitize_id("01e") == "n_01e"
+
+    def test_empty_id_gets_prefixed(self):
+        assert _sanitize_id("") == "n_"
+
 
 # ---------------------------------------------------------------------------
 # Mermaid escaping
@@ -237,6 +243,24 @@ class TestSemanticGraphToMermaid:
         result = semantic_graph_to_mermaid(SIMPLE_GRAPH)
         assert 'x[' in result or 'x(' in result
         assert '__multiply_1' in result
+
+    def test_scientific_notation_like_node_id_does_not_leak_into_label(self):
+        graph = {
+            "nodes": [
+                {
+                    "id": "01e",
+                    "label": "acceleration",
+                    "type": "vector",
+                    "latex": "a",
+                },
+            ],
+            "edges": [],
+        }
+        result = semantic_graph_to_mermaid(graph, label_mode="latex")
+        lines = {line.strip() for line in result.splitlines()}
+        assert 'n_01e["$a$"]:::vector' in lines
+        assert '01e["$a$"]:::vector' not in lines
+        assert "01e a" not in result
 
     def test_edges_present(self):
         result = semantic_graph_to_mermaid(SIMPLE_GRAPH)


### PR DESCRIPTION
## Summary
- Fixes #177: node IDs like `01e` were emitted bare into Mermaid, which parses them as scientific-notation tokens and leaks the trailing chars into the label.
- `_sanitize_id` (Python) and `SemanticGraphPanel.sanitizeId` (JS) now prefix `n_` when the sanitized ID is empty or doesn't start with `[A-Za-z_]`, and defensively coerce non-string IDs.
- Adds a `CODEX.md` UI testing note documenting `./algebench <file> --server-only --debug --port 8785` for in-Codex browser testing.

## Test plan
- [x] `pytest tests/test_graph_to_mermaid.py` — new cases for `"01e"`, empty ID, and an integration test asserting `n_01e["\$a\$"]` lands in the Mermaid output instead of a malformed `01e` node.
- [x] Manually load a graph containing a node with a numeric/scientific-notation-style ID in the panel and confirm it renders without leaking into the label.

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>