### PR TITLE
fix(ci): run LOC report on PRs instead of pushing to main

### DIFF
--- a/.github/workflows/loc-report.yml
+++ b/.github/workflows/loc-report.yml
@@ -1,7 +1,7 @@
 name: Lines of Code Report
 
 on:
-  push:
+  pull_request:
     branches: [main]
   workflow_dispatch:
 
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: loc-report
+  group: loc-report-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
 
       - uses: taiki-e/install-action@v2
         with:
@@ -34,5 +36,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add LOC-REPORT.md
           git diff --cached --quiet || git commit -m "docs: update lines-of-code report [skip ci]"
-          git pull --rebase
           git push


### PR DESCRIPTION
## Summary
- Triggers LOC report generation on `pull_request` instead of `push` to main
- Report commits to the PR branch, merges with the PR — no post-merge bot push needed
- Fixes branch protection violation where github-actions[bot] couldn't push to main

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>