### PR TITLE
fix(ui): pin graph JSON button width on narrow viewports

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -3814,6 +3814,7 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     padding-left: 0;
     padding-right: 0;
     text-align: center;
+    flex-shrink: 0;
 }
 #graph-show-json {
     width: 36px;

--- a/static/style.css
+++ b/static/style.css
@@ -3815,6 +3815,14 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     padding-right: 0;
     text-align: center;
 }
+#graph-show-json {
+    width: 36px;
+    min-width: 36px;
+    padding-left: 0;
+    padding-right: 0;
+    text-align: center;
+    flex-shrink: 0;
+}
 
 /* Edge-semantics legend — painted from the active theme's ``edgeStyles``
    (forwarded by ``/api/graph/mermaid``). Sits in the bottom-left of the


### PR DESCRIPTION
## Summary

- Adds a fixed-width CSS rule for the `#graph-show-json` (`{ }`) button in the semantic graph controls so it no longer shrinks when the viewport is narrow.
- Uses the same pinning pattern already applied to `#graph-mode-toggle`: `width: 36px`, `min-width: 36px`, `flex-shrink: 0`.

## Test plan

- [x] Verified at desktop, 600px, and mobile (375px) viewports — button holds 36px at all sizes
- [ ] Visual check that the `{ }` button renders correctly alongside other graph controls

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>