### PR TITLE
feat(graph): bidirectional graph-proof sync with loop guards

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -261,6 +261,7 @@ function switchPanelTab(tabName) {
     });
     // Focus input and greet only when chat history is empty
     if (tabName === 'chat') {
+        if (typeof refreshProofPanel === 'function') refreshProofPanel();
         const input = document.getElementById('chat-input');
         if (input) setTimeout(() => input.focus(), 50);
         if (chatAvailable && !welcomeInFlight && !shouldSkipWelcome()) {

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -521,28 +521,33 @@ function handleTreeStepClick(entry, stepIdx) {
     const step = proof && proof.steps && proof.steps[stepIdx];
     if (!step) return;
 
-    const sceneStep = step.sceneStep;
-    if (sceneStep != null && typeof window.navigateTo === 'function') {
-        if (typeof sceneStep === 'string' && sceneStep.includes(':')) {
-            const [si, sti] = sceneStep.split(':').map(Number);
-            if (!Number.isNaN(si) && !Number.isNaN(sti)) {
-                window.navigateTo(si, sti);
-                // after navigate, ensure the right proof/step is active
+    state._graphSyncInProgress = true;
+    try {
+        const sceneStep = step.sceneStep;
+        if (sceneStep != null && typeof window.navigateTo === 'function') {
+            if (typeof sceneStep === 'string' && sceneStep.includes(':')) {
+                const [si, sti] = sceneStep.split(':').map(Number);
+                if (!Number.isNaN(si) && !Number.isNaN(sti)) {
+                    window.navigateTo(si, sti);
+                    _forceActivateProofStep(entry, stepIdx);
+                    return;
+                }
+            } else if (entry.sceneIndex != null) {
+                window.navigateTo(entry.sceneIndex, Number(sceneStep));
                 _forceActivateProofStep(entry, stepIdx);
                 return;
             }
-        } else if (entry.sceneIndex != null) {
-            window.navigateTo(entry.sceneIndex, Number(sceneStep));
-            _forceActivateProofStep(entry, stepIdx);
-            return;
         }
+        // Fallback: scene-level navigation, then activate the proof step directly
+        if (entry.sceneIndex != null && typeof window.navigateTo === 'function' &&
+            entry.sceneIndex !== state.currentSceneIndex) {
+            window.navigateTo(entry.sceneIndex, state.currentStepIndex);
+        }
+        _forceActivateProofStep(entry, stepIdx);
+    } finally {
+        state._graphSyncInProgress = false;
+        if (isGraphModeActive()) renderCurrentStepGraph();
     }
-    // Fallback: scene-level navigation, then activate the proof step directly
-    if (entry.sceneIndex != null && typeof window.navigateTo === 'function' &&
-        entry.sceneIndex !== state.currentSceneIndex) {
-        window.navigateTo(entry.sceneIndex, state.currentStepIndex);
-    }
-    _forceActivateProofStep(entry, stepIdx);
 }
 
 function _forceActivateProofStep(entry, stepIdx) {
@@ -1497,7 +1502,16 @@ function escapeHtml(s) {
 function onStepChange() {
     updateTreeHighlight();
     updateShowJsonButtonState();
+    if (state._graphSyncInProgress) return;
     if (isGraphModeActive()) renderCurrentStepGraph();
+}
+
+function onGraphSelectionChange(e) {
+    if (state._graphSyncInProgress) return;
+    if (!e.detail || !e.detail.activeNode) return;
+    // The graph is rendered for the current proof step, so selection
+    // doesn't require navigation. Guard is checked above to prevent
+    // loops when renderCurrentStepGraph preserves a prior selection.
 }
 
 function onProofLoad() {
@@ -1714,6 +1728,7 @@ function init() {
     setupControlsOverflowWatcher();
     window.addEventListener('algebench:stepchange', onStepChange);
     window.addEventListener('algebench:proofload', onProofLoad);
+    window.addEventListener('algebench:graphselectionchange', onGraphSelectionChange);
 }
 
 if (document.readyState === 'loading') {

--- a/static/main.js
+++ b/static/main.js
@@ -20,7 +20,7 @@ import { navigateTo, setupSceneDock, loadScene, loadLesson, isLessonFormat,
 import { buildSceneTree } from '/context-browser.js';
 import { setupJsonViewer, setupContextStatusPopup } from '/json-browser.js';
 import { renderMarkdown, renderKaTeX } from '/labels.js';
-import { setupProofPanel, navigateProof, loadProof, getProofContext } from '/proof.js';
+import { setupProofPanel, navigateProof, loadProof, getProofContext, refreshProofPanel } from '/proof.js';
 
 // Domain library registry — scripts under static/domains/<name>/index.js self-register here.
 window.AlgeBenchDomains = window.AlgeBenchDomains || {
@@ -91,6 +91,7 @@ window.worldCameraToData = worldCameraToData;
 window.navigateProof = navigateProof;
 window.loadProof = loadProof;
 window.getProofContext = getProofContext;
+window.refreshProofPanel = refreshProofPanel;
 
 // State proxies — chat.js reads lessonSpec, currentSpec, currentSceneIndex,
 // currentStepIndex, sceneSliders, and CAMERA_VIEWS as bare globals.

--- a/static/overlay.js
+++ b/static/overlay.js
@@ -90,6 +90,9 @@ export function setupExplainToggle() {
         const isHidden = panel.classList.toggle('hidden');
         toggle.classList.toggle('active', !isHidden);
         handle.style.display = isHidden ? 'none' : 'block';
+        if (!isHidden && typeof window.refreshProofPanel === 'function') {
+            window.refreshProofPanel();
+        }
         setTimeout(() => window.dispatchEvent(new Event('resize')), 50);
     });
 

--- a/static/proof.js
+++ b/static/proof.js
@@ -941,6 +941,13 @@ function _setupProofTabs() {
     });
 }
 
+// ---- Refresh (re-render current step without changing state) ----
+
+export function refreshProofPanel() {
+    if (!_activeProof()) return;
+    navigateProof(state.proofStepIndex);
+}
+
 // ---- Setup (called once on DOMContentLoaded) ----
 
 export function setupProofPanel() {

--- a/static/proof.js
+++ b/static/proof.js
@@ -944,8 +944,14 @@ function _setupProofTabs() {
 // ---- Refresh (re-render current step without changing state) ----
 
 export function refreshProofPanel() {
-    if (!_activeProof()) return;
-    navigateProof(state.proofStepIndex);
+    if (!_activeProof() || !state.proofExpanded) return;
+    if (state.proofViewMode === 'list') {
+        _renderList();
+    } else {
+        _renderSlide();
+    }
+    _updateCounter();
+    _updateNavButtons();
 }
 
 // ---- Setup (called once on DOMContentLoaded) ----

--- a/static/state.js
+++ b/static/state.js
@@ -108,7 +108,8 @@ export const state = {
     proofViewMode: 'slide',       // 'list' | 'slide'
     proofSyncEnabled: true,       // bidirectional sceneStep linking
     proofExpanded: false,         // whether proof panel is expanded in chat tab
-    _proofSyncInProgress: false,  // guard against infinite sync loops
+    _proofSyncInProgress: false,  // guard against infinite proof↔scene sync loops
+    _graphSyncInProgress: false,  // guard against infinite graph↔proof sync loops
     _proofTabMode: 'context',    // 'context' | 'all' — which proof tab is active
     _proofPreRendered: null,      // cached pre-rendered step HTML nodes (per active proof)
     _proofPreRenderedAll: {},     // cached pre-rendered step HTML nodes keyed by proof id


### PR DESCRIPTION
## Summary

- Adds a `_graphSyncInProgress` state flag to break infinite render loops between semantic graph tree clicks, scene navigation, and `stepchange` events firing back into the graph renderer.
- Introduces `refreshProofPanel()` — re-renders the current proof step without changing navigation state — called when the chat tab or explain panel becomes visible.
- Registers a guarded `onGraphSelectionChange` listener for `algebench:graphselectionchange` events.

## Details

When a user clicks a proof step in the graph tree view, `handleTreeStepClick` navigates the scene, which emits `stepchange`, which previously called `renderCurrentStepGraph` again — creating a loop. The new guard wraps the click handler in a try/finally block that sets `_graphSyncInProgress`, and `onStepChange` early-returns when that flag is active.

The `refreshProofPanel` export ensures the proof panel stays current when toggling visibility (chat tab switch or explain panel open) without side-effecting the step index.

## Files changed

| File | Change |
|------|--------|
| `static/state.js` | Add `_graphSyncInProgress` flag |
| `static/graph-view.js` | Guard `handleTreeStepClick`, add `onGraphSelectionChange` listener |
| `static/proof.js` | Export `refreshProofPanel()` |
| `static/main.js` | Import and expose `refreshProofPanel` on window |
| `static/chat.js` | Call `refreshProofPanel` on chat tab switch |
| `static/overlay.js` | Call `refreshProofPanel` on explain panel toggle |

## Test plan

- [x] Click proof steps in graph tree view — scene navigates without infinite re-renders
- [x] Switch between chat and graph tabs — proof panel refreshes correctly
- [x] Toggle explain panel open/closed — proof content stays in sync
- [ ] Verify no console errors or flickering during rapid navigation

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>