### PR TITLE
fix(graph): rename op "negate" to "negation" with correct minus glyph

### DIFF
--- a/docs/semantic-graph-visualization.md
+++ b/docs/semantic-graph-visualization.md
@@ -62,7 +62,7 @@ and by the HTTP API.
 Key responsibilities:
 
 - **Shape resolution** — three-level fallback: op-specific shape
-  (e.g. `negate` → `inv_triangle`) → theme's `nodeStyles.<type>.shape` →
+  (e.g. `negation` → `inv_triangle`) → theme's `nodeStyles.<type>.shape` →
   `rect`. The graph schema is semantic-only; shape never leaks into the
   graph JSON.
 - **Class emission** — each referenced node type / role / variant becomes

--- a/schemas/semantic-graph.schema.json
+++ b/schemas/semantic-graph.schema.json
@@ -35,7 +35,7 @@
     "operatorOp": {
       "type": "string",
       "enum": [
-        "add", "subtract", "multiply", "divide", "power", "equals", "negate",
+        "add", "subtract", "multiply", "divide", "power", "equals", "negation",
         "derivative", "integral", "sum", "product",
         "sin", "cos", "tan", "log", "exp", "sqrt", "abs",
         "arcsin", "arccos", "arctan"

--- a/scripts/graph_to_mermaid.py
+++ b/scripts/graph_to_mermaid.py
@@ -73,7 +73,7 @@ OPERATOR_SYMBOLS: dict[str, str] = {
     "subtract": "−",
     "multiply": "×",
     "divide": "÷",
-    "negate": "−",
+    "negation": "−",
     "power": "(·)ⁿ",
     "equals": "=",
     "derivative": "d/dt",
@@ -98,7 +98,7 @@ OPERATOR_LATEX: dict[str, str] = {
     "subtract": "-",
     "multiply": r"\times",
     "divide": r"\div",
-    "negate": "-",
+    "negation": "-",
     "power": r"(\cdot)^n",
     "equals": "=",
     "derivative": r"\frac{d}{dt}",
@@ -120,11 +120,11 @@ OPERATOR_LATEX: dict[str, str] = {
 # (``additionalProperties: false`` at the node level), so authors can't
 # pin a shape on a node directly. Instead, the renderer gives certain
 # operators a characteristic shape so the visual reads at a glance —
-# e.g. unary ``negate`` as a flipped triangle. Themes can still override
+# e.g. unary ``negation`` as a flipped triangle. Themes can still override
 # the type-level default via ``nodeStyles.operator.shape``; entries here
 # only apply when the theme hasn't set one.
 OP_DEFAULT_SHAPES: dict[str, str] = {
-    "negate": "inv_triangle",
+    "negation": "inv_triangle",
 }
 
 
@@ -563,7 +563,7 @@ def semantic_graph_to_mermaid(
         ns = node_styles.get(ntype, {})
         # Shape resolution order:
         #   1. op-specific default (``OP_DEFAULT_SHAPES[op]``) —
-        #      e.g. unary ``negate`` always renders as an inverted
+        #      e.g. unary ``negation`` always renders as an inverted
         #      triangle, since "unary vs. binary" is a semantic
         #      distinction any theme should preserve
         #   2. theme's type-level shape (``nodeStyles.<type>.shape``)

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -627,9 +627,9 @@ class SemanticGraphBuilder:
             self._add_edge(base_id, node_id)
             return node_id
 
-        # --- Unary negation (Mul(-1, X)) — emit a single-input ``negate``
+        # --- Unary negation (Mul(-1, X)) — emit a single-input ``negation``
         # operator instead of the noisy ``× (-1)`` pair. The renderer
-        # gives ``negate`` an inverted-triangle default shape via
+        # gives ``negation`` an inverted-triangle default shape via
         # ``graph_to_mermaid.OP_DEFAULT_SHAPES`` so the flip reads at a
         # glance; no shape lives on the node itself (graph schema is
         # semantic-only).
@@ -639,11 +639,11 @@ class SemanticGraphBuilder:
             and expr.args[0] == sympy.S.NegativeOne
         ):
             rest = expr.args[1:]
-            node_id = self._next_id("negate")
+            node_id = self._next_id("negation")
             self._add_node(
                 node_id,
                 type="operator",
-                op="negate",
+                op="negation",
             )
             if len(rest) == 1:
                 child_id = self._walk(rest[0])

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -139,7 +139,7 @@ function operatorGlyph(node) {
     const glyphs = {
         equals: '=', multiply: '×', add: '+', subtract: '−',
         divide: '÷', integral: '∫',
-        implies: '⇒', iff: '⇔', negate: '¬', conjunction: '∧',
+        implies: '⇒', iff: '⇔', negation: '−', not: '¬', logical_not: '¬', conjunction: '∧',
         disjunction: '∨', sum: '∑', product: '∏', limit: 'lim',
         factorial: '!', sqrt: '√(·)', log: 'log', logarithm: 'log',
         exp: 'exp', sin: 'sin', cos: 'cos', tan: 'tan',

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -802,7 +802,7 @@ class TestEdgeSemantics:
         assert len(incoming) == 1
         assert incoming[0]["from"] == "x"
         # And no negate/exponent helper nodes leaked through.
-        assert not _find_nodes(g, type="operator", op="negate")
+        assert not _find_nodes(g, type="operator", op="negation")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Renames the `negate` operator to `negation` across the entire codebase — schema, LaTeX parser, D3 renderer, Mermaid converter, docs, and tests.
- Fixes the glyph: `negation` now renders as `−` (arithmetic minus) instead of `¬` (logical NOT), which was mathematically incorrect for vector/scalar negation.

## Files changed

| File | Change |
|------|--------|
| `schemas/semantic-graph.schema.json` | `negate` → `negation` in operatorOp enum |
| `scripts/latex_to_graph.py` | Parser emits `op: "negation"` and `_next_id("negation")` |
| `scripts/graph_to_mermaid.py` | All three lookup tables + comments updated |
| `static/graph-panel/d3-semantic-graph.js` | Glyph map: `negation: '−'` (was `negate: '¬'`) |
| `tests/test_latex_to_graph.py` | Test assertion updated |
| `docs/semantic-graph-visualization.md` | Comment updated |

## Test plan

- [x] 126 parser tests pass
- [ ] Load a lesson with vector negation (e.g. Newton's Third Law) — verify `−` glyph renders in the semantic graph hexagon, not `¬` or raw `negate` text

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>