### PR TITLE
fix(graph): group comma-joined operand clauses under conjunction in implies/iff (#208)

### DIFF
--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -1224,8 +1224,13 @@ def latex_to_semantic_graph(latex: str, overrides: dict[str, dict[str, str]] | N
         # synthetic conjunction nodes (those already carry the full side
         # latex from creation; per-clause subexprs were set per-clause
         # above). For single-expression sides, the SymPy walk leaves an
-        # internal subexpr — overwrite with the raw side latex so the
-        # tooltip matches the original LaTeX exactly.
+        # internal subexpr — overwrite with the side slice so the
+        # tooltip reflects the side string we actually parsed.
+        # ``lhs_latex``/``rhs_latex`` come from
+        # ``_split_on_relation(preprocessed)``, so they are the
+        # preprocessed/cleaned side LaTeX (e.g. ``x_i`` brace-canonicalized
+        # to ``x_{i}``, spacing macros stripped). This matches the
+        # pre-existing convention for relation-side ``subexpr`` values.
         for node in builder.nodes:
             if node["id"] == lhs_id and not (lhs_expr is None):
                 node["subexpr"] = builder._restore_placeholders(lhs_latex.strip())

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -1153,21 +1153,7 @@ def latex_to_semantic_graph(latex: str, overrides: dict[str, dict[str, str]] | N
     independent statement in the same graph — no forced parent or
     relation node. Shared variables across clauses dedup to one node.
     """
-    # Step 1: detect whether a top-level comma is acting as a statement
-    # separator. Run this before preprocessing so brace/paren depth
-    # reflects the original LaTeX structure (``\text{a, b}`` and
-    # ``f(x, y)`` must not split).
-    clauses = _split_on_top_level_comma(latex)
-    if len(clauses) > 1:
-        # Step 2: build one subgraph per clause and return them together
-        # as independent roots in the same graph — no parent or
-        # ``comma`` / ``and`` relation node is emitted. The graph is
-        # multi-rooted; clauses connect only through organically shared
-        # variables.
-        return _build_comma_separated_graph(
-            clauses, overrides=overrides, domain=domain,
-        )
-
+    user_overrides = overrides
     compound_collapsed, compound_overrides = _collapse_compound_symbols(latex)
     collapsed, text_overrides = _collapse_text_commands(compound_collapsed)
     preprocessed = _preprocess_latex(collapsed)
@@ -1177,43 +1163,107 @@ def latex_to_semantic_graph(latex: str, overrides: dict[str, dict[str, str]] | N
     merged_overrides: dict[str, dict[str, str]] = {
         **compound_overrides,
         **text_overrides,
-        **(overrides or {}),
+        **(user_overrides or {}),
     }
     overrides = merged_overrides
 
-    # Check for relation operators that parse_latex cannot handle.
+    # Check for a top-level relation operator FIRST (before the comma
+    # split). When a relation is present, comma-joined clauses on either
+    # side are operand-level conjunctions — the comma scopes inside the
+    # connective's operand, not above it. See #208: previously the comma
+    # split ran first and orphaned the second RHS clause from the
+    # ``\implies`` node.
     rel = _split_on_relation(preprocessed)
     if rel is not None:
         lhs_latex, rel_meta, rhs_latex = rel
+        builder = SemanticGraphBuilder(overrides=overrides, latex_commands=latex_commands, original_latex=latex)
+
+        def _walk_relation_side(side_latex: str) -> tuple[str, sympy.Basic | None]:
+            """Walk a relation operand. Returns ``(root_id, expr)`` where
+            ``expr`` is the parsed SymPy expression for the side, or
+            ``None`` when the side is a comma-joined conjunction (no
+            single SymPy expression — each clause is parsed
+            independently and joined under a synthetic ``and`` relation
+            node)."""
+            side_clauses = _split_on_top_level_comma(side_latex)
+            if len(side_clauses) <= 1:
+                expr = parse_latex(side_latex)
+                return builder._walk(expr), expr
+
+            _leading_space = re.compile(r"^\s*(?:\\(?:quad|qquad|,|;|!|:)\s*)+")
+            clause_roots: list[str] = []
+            for clause in side_clauses:
+                cleaned = _leading_space.sub("", clause).strip()
+                sub_expr = parse_latex(cleaned)
+                cid = builder._walk(sub_expr)
+                for node in builder.nodes:
+                    if node["id"] == cid:
+                        node["subexpr"] = builder._restore_placeholders(cleaned)
+                        break
+                clause_roots.append(cid)
+            conj_id = builder._next_id("and")
+            builder._add_node(
+                conj_id,
+                type="relation",
+                op="and",
+                label="and",
+                emoji=",",
+                subexpr=builder._restore_placeholders(side_latex.strip()),
+            )
+            for cid in clause_roots:
+                builder._add_edge(cid, conj_id)
+            return conj_id, None
+
         try:
-            lhs_expr = parse_latex(lhs_latex)
-            rhs_expr = parse_latex(rhs_latex)
+            lhs_id, lhs_expr = _walk_relation_side(lhs_latex)
+            rhs_id, rhs_expr = _walk_relation_side(rhs_latex)
         except Exception as exc:
             raise ValueError(f"Failed to parse LaTeX: {exc}") from exc
 
-        builder = SemanticGraphBuilder(overrides=overrides, latex_commands=latex_commands, original_latex=latex)
-        lhs_id = builder._walk(lhs_expr)
-        rhs_id = builder._walk(rhs_expr)
+        # Restore subexpr on the side root nodes when they are *not*
+        # synthetic conjunction nodes (those already carry the full side
+        # latex from creation; per-clause subexprs were set per-clause
+        # above). For single-expression sides, the SymPy walk leaves an
+        # internal subexpr — overwrite with the raw side latex so the
+        # tooltip matches the original LaTeX exactly.
         for node in builder.nodes:
-            if node["id"] == lhs_id:
+            if node["id"] == lhs_id and not (lhs_expr is None):
                 node["subexpr"] = builder._restore_placeholders(lhs_latex.strip())
-            elif node["id"] == rhs_id:
+            elif node["id"] == rhs_id and not (rhs_expr is None):
                 node["subexpr"] = builder._restore_placeholders(rhs_latex.strip())
         rel_id = builder._next_id(rel_meta["op"])
         builder._add_node(rel_id, type="relation", subexpr=latex.strip(), **rel_meta)
         builder._add_edge(lhs_id, rel_id)
         builder._add_edge(rhs_id, rel_id)
         graph = {"nodes": builder.nodes, "edges": builder.edges}
-        # Classify based on both sides combined.  Relational expressions
-        # (inequalities, Eq) don't support arithmetic, so fall back gracefully.
-        try:
-            combined = lhs_expr - rhs_expr
-        except TypeError:
-            combined = lhs_expr
-        graph["classification"] = _classify_expression(combined)
+        # Classify based on both sides combined when both are single
+        # SymPy expressions. Relational expressions (inequalities, Eq)
+        # don't support arithmetic, so fall back gracefully. When either
+        # side is a comma-joined conjunction we have no single
+        # expression to classify, so default to algebraic.
+        if lhs_expr is not None and rhs_expr is not None:
+            try:
+                combined = lhs_expr - rhs_expr
+            except TypeError:
+                combined = lhs_expr
+            graph["classification"] = _classify_expression(combined)
+        else:
+            graph["classification"] = {"kind": "algebraic"}
         if domain:
             graph["domain"] = domain
         return graph
+
+    # No top-level relation. A top-level comma now acts as a statement
+    # separator (preserves existing ``a = 1, b = 2`` behavior — multiple
+    # independent rooted statements, no synthetic ``and`` node). Pass
+    # only the user-supplied overrides; the recursive call re-derives
+    # text/compound placeholders per clause so they don't collide with
+    # parent-scoped ``Xi_{N}`` ids.
+    clauses = _split_on_top_level_comma(latex)
+    if len(clauses) > 1:
+        return _build_comma_separated_graph(
+            clauses, overrides=user_overrides, domain=domain,
+        )
 
     try:
         expr = parse_latex(preprocessed)

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -368,6 +368,88 @@ class TestRelations:
         assert rel is not None
 
 
+class TestRelationOperandComma:
+    """Comma inside an \\implies / \\iff operand groups as a conjunction
+    on that side, not as a top-level statement separator (#208).
+
+    Previously the comma split ran before relation detection, so
+    ``A \\implies B, C`` parsed as two parallel rooted clauses
+    (``A \\implies B`` and ``C``) — the second consequent was orphaned
+    from the implies node entirely.
+    """
+
+    def _reaches(self, graph, src, dst):
+        """Return True iff a directed edge path exists from *src* to *dst*."""
+        adj: dict[str, list[str]] = {}
+        for e in graph["edges"]:
+            adj.setdefault(e["from"], []).append(e["to"])
+        seen = {src}
+        stack = [src]
+        while stack:
+            cur = stack.pop()
+            if cur == dst:
+                return True
+            for nxt in adj.get(cur, []):
+                if nxt not in seen:
+                    seen.add(nxt)
+                    stack.append(nxt)
+        return False
+
+    def test_implies_with_comma_rhs_groups_as_conjunction(self):
+        g = latex_to_semantic_graph(r"x > 0 \implies y = 1, z = 2")
+        impl = _find_node(g, type="relation", op="implies")
+        assert impl is not None
+        # Both consequent clauses must reach the implies node.
+        equals_nodes = _find_nodes(g, type="operator", op="equals")
+        assert len(equals_nodes) == 2
+        for eq in equals_nodes:
+            assert self._reaches(g, eq["id"], impl["id"]), (
+                f"clause {eq.get('subexpr')!r} does not reach implies"
+            )
+        # And they reach it through a synthetic ``and`` conjunction node.
+        conj = _find_node(g, type="relation", op="and")
+        assert conj is not None
+        assert self._reaches(g, conj["id"], impl["id"])
+
+    def test_iff_with_comma_rhs_groups_as_conjunction(self):
+        g = latex_to_semantic_graph(r"P \iff A, B")
+        iff = _find_node(g, type="relation", op="iff")
+        conj = _find_node(g, type="relation", op="and")
+        assert iff is not None and conj is not None
+        assert self._reaches(g, conj["id"], iff["id"])
+        assert self._reaches(g, "A", iff["id"])
+        assert self._reaches(g, "B", iff["id"])
+
+    def test_implies_with_comma_lhs_groups_as_conjunction(self):
+        """Comma on the LHS of an implication groups the antecedents."""
+        g = latex_to_semantic_graph(r"A, B \implies C")
+        impl = _find_node(g, type="relation", op="implies")
+        conj = _find_node(g, type="relation", op="and")
+        assert impl is not None and conj is not None
+        assert self._reaches(g, "A", conj["id"])
+        assert self._reaches(g, "B", conj["id"])
+        assert self._reaches(g, conj["id"], impl["id"])
+        assert self._reaches(g, "C", impl["id"])
+
+    def test_function_arg_comma_inside_implies_unaffected(self):
+        """Comma inside a function-argument group ``f(x, y)`` stays a
+        function arg — it's not at top level on the side, so no
+        conjunction node is emitted."""
+        g = latex_to_semantic_graph(r"x = 1 \implies f(x, y) = 0")
+        # No ``and`` conjunction should appear — comma is depth>0.
+        assert _find_node(g, type="relation", op="and") is None
+        impl = _find_node(g, type="relation", op="implies")
+        assert impl is not None
+
+    def test_top_level_comma_without_relation_unchanged(self):
+        """Without a top-level relation, comma still acts as a statement
+        separator — no synthetic ``and`` node."""
+        g = latex_to_semantic_graph(r"a = 1, b = 2")
+        assert _find_node(g, type="relation", op="and") is None
+        equals_nodes = _find_nodes(g, type="operator", op="equals")
+        assert len(equals_nodes) == 2
+
+
 class TestTextCommand:
     """\\text{NAME} should become a single text node, not decomposed into
     per-character multiplications (SymPy's parse_latex default behavior)."""


### PR DESCRIPTION
## Summary

- Reorders `latex_to_semantic_graph` so relation detection (`\implies`, `\iff`, etc.) runs before the top-level comma split. When a relation is present, comma-joined clauses on either operand side are joined under a synthetic `type=\"relation\", op=\"and\"` node and connected to the relation.
- The no-relation comma path is unchanged: `a = 1, b = 2` still emits independent rooted statements with no synthetic conjunction node.
- The recursive comma-clause path now receives the original user overrides only — not the parent's text/compound placeholders — so per-clause `Xi_{N}` ids stay scoped per clause.

The conjunction node renders the comma glyph the author wrote (not the wedge `∧`), to avoid visual collision with the existing power/exponent caret in the renderer.

Fixes #208.

## Test plan

- [x] `./run.sh -m pytest tests/` — 319 passed, 1 skipped
- [x] New `TestRelationOperandComma` cases:
  - implies + RHS comma → conjunction
  - iff + RHS comma → conjunction
  - implies + LHS comma → conjunction
  - function-arg comma `f(x, y)` inside implies → unchanged (no synthetic and-node)
  - top-level comma without relation `a = 1, b = 2` → unchanged (independent rooted statements)
- [x] Verified in-browser on the issue's repro: scene 7/9 \"Angles Encode Amplitudes\" → proof \"Deriving the Bloch parameterization\" → step 4 \"Parameterize the magnitudes\". The implies (⇒) at the top now connects to both `r_α = cos(θ/2)` and `r_β = sin(θ/2)` through a `,` conjunction node — no orphan subtree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)