### PR TITLE
docs: add proofs and semantic graph to README

### DIFF
--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 |---|---|
-| **Branch** | `ci/tokei-loc-report` |
-| **Commit** | `0ee07ce` |
-| **Date** | 2026-05-08 23:27:00 -0400 |
+| **Branch** | `docs/readme-proofs-and-graphs` |
+| **Commit** | `ea2419b` |
+| **Date** | 2026-05-08 23:56:12 -0400 |
 
 ## Language Breakdown
 
@@ -39,14 +39,14 @@ xychart-beta horizontal
  |- JavaScript             2          580          513           11           56
  (Total)                             1107         1018           23           66
 ─────────────────────────────────────────────────────────────────────────────────
- Markdown                 54        10254            0         7734         2520
+ Markdown                 55        10436            0         7858         2578
  |- BASH                  13          142          120           14            8
  |- JavaScript             1           10            6            3            1
  |- JSON                  33         1318         1318            0            0
  |- Python                 2           38           30            2            6
- (Total)                            11762         1474         7753         2535
+ (Total)                            11944         1474         7877         2593
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   179        93731        77607        10351         5773
+ Total                   180        93913        77607        10475         5831
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -60,7 +60,7 @@ xychart-beta horizontal
 ─────────────────────────────────────────────────────────────────────────────────
  |bench/static/graph-view.js         1869         1415          319          135
  |nch/static/json-browser.js         1403         1361            5           37
- |v/algebench/static/chat.js         1425         1160          113          152
+ |h/algebench/static/chat.js         1425         1160          113          152
  |lgebench/static/overlay.js         1168         1101           29           38
  |/algebench/static/proof.js         1109         1040           33           36
  |panel/d3-semantic-graph.js          968          804           42          122
@@ -71,9 +71,9 @@ xychart-beta horizontal
  |lgebench/static/sliders.js          526          444           30           52
  |bench/static/follow-cam.js          455          417            5           33
  |graph-panel/graph-panel.js          534          408           81           45
- |dev/algebench/static/ui.js          398          342           10           46
+ |nch/algebench/static/ui.js          398          342           10           46
  |atmospheric-entry/index.js          373          335            8           30
- |v/algebench/static/expr.js          356          326           20           10
+ |h/algebench/static/expr.js          356          326           20           10
  |bjects/animated-polygon.js          343          304            6           33
  |/objects/animated-curve.js          319          284            2           33
  |algebench/static/labels.js          323          275           22           26
@@ -82,7 +82,7 @@ xychart-beta horizontal
  |/static/objects/polygon.js          187          161            8           18
  |jects/animated-cylinder.js          147          134            1           12
  |/objects/animated-point.js          148          132            1           15
- |v/algebench/static/main.js          152          124           19            9
+ |h/algebench/static/main.js          152          124           19            9
  |/algebench/static/trust.js          131          112            6           13
  |h/static/objects/vector.js          121          109            0           12
  |c/objects/animated-line.js          112           99            1           12
@@ -95,8 +95,8 @@ xychart-beta horizontal
  |tatic/objects/ellipsoid.js           74           66            0            8
  |ic/objects/vector-field.js           72           64            0            8
  |nch/static/objects/axis.js           62           56            0            6
- |ch/static/objects/index.js           54           53            0            1
  |algebench/static/coords.js           71           53           13            5
+ |ch/static/objects/index.js           54           53            0            1
  |/static/objects/surface.js           52           48            0            4
  |ch/static/objects/plane.js           50           43            0            7
  |nch/static/objects/text.js           48           40            1            7
@@ -133,13 +133,13 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Python                   29        13620        10527         1507         1586
 ─────────────────────────────────────────────────────────────────────────────────
- |an/dev/algebench/server.py         2872         2302          327          243
+ |ebench/algebench/server.py         2872         2302          327          243
  |sts/test_latex_to_graph.py         1416         1096          140          180
  |/scripts/latex_to_graph.py         1327          986          228          113
  |semantic_graph_enricher.py         1106          762          214          130
  |semantic_graph_enricher.py          833          658          106           69
  |cripts/graph_to_mermaid.py          851          594          174           83
- |v/algebench/agent_tools.py          610          522           35           53
+ |h/algebench/agent_tools.py          610          522           35           53
  |ripts/audit_expressions.py          660          515           54           91
  |nch/scripts/render_math.py          509          469            4           36
  |cripts/validate_content.py          602          453           42          107
@@ -151,7 +151,7 @@ xychart-beta horizontal
  |/scripts/assemble_scene.py          187          144            1           42
  |/tests/test_render_math.py          177          124           18           35
  |graph_highlight_overlay.py          163          120           11           32
- |v/algebench/agents/base.py          124          105            0           19
+ |h/algebench/agents/base.py          124          105            0           19
  |h/models/semantic_graph.py          154          103           19           32
  |st_dot_notation_restore.py          146           99           19           28
  |ents/test_schema_parity.py           75           57            0           18
@@ -160,8 +160,8 @@ xychart-beta horizontal
  |/agents/test_base_agent.py           71           47            0           24
  |gebench/models/__init__.py           32           30            0            2
  |gebench/agents/__init__.py           20           18            0            2
- |h/tests/agents/__init__.py            0            0            0            0
  |lgebench/tests/__init__.py            0            0            0            0
+ |h/tests/agents/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Total                    29        13620        10527         1507         1586
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -5,8 +5,8 @@
 | Field | Value |
 |---|---|
 | **Branch** | `docs/readme-proofs-and-graphs` |
-| **Commit** | `dce8f72` |
-| **Date** | 2026-05-08 23:57:19 -0400 |
+| **Commit** | `1080119` |
+| **Date** | 2026-05-09 00:01:10 -0400 |
 
 ## Language Breakdown
 

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -5,8 +5,8 @@
 | Field | Value |
 |---|---|
 | **Branch** | `docs/readme-proofs-and-graphs` |
-| **Commit** | `ea2419b` |
-| **Date** | 2026-05-08 23:56:12 -0400 |
+| **Commit** | `dce8f72` |
+| **Date** | 2026-05-08 23:57:19 -0400 |
 
 ## Language Breakdown
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > **AI for human understanding — not for outsourcing thought.**
 
-Interactive 3D lessons with a live AI narrator. Spin up a scene, listen to it explain itself, then interrupt and ask *why* — the narrator answers in real time and the visualization responds.
+Interactive 3D lessons with a live AI narrator. Spin up a scene, listen to it explain itself, then interrupt and ask *what*, *how* and the *why* — the narrator answers in real time and the visualization responds.
 
 Step-by-step **proofs** walk through derivations alongside the 3D scene — each step shows the math, the justification, and highlighted regions you can click to see what changed. A **semantic graph** parses the current expression into an interactive flowchart of variables, operators, and relationships, so you can see the *structure* of an equation, not just its symbols. Proofs and the graph stay in sync: advance a proof step and the graph and 3D view update together.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AlgeBench
 
-**Math you can rotate, pause, and ask questions to.**
+**See and touch the math, and think with an AI.**
 
 > **AI for human understanding — not for outsourcing thought.**
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Interactive 3D lessons with a live AI narrator. Spin up a scene, listen to it explain itself, then interrupt and ask *why* — the narrator answers in real time and the visualization responds.
 
+Step-by-step **proofs** walk through derivations alongside the 3D scene — each step shows the math, the justification, and highlighted regions you can click to see what changed. A **semantic graph** parses the current expression into an interactive flowchart of variables, operators, and relationships, so you can see the *structure* of an equation, not just its symbols. Proofs and the graph stay in sync: advance a proof step and the graph and 3D view update together.
+
 **Made for:** self-taught learners, students, and educators who think math makes more sense when you can see it move.
 
 ![AlgeBench screenshot](docs/rotating-space-habitat.png)
@@ -161,6 +163,9 @@ algebench/
     ├── state.js       Shared mutable state
     ├── scene-loader.js  Scene/lesson loading, step navigation & undo
     ├── chat.js        AI chat panel, TTS, voice picker
+    ├── proof.js       Step-by-step proof panel with LaTeX rendering
+    ├── graph-view.js  Semantic graph tab (D3 expression flowcharts)
+    ├── graph-panel/   Graph renderers, themes, and layout engines
     ├── objects/       Element renderers
     │   ├── point.js, vector.js, polygon.js, sphere.js, …
     ├── domains/       Domain library plugins


### PR DESCRIPTION
## Summary
- Add a paragraph to the README intro describing the **proof panel** (step-by-step derivations with highlighted regions) and the **semantic graph** (interactive expression flowcharts) — two core features that were missing from the project description.
- Update the project-structure tree to include `proof.js`, `graph-view.js`, and `graph-panel/`.

## Test plan
- [ ] Verify the README renders correctly on GitHub
- [ ] Confirm the new paragraph reads naturally after the existing intro

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>