### PR TITLE
fix(graph): isolate D3 renderer state per proof step

### DIFF
--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -235,6 +235,21 @@ export class D3SemanticGraphRenderer {
         return this._activeNodeId;
     }
 
+    saveState() {
+        return {
+            collapsed: new Set(this._collapsed),
+            activeNodeId: this._activeNodeId,
+            positionById: new Map(this._positionById),
+        };
+    }
+
+    restoreState(snapshot) {
+        if (!snapshot) return;
+        this._collapsed = new Set(snapshot.collapsed);
+        this._activeNodeId = snapshot.activeNodeId;
+        this._positionById = new Map(snapshot.positionById);
+    }
+
     destroy() {
         this._destroyed = true;
         this.container.innerHTML = '';

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -831,6 +831,9 @@ export class D3SemanticGraphRenderer {
         if (!this._svg) return;
         const activeId = this._activeNodeId;
 
+        this._nodeLayer.selectAll('g.d3sg-node')
+            .attr('class', d => this._nodeClass(d));
+
         if (!activeId) {
             // Clear all dimming
             this._nodeLayer.selectAll('g.d3sg-node').style('opacity', 1);

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -248,6 +248,7 @@ export class D3SemanticGraphRenderer {
         this._collapsed = new Set(snapshot.collapsed);
         this._activeNodeId = snapshot.activeNodeId;
         this._positionById = new Map(snapshot.positionById);
+        if (this._svg) this._applyHighlight();
     }
 
     destroy() {

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -601,6 +601,7 @@ function clearGraph() {
     if (_currentD3Renderer) {
         try { _currentD3Renderer.destroy(); } catch {}
         _currentD3Renderer = null;
+        _d3LastStepKey = null;
     }
     if (_d3NodeAskBtn && _d3NodeAskBtn.parentNode) _d3NodeAskBtn.remove();
     _d3NodeAskBtn = null;
@@ -701,13 +702,12 @@ async function _renderWithD3(container, graph, step, key) {
         _d3StepStates.set(_d3LastStepKey, _currentD3Renderer.saveState());
     }
 
-    await _currentD3Renderer.render(graph);
-
     const saved = _d3StepStates.get(stepKey);
     if (saved) {
         _currentD3Renderer.restoreState(saved);
-        await _currentD3Renderer.update({});
     }
+
+    await _currentD3Renderer.render(graph);
     _d3LastStepKey = stepKey;
     _currentSemanticKey = key;
 

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -30,6 +30,8 @@ let _d3NodeAskBtn = null;
 let _d3NodeAskHideTimer = null;
 let _d3HoveredNodeId = null;
 let _d3ActiveGraph = null;
+let _d3StepStates = new Map();
+let _d3LastStepKey = null;
 
 // Persisted user preferences. localStorage keys are versioned with an
 // `algebench.graph.` prefix so future format changes can be migrated without
@@ -694,7 +696,19 @@ async function _renderWithD3(container, graph, step, key) {
         await _currentD3Renderer.update({ direction: _currentDirection, labels: _currentLabels, theme: _currentTheme });
     }
 
+    const stepKey = stableStepKey(step);
+    if (_currentD3Renderer && _d3LastStepKey && _d3LastStepKey !== stepKey) {
+        _d3StepStates.set(_d3LastStepKey, _currentD3Renderer.saveState());
+    }
+
     await _currentD3Renderer.render(graph);
+
+    const saved = _d3StepStates.get(stepKey);
+    if (saved) {
+        _currentD3Renderer.restoreState(saved);
+        await _currentD3Renderer.update({});
+    }
+    _d3LastStepKey = stepKey;
     _currentSemanticKey = key;
 
     // Apply zoom to the D3 card
@@ -1487,6 +1501,8 @@ function onStepChange() {
 }
 
 function onProofLoad() {
+    _d3StepStates.clear();
+    _d3LastStepKey = null;
     rebuildProofTree();
     onStepChange();
 }


### PR DESCRIPTION
## Summary

Closes #224.

- Add `saveState()` / `restoreState()` methods to `D3SemanticGraphRenderer` that snapshot and restore `_collapsed`, `_activeNodeId`, and `_positionById`
- Wire a per-step state map (`_d3StepStates`) in `graph-view.js` keyed by `stableStepKey(step)` — saves on step-out, restores on step-in
- Clear saved states on proof load to prevent stale state from previous lessons

## Test plan

- [x] 319 pytest tests pass
- [x] Browser-verified: load Semantic Graph Demo, switch to D3 renderer, collapse a node on step 1, switch to step 2 → collapsed state does not bleed, switch back to step 1 → collapsed state is restored
- [x] No console errors from state isolation code
- [ ] Verify node positions are also preserved across step switches
- [ ] Verify active node selection is preserved across step switches

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>