### PR TITLE
fix(graph): render relation node glyph as plain Unicode, lock to canonical symbol (#170)

### DIFF
--- a/scripts/graph_to_mermaid.py
+++ b/scripts/graph_to_mermaid.py
@@ -146,6 +146,21 @@ DEFAULT_WEIGHT_BASE_PX = 2.0  # when the theme doesn't define a
 # than confusing it for yet another operand flowing into an operator.
 _LOGICAL_CONNECTIVE_OPS = frozenset({"implies", "iff"})
 
+# Canonical glyph for each relation ``op`` the parser emits (see
+# ``scripts/latex_to_graph.RELATION_MAP``). Used by ``_format_label`` so
+# the renderer always shows a clean math glyph for known connectives even
+# when the enricher has overwritten ``emoji`` with something inappropriate
+# (e.g. Gemini occasionally returns ``➡️`` U+27A1 + U+FE0F for ``implies``,
+# which KaTeX parses as ``➡`` text + a phantom ``\R`` accent and renders
+# as a garbled ``→ⓡ`` artifact — see issue #170).
+RELATION_SYMBOLS: dict[str, str] = {
+    "implies": "⟹",
+    "iff": "⟺",
+    "proportional": "∝",
+    "approximately": "≈",
+    "maps_to": "→",
+}
+
 
 def _resolve_edge_width(
     semantic: str | None,
@@ -262,13 +277,20 @@ def _format_label(
 
     if node_type == "relation":
         # Render the relation glyph as plain Unicode text — NOT wrapped in
-        # ``$...$``. The parser sets ``emoji`` from RELATION_MAP (e.g. ``⟹``
-        # for ``implies``); Mermaid's HTML labels render the codepoint
-        # directly with the page font. Routing through KaTeX is fragile —
-        # KaTeX mis-parses emoji-presentation codepoints like ``➡️``
-        # (U+27A1 + U+FE0F) as text plus a phantom accent, producing the
-        # garbled ``→ⓡ`` artifact from issue #170.
-        return node.get("emoji") or node.get("label", op)
+        # ``$...$``. These are arrow/relation glyphs (``⟹``, ``⟺``, ``∝``…)
+        # that Mermaid's HTML labels render directly with the page font.
+        # Routing them through KaTeX is fragile: KaTeX produces poor output
+        # for emoji-style codepoints (e.g. ``➡️`` U+27A1 + U+FE0F renders as
+        # ``➡`` with a phantom ``\R`` accent), and the enricher occasionally
+        # rewrites ``emoji`` to such a codepoint. Prefer the canonical glyph
+        # for the known ``op`` so the visual stays stable regardless.
+        sym = RELATION_SYMBOLS.get(op)
+        if sym:
+            return sym
+        rel_emoji = node.get("emoji", "")
+        if rel_emoji:
+            return rel_emoji
+        return node.get("label", op)
 
     # --- Symbol / number nodes ---
     # ``node.id`` is a machine identifier, never a display symbol — it may

--- a/scripts/graph_to_mermaid.py
+++ b/scripts/graph_to_mermaid.py
@@ -146,21 +146,6 @@ DEFAULT_WEIGHT_BASE_PX = 2.0  # when the theme doesn't define a
 # than confusing it for yet another operand flowing into an operator.
 _LOGICAL_CONNECTIVE_OPS = frozenset({"implies", "iff"})
 
-# Canonical glyph for each relation ``op`` the parser emits (see
-# ``scripts/latex_to_graph.RELATION_MAP``). Used by ``_format_label`` so
-# the renderer always shows a clean math glyph for known connectives even
-# when the enricher has overwritten ``emoji`` with something inappropriate
-# (e.g. Gemini occasionally returns ``➡️`` U+27A1 + U+FE0F for ``implies``,
-# which KaTeX parses as ``➡`` text + a phantom ``\R`` accent and renders
-# as a garbled ``→ⓡ`` artifact — see issue #170).
-RELATION_SYMBOLS: dict[str, str] = {
-    "implies": "⟹",
-    "iff": "⟺",
-    "proportional": "∝",
-    "approximately": "≈",
-    "maps_to": "→",
-}
-
 
 def _resolve_edge_width(
     semantic: str | None,
@@ -277,20 +262,13 @@ def _format_label(
 
     if node_type == "relation":
         # Render the relation glyph as plain Unicode text — NOT wrapped in
-        # ``$...$``. These are arrow/relation glyphs (``⟹``, ``⟺``, ``∝``…)
-        # that Mermaid's HTML labels render directly with the page font.
-        # Routing them through KaTeX is fragile: KaTeX produces poor output
-        # for emoji-style codepoints (e.g. ``➡️`` U+27A1 + U+FE0F renders as
-        # ``➡`` with a phantom ``\R`` accent), and the enricher occasionally
-        # rewrites ``emoji`` to such a codepoint. Prefer the canonical glyph
-        # for the known ``op`` so the visual stays stable regardless.
-        sym = RELATION_SYMBOLS.get(op)
-        if sym:
-            return sym
-        rel_emoji = node.get("emoji", "")
-        if rel_emoji:
-            return rel_emoji
-        return node.get("label", op)
+        # ``$...$``. The parser sets ``emoji`` from RELATION_MAP (e.g. ``⟹``
+        # for ``implies``); Mermaid's HTML labels render the codepoint
+        # directly with the page font. Routing through KaTeX is fragile —
+        # KaTeX mis-parses emoji-presentation codepoints like ``➡️``
+        # (U+27A1 + U+FE0F) as text plus a phantom accent, producing the
+        # garbled ``→ⓡ`` artifact from issue #170.
+        return node.get("emoji") or node.get("label", op)
 
     # --- Symbol / number nodes ---
     # ``node.id`` is a machine identifier, never a display symbol — it may

--- a/scripts/graph_to_mermaid.py
+++ b/scripts/graph_to_mermaid.py
@@ -146,6 +146,21 @@ DEFAULT_WEIGHT_BASE_PX = 2.0  # when the theme doesn't define a
 # than confusing it for yet another operand flowing into an operator.
 _LOGICAL_CONNECTIVE_OPS = frozenset({"implies", "iff"})
 
+# Canonical glyph for each relation ``op`` the parser emits (see
+# ``scripts/latex_to_graph.RELATION_MAP``). Used by ``_format_label`` so
+# the renderer always shows a clean math glyph for known connectives even
+# when the enricher has overwritten ``emoji`` with something inappropriate
+# (e.g. Gemini occasionally returns ``➡️`` U+27A1 + U+FE0F for ``implies``,
+# which KaTeX parses as ``➡`` text + a phantom ``\R`` accent and renders
+# as a garbled ``→ⓡ`` artifact — see issue #170).
+RELATION_SYMBOLS: dict[str, str] = {
+    "implies": "⟹",
+    "iff": "⟺",
+    "proportional": "∝",
+    "approximately": "≈",
+    "maps_to": "→",
+}
+
 
 def _resolve_edge_width(
     semantic: str | None,
@@ -261,11 +276,21 @@ def _format_label(
         return f"${symbol}$"
 
     if node_type == "relation":
+        # Render the relation glyph as plain Unicode text — NOT wrapped in
+        # ``$...$``. These are arrow/relation glyphs (``⟹``, ``⟺``, ``∝``…)
+        # that Mermaid's HTML labels render directly with the page font.
+        # Routing them through KaTeX is fragile: KaTeX produces poor output
+        # for emoji-style codepoints (e.g. ``➡️`` U+27A1 + U+FE0F renders as
+        # ``➡`` with a phantom ``\R`` accent), and the enricher occasionally
+        # rewrites ``emoji`` to such a codepoint. Prefer the canonical glyph
+        # for the known ``op`` so the visual stays stable regardless.
+        sym = RELATION_SYMBOLS.get(op)
+        if sym:
+            return sym
         rel_emoji = node.get("emoji", "")
-        rel_label = node.get("label", op)
         if rel_emoji:
-            return f"${rel_emoji}$"
-        return rel_label
+            return rel_emoji
+        return node.get("label", op)
 
     # --- Symbol / number nodes ---
     # ``node.id`` is a machine identifier, never a display symbol — it may

--- a/tests/test_graph_to_mermaid.py
+++ b/tests/test_graph_to_mermaid.py
@@ -133,6 +133,56 @@ class TestLabelFormatting:
         node = {"id": "z", "label": "z", "type": "scalar"}
         assert _format_label(node, "emoji") == "$z$"
 
+    def test_relation_uses_canonical_glyph_not_emoji_field(self):
+        # Issue #170: the enricher (Gemini) sometimes overwrites the
+        # parser-supplied ``emoji`` for an ``implies`` relation node with a
+        # emoji-presentation codepoint such as ``➡️`` (U+27A1 + U+FE0F).
+        # KaTeX parses that as ``➡`` text + a phantom ``\R`` accent, which
+        # rendered as a garbled ``→ⓡ`` glyph in the diamond. The renderer
+        # must lock known relation ops to their canonical math glyph.
+        node = {
+            "id": "__implies_1",
+            "type": "relation",
+            "op": "implies",
+            "emoji": "➡️",
+            "label": "implies",
+        }
+        # Plain Unicode glyph — NOT wrapped in ``$...$``. Mermaid's HTML
+        # label renders the codepoint directly with the page font.
+        assert _format_label(node, "emoji") == "⟹"
+
+    def test_relation_canonical_glyph_for_each_known_op(self):
+        # Lock the expected glyph for every relation op the parser emits
+        # via ``RELATION_MAP`` (see ``scripts/latex_to_graph.py``).
+        cases = {
+            "implies": "⟹",
+            "iff": "⟺",
+            "proportional": "∝",
+            "approximately": "≈",
+            "maps_to": "→",
+        }
+        for op_name, glyph in cases.items():
+            node = {"id": f"__{op_name}_1", "type": "relation", "op": op_name}
+            assert _format_label(node, "emoji") == glyph, (
+                f"relation op {op_name!r} should render as {glyph!r}"
+            )
+
+    def test_relation_unknown_op_falls_back_to_emoji(self):
+        # An unknown relation op (hand-authored or future addition) still
+        # gets its ``emoji`` rendered — but as plain Unicode text, never
+        # wrapped in ``$...$`` so KaTeX doesn't mangle emoji glyphs.
+        node = {
+            "id": "__custom_1",
+            "type": "relation",
+            "op": "custom_op",
+            "emoji": "🔁",
+        }
+        assert _format_label(node, "emoji") == "🔁"
+
+    def test_relation_no_emoji_no_op_falls_back_to_label(self):
+        node = {"id": "__rel_1", "type": "relation", "op": "weird", "label": "weird"}
+        assert _format_label(node, "emoji") == "weird"
+
 
 # ---------------------------------------------------------------------------
 # ID sanitization

--- a/tests/test_graph_to_mermaid.py
+++ b/tests/test_graph_to_mermaid.py
@@ -179,7 +179,9 @@ class TestLabelFormatting:
         }
         assert _format_label(node, "emoji") == "🔁"
 
-    def test_relation_no_emoji_no_op_falls_back_to_label(self):
+    def test_relation_unknown_op_no_emoji_falls_back_to_label(self):
+        # Op is set but not in RELATION_SYMBOLS, and emoji is missing →
+        # last-resort fallback is the node's ``label``.
         node = {"id": "__rel_1", "type": "relation", "op": "weird", "label": "weird"}
         assert _format_label(node, "emoji") == "weird"
 

--- a/tests/test_graph_to_mermaid.py
+++ b/tests/test_graph_to_mermaid.py
@@ -133,53 +133,24 @@ class TestLabelFormatting:
         node = {"id": "z", "label": "z", "type": "scalar"}
         assert _format_label(node, "emoji") == "$z$"
 
-    def test_relation_uses_canonical_glyph_not_emoji_field(self):
-        # Issue #170: the enricher (Gemini) sometimes overwrites the
-        # parser-supplied ``emoji`` for an ``implies`` relation node with a
-        # emoji-presentation codepoint such as ``➡️`` (U+27A1 + U+FE0F).
-        # KaTeX parses that as ``➡`` text + a phantom ``\R`` accent, which
-        # rendered as a garbled ``→ⓡ`` glyph in the diamond. The renderer
-        # must lock known relation ops to their canonical math glyph.
+    def test_relation_emoji_renders_as_plain_unicode(self):
+        # Issue #170: relation nodes used to wrap their emoji glyph in
+        # ``$...$`` for KaTeX. That mangled emoji-presentation codepoints
+        # like ``➡️`` (U+27A1 + U+FE0F) into a garbled ``→ⓡ`` artifact —
+        # KaTeX parses U+FE0F as an accent on the previous glyph. Relation
+        # glyphs (``⟹``, ``⟺``, ``∝``…) belong in plain text, not math.
         node = {
             "id": "__implies_1",
             "type": "relation",
             "op": "implies",
-            "emoji": "➡️",
+            "emoji": "⟹",
             "label": "implies",
         }
-        # Plain Unicode glyph — NOT wrapped in ``$...$``. Mermaid's HTML
-        # label renders the codepoint directly with the page font.
-        assert _format_label(node, "emoji") == "⟹"
+        out = _format_label(node, "emoji")
+        assert out == "⟹"
+        assert "$" not in out, "relation glyph must not be wrapped in $...$ for KaTeX"
 
-    def test_relation_canonical_glyph_for_each_known_op(self):
-        # Lock the expected glyph for every relation op the parser emits
-        # via ``RELATION_MAP`` (see ``scripts/latex_to_graph.py``).
-        cases = {
-            "implies": "⟹",
-            "iff": "⟺",
-            "proportional": "∝",
-            "approximately": "≈",
-            "maps_to": "→",
-        }
-        for op_name, glyph in cases.items():
-            node = {"id": f"__{op_name}_1", "type": "relation", "op": op_name}
-            assert _format_label(node, "emoji") == glyph, (
-                f"relation op {op_name!r} should render as {glyph!r}"
-            )
-
-    def test_relation_unknown_op_falls_back_to_emoji(self):
-        # An unknown relation op (hand-authored or future addition) still
-        # gets its ``emoji`` rendered — but as plain Unicode text, never
-        # wrapped in ``$...$`` so KaTeX doesn't mangle emoji glyphs.
-        node = {
-            "id": "__custom_1",
-            "type": "relation",
-            "op": "custom_op",
-            "emoji": "🔁",
-        }
-        assert _format_label(node, "emoji") == "🔁"
-
-    def test_relation_no_emoji_no_op_falls_back_to_label(self):
+    def test_relation_no_emoji_falls_back_to_label(self):
         node = {"id": "__rel_1", "type": "relation", "op": "weird", "label": "weird"}
         assert _format_label(node, "emoji") == "weird"
 

--- a/tests/test_graph_to_mermaid.py
+++ b/tests/test_graph_to_mermaid.py
@@ -133,24 +133,53 @@ class TestLabelFormatting:
         node = {"id": "z", "label": "z", "type": "scalar"}
         assert _format_label(node, "emoji") == "$z$"
 
-    def test_relation_emoji_renders_as_plain_unicode(self):
-        # Issue #170: relation nodes used to wrap their emoji glyph in
-        # ``$...$`` for KaTeX. That mangled emoji-presentation codepoints
-        # like ``➡️`` (U+27A1 + U+FE0F) into a garbled ``→ⓡ`` artifact —
-        # KaTeX parses U+FE0F as an accent on the previous glyph. Relation
-        # glyphs (``⟹``, ``⟺``, ``∝``…) belong in plain text, not math.
+    def test_relation_uses_canonical_glyph_not_emoji_field(self):
+        # Issue #170: the enricher (Gemini) sometimes overwrites the
+        # parser-supplied ``emoji`` for an ``implies`` relation node with a
+        # emoji-presentation codepoint such as ``➡️`` (U+27A1 + U+FE0F).
+        # KaTeX parses that as ``➡`` text + a phantom ``\R`` accent, which
+        # rendered as a garbled ``→ⓡ`` glyph in the diamond. The renderer
+        # must lock known relation ops to their canonical math glyph.
         node = {
             "id": "__implies_1",
             "type": "relation",
             "op": "implies",
-            "emoji": "⟹",
+            "emoji": "➡️",
             "label": "implies",
         }
-        out = _format_label(node, "emoji")
-        assert out == "⟹"
-        assert "$" not in out, "relation glyph must not be wrapped in $...$ for KaTeX"
+        # Plain Unicode glyph — NOT wrapped in ``$...$``. Mermaid's HTML
+        # label renders the codepoint directly with the page font.
+        assert _format_label(node, "emoji") == "⟹"
 
-    def test_relation_no_emoji_falls_back_to_label(self):
+    def test_relation_canonical_glyph_for_each_known_op(self):
+        # Lock the expected glyph for every relation op the parser emits
+        # via ``RELATION_MAP`` (see ``scripts/latex_to_graph.py``).
+        cases = {
+            "implies": "⟹",
+            "iff": "⟺",
+            "proportional": "∝",
+            "approximately": "≈",
+            "maps_to": "→",
+        }
+        for op_name, glyph in cases.items():
+            node = {"id": f"__{op_name}_1", "type": "relation", "op": op_name}
+            assert _format_label(node, "emoji") == glyph, (
+                f"relation op {op_name!r} should render as {glyph!r}"
+            )
+
+    def test_relation_unknown_op_falls_back_to_emoji(self):
+        # An unknown relation op (hand-authored or future addition) still
+        # gets its ``emoji`` rendered — but as plain Unicode text, never
+        # wrapped in ``$...$`` so KaTeX doesn't mangle emoji glyphs.
+        node = {
+            "id": "__custom_1",
+            "type": "relation",
+            "op": "custom_op",
+            "emoji": "🔁",
+        }
+        assert _format_label(node, "emoji") == "🔁"
+
+    def test_relation_no_emoji_no_op_falls_back_to_label(self):
         node = {"id": "__rel_1", "type": "relation", "op": "weird", "label": "weird"}
         assert _format_label(node, "emoji") == "weird"
 


### PR DESCRIPTION
Closes #170.

## Summary
- Adds `RELATION_SYMBOLS` map keying each parser-emitted relation `op` to its canonical Unicode glyph (`implies`→`⟹`, `iff`→`⟺`, `proportional`→`∝`, `approximately`→`≈`, `maps_to`→`→`).
- Rewrites the relation branch of `_format_label` to (a) prefer the canonical glyph for known ops — locking the visual against enricher tampering — and (b) emit the glyph as plain Unicode text rather than wrapping in `$...$` so it never goes through KaTeX.
- Adds 4 unit tests: bug-specific case (`emoji` overwritten with `➡️` still renders as `⟹`), every known relation op, and graceful fallback to `emoji` then `label` for unknown ops.

## Why
The implication node in the semantic-graph diamond rendered as a garbled `→ⓡ` artifact (issue #170). Two contributing causes, one fix:

1. **Enricher tampering.** Gemini occasionally overwrites the parser's canonical `⟹` (U+27F9, math symbol) on a relation node with `➡️` (U+27A1 + U+FE0F variation selector for emoji presentation). KaTeX parses the variation selector as an accent on the next codepoint, so `➡️` becomes `➡` text plus a phantom `\R` glyph stacked under `\circ` — the visible `→ⓡ` artifact.
2. **Wrong rendering path.** `_format_label` wrapped relation-node `emoji` in `$...$` to send it through KaTeX. Math operators belong in math mode; relation glyphs (`⟹`, `⟺`, `∝`, …) are Unicode glyphs that Mermaid's HTML labels render directly with the page font.

The canonical-glyph table makes the visual robust against future enricher tampering as well.

## Reviewer notes
- The fix preserves backward-compatibility for hand-authored relation nodes with custom `emoji` for unknown ops — those still render (as plain Unicode, never math).
- Operator nodes (`+`, `=`, `\times`, …) are unchanged — they continue to use `OPERATOR_LATEX` / `OPERATOR_SYMBOLS` and KaTeX, which is correct for math symbols.
- All 217 tests in the related semantic-graph suites pass.

## Test plan
- [x] `pytest tests/test_graph_to_mermaid.py` — 57 pass (4 new)
- [x] `pytest tests/test_latex_to_graph.py tests/test_graph_to_mermaid.py tests/test_dot_notation_restore.py tests/test_semantic_graph_themes.py` — 217 pass
- [x] End-to-end browser verification: navigate to *Quantum States on the Bloch Sphere* → *Angles Encode Amplitudes* → *Deriving the Bloch parameterization* → step 4 *Parameterize the magnitudes*, open the Math dock, observe a clean `⟹` glyph in the relation diamond instead of the previous `→ⓡ` artifact.

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>