### PR TITLE
feat(graph): add D3-based semantic graph renderer with interactive features (#216)

### DIFF
--- a/scenes/draft/graph-panel-demo.json
+++ b/scenes/draft/graph-panel-demo.json
@@ -6,25 +6,73 @@
       "description": "Demonstrates the semantic graph dock view.",
       "markdown": "## Semantic Graph Demo\n\nSwitch to the **Graph** tab in the left dock to view interactive Mermaid diagrams for each proof step. Each equation appears in both its canonical form and a physically-equivalent alternate form, so you can see how the semantic graph reshapes as the algebra is rewritten.",
       "range": [
-        [-5, 5],
-        [-5, 5],
-        [-5, 5]
+        [
+          -5,
+          5
+        ],
+        [
+          -5,
+          5
+        ],
+        [
+          -5,
+          5
+        ]
       ],
       "camera": {
-        "position": [6, 4, 6],
-        "target": [0, 0, 0]
+        "position": [
+          6,
+          4,
+          6
+        ],
+        "target": [
+          0,
+          0,
+          0
+        ]
       },
       "elements": [],
       "steps": [
-        { "title": "Newton's Second Law", "description": "$F = m \\cdot a$" },
-        { "title": "Newton's Second Law (momentum form)", "description": "$F = \\dfrac{dp}{dt}$" },
-        { "title": "Mass-energy equivalence", "description": "$E = m c^2$" },
-        { "title": "Relativistic energy-momentum", "description": "$E^2 = (pc)^2 + (mc^2)^2$" },
-        { "title": "Uniform acceleration (velocity)", "description": "$v = v_0 + a t$" },
-        { "title": "Uniform acceleration (position)", "description": "$x = x_0 + v_0 t + \\tfrac{1}{2} a t^2$" },
-        { "title": "Schrödinger equation (compact)", "description": "$i\\hbar\\,\\dfrac{\\partial \\psi}{\\partial t} = \\hat{H}\\,\\psi$" },
-        { "title": "Schrödinger equation (expanded)", "description": "$i\\hbar\\,\\dfrac{\\partial \\psi}{\\partial t} = -\\dfrac{\\hbar^2}{2m}\\nabla^2 \\psi + V\\psi$" },
-        { "title": "Higher powers and a quotient (^3, ^4, ^n, ^-3, ^-4, ^-n, a/b)", "description": "$y = x^3 + x^4 + x^n + x^{-3} + x^{-4} + x^{-n} + \\frac{a}{b}$" }
+        {
+          "title": "Newton's Second Law",
+          "description": "$F = m \\cdot a$"
+        },
+        {
+          "title": "Newton's Second Law (momentum form)",
+          "description": "$F = \\dfrac{dp}{dt}$"
+        },
+        {
+          "title": "Mass-energy equivalence",
+          "description": "$E = m c^2$"
+        },
+        {
+          "title": "Relativistic energy-momentum",
+          "description": "$E^2 = (pc)^2 + (mc^2)^2$"
+        },
+        {
+          "title": "Uniform acceleration (velocity)",
+          "description": "$v = v_0 + a t$"
+        },
+        {
+          "title": "Uniform acceleration (position)",
+          "description": "$x = x_0 + v_0 t + \\tfrac{1}{2} a t^2$"
+        },
+        {
+          "title": "Schrödinger equation (compact)",
+          "description": "$i\\hbar\\,\\dfrac{\\partial \\psi}{\\partial t} = \\hat{H}\\,\\psi$"
+        },
+        {
+          "title": "Schrödinger equation (expanded)",
+          "description": "$i\\hbar\\,\\dfrac{\\partial \\psi}{\\partial t} = -\\dfrac{\\hbar^2}{2m}\\nabla^2 \\psi + V\\psi$"
+        },
+        {
+          "title": "Partial derivatives — 2D transport equation",
+          "description": "$\\dfrac{\\partial \\rho}{\\partial t} + u\\,\\dfrac{\\partial \\rho}{\\partial x} + v\\,\\dfrac{\\partial \\rho}{\\partial y} = 0$"
+        },
+        {
+          "title": "Higher powers and a quotient (^3, ^4, ^n, ^-3, ^-4, ^-n, a/b)",
+          "description": "$y = x^3 + x^4 + x^n + x^{-3} + x^{-4} + x^{-n} + \\frac{a}{b}$"
+        }
       ],
       "proof": {
         "id": "physics-equations-demo",
@@ -54,7 +102,7 @@
                     "id": "F",
                     "label": "force",
                     "description": "Net force: the vector sum of all forces acting on the object. Measured in newtons (N = kg·m/s²). In this law, force is the *cause* — the external push or pull that changes the object's motion.",
-                    "emoji": "\ud83c\udff9",
+                    "emoji": "🏹",
                     "type": "vector",
                     "latex": "F",
                     "quantity": "force",
@@ -74,7 +122,7 @@
                     "id": "m",
                     "label": "mass",
                     "description": "Inertial mass: the object's resistance to changes in its motion. A larger mass means a smaller acceleration for the same applied force. Treated as a positive, time-independent scalar parameter.",
-                    "emoji": "\u2696\ufe0f",
+                    "emoji": "⚖️",
                     "type": "scalar",
                     "latex": "m",
                     "quantity": "mass",
@@ -87,7 +135,7 @@
                     "id": "a",
                     "label": "acceleration",
                     "description": "Acceleration: the time rate of change of velocity, dv/dt. A vector quantity — both the magnitude (how quickly speed changes) and direction (which way velocity is changing) matter. Responds linearly to applied force.",
-                    "emoji": "\ud83e\udded",
+                    "emoji": "🧭",
                     "type": "vector",
                     "latex": "a",
                     "quantity": "acceleration",
@@ -98,12 +146,26 @@
                   }
                 ],
                 "edges": [
-                  { "from": "F", "to": "__equals_1" },
-                  { "from": "m", "to": "__multiply_2" },
-                  { "from": "a", "to": "__multiply_2" },
-                  { "from": "__multiply_2", "to": "__equals_1" }
+                  {
+                    "from": "F",
+                    "to": "__equals_1"
+                  },
+                  {
+                    "from": "m",
+                    "to": "__multiply_2"
+                  },
+                  {
+                    "from": "a",
+                    "to": "__multiply_2"
+                  },
+                  {
+                    "from": "__multiply_2",
+                    "to": "__equals_1"
+                  }
                 ],
-                "classification": { "kind": "algebraic" }
+                "classification": {
+                  "kind": "algebraic"
+                }
               }
             }
           },
@@ -129,7 +191,7 @@
                     "id": "F",
                     "label": "force",
                     "description": "Net force on the system. Identical conceptually to the F in F = m·a, but here it is defined as *whatever it takes* to change the system's momentum — a definition that survives into relativistic mechanics.",
-                    "emoji": "\ud83c\udff9",
+                    "emoji": "🏹",
                     "type": "vector",
                     "latex": "F",
                     "quantity": "force",
@@ -150,7 +212,7 @@
                     "id": "p",
                     "label": "momentum",
                     "description": "Linear momentum, p = m·v. The primary conserved quantity of translation symmetry — total p of an isolated system is constant (Noether's theorem). Vector; points in the direction of motion.",
-                    "emoji": "\ud83d\ude80",
+                    "emoji": "🚀",
                     "type": "vector",
                     "latex": "p",
                     "quantity": "momentum",
@@ -163,7 +225,7 @@
                     "id": "t",
                     "label": "time",
                     "description": "Time: the independent variable with respect to which momentum evolves. Treated as the universal Newtonian parameter (same for all observers) — relativity modifies this later.",
-                    "emoji": "\u23f1\ufe0f",
+                    "emoji": "⏱️",
                     "type": "scalar",
                     "latex": "t",
                     "quantity": "time",
@@ -174,16 +236,32 @@
                   }
                 ],
                 "edges": [
-                  { "from": "F", "to": "__equals_1" },
-                  { "from": "p", "to": "__derivative_p_t" },
-                  { "from": "t", "to": "__derivative_p_t" },
-                  { "from": "__derivative_p_t", "to": "__equals_1" }
+                  {
+                    "from": "F",
+                    "to": "__equals_1"
+                  },
+                  {
+                    "from": "p",
+                    "to": "__derivative_p_t"
+                  },
+                  {
+                    "from": "t",
+                    "to": "__derivative_p_t"
+                  },
+                  {
+                    "from": "__derivative_p_t",
+                    "to": "__equals_1"
+                  }
                 ],
                 "classification": {
                   "kind": "ODE",
                   "order": 1,
-                  "dependent_variables": ["p"],
-                  "independent_variables": ["t"]
+                  "dependent_variables": [
+                    "p"
+                  ],
+                  "independent_variables": [
+                    "t"
+                  ]
                 }
               }
             }
@@ -210,7 +288,7 @@
                     "id": "E",
                     "label": "energy",
                     "description": "Rest energy: the intrinsic energy an object carries by virtue of its mass alone (i.e. at zero momentum in its own rest frame). Equivalent to about 9 × 10¹⁶ J per kilogram — enormous, because c² is enormous.",
-                    "emoji": "\u26a1",
+                    "emoji": "⚡",
                     "type": "scalar",
                     "latex": "E",
                     "quantity": "energy",
@@ -230,7 +308,7 @@
                     "id": "m",
                     "label": "mass",
                     "description": "Rest mass (invariant mass): the mass measured in the object's own rest frame. Unlike the obsolete 'relativistic mass', rest mass is a Lorentz invariant — every observer agrees on its value.",
-                    "emoji": "\u2696\ufe0f",
+                    "emoji": "⚖️",
                     "type": "scalar",
                     "latex": "m",
                     "quantity": "mass",
@@ -251,7 +329,7 @@
                     "id": "c",
                     "label": "speed of light",
                     "description": "Speed of light in vacuum: a universal constant, exactly 299,792,458 m/s by definition. It is the maximum signal speed, the conversion factor between space and time coordinates, and the scale on which mass-energy equivalence operates.",
-                    "emoji": "\ud83d\udca1",
+                    "emoji": "💡",
                     "type": "scalar",
                     "latex": "c",
                     "quantity": "velocity",
@@ -263,13 +341,30 @@
                   }
                 ],
                 "edges": [
-                  { "from": "E", "to": "__equals_1" },
-                  { "from": "m", "to": "__multiply_2" },
-                  { "from": "c", "to": "__power_3" },
-                  { "from": "__power_3", "to": "__multiply_2" },
-                  { "from": "__multiply_2", "to": "__equals_1" }
+                  {
+                    "from": "E",
+                    "to": "__equals_1"
+                  },
+                  {
+                    "from": "m",
+                    "to": "__multiply_2"
+                  },
+                  {
+                    "from": "c",
+                    "to": "__power_3"
+                  },
+                  {
+                    "from": "__power_3",
+                    "to": "__multiply_2"
+                  },
+                  {
+                    "from": "__multiply_2",
+                    "to": "__equals_1"
+                  }
                 ],
-                "classification": { "kind": "algebraic" }
+                "classification": {
+                  "kind": "algebraic"
+                }
               }
             }
           },
@@ -303,7 +398,7 @@
                     "id": "E",
                     "label": "energy",
                     "description": "Total relativistic energy: includes both the rest energy (mc²) and the kinetic contribution from motion. For a particle at rest this collapses to E = mc²; for a photon (m = 0) it collapses to E = pc.",
-                    "emoji": "\u26a1",
+                    "emoji": "⚡",
                     "type": "scalar",
                     "latex": "E",
                     "quantity": "energy",
@@ -338,7 +433,7 @@
                     "id": "p",
                     "label": "momentum",
                     "description": "Relativistic momentum: p = γ·m·v where γ is the Lorentz factor. For massless particles (photons) momentum is defined purely by p = E/c — mass is not required to carry momentum.",
-                    "emoji": "\ud83d\ude80",
+                    "emoji": "🚀",
                     "type": "vector",
                     "latex": "p",
                     "quantity": "momentum",
@@ -351,7 +446,7 @@
                     "id": "c",
                     "label": "speed of light",
                     "description": "Universal constant that couples space and time. Exactly 299,792,458 m/s by definition of the metre. Shared between the pc and mc² terms because it's the same fundamental conversion factor in both.",
-                    "emoji": "\ud83d\udca1",
+                    "emoji": "💡",
                     "type": "scalar",
                     "latex": "c",
                     "quantity": "velocity",
@@ -388,7 +483,7 @@
                     "id": "m",
                     "label": "mass",
                     "description": "Rest (invariant) mass. Same quantity as in E = mc² — a Lorentz scalar that every observer agrees on, unrelated to the particle's velocity.",
-                    "emoji": "\u2696\ufe0f",
+                    "emoji": "⚖️",
                     "type": "scalar",
                     "latex": "m",
                     "quantity": "mass",
@@ -399,20 +494,58 @@
                   }
                 ],
                 "edges": [
-                  { "from": "E", "to": "__power_E" },
-                  { "from": "__power_E", "to": "__equals_1" },
-                  { "from": "p", "to": "__multiply_pc" },
-                  { "from": "c", "to": "__multiply_pc" },
-                  { "from": "__multiply_pc", "to": "__power_pc" },
-                  { "from": "__power_pc", "to": "__add_rhs" },
-                  { "from": "c", "to": "__power_c2" },
-                  { "from": "__power_c2", "to": "__multiply_mc2" },
-                  { "from": "m", "to": "__multiply_mc2" },
-                  { "from": "__multiply_mc2", "to": "__power_mc" },
-                  { "from": "__power_mc", "to": "__add_rhs" },
-                  { "from": "__add_rhs", "to": "__equals_1" }
+                  {
+                    "from": "E",
+                    "to": "__power_E"
+                  },
+                  {
+                    "from": "__power_E",
+                    "to": "__equals_1"
+                  },
+                  {
+                    "from": "p",
+                    "to": "__multiply_pc"
+                  },
+                  {
+                    "from": "c",
+                    "to": "__multiply_pc"
+                  },
+                  {
+                    "from": "__multiply_pc",
+                    "to": "__power_pc"
+                  },
+                  {
+                    "from": "__power_pc",
+                    "to": "__add_rhs"
+                  },
+                  {
+                    "from": "c",
+                    "to": "__power_c2"
+                  },
+                  {
+                    "from": "__power_c2",
+                    "to": "__multiply_mc2"
+                  },
+                  {
+                    "from": "m",
+                    "to": "__multiply_mc2"
+                  },
+                  {
+                    "from": "__multiply_mc2",
+                    "to": "__power_mc"
+                  },
+                  {
+                    "from": "__power_mc",
+                    "to": "__add_rhs"
+                  },
+                  {
+                    "from": "__add_rhs",
+                    "to": "__equals_1"
+                  }
                 ],
-                "classification": { "kind": "algebraic" }
+                "classification": {
+                  "kind": "algebraic"
+                }
               }
             }
           },
@@ -438,7 +571,7 @@
                     "id": "v",
                     "label": "velocity",
                     "description": "Final velocity at time t. A vector: direction matters. For straight-line motion with constant a it evolves linearly in time; for curved motion the equation applies component-wise.",
-                    "emoji": "\ud83d\udca8",
+                    "emoji": "💨",
                     "type": "vector",
                     "latex": "v",
                     "quantity": "velocity",
@@ -458,7 +591,7 @@
                     "id": "v_{0}",
                     "label": "initial velocity",
                     "description": "Initial velocity at t = 0: the boundary condition fixing where the velocity trajectory begins. Vector quantity, same units as v.",
-                    "emoji": "\ud83d\udd23",
+                    "emoji": "🔣",
                     "type": "scalar",
                     "latex": "v_{0}",
                     "quantity": "velocity",
@@ -478,7 +611,7 @@
                     "id": "a",
                     "label": "acceleration",
                     "description": "Constant acceleration over the motion. The uniform-a assumption is what makes this equation linear; general motion requires integrating a(t).",
-                    "emoji": "\ud83e\udded",
+                    "emoji": "🧭",
                     "type": "vector",
                     "latex": "a",
                     "quantity": "acceleration",
@@ -491,7 +624,7 @@
                     "id": "t",
                     "label": "time",
                     "description": "Elapsed time since the initial moment t = 0. The independent variable — plotting v versus t yields a straight line with slope a and intercept v₀.",
-                    "emoji": "\u23f1\ufe0f",
+                    "emoji": "⏱️",
                     "type": "scalar",
                     "latex": "t",
                     "quantity": "time",
@@ -502,14 +635,34 @@
                   }
                 ],
                 "edges": [
-                  { "from": "v", "to": "__equals_1" },
-                  { "from": "v_{0}", "to": "__add_2" },
-                  { "from": "a", "to": "__multiply_3" },
-                  { "from": "t", "to": "__multiply_3" },
-                  { "from": "__multiply_3", "to": "__add_2" },
-                  { "from": "__add_2", "to": "__equals_1" }
+                  {
+                    "from": "v",
+                    "to": "__equals_1"
+                  },
+                  {
+                    "from": "v_{0}",
+                    "to": "__add_2"
+                  },
+                  {
+                    "from": "a",
+                    "to": "__multiply_3"
+                  },
+                  {
+                    "from": "t",
+                    "to": "__multiply_3"
+                  },
+                  {
+                    "from": "__multiply_3",
+                    "to": "__add_2"
+                  },
+                  {
+                    "from": "__add_2",
+                    "to": "__equals_1"
+                  }
                 ],
-                "classification": { "kind": "algebraic" }
+                "classification": {
+                  "kind": "algebraic"
+                }
               }
             }
           },
@@ -535,7 +688,7 @@
                     "id": "x",
                     "label": "position",
                     "description": "Position at time t. A vector in general; its time evolution is quadratic under constant acceleration, producing the familiar parabolic trajectories of projectiles.",
-                    "emoji": "\ud83d\udccd",
+                    "emoji": "📍",
                     "type": "vector",
                     "latex": "x",
                     "quantity": "length",
@@ -555,7 +708,7 @@
                     "id": "x_{0}",
                     "label": "initial position",
                     "description": "Initial position at t = 0 — the fixed starting point of the trajectory. Boundary condition: changes the intercept but not the shape of the x(t) curve.",
-                    "emoji": "\ud83d\udea9",
+                    "emoji": "🚩",
                     "type": "vector",
                     "latex": "x_{0}",
                     "quantity": "length",
@@ -575,7 +728,7 @@
                     "id": "v_{0}",
                     "label": "initial velocity",
                     "description": "Initial velocity at t = 0. Unlike the velocity form, here it multiplies t directly (no acceleration coupling) — it accounts for whatever motion was already underway when the clock started.",
-                    "emoji": "\ud83d\udd23",
+                    "emoji": "🔣",
                     "type": "vector",
                     "latex": "v_{0}",
                     "quantity": "velocity",
@@ -595,7 +748,7 @@
                     "id": "__num_half",
                     "label": "one half",
                     "description": "The rational constant ½, produced by integrating t with respect to t. Dimensionless.",
-                    "emoji": "\ud83d\udd22",
+                    "emoji": "🔢",
                     "type": "number",
                     "latex": "\\tfrac{1}{2}",
                     "value": 0.5,
@@ -606,7 +759,7 @@
                     "id": "a",
                     "label": "acceleration",
                     "description": "Constant acceleration vector. Assumed time-independent in this kinematic family of equations — relaxing this assumption breaks the simple quadratic form.",
-                    "emoji": "\ud83e\udded",
+                    "emoji": "🧭",
                     "type": "vector",
                     "latex": "a",
                     "quantity": "acceleration",
@@ -627,7 +780,7 @@
                     "id": "t",
                     "label": "time",
                     "description": "Elapsed time since t = 0. Same independent variable as in the velocity form; appears linearly (in the v₀t term) and quadratically (in the ½at² term).",
-                    "emoji": "\u23f1\ufe0f",
+                    "emoji": "⏱️",
                     "type": "scalar",
                     "latex": "t",
                     "quantity": "time",
@@ -638,19 +791,54 @@
                   }
                 ],
                 "edges": [
-                  { "from": "x", "to": "__equals_1" },
-                  { "from": "x_{0}", "to": "__add_rhs" },
-                  { "from": "v_{0}", "to": "__mult_v0t" },
-                  { "from": "t", "to": "__mult_v0t" },
-                  { "from": "__mult_v0t", "to": "__add_rhs" },
-                  { "from": "__num_half", "to": "__mult_half_at2" },
-                  { "from": "a", "to": "__mult_half_at2" },
-                  { "from": "t", "to": "__power_t2" },
-                  { "from": "__power_t2", "to": "__mult_half_at2" },
-                  { "from": "__mult_half_at2", "to": "__add_rhs" },
-                  { "from": "__add_rhs", "to": "__equals_1" }
+                  {
+                    "from": "x",
+                    "to": "__equals_1"
+                  },
+                  {
+                    "from": "x_{0}",
+                    "to": "__add_rhs"
+                  },
+                  {
+                    "from": "v_{0}",
+                    "to": "__mult_v0t"
+                  },
+                  {
+                    "from": "t",
+                    "to": "__mult_v0t"
+                  },
+                  {
+                    "from": "__mult_v0t",
+                    "to": "__add_rhs"
+                  },
+                  {
+                    "from": "__num_half",
+                    "to": "__mult_half_at2"
+                  },
+                  {
+                    "from": "a",
+                    "to": "__mult_half_at2"
+                  },
+                  {
+                    "from": "t",
+                    "to": "__power_t2"
+                  },
+                  {
+                    "from": "__power_t2",
+                    "to": "__mult_half_at2"
+                  },
+                  {
+                    "from": "__mult_half_at2",
+                    "to": "__add_rhs"
+                  },
+                  {
+                    "from": "__add_rhs",
+                    "to": "__equals_1"
+                  }
                 ],
-                "classification": { "kind": "algebraic" }
+                "classification": {
+                  "kind": "algebraic"
+                }
               }
             }
           },
@@ -683,7 +871,7 @@
                     "id": "i",
                     "label": "imaginary unit",
                     "description": "The imaginary unit, i = √(−1). Pulls the time derivative into the complex plane — without it, ∂/∂t would describe diffusion (real-valued decay); with it, we get oscillatory wavefunctions and interference.",
-                    "emoji": "\ud83d\udd35",
+                    "emoji": "🔵",
                     "type": "constant",
                     "latex": "i",
                     "quantity": "dimensionless",
@@ -696,7 +884,7 @@
                     "id": "hbar",
                     "label": "reduced Planck constant",
                     "description": "ℏ = h/(2π) ≈ 1.054 × 10⁻³⁴ J·s. Sets the scale of quantum effects — actions much larger than ℏ behave classically; actions of order ℏ require quantum mechanics.",
-                    "emoji": "\ud83d\udcd0",
+                    "emoji": "📐",
                     "type": "constant",
                     "latex": "\\hbar",
                     "quantity": "action",
@@ -718,7 +906,7 @@
                     "id": "psi",
                     "label": "wavefunction",
                     "description": "Quantum state (wavefunction). A complex-valued function of position and time whose squared modulus |ψ|² gives the probability density. Normalized such that ∫|ψ|² dV = 1.",
-                    "emoji": "\ud83c\udf0a",
+                    "emoji": "🌊",
                     "type": "scalar",
                     "latex": "\\psi",
                     "quantity": "probability_amplitude",
@@ -731,7 +919,7 @@
                     "id": "Hhat",
                     "label": "Hamiltonian",
                     "description": "Hamiltonian operator Ĥ — the total-energy operator of the system. Typically Ĥ = T̂ + V̂ (kinetic plus potential). Hermitian (real eigenvalues = allowed energies), and it generates time translation via the Schrödinger equation. When ψ feeds in, the output is Ĥψ — the *action* of the operator on the state, not a product.",
-                    "emoji": "\ud83d\udd2e",
+                    "emoji": "🔮",
                     "type": "operator",
                     "op": "hamiltonian",
                     "latex": "\\hat{H}",
@@ -743,19 +931,44 @@
                   }
                 ],
                 "edges": [
-                  { "from": "i", "to": "__mult_lhs" },
-                  { "from": "hbar", "to": "__mult_lhs" },
-                  { "from": "psi", "to": "__deriv_psi_t" },
-                  { "from": "__deriv_psi_t", "to": "__mult_lhs" },
-                  { "from": "__mult_lhs", "to": "__equals_1" },
-                  { "from": "psi", "to": "Hhat" },
-                  { "from": "Hhat", "to": "__equals_1" }
+                  {
+                    "from": "i",
+                    "to": "__mult_lhs"
+                  },
+                  {
+                    "from": "hbar",
+                    "to": "__mult_lhs"
+                  },
+                  {
+                    "from": "psi",
+                    "to": "__deriv_psi_t"
+                  },
+                  {
+                    "from": "__deriv_psi_t",
+                    "to": "__mult_lhs"
+                  },
+                  {
+                    "from": "__mult_lhs",
+                    "to": "__equals_1"
+                  },
+                  {
+                    "from": "psi",
+                    "to": "Hhat"
+                  },
+                  {
+                    "from": "Hhat",
+                    "to": "__equals_1"
+                  }
                 ],
                 "classification": {
                   "kind": "PDE",
                   "order": 1,
-                  "dependent_variables": ["psi"],
-                  "independent_variables": ["t"]
+                  "dependent_variables": [
+                    "psi"
+                  ],
+                  "independent_variables": [
+                    "t"
+                  ]
                 }
               }
             }
@@ -789,7 +1002,7 @@
                     "id": "i",
                     "label": "imaginary unit",
                     "description": "The imaginary unit i = √(−1). Essential: without i, ∂/∂t would describe diffusion; with i, probability is conserved and we get unitary evolution.",
-                    "emoji": "\ud83d\udd35",
+                    "emoji": "🔵",
                     "type": "constant",
                     "latex": "i",
                     "quantity": "dimensionless",
@@ -801,7 +1014,7 @@
                     "id": "hbar",
                     "label": "reduced Planck constant",
                     "description": "ℏ ≈ 1.054 × 10⁻³⁴ J·s. Sets the scale where quantum effects matter. Appears squared in the kinetic term — a direct consequence of quantizing p = -iℏ∇ and then forming p²/(2m).",
-                    "emoji": "\ud83d\udcd0",
+                    "emoji": "📐",
                     "type": "constant",
                     "latex": "\\hbar",
                     "quantity": "action",
@@ -823,7 +1036,7 @@
                     "id": "psi",
                     "label": "wavefunction",
                     "description": "Complex-valued wavefunction ψ(r, t). |ψ|² gives probability density; phase matters too (interference). Shared across the time derivative, the Laplacian, and the potential multiplication.",
-                    "emoji": "\ud83c\udf0a",
+                    "emoji": "🌊",
                     "type": "scalar",
                     "latex": "\\psi",
                     "quantity": "probability_amplitude",
@@ -850,7 +1063,7 @@
                     "id": "__num_neg_1",
                     "label": "negative one",
                     "description": "The numerical constant −1, standing in for the explicit minus sign on the kinetic term.",
-                    "emoji": "\u2796",
+                    "emoji": "➖",
                     "type": "number",
                     "latex": "-1",
                     "value": -1,
@@ -884,7 +1097,7 @@
                     "id": "__num_2",
                     "label": "two",
                     "description": "The numerical constant 2, from the classical kinetic-energy formula p²/(2m).",
-                    "emoji": "\ud83d\udd22",
+                    "emoji": "🔢",
                     "type": "number",
                     "latex": "2",
                     "value": 2,
@@ -895,7 +1108,7 @@
                     "id": "m",
                     "label": "mass",
                     "description": "Mass of the quantum particle. Determines how strongly the kinetic operator smooths / spreads the wavefunction — lighter particles exhibit more pronounced quantum behavior.",
-                    "emoji": "\u2696\ufe0f",
+                    "emoji": "⚖️",
                     "type": "scalar",
                     "latex": "m",
                     "quantity": "mass",
@@ -924,7 +1137,7 @@
                     "id": "V",
                     "label": "potential energy",
                     "description": "Potential energy function V(r) — an external scalar field (e.g. electrostatic for hydrogen, harmonic for an oscillator, infinite walls for a box). Shapes the Hamiltonian's spectrum and the geometry of stationary states.",
-                    "emoji": "\ud83c\udfd4\ufe0f",
+                    "emoji": "🏔️",
                     "type": "scalar",
                     "latex": "V",
                     "quantity": "energy",
@@ -935,31 +1148,97 @@
                   }
                 ],
                 "edges": [
-                  { "from": "i", "to": "__mult_lhs" },
-                  { "from": "hbar", "to": "__mult_lhs" },
-                  { "from": "psi", "to": "__deriv_psi_t" },
-                  { "from": "__deriv_psi_t", "to": "__mult_lhs" },
-                  { "from": "__mult_lhs", "to": "__equals_1" },
-                  { "from": "hbar", "to": "__power_hbar2" },
-                  { "from": "__num_2", "to": "__mult_2m" },
-                  { "from": "m", "to": "__mult_2m" },
-                  { "from": "__power_hbar2", "to": "__div_coef", "semantic": "direct" },
-                  { "from": "__mult_2m", "to": "__div_coef", "semantic": "inverse" },
-                  { "from": "psi", "to": "__laplacian_psi" },
-                  { "from": "__num_neg_1", "to": "__mult_kinetic" },
-                  { "from": "__div_coef", "to": "__mult_kinetic" },
-                  { "from": "__laplacian_psi", "to": "__mult_kinetic" },
-                  { "from": "__mult_kinetic", "to": "__add_rhs" },
-                  { "from": "V", "to": "__mult_potential" },
-                  { "from": "psi", "to": "__mult_potential" },
-                  { "from": "__mult_potential", "to": "__add_rhs" },
-                  { "from": "__add_rhs", "to": "__equals_1" }
+                  {
+                    "from": "i",
+                    "to": "__mult_lhs"
+                  },
+                  {
+                    "from": "hbar",
+                    "to": "__mult_lhs"
+                  },
+                  {
+                    "from": "psi",
+                    "to": "__deriv_psi_t"
+                  },
+                  {
+                    "from": "__deriv_psi_t",
+                    "to": "__mult_lhs"
+                  },
+                  {
+                    "from": "__mult_lhs",
+                    "to": "__equals_1"
+                  },
+                  {
+                    "from": "hbar",
+                    "to": "__power_hbar2"
+                  },
+                  {
+                    "from": "__num_2",
+                    "to": "__mult_2m"
+                  },
+                  {
+                    "from": "m",
+                    "to": "__mult_2m"
+                  },
+                  {
+                    "from": "__power_hbar2",
+                    "to": "__div_coef",
+                    "semantic": "direct"
+                  },
+                  {
+                    "from": "__mult_2m",
+                    "to": "__div_coef",
+                    "semantic": "inverse"
+                  },
+                  {
+                    "from": "psi",
+                    "to": "__laplacian_psi"
+                  },
+                  {
+                    "from": "__num_neg_1",
+                    "to": "__mult_kinetic"
+                  },
+                  {
+                    "from": "__div_coef",
+                    "to": "__mult_kinetic"
+                  },
+                  {
+                    "from": "__laplacian_psi",
+                    "to": "__mult_kinetic"
+                  },
+                  {
+                    "from": "__mult_kinetic",
+                    "to": "__add_rhs"
+                  },
+                  {
+                    "from": "V",
+                    "to": "__mult_potential"
+                  },
+                  {
+                    "from": "psi",
+                    "to": "__mult_potential"
+                  },
+                  {
+                    "from": "__mult_potential",
+                    "to": "__add_rhs"
+                  },
+                  {
+                    "from": "__add_rhs",
+                    "to": "__equals_1"
+                  }
                 ],
                 "classification": {
                   "kind": "PDE",
                   "order": 2,
-                  "dependent_variables": ["psi"],
-                  "independent_variables": ["t", "x", "y", "z"]
+                  "dependent_variables": [
+                    "psi"
+                  ],
+                  "independent_variables": [
+                    "t",
+                    "x",
+                    "y",
+                    "z"
+                  ]
                 }
               }
             }
@@ -967,10 +1246,247 @@
           {
             "id": "proof-step-8",
             "type": "step",
+            "label": "Partial derivatives — 2D transport equation",
+            "math": "\\frac{\\partial \\rho}{\\partial t} + u\\,\\frac{\\partial \\rho}{\\partial x} + v\\,\\frac{\\partial \\rho}{\\partial y} = 0",
+            "justification": "The 2D advection (transport) equation: density ρ is carried along by a velocity field (u, v) without diffusion. Each partial derivative operator differentiates with respect to a different independent variable — t, x, or y — so the D3 renderer shows d·/dt, d·/dx, and d·/dy on distinct operator nodes.",
+            "sceneStep": 8,
+            "semanticGraph": {
+              "graph": {
+                "domain": "fluid_dynamics",
+                "nodes": [
+                  {
+                    "id": "__equals_1",
+                    "type": "operator",
+                    "op": "equals",
+                    "description": "Equates the sum of partial derivatives to zero — stating that ρ is conserved along fluid trajectories.",
+                    "subexpr": "\\frac{\\partial \\rho}{\\partial t} + u \\frac{\\partial \\rho}{\\partial x} + v \\frac{\\partial \\rho}{\\partial y} = 0"
+                  },
+                  {
+                    "id": "__add_lhs",
+                    "type": "operator",
+                    "op": "add",
+                    "description": "Three-term sum: the local time rate of change plus the two advective flux contributions.",
+                    "subexpr": "\\frac{\\partial \\rho}{\\partial t} + u \\frac{\\partial \\rho}{\\partial x} + v \\frac{\\partial \\rho}{\\partial y}"
+                  },
+                  {
+                    "id": "__deriv_rho_t",
+                    "type": "operator",
+                    "op": "derivative",
+                    "with_respect_to": "t",
+                    "description": "Partial time derivative of density: how ρ changes at a fixed spatial point.",
+                    "subexpr": "\\frac{\\partial \\rho}{\\partial t}"
+                  },
+                  {
+                    "id": "__mult_u_drho_x",
+                    "type": "operator",
+                    "op": "multiply",
+                    "description": "Advective flux in x: the horizontal velocity u times the spatial gradient ∂ρ/∂x.",
+                    "subexpr": "u \\frac{\\partial \\rho}{\\partial x}"
+                  },
+                  {
+                    "id": "u_vel",
+                    "label": "x-velocity",
+                    "description": "Horizontal component of the velocity field. Determines how fast ρ is carried in the x direction.",
+                    "emoji": "➡️",
+                    "type": "scalar",
+                    "latex": "u",
+                    "quantity": "velocity",
+                    "dimension": "L·T⁻¹",
+                    "unit": "m/s",
+                    "role": "parameter",
+                    "subexpr": "u"
+                  },
+                  {
+                    "id": "__deriv_rho_x",
+                    "type": "operator",
+                    "op": "derivative",
+                    "with_respect_to": "x",
+                    "description": "Partial x-derivative of density: the spatial gradient of ρ in the horizontal direction.",
+                    "subexpr": "\\frac{\\partial \\rho}{\\partial x}"
+                  },
+                  {
+                    "id": "__mult_v_drho_y",
+                    "type": "operator",
+                    "op": "multiply",
+                    "description": "Advective flux in y: the vertical velocity v times the spatial gradient ∂ρ/∂y.",
+                    "subexpr": "v \\frac{\\partial \\rho}{\\partial y}"
+                  },
+                  {
+                    "id": "v_vel",
+                    "label": "y-velocity",
+                    "description": "Vertical component of the velocity field. Determines how fast ρ is carried in the y direction.",
+                    "emoji": "⬆️",
+                    "type": "scalar",
+                    "latex": "v",
+                    "quantity": "velocity",
+                    "dimension": "L·T⁻¹",
+                    "unit": "m/s",
+                    "role": "parameter",
+                    "subexpr": "v"
+                  },
+                  {
+                    "id": "__deriv_rho_y",
+                    "type": "operator",
+                    "op": "derivative",
+                    "with_respect_to": "y",
+                    "description": "Partial y-derivative of density: the spatial gradient of ρ in the vertical direction.",
+                    "subexpr": "\\frac{\\partial \\rho}{\\partial y}"
+                  },
+                  {
+                    "id": "rho",
+                    "label": "density",
+                    "description": "Scalar density field ρ(x, y, t). The quantity being transported by the velocity field without sources or sinks.",
+                    "emoji": "🌫️",
+                    "type": "scalar",
+                    "latex": "\\rho",
+                    "quantity": "density",
+                    "dimension": "M·L⁻³",
+                    "unit": "kg/m³",
+                    "role": "state_variable",
+                    "subexpr": "\\rho"
+                  },
+                  {
+                    "id": "__num_0",
+                    "label": "0",
+                    "description": "Zero on the right-hand side — no sources or sinks.",
+                    "emoji": "🔢",
+                    "type": "number",
+                    "value": 0,
+                    "role": "constant",
+                    "subexpr": "0"
+                  },
+                  {
+                    "id": "var_t",
+                    "label": "time",
+                    "description": "Independent variable: time coordinate.",
+                    "emoji": "🕐",
+                    "type": "scalar",
+                    "latex": "t",
+                    "quantity": "time",
+                    "dimension": "T",
+                    "unit": "s",
+                    "role": "independent_variable",
+                    "subexpr": "t"
+                  },
+                  {
+                    "id": "var_x",
+                    "label": "x-position",
+                    "description": "Independent variable: horizontal spatial coordinate.",
+                    "emoji": "📏",
+                    "type": "scalar",
+                    "latex": "x",
+                    "quantity": "length",
+                    "dimension": "L",
+                    "unit": "m",
+                    "role": "independent_variable",
+                    "subexpr": "x"
+                  },
+                  {
+                    "id": "var_y",
+                    "label": "y-position",
+                    "description": "Independent variable: vertical spatial coordinate.",
+                    "emoji": "📐",
+                    "type": "scalar",
+                    "latex": "y",
+                    "quantity": "length",
+                    "dimension": "L",
+                    "unit": "m",
+                    "role": "independent_variable",
+                    "subexpr": "y"
+                  }
+                ],
+                "edges": [
+                  {
+                    "from": "rho",
+                    "to": "__deriv_rho_t"
+                  },
+                  {
+                    "from": "var_t",
+                    "to": "__deriv_rho_t"
+                  },
+                  {
+                    "from": "rho",
+                    "to": "__deriv_rho_x"
+                  },
+                  {
+                    "from": "var_x",
+                    "to": "__deriv_rho_x"
+                  },
+                  {
+                    "from": "rho",
+                    "to": "__deriv_rho_y"
+                  },
+                  {
+                    "from": "var_y",
+                    "to": "__deriv_rho_y"
+                  },
+                  {
+                    "from": "__deriv_rho_t",
+                    "to": "__add_lhs"
+                  },
+                  {
+                    "from": "u_vel",
+                    "to": "__mult_u_drho_x",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "__deriv_rho_x",
+                    "to": "__mult_u_drho_x",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "__mult_u_drho_x",
+                    "to": "__add_lhs"
+                  },
+                  {
+                    "from": "v_vel",
+                    "to": "__mult_v_drho_y",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "__deriv_rho_y",
+                    "to": "__mult_v_drho_y",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "__mult_v_drho_y",
+                    "to": "__add_lhs"
+                  },
+                  {
+                    "from": "__add_lhs",
+                    "to": "__equals_1"
+                  },
+                  {
+                    "from": "__num_0",
+                    "to": "__equals_1"
+                  }
+                ],
+                "classification": {
+                  "kind": "PDE",
+                  "order": 1,
+                  "dependent_variables": [
+                    "rho"
+                  ],
+                  "independent_variables": [
+                    "t",
+                    "x",
+                    "y"
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "id": "proof-step-9",
+            "type": "step",
             "label": "Higher powers and a quotient — ^3, ^4, ^n, ^-3, ^-4, ^-n, a/b",
             "math": "y = x^3 + x^4 + x^n + x^{-3} + x^{-4} + x^{-n} + \\frac{a}{b}",
             "justification": "Positive integer exponents read as direct (red) at increasing widths; negative integer exponents read as inverse (blue) at the same widths. The symbolic −n is also tagged inverse with default weight 1 — the renderer can read sign from the leading minus even without a magnitude. Only the positive symbolic n stays neutral. The quotient a/b shows the multiply-with-denominator pattern: the numerator's edge from a paints direct (factor); the edge from the inverse-power (b^-1) paints inverse — the multiply combiner no longer overrides the renderer's power-source inference.",
-            "sceneStep": 8,
+            "sceneStep": 9,
             "semanticGraph": {
               "graph": {
                 "domain": "algebra",
@@ -1090,31 +1606,89 @@
                   }
                 ],
                 "edges": [
-                  { "from": "y", "to": "__equals_1" },
-                  { "from": "x", "to": "__power_x3" },
-                  { "from": "x", "to": "__power_x4" },
-                  { "from": "x", "to": "__power_xn" },
-                  { "from": "x", "to": "__power_x_neg3" },
-                  { "from": "x", "to": "__power_x_neg4" },
-                  { "from": "x", "to": "__power_x_negn" },
-                  { "from": "__power_x3", "to": "__add_rhs" },
-                  { "from": "__power_x4", "to": "__add_rhs" },
-                  { "from": "__power_xn", "to": "__add_rhs" },
-                  { "from": "__power_x_neg3", "to": "__add_rhs" },
-                  { "from": "__power_x_neg4", "to": "__add_rhs" },
-                  { "from": "__power_x_negn", "to": "__add_rhs" },
-                  { "from": "a", "to": "__multiply_div", "semantic": "direct", "weight": 1.0 },
-                  { "from": "b", "to": "__power_b_neg1" },
-                  { "from": "__power_b_neg1", "to": "__multiply_div" },
-                  { "from": "__multiply_div", "to": "__add_rhs" },
-                  { "from": "__add_rhs", "to": "__equals_1" }
+                  {
+                    "from": "y",
+                    "to": "__equals_1"
+                  },
+                  {
+                    "from": "x",
+                    "to": "__power_x3"
+                  },
+                  {
+                    "from": "x",
+                    "to": "__power_x4"
+                  },
+                  {
+                    "from": "x",
+                    "to": "__power_xn"
+                  },
+                  {
+                    "from": "x",
+                    "to": "__power_x_neg3"
+                  },
+                  {
+                    "from": "x",
+                    "to": "__power_x_neg4"
+                  },
+                  {
+                    "from": "x",
+                    "to": "__power_x_negn"
+                  },
+                  {
+                    "from": "__power_x3",
+                    "to": "__add_rhs"
+                  },
+                  {
+                    "from": "__power_x4",
+                    "to": "__add_rhs"
+                  },
+                  {
+                    "from": "__power_xn",
+                    "to": "__add_rhs"
+                  },
+                  {
+                    "from": "__power_x_neg3",
+                    "to": "__add_rhs"
+                  },
+                  {
+                    "from": "__power_x_neg4",
+                    "to": "__add_rhs"
+                  },
+                  {
+                    "from": "__power_x_negn",
+                    "to": "__add_rhs"
+                  },
+                  {
+                    "from": "a",
+                    "to": "__multiply_div",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "b",
+                    "to": "__power_b_neg1"
+                  },
+                  {
+                    "from": "__power_b_neg1",
+                    "to": "__multiply_div"
+                  },
+                  {
+                    "from": "__multiply_div",
+                    "to": "__add_rhs"
+                  },
+                  {
+                    "from": "__add_rhs",
+                    "to": "__equals_1"
+                  }
                 ],
-                "classification": { "kind": "algebraic" }
+                "classification": {
+                  "kind": "algebraic"
+                }
               }
             }
           },
           {
-            "id": "proof-step-9",
+            "id": "proof-step-10",
             "type": "given",
             "label": "Disconnected statements — comma-separated clauses (issue #144)",
             "math": "a = 1, \\quad b = 2",
@@ -1175,12 +1749,27 @@
                   }
                 ],
                 "edges": [
-                  { "from": "a", "to": "c0___equals_1" },
-                  { "from": "c0___num_2", "to": "c0___equals_1" },
-                  { "from": "b", "to": "c1___equals_1" },
-                  { "from": "c1___num_2", "to": "c1___equals_1" }
+                  {
+                    "from": "a",
+                    "to": "c0___equals_1"
+                  },
+                  {
+                    "from": "c0___num_2",
+                    "to": "c0___equals_1"
+                  },
+                  {
+                    "from": "b",
+                    "to": "c1___equals_1"
+                  },
+                  {
+                    "from": "c1___num_2",
+                    "to": "c1___equals_1"
+                  }
                 ],
-                "classification": { "kind": "statements", "count": 2 }
+                "classification": {
+                  "kind": "statements",
+                  "count": 2
+                }
               }
             }
           }

--- a/scripts/graph_to_mermaid.py
+++ b/scripts/graph_to_mermaid.py
@@ -221,7 +221,9 @@ def validate_graph(graph: dict[str, Any]) -> list[str]:
 def load_theme(name: str, theme_dir: Path | None = None) -> dict[str, Any]:
     """Load a theme JSON file by name from the semantic-graph theme directory."""
     d = theme_dir or THEME_DIR
-    path = d / f"{name}.json"
+    path = (d / f"{name}.json").resolve()
+    if not path.is_relative_to(d.resolve()):
+        raise FileNotFoundError(f"Theme {name!r} not found in {d}.")
     if not path.exists():
         available = sorted(p.stem for p in d.glob("*.json"))
         raise FileNotFoundError(

--- a/server.py
+++ b/server.py
@@ -2204,6 +2204,9 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
     @fastapp.get("/api/graph/theme/{name}")
     async def get_graph_theme(name: str):
         """Return the full JSON for a single semantic-graph theme."""
+        import re
+        if not re.fullmatch(r"[A-Za-z0-9_-]+", name):
+            return JSONResponse({"error": "invalid theme name"}, status_code=400)
         try:
             g2m = _load_script_module("scripts/graph_to_mermaid.py", "graph_to_mermaid")
             theme = g2m.load_theme(name)

--- a/server.py
+++ b/server.py
@@ -2201,6 +2201,18 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
         except Exception as e:
             return JSONResponse({"error": str(e), "themes": []}, status_code=500)
 
+    @fastapp.get("/api/graph/theme/{name}")
+    async def get_graph_theme(name: str):
+        """Return the full JSON for a single semantic-graph theme."""
+        try:
+            g2m = _load_script_module("scripts/graph_to_mermaid.py", "graph_to_mermaid")
+            theme = g2m.load_theme(name)
+            return JSONResponse(theme)
+        except FileNotFoundError:
+            return JSONResponse({"error": f"theme '{name}' not found"}, status_code=404)
+        except Exception as e:
+            return JSONResponse({"error": str(e)}, status_code=500)
+
     class MermaidRenderRequest(BaseModel):
         graph: dict = {}
         theme: str = "default-light"

--- a/static/graph-panel/d3-semantic-graph.css
+++ b/static/graph-panel/d3-semantic-graph.css
@@ -81,6 +81,21 @@ svg.d3-semantic-graph {
     opacity: 0.85;
 }
 
+/* Invisible hit target for flat themes */
+.d3sg-hit-target {
+    transition: stroke 0.12s ease-out, stroke-opacity 0.12s ease-out;
+}
+.d3sg-node:hover .d3sg-hit-target {
+    stroke: #7ea8ff !important;
+    stroke-width: 1.5px !important;
+    stroke-opacity: 0.45;
+}
+.d3sg-node.active .d3sg-hit-target {
+    stroke: #7ea8ff !important;
+    stroke-width: 1.5px !important;
+    stroke-opacity: 0.6;
+}
+
 /* Active node ring */
 .d3sg-node.active .d3sg-var-bg {
     stroke: #6df08e;

--- a/static/graph-panel/d3-semantic-graph.css
+++ b/static/graph-panel/d3-semantic-graph.css
@@ -1,0 +1,102 @@
+/* D3 Semantic Graph Renderer — dark theme styles */
+
+.d3-graph-card {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+svg.d3-semantic-graph {
+    display: block;
+    width: 100%;
+    height: 100%;
+    overflow: visible;
+}
+
+/* Variable nodes: green circle */
+.d3sg-var-bg {
+    fill: #1f4d2a;
+    stroke: #3b8c52;
+    stroke-width: 1.5px;
+    transition: filter 0.12s ease-out;
+}
+.d3sg-node:hover .d3sg-var-bg {
+    filter: brightness(1.3);
+}
+
+/* Operator nodes: dark hexagon */
+.d3sg-op-bg {
+    fill: #1a2440;
+    stroke: #3a4d80;
+    stroke-width: 1.5px;
+    transition: filter 0.12s ease-out;
+}
+.d3sg-node:hover .d3sg-op-bg {
+    filter: brightness(1.3);
+}
+
+/* Collapsed tile */
+.d3sg-tile-bg {
+    fill: #222a44;
+    stroke: #5a8aff;
+    stroke-width: 2px;
+    transition: filter 0.12s ease-out;
+}
+.d3sg-node:hover .d3sg-tile-bg {
+    filter: brightness(1.25);
+}
+
+/* Node labels */
+.d3sg-label {
+    fill: #dde6ff;
+    pointer-events: none;
+    user-select: none;
+}
+
+.d3sg-katex-host {
+    color: #dde6ff;
+    font-size: 14px;
+    pointer-events: none;
+    user-select: none;
+}
+
+.d3sg-katex-host .katex {
+    font-size: 0.9em;
+}
+
+/* Edge labels */
+.d3sg-edge-label {
+    fill: #aebbd1;
+    font-size: 11px;
+    paint-order: stroke;
+    stroke: #131a2c;
+    stroke-width: 4px;
+    pointer-events: none;
+}
+
+/* Chevron (collapse/expand indicator) */
+.d3sg-chevron {
+    fill: #a8c5ff;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.12s ease-out;
+}
+.d3sg-node:hover .d3sg-chevron {
+    opacity: 0.85;
+}
+
+/* Active node ring */
+.d3sg-node.active .d3sg-var-bg {
+    stroke: #6df08e;
+    stroke-width: 2.5px;
+}
+.d3sg-node.active .d3sg-op-bg {
+    stroke: #7ea8ff;
+    stroke-width: 2.5px;
+}
+.d3sg-node.active .d3sg-tile-bg {
+    stroke: #7ea8ff;
+    stroke-width: 2.5px;
+}

--- a/static/graph-panel/d3-semantic-graph.css
+++ b/static/graph-panel/d3-semantic-graph.css
@@ -51,7 +51,7 @@ svg.d3-semantic-graph {
 
 .d3sg-katex-host {
     color: #dde6ff;
-    font-size: 14px;
+    font-size: 17px;
     pointer-events: none;
     user-select: none;
 }

--- a/static/graph-panel/d3-semantic-graph.css
+++ b/static/graph-panel/d3-semantic-graph.css
@@ -70,15 +70,18 @@ svg.d3-semantic-graph {
     pointer-events: none;
 }
 
-/* Chevron (collapse/expand indicator) */
+/* Chevron (collapse/expand button) */
 .d3sg-chevron {
-    fill: #a8c5ff;
     opacity: 0;
-    pointer-events: none;
+    cursor: pointer;
+    pointer-events: all;
     transition: opacity 0.12s ease-out;
 }
 .d3sg-node:hover .d3sg-chevron {
-    opacity: 0.85;
+    opacity: 0.7;
+}
+.d3sg-chevron:hover {
+    opacity: 1 !important;
 }
 
 /* Invisible hit target for flat themes */

--- a/static/graph-panel/d3-semantic-graph.css
+++ b/static/graph-panel/d3-semantic-graph.css
@@ -15,10 +15,8 @@ svg.d3-semantic-graph {
     overflow: visible;
 }
 
-/* Variable nodes: green circle */
+/* Variable nodes — fill/stroke set by theme via inline attributes */
 .d3sg-var-bg {
-    fill: #1f4d2a;
-    stroke: #3b8c52;
     stroke-width: 1.5px;
     transition: filter 0.12s ease-out;
 }
@@ -26,10 +24,8 @@ svg.d3-semantic-graph {
     filter: brightness(1.3);
 }
 
-/* Operator nodes: dark hexagon */
+/* Operator nodes — fill/stroke set by theme via inline attributes */
 .d3sg-op-bg {
-    fill: #1a2440;
-    stroke: #3a4d80;
     stroke-width: 1.5px;
     transition: filter 0.12s ease-out;
 }
@@ -37,10 +33,8 @@ svg.d3-semantic-graph {
     filter: brightness(1.3);
 }
 
-/* Collapsed tile */
+/* Collapsed tile — fill/stroke set by theme via inline attributes */
 .d3sg-tile-bg {
-    fill: #222a44;
-    stroke: #5a8aff;
     stroke-width: 2px;
     transition: filter 0.12s ease-out;
 }

--- a/static/graph-panel/d3-semantic-graph.css
+++ b/static/graph-panel/d3-semantic-graph.css
@@ -88,12 +88,7 @@ svg.d3-semantic-graph {
 .d3sg-node:hover .d3sg-hit-target {
     stroke: #7ea8ff !important;
     stroke-width: 1.5px !important;
-    stroke-opacity: 0.45;
-}
-.d3sg-node.active .d3sg-hit-target {
-    stroke: #7ea8ff !important;
-    stroke-width: 1.5px !important;
-    stroke-opacity: 0.6;
+    stroke-opacity: 0.4;
 }
 
 /* Active node ring */

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -133,15 +133,33 @@ function graphToTree(graph) {
         edgeSemanticMap[`${e.from}->${e.to}`] = inferEdgeSemantic(e, nodeById);
     }
 
-    const visited = new Set();
+    const visiting = new Set();
+    let cloneSeq = 0;
     function buildTree(id) {
-        if (visited.has(id)) return null;
-        visited.add(id);
+        // Prevent infinite recursion on cycles, but allow DAG sharing:
+        // leaf nodes (no children) are cloned; interior nodes are skipped
+        // to avoid exponential blowup.
+        if (visiting.has(id)) return null;
         const node = nodeById[id];
         if (!node) return null;
-        const treeNode = { ...node, children: [], _edgeSemantic: null };
         const kids = childrenOf[id] || [];
+        const isLeaf = kids.length === 0;
+        if (!isLeaf && visiting.has(id)) return null;
+
+        visiting.add(id);
+        const treeNode = { ...node, children: [], _edgeSemantic: null };
         for (const kid of kids) {
+            const kidNode = nodeById[kid];
+            const kidKids = childrenOf[kid] || [];
+            const kidIsLeaf = kidKids.length === 0;
+            // Clone leaf nodes that were already placed elsewhere in the tree
+            if (kidIsLeaf && visiting.has(kid) && kidNode) {
+                const clone = { ...kidNode, id: `${kid}__clone${++cloneSeq}`,
+                    _cloneOf: kid, children: [], _edgeSemantic: null };
+                clone._edgeSemantic = edgeSemanticMap[`${kid}->${id}`] || 'neutral';
+                treeNode.children.push(clone);
+                continue;
+            }
             const child = buildTree(kid);
             if (child) {
                 child._edgeSemantic = edgeSemanticMap[`${kid}->${id}`] || 'neutral';
@@ -173,10 +191,12 @@ function getNodeLabel(node, labelMode) {
 function operatorGlyph(node) {
     const glyphs = {
         equals: '=', multiply: '×', add: '+', subtract: '−',
-        divide: '÷', power: '^', integral: '∫',
+        divide: '÷', integral: '∫',
         implies: '⇒', iff: '⇔', negate: '¬', conjunction: '∧',
         disjunction: '∨', sum: '∑', product: '∏', limit: 'lim',
-        factorial: '!', sqrt: '√', logarithm: 'log', function: 'f',
+        factorial: '!', sqrt: '√(·)', log: 'log', logarithm: 'log',
+        exp: 'exp', sin: 'sin', cos: 'cos', tan: 'tan',
+        Abs: '|·|', abs: '|·|', function: 'f',
     };
     if (node.op === 'derivative') return 'd·/d·';
     if (node.op === 'power') {
@@ -585,7 +605,7 @@ export class D3SemanticGraphRenderer {
     }
 
     _handleNodeClick(d) {
-        const nodeId = d.data.id;
+        const nodeId = d.data._cloneOf || d.data.id;
         if (this._activeNodeId === nodeId) {
             this._activeNodeId = null;
         } else {

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -166,11 +166,12 @@ function getNodeLabel(node, labelMode) {
 function operatorGlyph(node) {
     const glyphs = {
         equals: '=', multiply: '×', add: '+', subtract: '−',
-        divide: '÷', power: '^', derivative: 'd/d', integral: '∫',
+        divide: '÷', power: '^', integral: '∫',
         implies: '⇒', iff: '⇔', negate: '¬', conjunction: '∧',
         disjunction: '∨', sum: '∑', product: '∏', limit: 'lim',
         factorial: '!', sqrt: '√', logarithm: 'log', function: 'f',
     };
+    if (node.op === 'derivative') return 'd·/d·';
     return glyphs[node.op] || node.op || node.label || '?';
 }
 

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -386,14 +386,41 @@ export class D3SemanticGraphRenderer {
         for (const n of nodes) this._positionById.set(n.data.id, { x: n.x, y: n.y });
     }
 
-    _diagonal(d3, source, target) {
+    _nodeRadius(d) {
+        if (!d || !d.data) return 26;
+        if (d.data._collapsed) return 24;
+        const style = this._nodeStyle(d.data.type);
+        const invisible = (!style.fill || style.fill === 'none') &&
+                           (!style.stroke || style.stroke === 'none');
+        if (invisible) return 18;
+        const kind = d.data.type;
+        if (kind === 'operator' || kind === 'relation' || kind === 'function') return 28;
+        return 26;
+    }
+
+    _shortenPoint(point, other, radius) {
+        const dx = other.x - point.x;
+        const dy = other.y - point.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist < 1) return { x: point.x, y: point.y };
+        const ratio = radius / dist;
+        return { x: point.x + dx * ratio, y: point.y + dy * ratio };
+    }
+
+    _diagonal(d3, source, target, sourceNode, targetNode) {
+        const sr = sourceNode ? this._nodeRadius(sourceNode) : 0;
+        const tr = targetNode ? this._nodeRadius(targetNode) : 0;
+
+        const s = sr ? this._shortenPoint(source, target, sr) : source;
+        const t = tr ? this._shortenPoint(target, source, tr) : target;
+
         const horizontal = this._isHorizontal();
         if (horizontal) {
-            const midX = (source.x + target.x) / 2;
-            return `M${source.x},${source.y} C${midX},${source.y} ${midX},${target.y} ${target.x},${target.y}`;
+            const midX = (s.x + t.x) / 2;
+            return `M${s.x},${s.y} C${midX},${s.y} ${midX},${t.y} ${t.x},${t.y}`;
         }
-        const midY = (source.y + target.y) / 2;
-        return `M${source.x},${source.y} C${source.x},${midY} ${target.x},${midY} ${target.x},${target.y}`;
+        const midY = (s.y + t.y) / 2;
+        return `M${s.x},${s.y} C${s.x},${midY} ${t.x},${midY} ${t.x},${t.y}`;
     }
 
     _startPos(id) {
@@ -415,26 +442,26 @@ export class D3SemanticGraphRenderer {
             .attr('stroke-linecap', 'round')
             .attr('d', d => {
                 const p = this._startPos(d.target.data.id);
-                return this._diagonal(d3, p, p);
+                return this._diagonal(d3, p, p, null, null);
             })
             .style('opacity', 0)
             .transition(transition)
             .style('opacity', 1)
-            .attr('d', d => this._diagonal(d3, d.source, d.target));
+            .attr('d', d => this._diagonal(d3, d.source, d.target, d.source, d.target));
 
         link.transition(transition)
             .attr('class', d => `d3sg-link d3sg-edge-${d.semantic}`)
             .attr('stroke', d => this._edgeColor(d.semantic))
             .attr('stroke-width', d => this._edgeWidth(d.semantic))
             .style('opacity', 1)
-            .attr('d', d => this._diagonal(d3, d.source, d.target));
+            .attr('d', d => this._diagonal(d3, d.source, d.target, d.source, d.target));
 
         link.exit()
             .transition(transition)
             .style('opacity', 0)
             .attr('d', () => {
                 const p = this._startPos(this._lastInteractionId);
-                return this._diagonal(d3, p, p);
+                return this._diagonal(d3, p, p, null, null);
             })
             .remove();
     }
@@ -586,7 +613,21 @@ export class D3SemanticGraphRenderer {
             return;
         }
 
-        if (isOp) {
+        const invisible = (!style.fill || style.fill === 'none') &&
+                           (!style.stroke || style.stroke === 'none');
+
+        if (invisible) {
+            const bw = 56, bh = 36;
+            group.append('rect')
+                .attr('class', isOp ? 'd3sg-op-bg' : 'd3sg-var-bg')
+                .attr('x', -bw / 2)
+                .attr('y', -bh / 2)
+                .attr('width', bw)
+                .attr('height', bh)
+                .attr('rx', 4)
+                .attr('fill', 'transparent')
+                .attr('stroke', 'none');
+        } else if (isOp) {
             const r = 28;
             const points = Array.from({ length: 6 }, (_, i) => {
                 const angle = (Math.PI / 3) * i - Math.PI / 6;
@@ -605,7 +646,7 @@ export class D3SemanticGraphRenderer {
                 .attr('stroke', style.stroke || '');
         }
 
-        this._renderLabel(group, data, isOp ? 56 : 52, false, style);
+        this._renderLabel(group, data, invisible ? 56 : (isOp ? 56 : 52), false, style);
 
         if (isOp && data.children && data.children.length > 0) {
             group.append('text')

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -152,15 +152,13 @@ function graphToTree(graph) {
  */
 function getNodeLabel(node, labelMode) {
     if (node.type === 'operator' || node.type === 'relation' || node.type === 'function') {
-        const glyph = operatorGlyph(node);
-        if (labelMode === 'minimal') return glyph;
-        if (node.description && labelMode !== 'minimal') return glyph;
-        return glyph;
+        return operatorGlyph(node);
     }
-    if (labelMode === 'minimal') {
-        return node.emoji || node.latex || node.label || node.id;
-    }
-    return node.latex || node.label || node.id;
+    const base = (labelMode === 'minimal')
+        ? (node.emoji || node.latex || node.label || node.id)
+        : (node.latex || node.label || node.id);
+    if (node.emoji && base !== node.emoji) return node.emoji + ' ' + base;
+    return base;
 }
 
 function operatorGlyph(node) {
@@ -735,6 +733,12 @@ export class D3SemanticGraphRenderer {
             const span = document.createElement('span');
             try {
                 this.katex.render(latex, span, { throwOnError: false, displayMode: false });
+                if (data.emoji) {
+                    const emojiSpan = document.createElement('span');
+                    emojiSpan.textContent = data.emoji;
+                    emojiSpan.style.marginRight = '4px';
+                    div.node().appendChild(emojiSpan);
+                }
                 div.node().appendChild(span);
             } catch (_) {
                 div.text(data.label || data.id);

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -1,0 +1,644 @@
+/**
+ * D3SemanticGraphRenderer — renders a semantic graph model directly with D3.
+ *
+ * Consumes the flat {nodes, edges} semantic graph model and converts it to a
+ * tree for layout. Renders with D3 keyed joins (enter/update/exit), supporting
+ * collapse/expand, KaTeX labels via foreignObject, and edge-semantic coloring.
+ *
+ * This renderer does NOT touch the Mermaid path — it exists as an alternative.
+ */
+
+const D3_CDN_URL = 'https://cdn.jsdelivr.net/npm/d3@7/+esm';
+
+let _d3 = null;
+let _d3LoadPromise = null;
+
+function loadD3() {
+    if (_d3) return Promise.resolve(_d3);
+    if (_d3LoadPromise) return _d3LoadPromise;
+    _d3LoadPromise = import(D3_CDN_URL).then(mod => {
+        _d3 = mod;
+        return mod;
+    });
+    _d3LoadPromise.catch(() => { _d3LoadPromise = null; });
+    return _d3LoadPromise;
+}
+
+// Edge semantic → stroke color (dark theme)
+const EDGE_COLORS = {
+    direct: '#e74c3c',
+    inverse: '#5b8fc7',
+    neutral: '#7e8aa3',
+};
+
+const EDGE_WIDTHS = {
+    direct: 2.5,
+    inverse: 1.8,
+    neutral: 1.4,
+};
+
+// Infer edge semantic from graph structure when not explicitly tagged
+function inferEdgeSemantic(edge, nodeById) {
+    if (edge.semantic) return edge.semantic;
+    const src = nodeById[edge.from];
+    const dst = nodeById[edge.to];
+    if (src && src.op === 'power') {
+        const raw = src.exponent;
+        const n = parseFloat(raw);
+        if (Number.isFinite(n)) {
+            if (n < 0) return 'inverse';
+            if (Math.abs(n) > 1) return 'direct';
+        } else if (typeof raw === 'string' && raw.trimStart().startsWith('-')) {
+            return 'inverse';
+        }
+    }
+    if (dst && dst.op === 'multiply') return 'direct';
+    return 'neutral';
+}
+
+/**
+ * Convert flat {nodes, edges} to a rooted tree for d3.hierarchy.
+ * Finds the root (node with no incoming edges, or the first relation/equals
+ * operator), then builds children arrays by following edges.
+ */
+function graphToTree(graph) {
+    const nodes = graph.nodes || [];
+    const edges = graph.edges || [];
+    if (!nodes.length) return null;
+
+    const nodeById = Object.create(null);
+    for (const n of nodes) nodeById[n.id] = { ...n, children: [] };
+
+    // Edges flow from operands → operator (leaf → root), so the root is the
+    // node that never appears as an edge source (no outgoing edges).
+    const hasOutgoing = new Set();
+    for (const e of edges) hasOutgoing.add(e.from);
+
+    let rootId = null;
+    const candidates = nodes.filter(n => !hasOutgoing.has(n.id));
+    if (candidates.length) {
+        const relNode = candidates.find(n =>
+            n.type === 'relation' || n.op === 'equals' || n.op === 'implies' || n.op === 'iff');
+        rootId = relNode ? relNode.id : candidates[0].id;
+    } else {
+        const eq = nodes.find(n => n.op === 'equals');
+        rootId = eq ? eq.id : nodes[0].id;
+    }
+
+    // Build parent→child from edges (from→to means "from" is child of "to"
+    // in our model: edges point from operands toward the operator/root).
+    // So the children of a node are those that have edges pointing TO that node.
+    const childrenOf = Object.create(null);
+    const edgeSemanticMap = Object.create(null);
+    for (const e of edges) {
+        if (!childrenOf[e.to]) childrenOf[e.to] = [];
+        childrenOf[e.to].push(e.from);
+        edgeSemanticMap[`${e.from}->${e.to}`] = inferEdgeSemantic(e, nodeById);
+    }
+
+    const visited = new Set();
+    function buildTree(id) {
+        if (visited.has(id)) return null;
+        visited.add(id);
+        const node = nodeById[id];
+        if (!node) return null;
+        const treeNode = { ...node, children: [], _edgeSemantic: null };
+        const kids = childrenOf[id] || [];
+        for (const kid of kids) {
+            const child = buildTree(kid);
+            if (child) {
+                child._edgeSemantic = edgeSemanticMap[`${kid}->${id}`] || 'neutral';
+                treeNode.children.push(child);
+            }
+        }
+        return treeNode;
+    }
+
+    return buildTree(rootId);
+}
+
+/**
+ * Get the display label for a node, respecting label detail level.
+ * @param {Object} node
+ * @param {'minimal'|'description'|'full'} labelMode
+ */
+function getNodeLabel(node, labelMode) {
+    if (node.type === 'operator' || node.type === 'relation' || node.type === 'function') {
+        const glyph = operatorGlyph(node);
+        if (labelMode === 'minimal') return glyph;
+        if (node.description && labelMode !== 'minimal') return glyph;
+        return glyph;
+    }
+    if (labelMode === 'minimal') {
+        return node.emoji || node.latex || node.label || node.id;
+    }
+    return node.latex || node.label || node.id;
+}
+
+function operatorGlyph(node) {
+    const glyphs = {
+        equals: '=', multiply: '×', add: '+', subtract: '−',
+        divide: '÷', power: '^', derivative: 'd/d', integral: '∫',
+        implies: '⇒', iff: '⇔', negate: '¬', conjunction: '∧',
+        disjunction: '∨', sum: '∑', product: '∏', limit: 'lim',
+        factorial: '!', sqrt: '√', logarithm: 'log', function: 'f',
+    };
+    return glyphs[node.op] || node.op || node.label || '?';
+}
+
+export class D3SemanticGraphRenderer {
+    /**
+     * @param {HTMLElement} container — the DOM element to render into
+     * @param {Object} opts
+     * @param {Object} [opts.katex] — KaTeX instance for label rendering
+     * @param {'top-down'|'left-right'|'right-left'|'bottom-up'} [opts.direction]
+     * @param {'minimal'|'description'|'full'} [opts.labels]
+     * @param {Function} [opts.onNodeClick] — callback(nodeId, nodeData)
+     * @param {Function} [opts.onNodeHover] — callback(nodeId|null, nodeData|null, event)
+     * @param {Function} [opts.onBackgroundClick] — callback()
+     */
+    constructor(container, opts = {}) {
+        this.container = container;
+        this.katex = opts.katex || (typeof window !== 'undefined' && window.katex);
+        this.direction = opts.direction || 'left-right';
+        this.labels = opts.labels || 'description';
+        this.onNodeClick = opts.onNodeClick || null;
+        this.onNodeHover = opts.onNodeHover || null;
+        this.onBackgroundClick = opts.onBackgroundClick || null;
+
+        this._graph = null;
+        this._tree = null;
+        this._collapsed = new Set();
+        this._svg = null;
+        this._d3 = null;
+        this._positionById = new Map();
+        this._lastInteractionId = null;
+        this._activeNodeId = null;
+        this._destroyed = false;
+    }
+
+    async render(graph) {
+        if (this._destroyed) return;
+        this._graph = graph;
+        this._d3 = await loadD3();
+        if (this._destroyed) return;
+
+        this._tree = graphToTree(graph);
+        if (!this._tree) {
+            this.container.innerHTML = '<div style="color:#7e8aa3;padding:2rem;text-align:center;">No renderable tree structure.</div>';
+            return;
+        }
+        this._lastInteractionId = this._tree.id;
+        this._setupSvg();
+        this._renderTree();
+    }
+
+    update(opts = {}) {
+        if (opts.direction) this.direction = opts.direction;
+        if (opts.labels) this.labels = opts.labels;
+        if (this._d3 && this._tree) {
+            this._renderTree();
+        }
+    }
+
+    selectNode(nodeId) {
+        this._activeNodeId = nodeId;
+        this._applyHighlight();
+    }
+
+    clearSelection() {
+        this._activeNodeId = null;
+        this._applyHighlight();
+    }
+
+    get activeNode() {
+        return this._activeNodeId;
+    }
+
+    destroy() {
+        this._destroyed = true;
+        this.container.innerHTML = '';
+        this._svg = null;
+        this._graph = null;
+        this._tree = null;
+        this._positionById.clear();
+    }
+
+    // ─── Private ──────────────────────────────────────────────────────
+
+    _setupSvg() {
+        const d3 = this._d3;
+        this.container.innerHTML = '';
+
+        const card = document.createElement('div');
+        card.className = 'gv-card d3-graph-card';
+        this.container.appendChild(card);
+
+        this._svg = d3.select(card)
+            .append('svg')
+            .attr('class', 'd3-semantic-graph')
+            .attr('width', '100%')
+            .attr('height', '100%')
+            .attr('preserveAspectRatio', 'xMidYMid meet');
+
+        this._linkLayer = this._svg.append('g').attr('class', 'd3sg-links');
+        this._labelLayer = this._svg.append('g').attr('class', 'd3sg-edge-labels');
+        this._nodeLayer = this._svg.append('g').attr('class', 'd3sg-nodes');
+
+        // Background click
+        this._svg.on('click', (event) => {
+            if (event.target === this._svg.node() || event.target.tagName === 'svg') {
+                this._activeNodeId = null;
+                this._applyHighlight();
+                if (this.onBackgroundClick) this.onBackgroundClick();
+            }
+        });
+    }
+
+    _cloneVisible(node) {
+        const isCollapsed = this._collapsed.has(node.id);
+        return {
+            ...node,
+            _collapsed: isCollapsed,
+            children: isCollapsed ? [] : (node.children || []).map(c => this._cloneVisible(c)),
+        };
+    }
+
+    _isHorizontal() {
+        return this.direction === 'left-right' || this.direction === 'right-left';
+    }
+
+    _isReversed() {
+        return this.direction === 'right-left' || this.direction === 'bottom-up';
+    }
+
+    _renderTree(interactionId) {
+        const d3 = this._d3;
+        if (interactionId) this._lastInteractionId = interactionId;
+
+        const visibleRoot = this._cloneVisible(this._tree);
+        const root = d3.hierarchy(visibleRoot);
+
+        const horizontal = this._isHorizontal();
+        const nodeSpacing = horizontal ? [80, 180] : [160, 100];
+        const layout = d3.tree()
+            .nodeSize(nodeSpacing)
+            .separation((a, b) => a.parent === b.parent ? 1 : 1.15);
+        layout(root);
+
+        const nodes = root.descendants();
+        const links = root.links().map(link => ({
+            ...link,
+            id: `${link.source.data.id}--${link.target.data.id}`,
+            semantic: link.target.data._edgeSemantic || 'neutral',
+        }));
+
+        // Flip axes for horizontal layout and compute bounding box
+        if (horizontal) {
+            for (const n of nodes) { const tmp = n.x; n.x = n.y; n.y = tmp; }
+        }
+
+        // Center the graph within a viewBox
+        const xs = nodes.map(n => n.x);
+        const ys = nodes.map(n => n.y);
+        const minX = Math.min(...xs) - 100;
+        const maxX = Math.max(...xs) + 100;
+        const minY = Math.min(...ys) - 60;
+        const maxY = Math.max(...ys) + 60;
+        const width = Math.max(maxX - minX, 300);
+        const height = Math.max(maxY - minY, 200);
+
+        if (this._isReversed()) {
+            const midX = (minX + maxX) / 2;
+            for (const n of nodes) n.x = midX - (n.x - midX);
+        }
+
+        this._svg.attr('viewBox', `${minX} ${minY} ${width} ${height}`);
+
+        const duration = 360;
+        const transition = this._svg.transition().duration(duration).ease(d3.easeCubicOut);
+
+        this._renderLinks(links, transition, d3);
+        this._renderEdgeLabels(links, transition, d3);
+        this._renderNodes(nodes, transition, d3);
+
+        // Store positions for enter/exit animations
+        for (const n of nodes) this._positionById.set(n.data.id, { x: n.x, y: n.y });
+    }
+
+    _diagonal(d3, source, target) {
+        const horizontal = this._isHorizontal();
+        if (horizontal) {
+            const midX = (source.x + target.x) / 2;
+            return `M${source.x},${source.y} C${midX},${source.y} ${midX},${target.y} ${target.x},${target.y}`;
+        }
+        const midY = (source.y + target.y) / 2;
+        return `M${source.x},${source.y} C${source.x},${midY} ${target.x},${midY} ${target.x},${target.y}`;
+    }
+
+    _startPos(id) {
+        return this._positionById.get(id) ||
+            this._positionById.get(this._lastInteractionId) ||
+            { x: 0, y: 0 };
+    }
+
+    _renderLinks(links, transition, d3) {
+        const link = this._linkLayer.selectAll('path.d3sg-link')
+            .data(links, d => d.id);
+
+        link.enter()
+            .append('path')
+            .attr('class', d => `d3sg-link d3sg-edge-${d.semantic}`)
+            .attr('fill', 'none')
+            .attr('stroke', d => EDGE_COLORS[d.semantic] || EDGE_COLORS.neutral)
+            .attr('stroke-width', d => EDGE_WIDTHS[d.semantic] || 1.4)
+            .attr('stroke-linecap', 'round')
+            .attr('d', d => {
+                const p = this._startPos(d.target.data.id);
+                return this._diagonal(d3, p, p);
+            })
+            .style('opacity', 0)
+            .transition(transition)
+            .style('opacity', 1)
+            .attr('d', d => this._diagonal(d3, d.source, d.target));
+
+        link.transition(transition)
+            .attr('class', d => `d3sg-link d3sg-edge-${d.semantic}`)
+            .attr('stroke', d => EDGE_COLORS[d.semantic] || EDGE_COLORS.neutral)
+            .attr('stroke-width', d => EDGE_WIDTHS[d.semantic] || 1.4)
+            .style('opacity', 1)
+            .attr('d', d => this._diagonal(d3, d.source, d.target));
+
+        link.exit()
+            .transition(transition)
+            .style('opacity', 0)
+            .attr('d', () => {
+                const p = this._startPos(this._lastInteractionId);
+                return this._diagonal(d3, p, p);
+            })
+            .remove();
+    }
+
+    _renderEdgeLabels(links, transition, d3) {
+        const labeled = links.filter(d => d.semantic && d.semantic !== 'neutral');
+
+        const label = this._labelLayer.selectAll('text.d3sg-edge-label')
+            .data(labeled, d => d.id);
+
+        label.enter()
+            .append('text')
+            .attr('class', 'd3sg-edge-label')
+            .attr('text-anchor', 'middle')
+            .attr('dominant-baseline', 'middle')
+            .attr('x', d => this._startPos(d.target.data.id).x)
+            .attr('y', d => this._startPos(d.target.data.id).y)
+            .style('opacity', 0)
+            .text(d => d.semantic)
+            .transition(transition)
+            .style('opacity', 1)
+            .attr('x', d => (d.source.x + d.target.x) / 2)
+            .attr('y', d => (d.source.y + d.target.y) / 2 - 8);
+
+        label.transition(transition)
+            .style('opacity', 1)
+            .attr('x', d => (d.source.x + d.target.x) / 2)
+            .attr('y', d => (d.source.y + d.target.y) / 2 - 8)
+            .text(d => d.semantic);
+
+        label.exit().transition(transition).style('opacity', 0).remove();
+    }
+
+    _renderNodes(nodes, transition, d3) {
+        const self = this;
+        const node = this._nodeLayer.selectAll('g.d3sg-node')
+            .data(nodes, d => d.data.id);
+
+        const nodeEnter = node.enter()
+            .append('g')
+            .attr('class', d => this._nodeClass(d))
+            .attr('transform', d => {
+                const p = this._startPos(d.data.id);
+                return `translate(${p.x},${p.y}) scale(0.85)`;
+            })
+            .style('opacity', 0)
+            .style('cursor', d => this._isCollapsible(d) ? 'pointer' : 'default')
+            .on('click', function (event, d) {
+                event.stopPropagation();
+                self._handleNodeClick(d);
+            })
+            .on('mouseenter', function (event, d) {
+                if (self.onNodeHover) self.onNodeHover(d.data.id, d.data, event);
+            })
+            .on('mouseleave', function (event) {
+                if (self.onNodeHover) self.onNodeHover(null, null, event);
+            });
+
+        nodeEnter.each(function (d) { self._drawNode(d3.select(this), d); });
+
+        nodeEnter.transition(transition)
+            .attr('transform', d => `translate(${d.x},${d.y}) scale(1)`)
+            .style('opacity', 1);
+
+        // Update
+        const nodeUpdate = node.merge(nodeEnter);
+        nodeUpdate.attr('class', d => this._nodeClass(d));
+        nodeUpdate.each(function (d) { self._drawNode(d3.select(this), d); });
+        nodeUpdate.transition(transition)
+            .attr('transform', d => `translate(${d.x},${d.y}) scale(1)`)
+            .style('opacity', 1);
+
+        // Exit
+        node.exit()
+            .transition(transition)
+            .attr('transform', () => {
+                const p = this._startPos(this._lastInteractionId);
+                return `translate(${p.x},${p.y}) scale(0.85)`;
+            })
+            .style('opacity', 0)
+            .remove();
+    }
+
+    _nodeClass(d) {
+        const kind = d.data.type;
+        const isOp = kind === 'operator' || kind === 'relation' || kind === 'function';
+        const base = isOp ? 'op' : 'var';
+        const collapsed = d.data._collapsed ? ' collapsed' : '';
+        const active = d.data.id === this._activeNodeId ? ' active' : '';
+        return `d3sg-node d3sg-${base}${collapsed}${active}`;
+    }
+
+    _isCollapsible(d) {
+        const kind = d.data.type;
+        return (kind === 'operator' || kind === 'relation' || kind === 'function') &&
+            (d.data.children && d.data.children.length > 0);
+    }
+
+    _handleNodeClick(d) {
+        const nodeId = d.data.id;
+
+        // Toggle collapse for operator nodes
+        if (this._isCollapsible(d) || d.data._collapsed) {
+            if (this._collapsed.has(nodeId)) {
+                this._collapsed.delete(nodeId);
+            } else {
+                this._collapsed.add(nodeId);
+            }
+            this._renderTree(nodeId);
+        }
+
+        // Selection
+        if (this._activeNodeId === nodeId) {
+            this._activeNodeId = null;
+        } else {
+            this._activeNodeId = nodeId;
+        }
+        this._applyHighlight();
+        if (this.onNodeClick) this.onNodeClick(nodeId, d.data);
+    }
+
+    _drawNode(group, d) {
+        group.selectAll('*').remove();
+        const data = d.data;
+        const isOp = data.type === 'operator' || data.type === 'relation' || data.type === 'function';
+
+        if (data._collapsed) {
+            // Collapsed tile: rounded rect with subexpr label
+            const label = data.subexpr || data.label || data.id;
+            const estimatedWidth = Math.max(100, Math.min(260, label.length * 7 + 30));
+            group.append('rect')
+                .attr('class', 'd3sg-tile-bg')
+                .attr('x', -estimatedWidth / 2)
+                .attr('y', -24)
+                .attr('width', estimatedWidth)
+                .attr('height', 48)
+                .attr('rx', 6);
+
+            this._renderLabel(group, data, estimatedWidth, true);
+
+            // Expand chevron
+            group.append('text')
+                .attr('class', 'd3sg-chevron')
+                .attr('x', estimatedWidth / 2 - 14)
+                .attr('y', -12)
+                .attr('font-size', '11px')
+                .text('▶');
+            return;
+        }
+
+        if (isOp) {
+            // Hexagon for operators
+            const r = 28;
+            const points = Array.from({ length: 6 }, (_, i) => {
+                const angle = (Math.PI / 3) * i - Math.PI / 6;
+                return `${r * Math.cos(angle)},${r * Math.sin(angle)}`;
+            }).join(' ');
+            group.append('polygon')
+                .attr('class', 'd3sg-op-bg')
+                .attr('points', points);
+        } else {
+            // Circle for variables/scalars/vectors/constants
+            group.append('circle')
+                .attr('class', 'd3sg-var-bg')
+                .attr('r', 26);
+        }
+
+        this._renderLabel(group, data, isOp ? 56 : 52, false);
+
+        // Collapse chevron for operators with children
+        if (isOp && data.children && data.children.length > 0) {
+            group.append('text')
+                .attr('class', 'd3sg-chevron')
+                .attr('x', 20)
+                .attr('y', -16)
+                .attr('font-size', '11px')
+                .text('▼');
+        }
+    }
+
+    _renderLabel(group, data, maxWidth, isCollapsed) {
+        const latex = isCollapsed
+            ? (data.subexpr || data.latex || null)
+            : (data.latex || null);
+
+        if (latex && this.katex) {
+            const fo = group.append('foreignObject')
+                .attr('x', -maxWidth / 2)
+                .attr('y', -14)
+                .attr('width', maxWidth)
+                .attr('height', 28)
+                .attr('class', 'd3sg-label-fo');
+
+            const div = fo.append('xhtml:div')
+                .attr('class', 'd3sg-katex-host')
+                .style('display', 'flex')
+                .style('justify-content', 'center')
+                .style('align-items', 'center')
+                .style('width', '100%')
+                .style('height', '100%')
+                .style('overflow', 'hidden');
+
+            const span = document.createElement('span');
+            try {
+                this.katex.render(latex, span, { throwOnError: false, displayMode: false });
+                div.node().appendChild(span);
+            } catch (_) {
+                div.text(data.label || data.id);
+            }
+        } else {
+            // Plain text label
+            const text = getNodeLabel(data, this.labels);
+            group.append('text')
+                .attr('class', 'd3sg-label')
+                .attr('text-anchor', 'middle')
+                .attr('dominant-baseline', 'middle')
+                .attr('font-size', isCollapsed ? '12px' : '14px')
+                .text(text);
+        }
+    }
+
+    _applyHighlight() {
+        if (!this._svg) return;
+        const activeId = this._activeNodeId;
+
+        if (!activeId) {
+            // Clear all dimming
+            this._nodeLayer.selectAll('g.d3sg-node').style('opacity', 1);
+            this._linkLayer.selectAll('path.d3sg-link').style('opacity', 1);
+            this._labelLayer.selectAll('text.d3sg-edge-label').style('opacity', 1);
+            return;
+        }
+
+        // Find upstream nodes from active
+        const upstream = this._getUpstream(activeId);
+
+        this._nodeLayer.selectAll('g.d3sg-node').style('opacity', d =>
+            upstream.has(d.data.id) ? 1 : 0.15
+        );
+
+        this._linkLayer.selectAll('path.d3sg-link').style('opacity', d =>
+            upstream.has(d.source.data.id) && upstream.has(d.target.data.id) ? 1 : 0.1
+        );
+
+        this._labelLayer.selectAll('text.d3sg-edge-label').style('opacity', d =>
+            upstream.has(d.source.data.id) && upstream.has(d.target.data.id) ? 1 : 0.1
+        );
+    }
+
+    _getUpstream(nodeId) {
+        // In our tree, "upstream" = the node itself plus all its descendants
+        // (since edges point from leaves to root, upstream means the subtree
+        // that feeds into this node).
+        const visited = new Set();
+        const edges = this._graph.edges || [];
+        const queue = [nodeId];
+        while (queue.length) {
+            const cur = queue.shift();
+            if (visited.has(cur)) continue;
+            visited.add(cur);
+            for (const e of edges) {
+                if (e.to === cur && !visited.has(e.from)) queue.push(e.from);
+            }
+        }
+        return visited;
+    }
+}

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -10,6 +10,15 @@
 
 const D3_CDN_URL = 'https://cdn.jsdelivr.net/npm/d3@7/+esm';
 
+const SUPERSCRIPT_MAP = {
+    '0': '⁰', '1': '¹', '2': '²', '3': '³', '4': '⁴',
+    '5': '⁵', '6': '⁶', '7': '⁷', '8': '⁸', '9': '⁹',
+    '+': '⁺', '-': '⁻', '−': '⁻', 'n': 'ⁿ', 'i': 'ⁱ',
+};
+function toSuperscript(s) {
+    return String(s).split('').map(c => SUPERSCRIPT_MAP[c] || c).join('');
+}
+
 let _d3 = null;
 let _d3LoadPromise = null;
 
@@ -170,6 +179,10 @@ function operatorGlyph(node) {
         factorial: '!', sqrt: '√', logarithm: 'log', function: 'f',
     };
     if (node.op === 'derivative') return 'd·/d·';
+    if (node.op === 'power') {
+        const exp = node.exponent || 'n';
+        return `(·)${toSuperscript(exp)}`;
+    }
     return glyphs[node.op] || node.op || node.label || '?';
 }
 

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -745,7 +745,7 @@ export class D3SemanticGraphRenderer {
                 .attr('class', 'd3sg-label')
                 .attr('text-anchor', 'middle')
                 .attr('dominant-baseline', 'middle')
-                .attr('font-size', isCollapsed ? '12px' : '14px')
+                .attr('font-size', isCollapsed ? '14px' : '17px')
                 .text(text);
             if (textColor) label.attr('fill', textColor);
         }

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -589,18 +589,24 @@ export class D3SemanticGraphRenderer {
         const isOp = data.type === 'operator' || data.type === 'relation' || data.type === 'function';
         const style = this._nodeStyle(data.type);
 
+        const invisible = (!style.fill || style.fill === 'none') &&
+                           (!style.stroke || style.stroke === 'none');
+
         if (data._collapsed) {
             const label = data.subexpr || data.label || data.id;
             const estimatedWidth = Math.max(100, Math.min(260, label.length * 7 + 30));
-            group.append('rect')
-                .attr('class', 'd3sg-tile-bg')
+            const tile = group.append('rect')
+                .attr('class', invisible ? 'd3sg-hit-target' : 'd3sg-tile-bg')
                 .attr('x', -estimatedWidth / 2)
                 .attr('y', -24)
                 .attr('width', estimatedWidth)
                 .attr('height', 48)
-                .attr('rx', 6)
-                .attr('fill', style.fill || '')
-                .attr('stroke', style.stroke || '');
+                .attr('rx', 6);
+            if (invisible) {
+                tile.style('fill', 'transparent').style('stroke', 'none');
+            } else {
+                tile.attr('fill', style.fill || '').attr('stroke', style.stroke || '');
+            }
 
             this._renderLabel(group, data, estimatedWidth, true, style);
 
@@ -613,20 +619,17 @@ export class D3SemanticGraphRenderer {
             return;
         }
 
-        const invisible = (!style.fill || style.fill === 'none') &&
-                           (!style.stroke || style.stroke === 'none');
-
         if (invisible) {
             const bw = 56, bh = 36;
             group.append('rect')
-                .attr('class', isOp ? 'd3sg-op-bg' : 'd3sg-var-bg')
+                .attr('class', 'd3sg-hit-target')
                 .attr('x', -bw / 2)
                 .attr('y', -bh / 2)
                 .attr('width', bw)
                 .attr('height', bh)
                 .attr('rx', 4)
-                .attr('fill', 'transparent')
-                .attr('stroke', 'none');
+                .style('fill', 'transparent')
+                .style('stroke', 'none');
         } else if (isOp) {
             const r = 28;
             const points = Array.from({ length: 6 }, (_, i) => {

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -574,18 +574,6 @@ export class D3SemanticGraphRenderer {
 
     _handleNodeClick(d) {
         const nodeId = d.data.id;
-
-        // Toggle collapse for operator nodes
-        if (this._isCollapsible(d) || d.data._collapsed) {
-            if (this._collapsed.has(nodeId)) {
-                this._collapsed.delete(nodeId);
-            } else {
-                this._collapsed.add(nodeId);
-            }
-            this._renderTree(nodeId);
-        }
-
-        // Selection
         if (this._activeNodeId === nodeId) {
             this._activeNodeId = null;
         } else {
@@ -593,6 +581,53 @@ export class D3SemanticGraphRenderer {
         }
         this._applyHighlight();
         if (this.onNodeClick) this.onNodeClick(nodeId, d.data);
+    }
+
+    _handleChevronClick(d) {
+        const nodeId = d.data.id;
+        if (this._collapsed.has(nodeId)) {
+            this._collapsed.delete(nodeId);
+        } else {
+            this._collapsed.add(nodeId);
+        }
+        this._renderTree(nodeId);
+    }
+
+    _chevronPos(isCollapsed) {
+        const glyph = isCollapsed ? '+' : '−';
+        const dir = this.direction;
+        if (dir === 'left-right') return { glyph, x: 22, y: -18 };
+        if (dir === 'right-left') return { glyph, x: -34, y: -18 };
+        if (dir === 'bottom-up') return { glyph, x: -6, y: -24 };
+        return { glyph, x: -6, y: 20 };
+    }
+
+    _appendChevron(group, d, isCollapsed) {
+        const cp = this._chevronPos(isCollapsed);
+        const self = this;
+        const sz = 14;
+        const g = group.append('g')
+            .attr('class', 'd3sg-chevron')
+            .attr('transform', `translate(${cp.x},${cp.y})`)
+            .on('click', function (event) {
+                event.stopPropagation();
+                self._handleChevronClick(d);
+            });
+        g.append('rect')
+            .attr('x', 0).attr('y', 0)
+            .attr('width', sz).attr('height', sz)
+            .attr('rx', 2)
+            .attr('fill', '#1a2440')
+            .attr('stroke', '#a8c5ff')
+            .attr('stroke-width', 1);
+        g.append('text')
+            .attr('x', sz / 2).attr('y', sz / 2 + 1)
+            .attr('text-anchor', 'middle')
+            .attr('dominant-baseline', 'middle')
+            .attr('font-size', '11px')
+            .attr('fill', '#a8c5ff')
+            .text(cp.glyph);
+        return g;
     }
 
     _drawNode(group, d) {
@@ -622,12 +657,11 @@ export class D3SemanticGraphRenderer {
 
             this._renderLabel(group, data, estimatedWidth, true, style);
 
-            group.append('text')
-                .attr('class', 'd3sg-chevron')
-                .attr('x', estimatedWidth / 2 - 14)
-                .attr('y', -12)
-                .attr('font-size', '11px')
-                .text('▶');
+            const cp = this._chevronPos(true);
+            const cx = cp.x < 0 ? -estimatedWidth / 2 + 4 : estimatedWidth / 2 - 16;
+            const cy = cp.y < 0 ? -16 : 16;
+            this._appendChevron(group, d, true)
+                .attr('transform', `translate(${cx},${cy})`);
             return;
         }
 
@@ -664,12 +698,7 @@ export class D3SemanticGraphRenderer {
         this._renderLabel(group, data, invisible ? 56 : (isOp ? 56 : 52), false, style);
 
         if (isOp && data.children && data.children.length > 0) {
-            group.append('text')
-                .attr('class', 'd3sg-chevron')
-                .attr('x', 20)
-                .attr('y', -16)
-                .attr('font-size', '11px')
-                .text('▼');
+            this._appendChevron(group, d, false);
         }
     }
 

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -165,7 +165,7 @@ export class D3SemanticGraphRenderer {
      * @param {'top-down'|'left-right'|'right-left'|'bottom-up'} [opts.direction]
      * @param {'minimal'|'description'|'full'} [opts.labels]
      * @param {Function} [opts.onNodeClick] — callback(nodeId, nodeData)
-     * @param {Function} [opts.onNodeHover] — callback(nodeId|null, nodeData|null, event)
+     * @param {Function} [opts.onNodeHover] — callback(nodeId|null, nodeData|null, nodeEl|null)
      * @param {Function} [opts.onBackgroundClick] — callback()
      */
     constructor(container, opts = {}) {
@@ -570,10 +570,10 @@ export class D3SemanticGraphRenderer {
                 self._handleNodeClick(d);
             })
             .on('mouseenter', function (event, d) {
-                if (self.onNodeHover) self.onNodeHover(d.data.id, d.data, event);
+                if (self.onNodeHover) self.onNodeHover(d.data.id, d.data, this);
             })
-            .on('mouseleave', function (event) {
-                if (self.onNodeHover) self.onNodeHover(null, null, event);
+            .on('mouseleave', function () {
+                if (self.onNodeHover) self.onNodeHover(null, null, null);
             });
 
         nodeEnter.each(function (d) { self._drawNode(d3.select(this), d); });

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -1,14 +1,16 @@
 /**
  * D3SemanticGraphRenderer — renders a semantic graph model directly with D3.
  *
- * Consumes the flat {nodes, edges} semantic graph model and converts it to a
- * tree for layout. Renders with D3 keyed joins (enter/update/exit), supporting
- * collapse/expand, KaTeX labels via foreignObject, and edge-semantic coloring.
+ * Consumes the flat {nodes, edges} semantic graph model and uses dagre for
+ * DAG layout (shared nodes appear once with multiple edges). Renders with
+ * D3 keyed joins (enter/update/exit), supporting collapse/expand, KaTeX
+ * labels via foreignObject, and edge-semantic coloring.
  *
  * This renderer does NOT touch the Mermaid path — it exists as an alternative.
  */
 
 const D3_CDN_URL = 'https://cdn.jsdelivr.net/npm/d3@7/+esm';
+const DAGRE_CDN_URL = 'https://cdn.jsdelivr.net/npm/@dagrejs/dagre@1.1.4/dist/dagre.min.js';
 
 const SUPERSCRIPT_MAP = {
     '0': '⁰', '1': '¹', '2': '²', '3': '³', '4': '⁴',
@@ -31,6 +33,28 @@ function loadD3() {
     });
     _d3LoadPromise.catch(() => { _d3LoadPromise = null; });
     return _d3LoadPromise;
+}
+
+let _dagre = null;
+let _dagreLoadPromise = null;
+
+function loadDagre() {
+    if (_dagre) return Promise.resolve(_dagre);
+    if (_dagreLoadPromise) return _dagreLoadPromise;
+    _dagreLoadPromise = new Promise((resolve, reject) => {
+        if (typeof window !== 'undefined' && window.dagre) {
+            _dagre = window.dagre;
+            resolve(_dagre);
+            return;
+        }
+        const script = document.createElement('script');
+        script.src = DAGRE_CDN_URL;
+        script.onload = () => { _dagre = window.dagre; resolve(_dagre); };
+        script.onerror = reject;
+        document.head.appendChild(script);
+    });
+    _dagreLoadPromise.catch(() => { _dagreLoadPromise = null; });
+    return _dagreLoadPromise;
 }
 
 // Default edge styles (fallback when theme has no edgeStyles)
@@ -93,84 +117,7 @@ function inferEdgeSemantic(edge, nodeById) {
     return 'neutral';
 }
 
-/**
- * Convert flat {nodes, edges} to a rooted tree for d3.hierarchy.
- * Finds the root (node with no incoming edges, or the first relation/equals
- * operator), then builds children arrays by following edges.
- */
-function graphToTree(graph) {
-    const nodes = graph.nodes || [];
-    const edges = graph.edges || [];
-    if (!nodes.length) return null;
-
-    const nodeById = Object.create(null);
-    for (const n of nodes) nodeById[n.id] = { ...n, children: [] };
-
-    // Edges flow from operands → operator (leaf → root), so the root is the
-    // node that never appears as an edge source (no outgoing edges).
-    const hasOutgoing = new Set();
-    for (const e of edges) hasOutgoing.add(e.from);
-
-    let rootId = null;
-    const candidates = nodes.filter(n => !hasOutgoing.has(n.id));
-    if (candidates.length) {
-        const relNode = candidates.find(n =>
-            n.type === 'relation' || n.op === 'equals' || n.op === 'implies' || n.op === 'iff');
-        rootId = relNode ? relNode.id : candidates[0].id;
-    } else {
-        const eq = nodes.find(n => n.op === 'equals');
-        rootId = eq ? eq.id : nodes[0].id;
-    }
-
-    // Build parent→child from edges (from→to means "from" is child of "to"
-    // in our model: edges point from operands toward the operator/root).
-    // So the children of a node are those that have edges pointing TO that node.
-    const childrenOf = Object.create(null);
-    const edgeSemanticMap = Object.create(null);
-    for (const e of edges) {
-        if (!childrenOf[e.to]) childrenOf[e.to] = [];
-        childrenOf[e.to].push(e.from);
-        edgeSemanticMap[`${e.from}->${e.to}`] = inferEdgeSemantic(e, nodeById);
-    }
-
-    const visiting = new Set();
-    let cloneSeq = 0;
-    function buildTree(id) {
-        // Prevent infinite recursion on cycles, but allow DAG sharing:
-        // leaf nodes (no children) are cloned; interior nodes are skipped
-        // to avoid exponential blowup.
-        if (visiting.has(id)) return null;
-        const node = nodeById[id];
-        if (!node) return null;
-        const kids = childrenOf[id] || [];
-        const isLeaf = kids.length === 0;
-        if (!isLeaf && visiting.has(id)) return null;
-
-        visiting.add(id);
-        const treeNode = { ...node, children: [], _edgeSemantic: null };
-        for (const kid of kids) {
-            const kidNode = nodeById[kid];
-            const kidKids = childrenOf[kid] || [];
-            const kidIsLeaf = kidKids.length === 0;
-            // Clone leaf nodes that were already placed elsewhere in the tree
-            if (kidIsLeaf && visiting.has(kid) && kidNode) {
-                const clone = { ...kidNode, id: `${kid}__clone${++cloneSeq}`,
-                    _cloneOf: kid, children: [], _edgeSemantic: null };
-                clone._edgeSemantic = edgeSemanticMap[`${kid}->${id}`] || 'neutral';
-                treeNode.children.push(clone);
-                continue;
-            }
-            const child = buildTree(kid);
-            if (child) {
-                child._edgeSemantic = edgeSemanticMap[`${kid}->${id}`] || 'neutral';
-                treeNode.children.push(child);
-            }
-        }
-        return treeNode;
-    }
-
-    return buildTree(rootId);
-}
+// No tree conversion needed — dagre handles DAG layout directly.
 
 /**
  * Get the display label for a node, respecting label detail level.
@@ -198,7 +145,11 @@ function operatorGlyph(node) {
         exp: 'exp', sin: 'sin', cos: 'cos', tan: 'tan',
         Abs: '|·|', abs: '|·|', function: 'f',
     };
-    if (node.op === 'derivative') return 'd·/d·';
+    if (node.op === 'derivative') {
+        if (node.with_respect_to && (!node._childIds || node._childIds.length <= 1))
+            return `d·/d${node.with_respect_to}`;
+        return 'd·/d·';
+    }
     if (node.op === 'power') {
         const exp = node.exponent || 'n';
         return `(·)${toSuperscript(exp)}`;
@@ -228,11 +179,11 @@ export class D3SemanticGraphRenderer {
         this.onBackgroundClick = opts.onBackgroundClick || null;
 
         this._graph = null;
-        this._tree = null;
         this._theme = null;
         this._collapsed = new Set();
         this._svg = null;
         this._d3 = null;
+        this._dagre = null;
         this._positionById = new Map();
         this._lastInteractionId = null;
         this._activeNodeId = null;
@@ -242,19 +193,20 @@ export class D3SemanticGraphRenderer {
     async render(graph) {
         if (this._destroyed) return;
         this._graph = graph;
-        this._d3 = await loadD3();
+        const [d3, dagre] = await Promise.all([loadD3(), loadDagre()]);
         if (this._destroyed) return;
+        this._d3 = d3;
+        this._dagre = dagre;
         this._theme = await fetchTheme(this.themeName);
         if (this._destroyed) return;
 
-        this._tree = graphToTree(graph);
-        if (!this._tree) {
-            this.container.innerHTML = '<div style="color:#7e8aa3;padding:2rem;text-align:center;">No renderable tree structure.</div>';
+        if (!graph.nodes || !graph.nodes.length) {
+            this.container.innerHTML = '<div style="color:#7e8aa3;padding:2rem;text-align:center;">No renderable graph structure.</div>';
             return;
         }
-        this._lastInteractionId = this._tree.id;
+        this._lastInteractionId = graph.nodes[0].id;
         this._setupSvg();
-        this._renderTree();
+        this._renderGraph();
     }
 
     async update(opts = {}) {
@@ -264,8 +216,8 @@ export class D3SemanticGraphRenderer {
             this.themeName = opts.theme;
             this._theme = await fetchTheme(this.themeName);
         }
-        if (this._d3 && this._tree) {
-            this._renderTree();
+        if (this._d3 && this._dagre && this._graph) {
+            this._renderGraph();
         }
     }
 
@@ -288,7 +240,6 @@ export class D3SemanticGraphRenderer {
         this.container.innerHTML = '';
         this._svg = null;
         this._graph = null;
-        this._tree = null;
         this._positionById.clear();
     }
 
@@ -347,50 +298,117 @@ export class D3SemanticGraphRenderer {
         });
     }
 
-    _cloneVisible(node) {
-        const isCollapsed = this._collapsed.has(node.id);
-        return {
-            ...node,
-            _collapsed: isCollapsed,
-            children: isCollapsed ? [] : (node.children || []).map(c => this._cloneVisible(c)),
-        };
-    }
-
     _isHorizontal() {
         return this.direction === 'left-right' || this.direction === 'right-left';
     }
 
-    _isReversed() {
-        return this.direction === 'right-left' || this.direction === 'bottom-up';
+    _layoutGraph() {
+        const dagre = this._dagre;
+        const graph = this._graph;
+        const nodes = graph.nodes || [];
+        const edges = graph.edges || [];
+
+        const nodeById = Object.create(null);
+        for (const n of nodes) nodeById[n.id] = n;
+
+        const childrenOf = Object.create(null);
+        for (const e of edges) {
+            if (!childrenOf[e.to]) childrenOf[e.to] = [];
+            childrenOf[e.to].push(e.from);
+        }
+
+        // BFS from roots to find visible nodes (stop at collapsed)
+        const hasOutgoing = new Set(edges.map(e => e.from));
+        const roots = nodes.filter(n => !hasOutgoing.has(n.id));
+
+        const visible = new Set();
+        const queue = roots.map(r => r.id);
+        while (queue.length) {
+            const id = queue.shift();
+            if (visible.has(id)) continue;
+            visible.add(id);
+            if (this._collapsed.has(id)) continue;
+            for (const child of (childrenOf[id] || [])) queue.push(child);
+        }
+
+        const rankdir = this.direction === 'top-down' ? 'TB' :
+                        this.direction === 'bottom-up' ? 'BT' :
+                        this.direction === 'left-right' ? 'LR' : 'RL';
+
+        const g = new dagre.graphlib.Graph({ multigraph: true });
+        g.setGraph({ rankdir, nodesep: 60, ranksep: 80, marginx: 40, marginy: 40 });
+        g.setDefaultEdgeLabel(() => ({}));
+
+        for (const n of nodes) {
+            if (!visible.has(n.id)) continue;
+            const isCollapsed = this._collapsed.has(n.id);
+            const isOp = n.type === 'operator' || n.type === 'relation' || n.type === 'function';
+            let w, h;
+            if (isCollapsed) {
+                const label = n.subexpr || n.label || n.id || '';
+                w = Math.max(100, Math.min(260, label.length * 7 + 30));
+                h = 48;
+            } else if (isOp) {
+                w = 56; h = 56;
+            } else {
+                w = 52; h = 52;
+            }
+            g.setNode(n.id, { width: w, height: h });
+        }
+
+        const edgeSemanticMap = Object.create(null);
+        for (const e of edges) {
+            if (!visible.has(e.from) || !visible.has(e.to)) continue;
+            const key = `${e.from}->${e.to}`;
+            edgeSemanticMap[key] = inferEdgeSemantic(e, nodeById);
+            g.setEdge(e.to, e.from, {}, key);
+        }
+
+        dagre.layout(g);
+
+        const nodeWrappers = Object.create(null);
+        const layoutNodes = [];
+        for (const id of g.nodes()) {
+            const pos = g.node(id);
+            const wrapper = {
+                data: {
+                    ...nodeById[id],
+                    _collapsed: this._collapsed.has(id),
+                    _childIds: childrenOf[id] || [],
+                },
+                x: pos.x,
+                y: pos.y,
+            };
+            nodeWrappers[id] = wrapper;
+            layoutNodes.push(wrapper);
+        }
+
+        const layoutEdges = [];
+        for (const e of edges) {
+            if (!visible.has(e.from) || !visible.has(e.to)) continue;
+            const src = nodeWrappers[e.to];
+            const tgt = nodeWrappers[e.from];
+            if (!src || !tgt) continue;
+            layoutEdges.push({
+                source: src,
+                target: tgt,
+                id: `${e.from}->${e.to}`,
+                semantic: edgeSemanticMap[`${e.from}->${e.to}`] || 'neutral',
+            });
+        }
+
+        return { nodes: layoutNodes, edges: layoutEdges };
     }
 
-    _renderTree(interactionId) {
+    _renderGraph(interactionId) {
         const d3 = this._d3;
         if (interactionId) this._lastInteractionId = interactionId;
 
-        const visibleRoot = this._cloneVisible(this._tree);
-        const root = d3.hierarchy(visibleRoot);
+        const layout = this._layoutGraph();
+        if (!layout) return;
 
-        const horizontal = this._isHorizontal();
-        const nodeSpacing = horizontal ? [80, 180] : [160, 100];
-        const layout = d3.tree()
-            .nodeSize(nodeSpacing)
-            .separation((a, b) => a.parent === b.parent ? 1 : 1.15);
-        layout(root);
+        const { nodes, edges: links } = layout;
 
-        const nodes = root.descendants();
-        const links = root.links().map(link => ({
-            ...link,
-            id: `${link.source.data.id}--${link.target.data.id}`,
-            semantic: link.target.data._edgeSemantic || 'neutral',
-        }));
-
-        // Flip axes for horizontal layout and compute bounding box
-        if (horizontal) {
-            for (const n of nodes) { const tmp = n.x; n.x = n.y; n.y = tmp; }
-        }
-
-        // Center the graph within a viewBox
         const xs = nodes.map(n => n.x);
         const ys = nodes.map(n => n.y);
         const minX = Math.min(...xs) - 100;
@@ -399,11 +417,6 @@ export class D3SemanticGraphRenderer {
         const maxY = Math.max(...ys) + 60;
         const width = Math.max(maxX - minX, 300);
         const height = Math.max(maxY - minY, 200);
-
-        if (this._isReversed()) {
-            const midX = (minX + maxX) / 2;
-            for (const n of nodes) n.x = midX - (n.x - midX);
-        }
 
         this._svg.attr('viewBox', `${minX} ${minY} ${width} ${height}`);
 
@@ -414,7 +427,6 @@ export class D3SemanticGraphRenderer {
         this._renderEdgeLabels(links, transition, d3);
         this._renderNodes(nodes, transition, d3);
 
-        // Store positions for enter/exit animations
         for (const n of nodes) this._positionById.set(n.data.id, { x: n.x, y: n.y });
     }
 
@@ -601,11 +613,11 @@ export class D3SemanticGraphRenderer {
     _isCollapsible(d) {
         const kind = d.data.type;
         return (kind === 'operator' || kind === 'relation' || kind === 'function') &&
-            (d.data.children && d.data.children.length > 0);
+            (d.data._childIds && d.data._childIds.length > 0);
     }
 
     _handleNodeClick(d) {
-        const nodeId = d.data._cloneOf || d.data.id;
+        const nodeId = d.data.id;
         if (this._activeNodeId === nodeId) {
             this._activeNodeId = null;
         } else {
@@ -622,7 +634,7 @@ export class D3SemanticGraphRenderer {
         } else {
             this._collapsed.add(nodeId);
         }
-        this._renderTree(nodeId);
+        this._renderGraph(nodeId);
     }
 
     _chevronPos(isCollapsed, shape) {
@@ -734,7 +746,7 @@ export class D3SemanticGraphRenderer {
 
         this._renderLabel(group, data, invisible ? 56 : (isOp ? 56 : 52), false, style);
 
-        if (isOp && data.children && data.children.length > 0) {
+        if (isOp && data._childIds && data._childIds.length > 0) {
             this._appendChevron(group, d, false);
         }
     }

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -386,33 +386,45 @@ export class D3SemanticGraphRenderer {
         for (const n of nodes) this._positionById.set(n.data.id, { x: n.x, y: n.y });
     }
 
-    _nodeRadius(d) {
-        if (!d || !d.data) return 26;
-        if (d.data._collapsed) return 24;
+    _nodeShape(d) {
+        if (!d || !d.data) return { type: 'circle', r: 26 };
         const style = this._nodeStyle(d.data.type);
         const invisible = (!style.fill || style.fill === 'none') &&
                            (!style.stroke || style.stroke === 'none');
-        if (invisible) return 18;
+        if (d.data._collapsed) {
+            const label = d.data.subexpr || d.data.label || d.data.id || '';
+            const w = Math.max(100, Math.min(260, label.length * 7 + 30));
+            return { type: 'rect', hw: w / 2, hh: 24 };
+        }
+        if (invisible) return { type: 'rect', hw: 28, hh: 18 };
         const kind = d.data.type;
-        if (kind === 'operator' || kind === 'relation' || kind === 'function') return 28;
-        return 26;
+        if (kind === 'operator' || kind === 'relation' || kind === 'function') return { type: 'circle', r: 28 };
+        return { type: 'circle', r: 26 };
     }
 
-    _shortenPoint(point, other, radius) {
-        const dx = other.x - point.x;
-        const dy = other.y - point.y;
+    _boundaryPoint(center, other, shape) {
+        const dx = other.x - center.x;
+        const dy = other.y - center.y;
         const dist = Math.sqrt(dx * dx + dy * dy);
-        if (dist < 1) return { x: point.x, y: point.y };
-        const ratio = radius / dist;
-        return { x: point.x + dx * ratio, y: point.y + dy * ratio };
+        if (dist < 1) return { x: center.x, y: center.y };
+
+        if (shape.type === 'rect') {
+            const nx = dx / dist, ny = dy / dist;
+            const tx = shape.hw / Math.max(Math.abs(nx), 1e-6);
+            const ty = shape.hh / Math.max(Math.abs(ny), 1e-6);
+            const t = Math.min(tx, ty);
+            return { x: center.x + nx * t, y: center.y + ny * t };
+        }
+        const ratio = shape.r / dist;
+        return { x: center.x + dx * ratio, y: center.y + dy * ratio };
     }
 
     _diagonal(d3, source, target, sourceNode, targetNode) {
-        const sr = sourceNode ? this._nodeRadius(sourceNode) : 0;
-        const tr = targetNode ? this._nodeRadius(targetNode) : 0;
+        const ss = sourceNode ? this._nodeShape(sourceNode) : null;
+        const ts = targetNode ? this._nodeShape(targetNode) : null;
 
-        const s = sr ? this._shortenPoint(source, target, sr) : source;
-        const t = tr ? this._shortenPoint(target, source, tr) : target;
+        const s = ss ? this._boundaryPoint(source, target, ss) : source;
+        const t = ts ? this._boundaryPoint(target, source, ts) : target;
 
         const horizontal = this._isHorizontal();
         if (horizontal) {

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -593,17 +593,26 @@ export class D3SemanticGraphRenderer {
         this._renderTree(nodeId);
     }
 
-    _chevronPos(isCollapsed) {
+    _chevronPos(isCollapsed, shape) {
         const glyph = isCollapsed ? '+' : '−';
+        const sz = 14, half = sz / 2;
         const dir = this.direction;
-        if (dir === 'left-right') return { glyph, x: 22, y: -18 };
-        if (dir === 'right-left') return { glyph, x: -34, y: -18 };
-        if (dir === 'bottom-up') return { glyph, x: -6, y: -24 };
-        return { glyph, x: -6, y: 20 };
+        if (shape.type === 'rect') {
+            if (dir === 'left-right')  return { glyph, x: shape.hw - half, y: -half };
+            if (dir === 'right-left')  return { glyph, x: -shape.hw - half, y: -half };
+            if (dir === 'bottom-up')   return { glyph, x: -half, y: -shape.hh - half };
+            return { glyph, x: -half, y: shape.hh - half };
+        }
+        const r = shape.r || 26;
+        if (dir === 'left-right')  return { glyph, x: r - half, y: -half };
+        if (dir === 'right-left')  return { glyph, x: -r - half, y: -half };
+        if (dir === 'bottom-up')   return { glyph, x: -half, y: -r - half };
+        return { glyph, x: -half, y: r - half };
     }
 
     _appendChevron(group, d, isCollapsed) {
-        const cp = this._chevronPos(isCollapsed);
+        const shape = this._nodeShape(d);
+        const cp = this._chevronPos(isCollapsed, shape);
         const self = this;
         const sz = 14;
         const g = group.append('g')
@@ -657,11 +666,7 @@ export class D3SemanticGraphRenderer {
 
             this._renderLabel(group, data, estimatedWidth, true, style);
 
-            const cp = this._chevronPos(true);
-            const cx = cp.x < 0 ? -estimatedWidth / 2 + 4 : estimatedWidth / 2 - 16;
-            const cy = cp.y < 0 ? -16 : 16;
-            this._appendChevron(group, d, true)
-                .attr('transform', `translate(${cx},${cy})`);
+            this._appendChevron(group, d, true);
             return;
         }
 

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -24,18 +24,46 @@ function loadD3() {
     return _d3LoadPromise;
 }
 
-// Edge semantic → stroke color (dark theme)
-const EDGE_COLORS = {
+// Default edge styles (fallback when theme has no edgeStyles)
+const DEFAULT_EDGE_COLORS = {
     direct: '#e74c3c',
     inverse: '#5b8fc7',
     neutral: '#7e8aa3',
 };
 
-const EDGE_WIDTHS = {
+const DEFAULT_EDGE_WIDTHS = {
     direct: 2.5,
     inverse: 1.8,
     neutral: 1.4,
 };
+
+// Default node styles (fallback when theme has no nodeStyles)
+const DEFAULT_NODE_STYLES = {
+    scalar:   { fill: '#1b3a1e', stroke: '#66bb6a', color: '#c8e6c9' },
+    vector:   { fill: '#1b3a1e', stroke: '#66bb6a', color: '#c8e6c9' },
+    constant: { fill: '#1b3a1e', stroke: '#66bb6a', color: '#c8e6c9' },
+    number:   { fill: '#1b3a1e', stroke: '#66bb6a', color: '#c8e6c9' },
+    operator: { fill: '#0f2540', stroke: '#42a5f5', color: '#bbdefb' },
+    function: { fill: '#0f2540', stroke: '#42a5f5', color: '#bbdefb' },
+    relation: { fill: '#2e1b33', stroke: '#ab47bc', color: '#e1bee7' },
+    expression: { fill: '#1b3a1e', stroke: '#66bb6a', color: '#c8e6c9' },
+    text:     { fill: '#1b3a1e', stroke: '#66bb6a', color: '#c8e6c9' },
+};
+
+let _themeCache = Object.create(null);
+
+async function fetchTheme(name) {
+    if (_themeCache[name]) return _themeCache[name];
+    try {
+        const res = await fetch(`/api/graph/theme/${encodeURIComponent(name)}`);
+        if (!res.ok) return null;
+        const theme = await res.json();
+        _themeCache[name] = theme;
+        return theme;
+    } catch {
+        return null;
+    }
+}
 
 // Infer edge semantic from graph structure when not explicitly tagged
 function inferEdgeSemantic(edge, nodeById) {
@@ -162,12 +190,14 @@ export class D3SemanticGraphRenderer {
         this.katex = opts.katex || (typeof window !== 'undefined' && window.katex);
         this.direction = opts.direction || 'left-right';
         this.labels = opts.labels || 'description';
+        this.themeName = opts.theme || 'default-dark';
         this.onNodeClick = opts.onNodeClick || null;
         this.onNodeHover = opts.onNodeHover || null;
         this.onBackgroundClick = opts.onBackgroundClick || null;
 
         this._graph = null;
         this._tree = null;
+        this._theme = null;
         this._collapsed = new Set();
         this._svg = null;
         this._d3 = null;
@@ -182,6 +212,8 @@ export class D3SemanticGraphRenderer {
         this._graph = graph;
         this._d3 = await loadD3();
         if (this._destroyed) return;
+        this._theme = await fetchTheme(this.themeName);
+        if (this._destroyed) return;
 
         this._tree = graphToTree(graph);
         if (!this._tree) {
@@ -193,9 +225,13 @@ export class D3SemanticGraphRenderer {
         this._renderTree();
     }
 
-    update(opts = {}) {
+    async update(opts = {}) {
         if (opts.direction) this.direction = opts.direction;
         if (opts.labels) this.labels = opts.labels;
+        if (opts.theme && opts.theme !== this.themeName) {
+            this.themeName = opts.theme;
+            this._theme = await fetchTheme(this.themeName);
+        }
         if (this._d3 && this._tree) {
             this._renderTree();
         }
@@ -222,6 +258,30 @@ export class D3SemanticGraphRenderer {
         this._graph = null;
         this._tree = null;
         this._positionById.clear();
+    }
+
+    // ─── Theme helpers ─────────────────────────────────────────────────
+
+    _nodeStyle(nodeType) {
+        const ts = this._theme?.nodeStyles;
+        if (ts && ts[nodeType]) return ts[nodeType];
+        return DEFAULT_NODE_STYLES[nodeType] || DEFAULT_NODE_STYLES.scalar;
+    }
+
+    _edgeColor(semantic) {
+        const es = this._theme?.edgeStyles;
+        if (es && es[semantic]) return es[semantic].stroke;
+        const single = this._theme?.edgeStyle;
+        if (single?.stroke && !this._theme?.paintBySemantic) return single.stroke;
+        return DEFAULT_EDGE_COLORS[semantic] || DEFAULT_EDGE_COLORS.neutral;
+    }
+
+    _edgeWidth(semantic) {
+        const es = this._theme?.edgeStyles;
+        if (es && es[semantic]) return es[semantic].strokeWidth || DEFAULT_EDGE_WIDTHS.neutral;
+        const single = this._theme?.edgeStyle;
+        if (single?.strokeWidth && !this._theme?.paintBySemantic) return single.strokeWidth;
+        return DEFAULT_EDGE_WIDTHS[semantic] || DEFAULT_EDGE_WIDTHS.neutral;
     }
 
     // ─── Private ──────────────────────────────────────────────────────
@@ -350,8 +410,8 @@ export class D3SemanticGraphRenderer {
             .append('path')
             .attr('class', d => `d3sg-link d3sg-edge-${d.semantic}`)
             .attr('fill', 'none')
-            .attr('stroke', d => EDGE_COLORS[d.semantic] || EDGE_COLORS.neutral)
-            .attr('stroke-width', d => EDGE_WIDTHS[d.semantic] || 1.4)
+            .attr('stroke', d => this._edgeColor(d.semantic))
+            .attr('stroke-width', d => this._edgeWidth(d.semantic))
             .attr('stroke-linecap', 'round')
             .attr('d', d => {
                 const p = this._startPos(d.target.data.id);
@@ -364,8 +424,8 @@ export class D3SemanticGraphRenderer {
 
         link.transition(transition)
             .attr('class', d => `d3sg-link d3sg-edge-${d.semantic}`)
-            .attr('stroke', d => EDGE_COLORS[d.semantic] || EDGE_COLORS.neutral)
-            .attr('stroke-width', d => EDGE_WIDTHS[d.semantic] || 1.4)
+            .attr('stroke', d => this._edgeColor(d.semantic))
+            .attr('stroke-width', d => this._edgeWidth(d.semantic))
             .style('opacity', 1)
             .attr('d', d => this._diagonal(d3, d.source, d.target));
 
@@ -500,9 +560,9 @@ export class D3SemanticGraphRenderer {
         group.selectAll('*').remove();
         const data = d.data;
         const isOp = data.type === 'operator' || data.type === 'relation' || data.type === 'function';
+        const style = this._nodeStyle(data.type);
 
         if (data._collapsed) {
-            // Collapsed tile: rounded rect with subexpr label
             const label = data.subexpr || data.label || data.id;
             const estimatedWidth = Math.max(100, Math.min(260, label.length * 7 + 30));
             group.append('rect')
@@ -511,11 +571,12 @@ export class D3SemanticGraphRenderer {
                 .attr('y', -24)
                 .attr('width', estimatedWidth)
                 .attr('height', 48)
-                .attr('rx', 6);
+                .attr('rx', 6)
+                .attr('fill', style.fill || '')
+                .attr('stroke', style.stroke || '');
 
-            this._renderLabel(group, data, estimatedWidth, true);
+            this._renderLabel(group, data, estimatedWidth, true, style);
 
-            // Expand chevron
             group.append('text')
                 .attr('class', 'd3sg-chevron')
                 .attr('x', estimatedWidth / 2 - 14)
@@ -526,7 +587,6 @@ export class D3SemanticGraphRenderer {
         }
 
         if (isOp) {
-            // Hexagon for operators
             const r = 28;
             const points = Array.from({ length: 6 }, (_, i) => {
                 const angle = (Math.PI / 3) * i - Math.PI / 6;
@@ -534,17 +594,19 @@ export class D3SemanticGraphRenderer {
             }).join(' ');
             group.append('polygon')
                 .attr('class', 'd3sg-op-bg')
-                .attr('points', points);
+                .attr('points', points)
+                .attr('fill', style.fill || '')
+                .attr('stroke', style.stroke || '');
         } else {
-            // Circle for variables/scalars/vectors/constants
             group.append('circle')
                 .attr('class', 'd3sg-var-bg')
-                .attr('r', 26);
+                .attr('r', 26)
+                .attr('fill', style.fill || '')
+                .attr('stroke', style.stroke || '');
         }
 
-        this._renderLabel(group, data, isOp ? 56 : 52, false);
+        this._renderLabel(group, data, isOp ? 56 : 52, false, style);
 
-        // Collapse chevron for operators with children
         if (isOp && data.children && data.children.length > 0) {
             group.append('text')
                 .attr('class', 'd3sg-chevron')
@@ -555,10 +617,11 @@ export class D3SemanticGraphRenderer {
         }
     }
 
-    _renderLabel(group, data, maxWidth, isCollapsed) {
+    _renderLabel(group, data, maxWidth, isCollapsed, style = {}) {
         const latex = isCollapsed
             ? (data.subexpr || data.latex || null)
             : (data.latex || null);
+        const textColor = style.color || null;
 
         if (latex && this.katex) {
             const fo = group.append('foreignObject')
@@ -576,6 +639,7 @@ export class D3SemanticGraphRenderer {
                 .style('width', '100%')
                 .style('height', '100%')
                 .style('overflow', 'hidden');
+            if (textColor) div.style('color', textColor);
 
             const span = document.createElement('span');
             try {
@@ -585,14 +649,14 @@ export class D3SemanticGraphRenderer {
                 div.text(data.label || data.id);
             }
         } else {
-            // Plain text label
             const text = getNodeLabel(data, this.labels);
-            group.append('text')
+            const label = group.append('text')
                 .attr('class', 'd3sg-label')
                 .attr('text-anchor', 'middle')
                 .attr('dominant-baseline', 'middle')
                 .attr('font-size', isCollapsed ? '12px' : '14px')
                 .text(text);
+            if (textColor) label.attr('fill', textColor);
         }
     }
 

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -404,10 +404,21 @@ export class D3SemanticGraphRenderer {
         const d3 = this._d3;
         if (interactionId) this._lastInteractionId = interactionId;
 
+        const oldPos = interactionId ? this._positionById.get(interactionId) : null;
+
         const layout = this._layoutGraph();
         if (!layout) return;
 
         const { nodes, edges: links } = layout;
+
+        if (oldPos && interactionId) {
+            const anchor = nodes.find(n => n.data.id === interactionId);
+            if (anchor) {
+                const dx = oldPos.x - anchor.x;
+                const dy = oldPos.y - anchor.y;
+                for (const n of nodes) { n.x += dx; n.y += dy; }
+            }
+        }
 
         const xs = nodes.map(n => n.x);
         const ys = nodes.map(n => n.y);

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -18,11 +18,13 @@
 
 import { state } from '/state.js';
 import { SemanticGraphPanel } from '/graph-panel/graph-panel.js';
+import { D3SemanticGraphRenderer } from '/graph-panel/d3-semantic-graph.js';
 
 let _currentGraphPanel = null;
 let _currentSemanticKey = null;
 let _activeStepForPanel = null;
 let _initDone = false;
+let _currentD3Renderer = null;
 
 // Persisted user preferences. localStorage keys are versioned with an
 // `algebench.graph.` prefix so future format changes can be migrated without
@@ -33,6 +35,7 @@ const LS_KEYS = {
     direction: 'algebench.graph.direction',
     labels: 'algebench.graph.labels',
     zoom: 'algebench.graph.zoom',
+    renderer: 'algebench.graph.renderer',
 };
 const _lsGet = (key, fallback) => {
     try { return localStorage.getItem(key) ?? fallback; } catch { return fallback; }
@@ -98,6 +101,8 @@ const LABEL_PRESETS = {
 };
 let _currentLabels = _lsGet(LS_KEYS.labels, 'description');
 if (!(_currentLabels in LABEL_PRESETS)) _currentLabels = 'description';
+let _currentRenderer = _lsGet(LS_KEYS.renderer, 'mermaid');
+if (_currentRenderer !== 'mermaid' && _currentRenderer !== 'd3') _currentRenderer = 'mermaid';
 // Authoritative list of available themes, populated from /api/graph/themes.
 // Each entry: { name, mode }. Used to filter the dropdown by current mode.
 let _allThemes = [];
@@ -586,6 +591,10 @@ function clearGraph() {
         try { _currentGraphPanel.destroy(); } catch {}
         _currentGraphPanel = null;
     }
+    if (_currentD3Renderer) {
+        try { _currentD3Renderer.destroy(); } catch {}
+        _currentD3Renderer = null;
+    }
     const infoHost = document.getElementById('graph-info-panel-host');
     if (infoHost) infoHost.innerHTML = '';
     const legend = document.getElementById('graph-edge-legend');
@@ -632,6 +641,120 @@ function hideErrorState() {
     if (empty) empty.style.display = '';
 }
 
+async function _renderWithD3(container, graph, step, key) {
+    const viewport = document.getElementById('graph-viewport');
+    if (viewport) {
+        viewport.classList.toggle('gv-theme-light', false);
+        viewport.classList.toggle('gv-theme-dark', true);
+    }
+
+    // Destroy previous Mermaid panel if it existed
+    if (_currentGraphPanel) {
+        try { _currentGraphPanel.destroy(); } catch {}
+        _currentGraphPanel = null;
+    }
+    const infoHost = document.getElementById('graph-info-panel-host');
+    if (infoHost) infoHost.innerHTML = '';
+
+    // Reuse or create D3 renderer
+    if (!_currentD3Renderer || _currentD3Renderer._destroyed) {
+        _currentD3Renderer = new D3SemanticGraphRenderer(container, {
+            katex: window.katex,
+            direction: _currentDirection,
+            labels: _currentLabels,
+            onNodeClick: (nodeId, nodeData) => {
+                _activeStepForPanel = step;
+                _showD3InfoPanel(nodeId, nodeData, graph);
+            },
+            onBackgroundClick: () => {
+                _hideD3InfoPanel();
+            },
+        });
+    } else {
+        _currentD3Renderer.update({ direction: _currentDirection, labels: _currentLabels });
+    }
+
+    await _currentD3Renderer.render(graph);
+    _currentSemanticKey = key;
+
+    // Apply zoom to the D3 card
+    const card = container.querySelector('.d3-graph-card');
+    if (card) card.style.transform = `scale(${(ZOOM_BASELINE * _zoom).toFixed(3)})`;
+
+    // Background enrichment (shared with Mermaid path)
+    enrichGraphInBackground(graph, key, step);
+}
+
+function _showD3InfoPanel(nodeId, nodeData, graph) {
+    const infoHost = document.getElementById('graph-info-panel-host');
+    if (!infoHost) return;
+    if (!nodeId) { _hideD3InfoPanel(); return; }
+
+    // Find the full node from graph model
+    const fullNode = (graph.nodes || []).find(n => n.id === nodeId) || nodeData;
+    infoHost.innerHTML = '';
+    const panel = buildInlineInfoPanel(infoHost);
+    if (!panel) return;
+
+    // Populate the inline panel
+    const symbolEl = panel.querySelector('.gp-symbol');
+    const fieldsEl = panel.querySelector('.gp-fields');
+    if (!symbolEl || !fieldsEl) return;
+
+    const latex = fullNode.latex || fullNode.subexpr;
+    if (latex && window.katex) {
+        try {
+            const span = document.createElement('span');
+            window.katex.render(latex, span, { displayMode: false, throwOnError: false });
+            symbolEl.innerHTML = '';
+            if (fullNode.emoji) symbolEl.appendChild(document.createTextNode(fullNode.emoji + ' '));
+            symbolEl.appendChild(span);
+        } catch (_) {
+            symbolEl.textContent = (fullNode.emoji || '') + ' ' + (fullNode.label || fullNode.id);
+        }
+    } else {
+        symbolEl.textContent = (fullNode.emoji || '') + ' ' + (fullNode.label || fullNode.id);
+    }
+    symbolEl.style.opacity = '1';
+    symbolEl.style.fontSize = '';
+
+    const FIELDS = [
+        ['label', 'Label'], ['type', 'Type'], ['role', 'Role'],
+        ['quantity', 'Quantity'], ['dimension', 'Dimension'],
+        ['unit', 'Unit'], ['value', 'Value'], ['op', 'Operation'],
+    ];
+    fieldsEl.innerHTML = '';
+    for (const [fkey, flabel] of FIELDS) {
+        if (!fullNode[fkey]) continue;
+        const row = document.createElement('div');
+        row.className = 'gp-field';
+        const k = document.createElement('span');
+        k.className = 'gp-key';
+        k.textContent = flabel;
+        const v = document.createElement('span');
+        v.className = 'gp-val';
+        v.textContent = fullNode[fkey];
+        row.append(k, v);
+        fieldsEl.appendChild(row);
+    }
+    if (fullNode.description) {
+        const desc = document.createElement('div');
+        desc.className = 'gp-description';
+        if (typeof window.renderKaTeX === 'function') {
+            desc.innerHTML = window.renderKaTeX(fullNode.description, false);
+        } else {
+            desc.textContent = fullNode.description;
+        }
+        fieldsEl.appendChild(desc);
+    }
+}
+
+function _hideD3InfoPanel() {
+    const infoHost = document.getElementById('graph-info-panel-host');
+    if (!infoHost) return;
+    infoHost.innerHTML = '';
+}
+
 async function renderCurrentStepGraph(force = false) {
     const container = document.getElementById('graph-mermaid-container');
     if (!container) return;
@@ -651,9 +774,16 @@ async function renderCurrentStepGraph(force = false) {
     }
 
     const key = stableStepKey(step) + '|' + _currentTheme + '|' +
-                _currentDirection + '|' + _currentLabels;
+                _currentDirection + '|' + _currentLabels + '|' + _currentRenderer;
     if (key === _currentSemanticKey && !force) return;
 
+    // ── D3 renderer path ──────────────────────────────────────────────
+    if (_currentRenderer === 'd3') {
+        await _renderWithD3(container, graph, step, key);
+        return;
+    }
+
+    // ── Mermaid renderer path (existing) ──────────────────────────────
     // Live regeneration from graph JSON so theme/direction/labels apply.
     let mermaidCode;
     let mode = 'dark';
@@ -1380,6 +1510,16 @@ async function setupGraphControls() {
             _currentLabels = labelsSel.value in LABEL_PRESETS
                 ? labelsSel.value : 'description';
             _lsSet(LS_KEYS.labels, _currentLabels);
+            renderCurrentStepGraph(true);
+        });
+    }
+    const rendererSel = document.getElementById('graph-renderer-select');
+    if (rendererSel) {
+        rendererSel.value = _currentRenderer;
+        rendererSel.addEventListener('change', () => {
+            _currentRenderer = rendererSel.value === 'd3' ? 'd3' : 'mermaid';
+            _lsSet(LS_KEYS.renderer, _currentRenderer);
+            clearGraph();
             renderCurrentStepGraph(true);
         });
     }

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -600,6 +600,11 @@ function clearGraph() {
         try { _currentD3Renderer.destroy(); } catch {}
         _currentD3Renderer = null;
     }
+    if (_d3NodeAskBtn && _d3NodeAskBtn.parentNode) _d3NodeAskBtn.remove();
+    _d3NodeAskBtn = null;
+    if (_d3NodeAskHideTimer) { clearTimeout(_d3NodeAskHideTimer); _d3NodeAskHideTimer = null; }
+    _d3HoveredNodeId = null;
+    _d3ActiveGraph = null;
     const infoHost = document.getElementById('graph-info-panel-host');
     if (infoHost) infoHost.innerHTML = '';
     const legend = document.getElementById('graph-edge-legend');

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -662,6 +662,7 @@ async function _renderWithD3(container, graph, step, key) {
             katex: window.katex,
             direction: _currentDirection,
             labels: _currentLabels,
+            theme: _currentTheme,
             onNodeClick: (nodeId, nodeData) => {
                 _activeStepForPanel = step;
                 _showD3InfoPanel(nodeId, nodeData, graph);
@@ -671,7 +672,7 @@ async function _renderWithD3(container, graph, step, key) {
             },
         });
     } else {
-        _currentD3Renderer.update({ direction: _currentDirection, labels: _currentLabels });
+        await _currentD3Renderer.update({ direction: _currentDirection, labels: _currentLabels, theme: _currentTheme });
     }
 
     await _currentD3Renderer.render(graph);

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -19,12 +19,17 @@
 import { state } from '/state.js';
 import { SemanticGraphPanel } from '/graph-panel/graph-panel.js';
 import { D3SemanticGraphRenderer } from '/graph-panel/d3-semantic-graph.js';
+import { makeAiAskButton } from '/labels.js';
 
 let _currentGraphPanel = null;
 let _currentSemanticKey = null;
 let _activeStepForPanel = null;
 let _initDone = false;
 let _currentD3Renderer = null;
+let _d3NodeAskBtn = null;
+let _d3NodeAskHideTimer = null;
+let _d3HoveredNodeId = null;
+let _d3ActiveGraph = null;
 
 // Persisted user preferences. localStorage keys are versioned with an
 // `algebench.graph.` prefix so future format changes can be migrated without
@@ -656,6 +661,8 @@ async function _renderWithD3(container, graph, step, key) {
     const infoHost = document.getElementById('graph-info-panel-host');
     if (infoHost) infoHost.innerHTML = '';
 
+    _d3ActiveGraph = graph;
+
     // Reuse or create D3 renderer
     if (!_currentD3Renderer || _currentD3Renderer._destroyed) {
         _currentD3Renderer = new D3SemanticGraphRenderer(container, {
@@ -664,11 +671,18 @@ async function _renderWithD3(container, graph, step, key) {
             labels: _currentLabels,
             theme: _currentTheme,
             onNodeClick: (nodeId, nodeData) => {
-                _activeStepForPanel = step;
-                _showD3InfoPanel(nodeId, nodeData, graph);
+                _showD3InfoPanel(nodeId, nodeData, _d3ActiveGraph);
             },
             onBackgroundClick: () => {
                 _hideD3InfoPanel();
+            },
+            onNodeHover: (nodeId, nodeData, nodeEl) => {
+                if (nodeId && nodeEl) {
+                    _d3HoveredNodeId = nodeId;
+                    _showD3NodeAskBtn(nodeEl);
+                } else {
+                    _hideD3NodeAskBtn();
+                }
             },
         });
     } else {
@@ -686,6 +700,74 @@ async function _renderWithD3(container, graph, step, key) {
     enrichGraphInBackground(graph, key, step);
 }
 
+function _buildD3NodeAskMessage(nodeId, graph) {
+    if (!nodeId || !graph) return 'Explain this graph node.';
+    const node = (graph.nodes || []).find(n => n.id === nodeId);
+    if (!node) return 'Explain this graph node.';
+    const lines = ['Explain this semantic graph node:'];
+    if (node.label) lines.push(`Label: ${node.label}`);
+    if (node.type) lines.push(`Type: ${node.type}`);
+    if (node.role) lines.push(`Role: ${node.role}`);
+    if (node.quantity) lines.push(`Quantity: ${node.quantity}`);
+    if (node.dimension) lines.push(`Dimension: ${node.dimension}`);
+    if (node.unit) lines.push(`Unit: ${node.unit}`);
+    if (node.value !== undefined) lines.push(`Value: ${node.value}`);
+    if (node.op) lines.push(`Operation: ${node.op}`);
+    if (node.subexpr) lines.push(`Expression: $${node.subexpr}$`);
+    if (node.description) lines.push(`Description: ${node.description}`);
+    const incoming = [], outgoing = [];
+    for (const e of (graph.edges || [])) {
+        if (e.to === nodeId && e.from !== nodeId) incoming.push(e.from);
+        if (e.from === nodeId && e.to !== nodeId) outgoing.push(e.to);
+    }
+    if (incoming.length) lines.push(`Incoming: ${incoming.join(', ')}`);
+    if (outgoing.length) lines.push(`Outgoing: ${outgoing.join(', ')}`);
+    return lines.join('\n');
+}
+
+function _ensureD3NodeAskBtn() {
+    if (_d3NodeAskBtn) return _d3NodeAskBtn;
+    const btn = makeAiAskButton(
+        'ai-ask-btn graph-node-ai-btn',
+        'Ask AI about this node',
+        () => _buildD3NodeAskMessage(_d3HoveredNodeId, _d3ActiveGraph),
+    );
+    btn.style.position = 'fixed';
+    btn.style.opacity = '0';
+    btn.style.pointerEvents = 'none';
+    btn.style.zIndex = '950';
+    btn.addEventListener('mouseenter', () => {
+        if (_d3NodeAskHideTimer) { clearTimeout(_d3NodeAskHideTimer); _d3NodeAskHideTimer = null; }
+    });
+    btn.addEventListener('mouseleave', () => _hideD3NodeAskBtn());
+    document.body.appendChild(btn);
+    _d3NodeAskBtn = btn;
+    return btn;
+}
+
+function _showD3NodeAskBtn(nodeEl) {
+    const btn = _ensureD3NodeAskBtn();
+    if (_d3NodeAskHideTimer) { clearTimeout(_d3NodeAskHideTimer); _d3NodeAskHideTimer = null; }
+    const shape = nodeEl.querySelector('polygon, circle, rect');
+    const r = (shape || nodeEl).getBoundingClientRect();
+    const btnW = btn.offsetWidth || 24;
+    const btnH = btn.offsetHeight || 24;
+    btn.style.left = (r.right - btnW / 2) + 'px';
+    btn.style.top = (r.top - btnH / 2) + 'px';
+    btn.style.opacity = '1';
+    btn.style.pointerEvents = 'auto';
+}
+
+function _hideD3NodeAskBtn() {
+    if (!_d3NodeAskBtn) return;
+    if (_d3NodeAskHideTimer) { clearTimeout(_d3NodeAskHideTimer); _d3NodeAskHideTimer = null; }
+    const btn = _d3NodeAskBtn;
+    _d3NodeAskHideTimer = setTimeout(() => {
+        btn.style.opacity = '0';
+        btn.style.pointerEvents = 'none';
+    }, 220);
+}
+
 function _showD3InfoPanel(nodeId, nodeData, graph) {
     const infoHost = document.getElementById('graph-info-panel-host');
     if (!infoHost) return;
@@ -696,6 +778,21 @@ function _showD3InfoPanel(nodeId, nodeData, graph) {
     infoHost.innerHTML = '';
     const panel = buildInlineInfoPanel(infoHost);
     if (!panel) return;
+
+    // Inject AI ask button into panel header
+    const h3 = panel.querySelector('h3');
+    if (h3 && !panel.querySelector('.graph-panel-ai-btn')) {
+        const header = document.createElement('div');
+        header.className = 'gp-header';
+        h3.replaceWith(header);
+        header.appendChild(h3);
+        const askBtn = makeAiAskButton(
+            'ai-ask-btn graph-panel-ai-btn',
+            'Ask AI about this node',
+            () => _buildD3NodeAskMessage(nodeId, graph),
+        );
+        header.appendChild(askBtn);
+    }
 
     // Populate the inline panel
     const symbolEl = panel.querySelector('.gp-symbol');

--- a/static/index.html
+++ b/static/index.html
@@ -19,6 +19,7 @@
      bundle off the critical path for users who stay in the 3D view. -->
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/graph-panel/graph-panel.css">
+<link rel="stylesheet" href="/graph-panel/d3-semantic-graph.css">
 </head>
 <body data-debug-mode="__DEBUG_MODE__">
 <div id="app">
@@ -84,6 +85,11 @@
                     </select>
                 </div>
                 <div id="graph-controls-right" class="graph-controls">
+                    <label for="graph-renderer-select" class="graph-ctrl-label">Renderer</label>
+                    <select id="graph-renderer-select" class="graph-ctrl-select">
+                        <option value="mermaid" selected>Mermaid</option>
+                        <option value="d3">D3</option>
+                    </select>
                     <button id="graph-show-json" class="graph-ctrl-btn" title="Show semantic graph in JSON browser" aria-label="Show semantic graph JSON" disabled>{ }</button>
                     <div id="graph-zoom-controls">
                         <button id="graph-zoom-out" class="graph-ctrl-btn" title="Zoom out" aria-label="Zoom out">&minus;</button>


### PR DESCRIPTION
## Summary

- **New D3 semantic graph renderer** as an alternative to the existing Mermaid-based renderer, with a toggle in the UI to switch between them
- **Dagre DAG layout** for proper directed acyclic graph rendering with shared nodes (replacing d3.tree which couldn't handle DAGs)
- **Theme support** — all existing graph themes (dark, light, flat variants) apply to the D3 renderer
- **Interactive features**: collapse/expand subtrees with anchored positioning (clicked node stays in place while others transition around it), node selection with info panel, hover effects
- **AI ask button** on both the floating hover state and the node details panel, matching the Mermaid renderer's functionality
- **Visual polish**: edge-to-boundary intersections for all node shapes, emoji labels, Unicode superscript exponents for power operators, derivative operator glyphs, direction-aware collapse/expand buttons

## Changes

| File | What |
|------|------|
| `static/graph-panel/d3-semantic-graph.js` | New D3 renderer: dagre layout, node rendering (variable/operator/relation shapes), edge routing, collapse/expand, theme integration |
| `static/graph-panel/d3-semantic-graph.css` | Styles for D3 graph nodes, edges, labels, hover/active states, chevron buttons |
| `static/graph-view.js` | Integration: D3 toggle, renderer lifecycle, AI ask button wiring (floating + panel), stale closure fix for step navigation |
| `static/index.html` | D3 toggle checkbox in the graph toolbar |
| `server.py` | Static file route for the new CSS |
| `scenes/draft/graph-panel-demo.json` | Extended demo scene for testing |

## Key decisions

- **Module-level `_d3ActiveGraph`** variable to avoid stale closures when the D3 renderer is reused across proof steps
- **Shape-level `getBoundingClientRect()`** for floating AI button positioning (targets the actual polygon/circle/rect, not the group element that includes labels)
- **Dagre over d3.tree** because the semantic graph has shared nodes (same variable feeding multiple operators), which is a DAG not a tree

## Test plan

- [x] Toggle between Mermaid and D3 renderers — both render correctly
- [x] Expand/collapse subtrees — clicked node stays anchored, others animate
- [x] AI ask button appears on hover and in node details panel
- [x] Navigate between proof steps — no stale data from previous steps
- [x] All themes render correctly in D3 mode
- [x] Edge routing stops at node boundaries for all shapes

Closes #216

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>