### PR TITLE
fix: annotation overlay cards, edge legend, and enrichment skip (#234)

### DIFF
--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 |---|---|
-| **Branch** | `docs/readme-proofs-and-graphs` |
-| **Commit** | `1080119` |
-| **Date** | 2026-05-09 00:01:10 -0400 |
+| **Branch** | `fix/234-annotation-node-style` |
+| **Commit** | `ca9ae74` |
+| **Date** | 2026-05-09 21:08:56 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [45631, 14798, 10527, 3989, 386, 137, 33]
+  bar [45734, 14925, 10686, 4129, 386, 137, 33]
 ```
 
 ## Summary by Language
@@ -26,10 +26,10 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- JSON                     40        45632        45631            0            1
- JavaScript               46        17068        14798          887         1383
- Python                   29        13620        10527         1507         1586
- CSS                       3         4320         3989          154          177
+ JSON                     40        45735        45734            0            1
+ JavaScript               46        17211        14925          887         1399
+ Python                   29        13810        10686         1520         1604
+ CSS                       3         4470         4129          156          185
  Shell                     2          172          137           14           21
  BASH                      1           41           33            4            4
  Plain Text                1            9            0            9            0
@@ -39,14 +39,14 @@ xychart-beta horizontal
  |- JavaScript             2          580          513           11           56
  (Total)                             1107         1018           23           66
 ─────────────────────────────────────────────────────────────────────────────────
- Markdown                 55        10436            0         7858         2578
+ Markdown                 55        10437            0         7859         2578
  |- BASH                  13          142          120           14            8
  |- JavaScript             1           10            6            3            1
  |- JSON                  33         1318         1318            0            0
  |- Python                 2           38           30            2            6
- (Total)                            11944         1474         7877         2593
+ (Total)                            11945         1474         7878         2593
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   180        93913        77607        10475         5831
+ Total                   180        94500        78136        10491         5873
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -56,14 +56,14 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- JavaScript               46        17068        14798          887         1383
+ JavaScript               46        17211        14925          887         1399
 ─────────────────────────────────────────────────────────────────────────────────
  |bench/static/graph-view.js         1869         1415          319          135
  |nch/static/json-browser.js         1403         1361            5           37
  |h/algebench/static/chat.js         1425         1160          113          152
  |lgebench/static/overlay.js         1168         1101           29           38
  |/algebench/static/proof.js         1109         1040           33           36
- |panel/d3-semantic-graph.js          968          804           42          122
+ |panel/d3-semantic-graph.js         1111          931           42          138
  |nch/static/scene-loader.js          939          798           46           95
  |algebench/static/camera.js          760          646           20           94
  |cislunar-dynamics/index.js          611          546            8           57
@@ -105,11 +105,11 @@ xychart-beta horizontal
  |/static/objects/vectors.js           23           19            0            4
  |ch/static/objects/point.js           23           18            0            5
 ─────────────────────────────────────────────────────────────────────────────────
- CSS                       3         4320         3989          154          177
+ CSS                       3         4470         4129          156          185
 ─────────────────────────────────────────────────────────────────────────────────
  |algebench/static/style.css         4097         3793          144          160
+ |anel/d3-semantic-graph.css          259          228           11           20
  |raph-panel/graph-panel.css          114          108            1            5
- |anel/d3-semantic-graph.css          109           88            9           12
 ─────────────────────────────────────────────────────────────────────────────────
  HTML                      1          347          336            7            4
 ─────────────────────────────────────────────────────────────────────────────────
@@ -121,7 +121,7 @@ xychart-beta horizontal
  |islunar-dynamics/docs.json          122          122            0            0
  |tmospheric-entry/docs.json           41           41            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    53        22054        19442         1048         1564
+ Total                    53        22347        19709         1050         1588
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -131,11 +131,11 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Python                   29        13620        10527         1507         1586
+ Python                   29        13810        10686         1520         1604
 ─────────────────────────────────────────────────────────────────────────────────
- |ebench/algebench/server.py         2872         2302          327          243
- |sts/test_latex_to_graph.py         1416         1096          140          180
- |/scripts/latex_to_graph.py         1327          986          228          113
+ |ebench/algebench/server.py         2931         2349          337          245
+ |sts/test_latex_to_graph.py         1491         1156          143          192
+ |/scripts/latex_to_graph.py         1382         1037          228          117
  |semantic_graph_enricher.py         1106          762          214          130
  |semantic_graph_enricher.py          833          658          106           69
  |cripts/graph_to_mermaid.py          851          594          174           83
@@ -152,7 +152,7 @@ xychart-beta horizontal
  |/tests/test_render_math.py          177          124           18           35
  |graph_highlight_overlay.py          163          120           11           32
  |h/algebench/agents/base.py          124          105            0           19
- |h/models/semantic_graph.py          154          103           19           32
+ |h/models/semantic_graph.py          155          104           19           32
  |st_dot_notation_restore.py          146           99           19           28
  |ents/test_schema_parity.py           75           57            0           18
  |t_semantic_graph_themes.py           69           51            0           18
@@ -163,7 +163,7 @@ xychart-beta horizontal
  |lgebench/tests/__init__.py            0            0            0            0
  |h/tests/agents/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    29        13620        10527         1507         1586
+ Total                    29        13810        10686         1520         1604
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -171,6 +171,6 @@ xychart-beta horizontal
 
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
-| JavaScript (frontend) | 14798 | 58% |
-| Python (backend) | 10527 | 42% |
-| **Total** | **25325** | **100%** |
+| JavaScript (frontend) | 14925 | 58% |
+| Python (backend) | 10686 | 42% |
+| **Total** | **25611** | **100%** |

--- a/models/semantic_graph.py
+++ b/models/semantic_graph.py
@@ -23,6 +23,7 @@ NodeType = Literal[
     "relation",
     "expression",
     "text",
+    "annotation",
 ]
 
 Role = Literal[

--- a/scenes/draft/graph-panel-demo.json
+++ b/scenes/draft/graph-panel-demo.json
@@ -72,6 +72,26 @@
         {
           "title": "Higher powers and a quotient (^3, ^4, ^n, ^-3, ^-4, ^-n, a/b)",
           "description": "$y = x^3 + x^4 + x^n + x^{-3} + x^{-4} + x^{-n} + \\frac{a}{b}$"
+        },
+        {
+          "title": "Annotation: constant velocity",
+          "description": "$F = \\dot{m} \\cdot v_e \\quad (v_e \\text{ constant})$"
+        },
+        {
+          "title": "Annotation: two assumptions",
+          "description": "$P V = n R T \\quad (T \\text{ constant}) \\quad (n \\text{ fixed})$"
+        },
+        {
+          "title": "Annotation: small angle",
+          "description": "$\\sin\\theta \\approx \\theta \\quad (\\theta \\text{ small})$"
+        },
+        {
+          "title": "Annotation: long latex annotation",
+          "description": "$W = \\int F \\, dx \\quad (F \\text{ conservative, } \\nabla \\times F = 0)$"
+        },
+        {
+          "title": "Annotation: paragraph-length",
+          "description": "$\\Delta S \\geq 0 \\quad (\\text{holds for isolated systems undergoing irreversible processes where no heat exchange with surroundings occurs})$"
         }
       ],
       "proof": {
@@ -1772,6 +1792,46 @@
                 }
               }
             }
+          },
+          {
+            "id": "proof-step-11",
+            "type": "given",
+            "label": "Annotation: constant exhaust velocity",
+            "math": "F = \\dot{m} \\cdot v_e \\quad (v_e \\text{ constant})",
+            "justification": "Rocket thrust with a parenthetical annotation indicating the exhaust velocity is constant. The annotation should appear as a separate rounded-rectangle node with dashed border.",
+            "sceneStep": 0
+          },
+          {
+            "id": "proof-step-12",
+            "type": "given",
+            "label": "Annotation: two assumptions",
+            "math": "P V = n R T \\quad (T \\text{ constant}) \\quad (n \\text{ fixed})",
+            "justification": "Ideal gas law with two parenthetical annotations — constant temperature and fixed amount of substance. Both should appear as separate annotation nodes.",
+            "sceneStep": 0
+          },
+          {
+            "id": "proof-step-13",
+            "type": "given",
+            "label": "Annotation: small angle approximation",
+            "math": "\\sin\\theta \\approx \\theta \\quad (\\theta \\text{ small})",
+            "justification": "Small-angle approximation with a single annotation. Tests that annotations work alongside the ≈ relation operator.",
+            "sceneStep": 0
+          },
+          {
+            "id": "proof-step-14",
+            "type": "given",
+            "label": "Annotation: long latex annotation",
+            "math": "W = \\int F \\, dx \\quad (F \\text{ conservative, } \\nabla \\times F = 0)",
+            "justification": "Work integral with a longer annotation containing both text and LaTeX symbols. Tests that the rounded rectangle sizes properly for longer content.",
+            "sceneStep": 0
+          },
+          {
+            "id": "proof-step-15",
+            "type": "given",
+            "label": "Annotation: paragraph-length",
+            "math": "\\Delta S \\geq 0 \\quad (\\text{holds for isolated systems undergoing irreversible processes where no heat exchange with surroundings occurs})",
+            "justification": "Entropy inequality with a paragraph-length annotation. Tests that the annotation rectangle expands vertically and wraps text across multiple lines.",
+            "sceneStep": 0
           }
         ]
       }

--- a/scenes/draft/graph-panel-demo.json
+++ b/scenes/draft/graph-panel-demo.json
@@ -1798,7 +1798,7 @@
             "type": "given",
             "label": "Annotation: constant exhaust velocity",
             "math": "F = \\dot{m} \\cdot v_e \\quad (v_e \\text{ constant})",
-            "justification": "Rocket thrust with a parenthetical annotation indicating the exhaust velocity is constant. The annotation should appear as a separate rounded-rectangle node with dashed border.",
+            "justification": "Rocket thrust with a parenthetical annotation indicating the exhaust velocity is constant. The annotation appears as a themed overlay card below the graph.",
             "sceneStep": 0
           },
           {
@@ -1806,7 +1806,7 @@
             "type": "given",
             "label": "Annotation: two assumptions",
             "math": "P V = n R T \\quad (T \\text{ constant}) \\quad (n \\text{ fixed})",
-            "justification": "Ideal gas law with two parenthetical annotations — constant temperature and fixed amount of substance. Both should appear as separate annotation nodes.",
+            "justification": "Ideal gas law with two parenthetical annotations — constant temperature and fixed amount of substance. Both appear as themed overlay cards below the graph.",
             "sceneStep": 0
           },
           {

--- a/schemas/semantic-graph-theme.schema.json
+++ b/schemas/semantic-graph-theme.schema.json
@@ -35,10 +35,11 @@
         "constant": { "$ref": "#/$defs/nodeStyle" },
         "operator": { "$ref": "#/$defs/nodeStyle" },
         "function": { "$ref": "#/$defs/nodeStyle" },
-        "relation": { "$ref": "#/$defs/nodeStyle" },
-        "result":   { "$ref": "#/$defs/nodeStyle" },
-        "set":      { "$ref": "#/$defs/nodeStyle" },
-        "boolean":  { "$ref": "#/$defs/nodeStyle" }
+        "relation":   { "$ref": "#/$defs/nodeStyle" },
+        "result":     { "$ref": "#/$defs/nodeStyle" },
+        "set":        { "$ref": "#/$defs/nodeStyle" },
+        "boolean":    { "$ref": "#/$defs/nodeStyle" },
+        "annotation": { "$ref": "#/$defs/nodeStyle" }
       }
     },
     "operatorVariants": {

--- a/schemas/semantic-graph.schema.json
+++ b/schemas/semantic-graph.schema.json
@@ -29,7 +29,7 @@
   "$defs": {
     "nodeType": {
       "type": "string",
-      "enum": ["scalar", "vector", "constant", "number", "operator", "function", "relation", "expression", "text"],
+      "enum": ["scalar", "vector", "constant", "number", "operator", "function", "relation", "expression", "text", "annotation"],
       "description": "The semantic role of the node."
     },
     "operatorOp": {

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -722,7 +722,7 @@ def _collapse_text_commands(latex: str) -> tuple[str, dict[str, dict[str, str]]]
             overrides[f"Xi_{{{idx}}}"] = {
                 "label": content,
                 "latex": r"\text{" + content + "}",
-                "type": "text",
+                "type": "annotation",
             }
         return rf"\Xi_{seen[content]}"
 
@@ -814,6 +814,47 @@ def _collapse_compound_symbols(latex: str) -> tuple[str, dict[str, dict[str, str
     )
     rewritten = re.sub(pattern, repl, latex)
     return rewritten, overrides
+
+
+def _extract_parenthetical_annotations(latex: str) -> tuple[str, list[dict[str, str]]]:
+    r"""Strip trailing parenthetical annotations from LaTeX.
+
+    Patterns like ``\quad (v_e \text{ constant})`` are common in physics
+    notation — they annotate an assumption about a variable rather than
+    contribute to the equation's mathematical structure.  SymPy cannot
+    parse these because the parenthesised content mixes free variables
+    with ``\text{...}`` prose, producing a juxtaposition that has no
+    operator between terms.
+
+    Detection heuristic: a parenthesised group at the *end* of the
+    string that contains at least one ``\text{...}`` and is preceded by
+    optional LaTeX spacing (``\quad``, ``\qquad``, whitespace).
+
+    Returns ``(cleaned_latex, annotations)`` where each annotation dict
+    has ``latex`` (the full parenthetical including parens) and ``label``
+    (a plain-text rendering suitable for the graph node).
+    """
+    annotations: list[dict[str, str]] = []
+    spacing = r"(?:\s|\\quad|\\qquad|\\,|\\;|\\!|\\:)*"
+    pattern = re.compile(
+        spacing + r"\(([^()]*\\text\{[^}]+\}[^()]*)\)\s*$"
+    )
+    while True:
+        m = pattern.search(latex)
+        if not m:
+            break
+        inner = m.group(1).strip()
+        label = re.sub(r"\\text\{([^}]+)\}", r"\1", inner)
+        label = re.sub(r"\\[A-Za-z]+\s*", "", label)
+        label = re.sub(r"[{}]", "", label)
+        label = re.sub(r"\s+", " ", label).strip()
+        annotations.append({
+            "latex": inner,
+            "label": label,
+            "type": "annotation",
+        })
+        latex = latex[:m.start()].rstrip()
+    return latex, annotations
 
 
 def _preprocess_latex(latex: str) -> str:
@@ -1154,6 +1195,7 @@ def latex_to_semantic_graph(latex: str, overrides: dict[str, dict[str, str]] | N
     relation node. Shared variables across clauses dedup to one node.
     """
     user_overrides = overrides
+    latex, parenthetical_annotations = _extract_parenthetical_annotations(latex)
     compound_collapsed, compound_overrides = _collapse_compound_symbols(latex)
     collapsed, text_overrides = _collapse_text_commands(compound_collapsed)
     preprocessed = _preprocess_latex(collapsed)
@@ -1256,6 +1298,7 @@ def latex_to_semantic_graph(latex: str, overrides: dict[str, dict[str, str]] | N
             graph["classification"] = {"kind": "algebraic"}
         if domain:
             graph["domain"] = domain
+        _inject_annotations(graph, parenthetical_annotations)
         return graph
 
     # No top-level relation. A top-level comma now acts as a statement
@@ -1266,9 +1309,11 @@ def latex_to_semantic_graph(latex: str, overrides: dict[str, dict[str, str]] | N
     # parent-scoped ``Xi_{N}`` ids.
     clauses = _split_on_top_level_comma(latex)
     if len(clauses) > 1:
-        return _build_comma_separated_graph(
+        graph = _build_comma_separated_graph(
             clauses, overrides=user_overrides, domain=domain,
         )
+        _inject_annotations(graph, parenthetical_annotations)
+        return graph
 
     try:
         expr = parse_latex(preprocessed)
@@ -1281,7 +1326,17 @@ def latex_to_semantic_graph(latex: str, overrides: dict[str, dict[str, str]] | N
     graph["classification"] = classification
     if domain:
         graph["domain"] = domain
+    _inject_annotations(graph, parenthetical_annotations)
     return graph
+
+
+def _inject_annotations(graph: dict, annotations: list[dict[str, str]]) -> None:
+    """Append parenthetical annotation nodes to the graph."""
+    for i, ann in enumerate(annotations):
+        node_id = f"__annotation_{i}"
+        node: dict[str, Any] = {"id": node_id}
+        node.update(ann)
+        graph.setdefault("nodes", []).append(node)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -831,8 +831,10 @@ def _extract_parenthetical_annotations(latex: str) -> tuple[str, list[dict[str, 
     optional LaTeX spacing (``\quad``, ``\qquad``, whitespace).
 
     Returns ``(cleaned_latex, annotations)`` where each annotation dict
-    has ``latex`` (the full parenthetical including parens) and ``label``
-    (a plain-text rendering suitable for the graph node).
+    has ``latex`` (the inner content without surrounding parens), ``label``
+    (a plain-text rendering suitable for the overlay card), and ``type``
+    (always ``"annotation"``).  Annotations are returned in source order
+    (left-to-right).
     """
     annotations: list[dict[str, str]] = []
     spacing = r"(?:\s|\\quad|\\qquad|\\,|\\;|\\!|\\:)*"
@@ -854,6 +856,7 @@ def _extract_parenthetical_annotations(latex: str) -> tuple[str, list[dict[str, 
             "type": "annotation",
         })
         latex = latex[:m.start()].rstrip()
+    annotations.reverse()
     return latex, annotations
 
 

--- a/server.py
+++ b/server.py
@@ -2322,13 +2322,13 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
             # Re-attached to the enriched result before returning.
             all_nodes = list(graph_in.get("nodes") or [])
             anno_nodes = [n for n in all_nodes if n.get("type") == "annotation"]
-            anno_ids = {n["id"] for n in anno_nodes}
+            anno_ids = {n.get("id") for n in anno_nodes} - {None}
             if anno_nodes:
                 graph_in = dict(graph_in)
                 graph_in["nodes"] = [n for n in all_nodes if n.get("type") != "annotation"]
-                all_edges = list(graph_in.get("edges") or [])
-                anno_edges = [e for e in all_edges if e.get("from") in anno_ids or e.get("to") in anno_ids]
-                graph_in["edges"] = [e for e in all_edges if e not in anno_edges]
+                orig_edges = list(graph_in.get("edges") or [])
+                anno_edges = [e for e in orig_edges if e.get("from") in anno_ids or e.get("to") in anno_ids]
+                graph_in["edges"] = [e for e in orig_edges if e.get("from") not in anno_ids and e.get("to") not in anno_ids]
             else:
                 anno_edges = []
 

--- a/server.py
+++ b/server.py
@@ -2316,6 +2316,22 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
             node_count = len(graph_in.get("nodes", []) or [])
             domain = graph_in.get("domain") or (context_in or {}).get("domain") or "?"
 
+            # Strip annotation nodes before validation and enrichment —
+            # they carry free-text labels that can exceed Pydantic field
+            # limits, and they aren't meaningful to the Gemini enricher.
+            # Re-attached to the enriched result before returning.
+            all_nodes = list(graph_in.get("nodes") or [])
+            anno_nodes = [n for n in all_nodes if n.get("type") == "annotation"]
+            anno_ids = {n["id"] for n in anno_nodes}
+            if anno_nodes:
+                graph_in = dict(graph_in)
+                graph_in["nodes"] = [n for n in all_nodes if n.get("type") != "annotation"]
+                all_edges = list(graph_in.get("edges") or [])
+                anno_edges = [e for e in all_edges if e.get("from") in anno_ids or e.get("to") in anno_ids]
+                graph_in["edges"] = [e for e in all_edges if e not in anno_edges]
+            else:
+                anno_edges = []
+
             # Validate the wire-format dict at the API boundary BEFORE any
             # short-circuit. Otherwise a caller could include any
             # ``"enrichment": {...}`` blob in their request and bypass the
@@ -2346,9 +2362,13 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
             # avoided. Keeping ``cached`` honest matters for any caller
             # that uses it for metrics.
             if graph_model.enrichment is not None:
+                enriched_out = graph_model.model_dump(by_alias=True, exclude_none=True)
+                if anno_nodes:
+                    enriched_out["nodes"].extend(anno_nodes)
+                    enriched_out["edges"].extend(anno_edges)
                 print(f"[enrich] input already enriched  nodes={node_count} domain={domain!r}", flush=True)
                 return JSONResponse({
-                    "enriched": graph_model.model_dump(by_alias=True, exclude_none=True),
+                    "enriched": enriched_out,
                     "cached": False,
                     "skipped": True,
                 })
@@ -2389,6 +2409,9 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
             # response — keeps the cache hit path returning dicts so the
             # ``cached`` shape is identical regardless of how it was built.
             enriched = enriched_model.model_dump(by_alias=True, exclude_none=True)
+            if anno_nodes:
+                enriched["nodes"].extend(anno_nodes)
+                enriched["edges"].extend(anno_edges)
             _graph_enrich_cache[key] = enriched
             print(f"[enrich] ok  cached  key={key[:8]}", flush=True)
             if DEBUG_MODE:

--- a/server.py
+++ b/server.py
@@ -814,13 +814,26 @@ def _derive_equation_chain_graph(latex: str) -> dict | None:
     """
     if not isinstance(latex, str) or not latex:
         return None
+    # Strip parenthetical annotations *before* any splitting — annotations
+    # may contain ``=`` (e.g. ``(\nabla \times F = 0)``) which would confuse
+    # the equation-chain splitter.
+    early_annotations: list[dict] = []
+    try:
+        _l2g = _load_script_module("scripts/latex_to_graph.py", "latex_to_graph")
+        if _l2g is not None:
+            latex, early_annotations = _l2g._extract_parenthetical_annotations(latex)
+    except Exception:
+        pass
     # Logical connectives (``\implies``, ``\iff``, …) bind looser than ``=``.
     # Splitting on ``=`` across one would collapse two distinct equations onto
     # a single central ``=`` node and bury the implication. Hand the whole
     # string to the single-expression parser instead — SymPy knows how to make
     # ``implies`` the root with the two ``=`` relations as its operands.
     if _has_top_level_logical_connective(latex):
-        return _derive_semantic_graph(latex)
+        graph = _derive_semantic_graph(latex)
+        if graph and early_annotations:
+            _l2g._inject_annotations(graph, early_annotations)
+        return graph
     # Top-level commas are statement separators (issue #144) and bind even
     # looser than ``=``. Splitting on ``=`` first would mangle a comma-
     # separated pair like ``a = b, c = d`` into three garbled sides
@@ -828,12 +841,21 @@ def _derive_equation_chain_graph(latex: str) -> dict | None:
     # single-expression parser, which knows how to split on top-level
     # commas and emit each clause as an independent statement.
     if _has_top_level_statement_comma(latex):
-        return _derive_semantic_graph(latex)
+        graph = _derive_semantic_graph(latex)
+        if graph and early_annotations:
+            _l2g._inject_annotations(graph, early_annotations)
+        return graph
     sides = _split_equation_chain_sides(latex)
     if len(sides) <= 1:
-        return _derive_semantic_graph(latex)
+        graph = _derive_semantic_graph(latex)
+        if graph and early_annotations:
+            _l2g._inject_annotations(graph, early_annotations)
+        return graph
     if len(sides) == 2:
-        return _derive_semantic_graph(f"{sides[0]} = {sides[1]}")
+        graph = _derive_semantic_graph(f"{sides[0]} = {sides[1]}")
+        if graph and early_annotations:
+            _l2g._inject_annotations(graph, early_annotations)
+        return graph
 
     try:
         l2g = _load_script_module("scripts/latex_to_graph.py", "latex_to_graph")
@@ -851,7 +873,14 @@ def _derive_equation_chain_graph(latex: str) -> dict | None:
     # to know about all of them regardless of which side introduced them.
     dotted_vars: dict[str, int] = {}
 
+    all_annotations: list[dict] = []
+
     for si, side in enumerate(sides):
+        # Strip trailing parenthetical annotations (e.g. ``(v_e \text{ constant})``)
+        # before the multichar-subscript pass replaces ``\text{…}`` with Greek
+        # placeholders — after that the regex can no longer detect them.
+        side, side_annotations = l2g._extract_parenthetical_annotations(side)
+        all_annotations.extend(side_annotations)
         # Lift ``\dot{m}`` → ``\frac{d m}{d t}`` (SymPy doesn't understand
         # overhead-dot notation natively but does produce ``Derivative``
         # nodes from the fraction form). Then peel visual accents
@@ -927,11 +956,13 @@ def _derive_equation_chain_graph(latex: str) -> dict | None:
         if r:
             merged_edges.append({"from": r, "to": equals_id})
 
-    return {
+    graph = {
         "nodes": list(merged_nodes.values()),
         "edges": merged_edges,
         "classification": {"kind": "algebraic"},
     }
+    l2g._inject_annotations(graph, all_annotations)
+    return graph
 
 
 def _derive_semantic_graph(
@@ -956,6 +987,10 @@ def _derive_semantic_graph(
     # (\vec, \hat, \mathbf, …) that SymPy can't parse, then swap multi-char
     # subscripts (\text{prop}, _{sp}, …) with Greek placeholders so SymPy
     # treats them as atomic symbols, then restore.
+    l2g = _load_script_module("scripts/latex_to_graph.py", "latex_to_graph")
+    annotations: list[dict] = []
+    if l2g is not None:
+        math_src, annotations = l2g._extract_parenthetical_annotations(math_src)
     dotted_vars: dict[str, int] = {}
     deriv_src = _rewrite_dot_derivatives(math_src, dotted_vars)
     deriv_src = _normalize_frac_derivatives(deriv_src)
@@ -963,7 +998,6 @@ def _derive_semantic_graph(
     stripped = _strip_accent_commands(deriv_src, accent_map)
     rewritten, mapping = _substitute_multichar_subscripts(stripped)
     try:
-        l2g = _load_script_module("scripts/latex_to_graph.py", "latex_to_graph")
         if l2g is None:
             graph = None
         elif domain:
@@ -987,6 +1021,8 @@ def _derive_semantic_graph(
             _restore_subscripts_in_graph(graph, mapping)
             _restore_accents_in_graph(graph, accent_map)
             _restore_dot_notation_in_graph(graph, dotted_vars)
+            if l2g is not None and annotations:
+                l2g._inject_annotations(graph, annotations)
     _latex_graph_cache[key] = graph
     return graph
 

--- a/static/graph-panel/d3-semantic-graph.css
+++ b/static/graph-panel/d3-semantic-graph.css
@@ -107,3 +107,72 @@ svg.d3-semantic-graph {
     stroke: #7ea8ff;
     stroke-width: 2.5px;
 }
+
+/* Annotation overlay — stacked at bottom of graph viewport */
+.d3sg-annotation-overlay {
+    position: absolute;
+    bottom: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    pointer-events: none;
+    z-index: 10;
+    max-width: min(90%, 420px);
+}
+
+.d3sg-anno-card {
+    position: relative;
+    pointer-events: all;
+    border: 1px dashed;
+    border-radius: 8px;
+    padding: 10px 36px 10px 18px;
+    font-size: 0.88em;
+    font-style: italic;
+    line-height: 1.45;
+    backdrop-filter: blur(8px);
+    opacity: 0.92;
+    text-align: center;
+    min-width: 0;
+    max-width: 100%;
+    box-sizing: border-box;
+}
+
+.d3sg-anno-content {
+    display: block;
+    text-align: center;
+}
+
+.d3sg-anno-card .katex {
+    font-size: 0.92em;
+}
+
+.d3sg-anno-ai-btn {
+    position: absolute;
+    top: 50%;
+    right: 6px;
+    transform: translateY(-50%);
+    width: 20px;
+    height: 20px;
+    border: none;
+    border-radius: 50%;
+    background: rgba(100, 110, 255, 0.15);
+    color: rgba(160, 170, 255, 0.8);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    opacity: 0;
+    transition: opacity 0.15s, background 0.15s, color 0.15s;
+}
+
+.d3sg-anno-card:hover .d3sg-anno-ai-btn {
+    opacity: 1;
+}
+
+.d3sg-anno-ai-btn:hover {
+    background: rgba(100, 110, 255, 0.35);
+    color: #c0c8ff;
+}

--- a/static/graph-panel/d3-semantic-graph.css
+++ b/static/graph-panel/d3-semantic-graph.css
@@ -176,3 +176,84 @@ svg.d3-semantic-graph {
     background: rgba(100, 110, 255, 0.35);
     color: #c0c8ff;
 }
+
+/* Edge semantics legend — bottom-left of graph viewport */
+.d3sg-edge-legend {
+    position: absolute;
+    left: 8px;
+    bottom: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px 10px;
+    background: rgba(10, 12, 26, 0.75);
+    border: 1px solid rgba(110, 124, 180, 0.35);
+    border-radius: 6px;
+    font-size: 0.72rem;
+    color: rgba(210, 218, 245, 0.92);
+    letter-spacing: 0.02em;
+    z-index: 2;
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    pointer-events: none;
+    user-select: none;
+}
+.d3sg-edge-legend.hidden { display: none; }
+.d3sg-edge-legend-title {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    opacity: 0.65;
+    margin-bottom: 2px;
+}
+.d3sg-edge-legend-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.d3sg-edge-legend-swatch {
+    --legend-stroke: currentColor;
+    --legend-stroke-width: 2px;
+    position: relative;
+    display: inline-block;
+    width: 30px;
+    height: 12px;
+    flex-shrink: 0;
+}
+.d3sg-edge-legend-swatch::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 50%;
+    width: 22px;
+    height: var(--legend-stroke-width);
+    background: var(--legend-stroke);
+    transform: translateY(-50%);
+}
+.d3sg-edge-legend-swatch[data-arrow="-.->"]::before,
+.d3sg-edge-legend-swatch[data-arrow="-.-"]::before {
+    background: none;
+    border-top: var(--legend-stroke-width) dotted var(--legend-stroke);
+    height: 0;
+}
+.d3sg-edge-legend-swatch[data-arrow="==>"]::before,
+.d3sg-edge-legend-swatch[data-arrow="==="]::before {
+    box-shadow: 0 -2px 0 var(--legend-stroke), 0 2px 0 var(--legend-stroke);
+}
+.d3sg-edge-legend-swatch::after {
+    content: "";
+    position: absolute;
+    right: 0;
+    top: 50%;
+    width: 0;
+    height: 0;
+    border-top: 5px solid transparent;
+    border-bottom: 5px solid transparent;
+    border-left: 8px solid var(--legend-stroke);
+    transform: translateY(-50%);
+}
+.d3sg-edge-legend-swatch[data-arrow="---"]::after,
+.d3sg-edge-legend-swatch[data-arrow="==="]::after,
+.d3sg-edge-legend-swatch[data-arrow="-.-"]::after {
+    display: none;
+}

--- a/static/graph-panel/d3-semantic-graph.css
+++ b/static/graph-panel/d3-semantic-graph.css
@@ -168,7 +168,8 @@ svg.d3-semantic-graph {
     transition: opacity 0.15s, background 0.15s, color 0.15s;
 }
 
-.d3sg-anno-card:hover .d3sg-anno-ai-btn {
+.d3sg-anno-card:hover .d3sg-anno-ai-btn,
+.d3sg-anno-card:focus-within .d3sg-anno-ai-btn {
     opacity: 1;
 }
 

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -66,6 +66,12 @@ const DEFAULT_EDGE_COLORS = {
     neutral: '#7e8aa3',
 };
 
+const EDGE_SEMANTIC_LABELS = [
+    ['direct',  'Proportional'],
+    ['inverse', 'Inversely proportional'],
+    ['neutral', 'Structural'],
+];
+
 const DEFAULT_EDGE_WIDTHS = {
     direct: 2.5,
     inverse: 1.8,
@@ -322,6 +328,11 @@ export class D3SemanticGraphRenderer {
         card.appendChild(overlay);
         this._annotationOverlay = overlay;
 
+        const legend = document.createElement('div');
+        legend.className = 'd3sg-edge-legend hidden';
+        card.appendChild(legend);
+        this._edgeLegend = legend;
+
         this._viewport = this._svg.append('g').attr('class', 'd3sg-viewport');
         this._linkLayer = this._viewport.append('g').attr('class', 'd3sg-links');
         this._labelLayer = this._viewport.append('g').attr('class', 'd3sg-edge-labels');
@@ -550,6 +561,7 @@ export class D3SemanticGraphRenderer {
         this._renderEdgeLabels(links, transition, d3);
         this._renderNodes(nodes, transition, d3);
         this._renderAnnotationOverlay();
+        this._renderEdgeLegend(layout.edges);
 
         for (const n of nodes) this._positionById.set(n.data.id, { x: n.x, y: n.y });
 
@@ -791,6 +803,62 @@ export class D3SemanticGraphRenderer {
             card.appendChild(aiBtn);
             el.appendChild(card);
         }
+    }
+
+    _renderEdgeLegend(layoutEdges) {
+        const el = this._edgeLegend;
+        if (!el) return;
+        el.innerHTML = '';
+
+        const theme = this._theme;
+        const styled = theme?.edgeStyles && typeof theme.edgeStyles === 'object'
+            ? theme.edgeStyles : {};
+
+        const present = new Set();
+        for (const e of layoutEdges || []) {
+            if (e.semantic) present.add(e.semantic);
+        }
+
+        const rows = [];
+        for (const [semantic, label] of EDGE_SEMANTIC_LABELS) {
+            const s = styled[semantic];
+            if (!s) continue;
+            if (present.size > 0 && !present.has(semantic)) continue;
+            rows.push({ semantic, label, style: s });
+        }
+
+        if (!rows.length) {
+            el.classList.add('hidden');
+            return;
+        }
+
+        const title = document.createElement('div');
+        title.className = 'd3sg-edge-legend-title';
+        title.textContent = 'Edges';
+        el.appendChild(title);
+
+        for (const row of rows) {
+            const item = document.createElement('div');
+            item.className = 'd3sg-edge-legend-item';
+
+            const swatch = document.createElement('span');
+            swatch.className = 'd3sg-edge-legend-swatch';
+            const stroke = row.style.stroke || 'currentColor';
+            const width = Number(row.style.strokeWidth || 2);
+            const arrow = row.style.arrow || '-->';
+            swatch.style.setProperty('--legend-stroke', stroke);
+            swatch.style.setProperty('--legend-stroke-width', `${width}px`);
+            swatch.dataset.arrow = arrow;
+            item.appendChild(swatch);
+
+            const lbl = document.createElement('span');
+            lbl.className = 'd3sg-edge-legend-label';
+            lbl.textContent = row.label;
+            item.appendChild(lbl);
+
+            el.appendChild(item);
+        }
+        el.classList.remove('hidden');
     }
 
     _nodeClass(d) {

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -447,6 +447,8 @@ export class D3SemanticGraphRenderer {
             childrenOf[e.to].push(e.from);
         }
 
+        const annoIds = new Set(nodes.filter(n => n.type === 'annotation').map(n => n.id));
+
         // BFS from roots to find visible nodes (stop at collapsed)
         const hasOutgoing = new Set(edges.map(e => e.from));
         const roots = nodes.filter(n => !hasOutgoing.has(n.id));
@@ -456,6 +458,7 @@ export class D3SemanticGraphRenderer {
         while (queue.length) {
             const id = queue.shift();
             if (visible.has(id)) continue;
+            if (annoIds.has(id)) continue;
             visible.add(id);
             if (this._collapsed.has(id)) continue;
             for (const child of (childrenOf[id] || [])) queue.push(child);

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -9,6 +9,8 @@
  * This renderer does NOT touch the Mermaid path — it exists as an alternative.
  */
 
+import { makeAiAskButton } from '/labels.js';
+
 const D3_CDN_URL = 'https://cdn.jsdelivr.net/npm/d3@7/+esm';
 const DAGRE_CDN_URL = 'https://cdn.jsdelivr.net/npm/@dagrejs/dagre@1.1.4/dist/dagre.min.js';
 
@@ -80,7 +82,8 @@ const DEFAULT_NODE_STYLES = {
     function: { fill: '#0f2540', stroke: '#42a5f5', color: '#bbdefb' },
     relation: { fill: '#2e1b33', stroke: '#ab47bc', color: '#e1bee7' },
     expression: { fill: '#1b3a1e', stroke: '#66bb6a', color: '#c8e6c9' },
-    text:     { fill: '#1b3a1e', stroke: '#66bb6a', color: '#c8e6c9' },
+    text:       { fill: '#1b3a1e', stroke: '#66bb6a', color: '#c8e6c9' },
+    annotation: { fill: '#2a2518', stroke: '#8d6e63', color: '#d7ccc8' },
 };
 
 let _themeCache = Object.create(null);
@@ -305,6 +308,7 @@ export class D3SemanticGraphRenderer {
 
         const card = document.createElement('div');
         card.className = 'gv-card d3-graph-card';
+        card.style.position = 'relative';
         this.container.appendChild(card);
 
         this._svg = d3.select(card)
@@ -312,6 +316,11 @@ export class D3SemanticGraphRenderer {
             .attr('class', 'd3-semantic-graph')
             .attr('width', '100%')
             .attr('height', '100%');
+
+        const overlay = document.createElement('div');
+        overlay.className = 'd3sg-annotation-overlay';
+        card.appendChild(overlay);
+        this._annotationOverlay = overlay;
 
         this._viewport = this._svg.append('g').attr('class', 'd3sg-viewport');
         this._linkLayer = this._viewport.append('g').attr('class', 'd3sg-links');
@@ -451,6 +460,7 @@ export class D3SemanticGraphRenderer {
 
         for (const n of nodes) {
             if (!visible.has(n.id)) continue;
+            if (n.type === 'annotation') continue;
             const isCollapsed = this._collapsed.has(n.id);
             const isOp = n.type === 'operator' || n.type === 'relation' || n.type === 'function';
             let w, h;
@@ -539,6 +549,7 @@ export class D3SemanticGraphRenderer {
         this._renderLinks(links, transition, d3);
         this._renderEdgeLabels(links, transition, d3);
         this._renderNodes(nodes, transition, d3);
+        this._renderAnnotationOverlay();
 
         for (const n of nodes) this._positionById.set(n.data.id, { x: n.x, y: n.y });
 
@@ -560,6 +571,7 @@ export class D3SemanticGraphRenderer {
         if (invisible) return { type: 'rect', hw: 28, hh: 18 };
         const kind = d.data.type;
         if (kind === 'operator' || kind === 'relation' || kind === 'function') return { type: 'circle', r: 28 };
+        if (kind === 'annotation') return { type: 'rect', hw: 28, hh: 18 };
         return { type: 'circle', r: 26 };
     }
 
@@ -716,6 +728,69 @@ export class D3SemanticGraphRenderer {
             })
             .style('opacity', 0)
             .remove();
+    }
+
+    _groupKatexWords(base) {
+        const text = base.textContent;
+        base.innerHTML = '';
+        const parts = text.split(/(\s+)/);
+        for (const part of parts) {
+            if (/^\s+$/.test(part)) {
+                base.appendChild(document.createTextNode(' '));
+            } else if (part) {
+                const span = document.createElement('span');
+                span.textContent = part;
+                span.style.whiteSpace = 'nowrap';
+                base.appendChild(span);
+            }
+        }
+    }
+
+    _renderAnnotationOverlay() {
+        const el = this._annotationOverlay;
+        if (!el) return;
+        el.innerHTML = '';
+        const graph = this._graph;
+        if (!graph || !graph.nodes) return;
+        const annotations = graph.nodes.filter(n => n.type === 'annotation');
+        if (!annotations.length) return;
+        const style = this._nodeStyle('annotation');
+        for (const ann of annotations) {
+            const card = document.createElement('div');
+            card.className = 'd3sg-anno-card';
+            card.style.background = style.fill || 'rgba(42,37,24,0.85)';
+            card.style.borderColor = style.stroke || '#8d6e63';
+            card.style.color = style.color || '#d7ccc8';
+            if (style.strokeWidth) card.style.borderWidth = style.strokeWidth + 'px';
+            if (style.fontSize) card.style.fontSize = style.fontSize + 'px';
+            const latex = ann.latex || ann.label || '';
+            const content = document.createElement('span');
+            content.className = 'd3sg-anno-content';
+            if (this.katex && latex) {
+                try {
+                    this.katex.render(latex, content, { throwOnError: false, displayMode: false });
+                    content.querySelectorAll('.katex-html').forEach(h => {
+                        h.style.whiteSpace = 'normal';
+                        h.style.display = 'block';
+                        h.style.textAlign = 'center';
+                    });
+                    content.querySelectorAll('.base').forEach(base => {
+                        base.style.display = 'inline';
+                        base.style.whiteSpace = 'normal';
+                        this._groupKatexWords(base);
+                    });
+                } catch (_) {
+                    content.textContent = latex;
+                }
+            } else {
+                content.textContent = latex;
+            }
+            card.appendChild(content);
+            const aiBtn = makeAiAskButton('d3sg-anno-ai-btn', 'Ask AI about this annotation',
+                () => 'Can you explain this annotation:\n' + latex);
+            card.appendChild(aiBtn);
+            el.appendChild(card);
+        }
     }
 
     _nodeClass(d) {

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -14,6 +14,8 @@ from scripts.latex_to_graph import (
     parse_var_overrides,
     _preprocess_latex,
     _split_on_top_level_comma,
+    _extract_parenthetical_annotations,
+    _inject_annotations,
 )
 
 
@@ -456,7 +458,7 @@ class TestTextCommand:
 
     def test_text_becomes_single_constant(self):
         g = latex_to_semantic_graph(r"T = \text{const}")
-        node = _find_node(g, type="text", label="const")
+        node = _find_node(g, type="annotation", label="const")
         assert node is not None
         assert node["latex"] == r"\text{const}"
         # No stray per-character symbols (c, o, n, s) should appear.
@@ -469,7 +471,7 @@ class TestTextCommand:
         g = latex_to_semantic_graph(
             r"T = \text{const} \implies dP = \frac{k_B T}{m}\, d\rho"
         )
-        assert _find_node(g, type="text", label="const") is not None
+        assert _find_node(g, type="annotation", label="const") is not None
         assert _find_node(g, type="relation", op="implies") is not None
         # Two equals nodes: one per side of the implication.
         equals_nodes = [n for n in g["nodes"]
@@ -480,9 +482,9 @@ class TestTextCommand:
         """Same \\text{...} content should map to one node, not duplicate."""
         g = latex_to_semantic_graph(r"\text{foo} + \text{foo} = \text{bar}")
         foo_nodes = [n for n in g["nodes"]
-                     if n.get("type") == "text" and n.get("label") == "foo"]
+                     if n.get("type") == "annotation" and n.get("label") == "foo"]
         assert len(foo_nodes) == 1
-        assert _find_node(g, type="text", label="bar") is not None
+        assert _find_node(g, type="annotation", label="bar") is not None
 
 
 # ---------------------------------------------------------------------------
@@ -1136,7 +1138,7 @@ class TestCommaSeparatedClauses:
         placeholders, the merge step would incorrectly dedup them into
         a single text node — clause 1's ``bar`` would disappear."""
         g = latex_to_semantic_graph(r"x = \text{foo}, y = \text{bar}")
-        text_nodes = _find_nodes(g, type="text")
+        text_nodes = _find_nodes(g, type="annotation")
         labels = sorted(n.get("label") for n in text_nodes)
         assert labels == ["bar", "foo"], (
             f"expected two distinct text nodes (foo, bar), got {labels!r} "
@@ -1151,7 +1153,7 @@ class TestCommaSeparatedClauses:
         distinct text nodes — each clause is an independent statement
         and text placeholders are per-clause, not globally shared."""
         g = latex_to_semantic_graph(r"x = \text{foo}, y = \text{foo}")
-        text_nodes = _find_nodes(g, type="text", label="foo")
+        text_nodes = _find_nodes(g, type="annotation", label="foo")
         assert len(text_nodes) == 2, (
             f"expected two independent 'foo' text nodes (one per clause), "
             f"got {len(text_nodes)}"
@@ -1414,3 +1416,76 @@ class TestCompoundSymbols:
                     assert "Theta" not in value, (
                         f"placeholder leaked into {field}={value!r}"
                     )
+
+
+# ---------------------------------------------------------------------------
+# Parenthetical annotation extraction
+# ---------------------------------------------------------------------------
+
+class TestParentheticalAnnotations:
+    """Tests for _extract_parenthetical_annotations and annotation node injection."""
+
+    def test_simple_text_annotation(self):
+        latex = r"F = m \cdot a \quad (v_e \text{ constant})"
+        cleaned, anns = _extract_parenthetical_annotations(latex)
+        assert cleaned == r"F = m \cdot a"
+        assert len(anns) == 1
+        assert anns[0]["type"] == "annotation"
+        assert "constant" in anns[0]["label"]
+        assert r"\text" in anns[0]["latex"]
+
+    def test_no_annotation(self):
+        latex = r"x^2 + y^2 = r^2"
+        cleaned, anns = _extract_parenthetical_annotations(latex)
+        assert cleaned == latex
+        assert anns == []
+
+    def test_plain_math_parentheses_not_extracted(self):
+        latex = r"(a + b)^2 = a^2 + 2ab + b^2"
+        cleaned, anns = _extract_parenthetical_annotations(latex)
+        assert cleaned == latex
+        assert anns == []
+
+    def test_qquad_spacing(self):
+        latex = r"E = mc^2 \qquad (c \text{ speed of light})"
+        cleaned, anns = _extract_parenthetical_annotations(latex)
+        assert cleaned == r"E = mc^2"
+        assert len(anns) == 1
+        assert "speed of light" in anns[0]["label"]
+
+    def test_multiple_annotations(self):
+        latex = r"a = b \quad (x \text{ pos}) \quad (y \text{ neg})"
+        cleaned, anns = _extract_parenthetical_annotations(latex)
+        assert cleaned == r"a = b"
+        assert len(anns) == 2
+
+    def test_inject_annotations_adds_nodes(self):
+        graph = {"nodes": [{"id": "x", "type": "variable"}], "edges": []}
+        anns = [
+            {"latex": r"v_e \text{ constant}", "label": "v_e constant", "type": "annotation"},
+        ]
+        _inject_annotations(graph, anns)
+        assert len(graph["nodes"]) == 2
+        anno = graph["nodes"][1]
+        assert anno["id"] == "__annotation_0"
+        assert anno["type"] == "annotation"
+        assert anno["label"] == "v_e constant"
+
+    def test_inject_empty_annotations(self):
+        graph = {"nodes": [{"id": "x", "type": "variable"}], "edges": []}
+        _inject_annotations(graph, [])
+        assert len(graph["nodes"]) == 1
+
+    def test_end_to_end_annotation_in_graph(self):
+        g = latex_to_semantic_graph(r"F = m a \quad (m \text{ constant})")
+        anno = _find_node(g, type="annotation")
+        assert anno is not None, "annotation node should be in graph"
+        assert anno["id"] == "__annotation_0"
+        assert "constant" in anno["label"]
+
+    def test_annotation_does_not_break_equation_parsing(self):
+        g = latex_to_semantic_graph(r"v = v_0 + a t \quad (a \text{ constant})")
+        eq = _find_node(g, op="equals")
+        assert eq is not None, "equation should still parse correctly"
+        anno = _find_node(g, type="annotation")
+        assert anno is not None

--- a/themes/semantic-graph/default-dark.json
+++ b/themes/semantic-graph/default-dark.json
@@ -14,6 +14,11 @@
     "result":     { "shape": "stadium", "fill": "#332a0b", "stroke": "#ffa726", "color": "#ffe0b2" },
     "annotation": { "shape": "circle",  "fill": "#131a2c", "stroke": "#4a5580", "color": "#b0bcd0" }
   },
-  "edgeStyle": { "stroke": "#aaa", "strokeWidth": 2 },
+  "edgeStyles": {
+    "direct":  { "stroke": "#ef5350", "strokeWidth": 3 },
+    "inverse": { "stroke": "#42a5f5", "strokeWidth": 1, "arrow": "-.->" },
+    "neutral": { "stroke": "#aaa",    "strokeWidth": 2 }
+  },
+  "paintBySemantic": true,
   "fontSize": 15
 }

--- a/themes/semantic-graph/default-dark.json
+++ b/themes/semantic-graph/default-dark.json
@@ -11,7 +11,8 @@
     "operator": { "shape": "circle",  "fill": "#0f2540", "stroke": "#42a5f5", "color": "#bbdefb" },
     "function": { "shape": "hexagon", "fill": "#0f2540", "stroke": "#42a5f5", "color": "#bbdefb" },
     "relation": { "shape": "diamond", "fill": "#332a0b", "stroke": "#ffa726", "color": "#ffe0b2" },
-    "result":   { "shape": "stadium", "fill": "#332a0b", "stroke": "#ffa726", "color": "#ffe0b2" }
+    "result":     { "shape": "stadium", "fill": "#332a0b", "stroke": "#ffa726", "color": "#ffe0b2" },
+    "annotation": { "shape": "circle",  "fill": "#131a2c", "stroke": "#4a5580", "color": "#b0bcd0" }
   },
   "edgeStyle": { "stroke": "#aaa", "strokeWidth": 2 },
   "fontSize": 15

--- a/themes/semantic-graph/default-light.json
+++ b/themes/semantic-graph/default-light.json
@@ -14,6 +14,11 @@
     "result":   { "shape": "stadium", "fill": "#fff8e1", "stroke": "#ffa726", "color": "#e65100" },
     "annotation": { "shape": "circle",  "fill": "#eef1f8", "stroke": "#7888a8", "color": "#3a4560" }
   },
-  "edgeStyle": { "stroke": "#777", "strokeWidth": 2 },
+  "edgeStyles": {
+    "direct":  { "stroke": "#ef5350", "strokeWidth": 3 },
+    "inverse": { "stroke": "#42a5f5", "strokeWidth": 1, "arrow": "-.->" },
+    "neutral": { "stroke": "#777",    "strokeWidth": 2 }
+  },
+  "paintBySemantic": true,
   "fontSize": 15
 }

--- a/themes/semantic-graph/default-light.json
+++ b/themes/semantic-graph/default-light.json
@@ -11,7 +11,8 @@
     "operator": { "shape": "circle",  "fill": "#e3f2fd", "stroke": "#42a5f5", "color": "#1565c0" },
     "function": { "shape": "hexagon", "fill": "#e3f2fd", "stroke": "#42a5f5", "color": "#1565c0" },
     "relation": { "shape": "diamond", "fill": "#fff8e1", "stroke": "#ffa726", "color": "#e65100" },
-    "result":   { "shape": "stadium", "fill": "#fff8e1", "stroke": "#ffa726", "color": "#e65100" }
+    "result":   { "shape": "stadium", "fill": "#fff8e1", "stroke": "#ffa726", "color": "#e65100" },
+    "annotation": { "shape": "circle",  "fill": "#eef1f8", "stroke": "#7888a8", "color": "#3a4560" }
   },
   "edgeStyle": { "stroke": "#777", "strokeWidth": 2 },
   "fontSize": 15

--- a/themes/semantic-graph/linalg-dark.json
+++ b/themes/semantic-graph/linalg-dark.json
@@ -12,7 +12,8 @@
     "operator": { "shape": "circle", "fill": "#2a2a3a", "stroke": "#555",    "color": "#ccc" },
     "function": { "shape": "circle", "fill": "#2a2a3a", "stroke": "#555",    "color": "#ccc" },
     "relation": { "shape": "diamond","fill": "#2a2a3a", "stroke": "#555",    "color": "#ccc" },
-    "result":   { "shape": "rect",   "fill": "none",    "stroke": "none",    "color": "#ccc" }
+    "result":   { "shape": "rect",   "fill": "none",    "stroke": "none",    "color": "#ccc" },
+    "annotation": { "shape": "circle",  "fill": "#1a1a28", "stroke": "#505060", "color": "#aaa" }
   },
   "edgeStyles": {
     "direct":  { "stroke": "#ef5350", "strokeWidth": 4 },

--- a/themes/semantic-graph/minimal-dark.json
+++ b/themes/semantic-graph/minimal-dark.json
@@ -11,7 +11,8 @@
     "operator": { "shape": "circle", "fill": "#2a2a3a", "stroke": "#555", "color": "#ccc" },
     "function": { "shape": "circle", "fill": "#2a2a3a", "stroke": "#555", "color": "#ccc" },
     "relation": { "shape": "diamond","fill": "#2a2a3a", "stroke": "#555", "color": "#ccc" },
-    "result":   { "shape": "rect",   "fill": "none",    "stroke": "none", "color": "#ccc" }
+    "result":   { "shape": "rect",   "fill": "none",    "stroke": "none", "color": "#ccc" },
+    "annotation": { "shape": "circle",  "fill": "#1a1a28", "stroke": "#505060", "color": "#aaa" }
   },
   "edgeStyles": {
     "direct":   { "stroke": "#ef5350", "strokeWidth": 4 },

--- a/themes/semantic-graph/minimal-flat-dark.json
+++ b/themes/semantic-graph/minimal-flat-dark.json
@@ -11,7 +11,8 @@
     "operator": { "shape": "rect", "fill": "none", "stroke": "none", "color": "#bbb" },
     "function": { "shape": "rect", "fill": "none", "stroke": "none", "color": "#bbb" },
     "relation": { "shape": "rect", "fill": "none", "stroke": "none", "color": "#bbb" },
-    "result":   { "shape": "rect", "fill": "none", "stroke": "none", "color": "#bbb" }
+    "result":   { "shape": "rect", "fill": "none", "stroke": "none", "color": "#bbb" },
+    "annotation": { "shape": "circle",  "fill": "#14141e", "stroke": "#3a3a4a", "color": "#888" }
   },
   "edgeStyle": { "stroke": "#aaa", "strokeWidth": 1 },
   "fontSize": 16

--- a/themes/semantic-graph/minimal-flat-dark.json
+++ b/themes/semantic-graph/minimal-flat-dark.json
@@ -14,6 +14,11 @@
     "result":   { "shape": "rect", "fill": "none", "stroke": "none", "color": "#bbb" },
     "annotation": { "shape": "circle",  "fill": "#14141e", "stroke": "#3a3a4a", "color": "#888" }
   },
-  "edgeStyle": { "stroke": "#aaa", "strokeWidth": 1 },
+  "edgeStyles": {
+    "direct":  { "stroke": "#c06060", "strokeWidth": 1.5 },
+    "inverse": { "stroke": "#6090b0", "strokeWidth": 1, "arrow": "-.->" },
+    "neutral": { "stroke": "#888",    "strokeWidth": 1 }
+  },
+  "paintBySemantic": true,
   "fontSize": 16
 }

--- a/themes/semantic-graph/minimal-flat-light.json
+++ b/themes/semantic-graph/minimal-flat-light.json
@@ -11,7 +11,8 @@
     "operator": { "shape": "rect", "fill": "none", "stroke": "none", "color": "#999" },
     "function": { "shape": "rect", "fill": "none", "stroke": "none", "color": "#999" },
     "relation": { "shape": "rect", "fill": "none", "stroke": "none", "color": "#999" },
-    "result":   { "shape": "rect", "fill": "none", "stroke": "none", "color": "#999" }
+    "result":   { "shape": "rect", "fill": "none", "stroke": "none", "color": "#999" },
+    "annotation": { "shape": "circle",  "fill": "#f3f3f6", "stroke": "#aaa", "color": "#666" }
   },
   "edgeStyle": { "stroke": "#777", "strokeWidth": 1 },
   "fontSize": 16

--- a/themes/semantic-graph/minimal-flat-light.json
+++ b/themes/semantic-graph/minimal-flat-light.json
@@ -14,6 +14,11 @@
     "result":   { "shape": "rect", "fill": "none", "stroke": "none", "color": "#999" },
     "annotation": { "shape": "circle",  "fill": "#f3f3f6", "stroke": "#aaa", "color": "#666" }
   },
-  "edgeStyle": { "stroke": "#777", "strokeWidth": 1 },
+  "edgeStyles": {
+    "direct":  { "stroke": "#b04040", "strokeWidth": 1.5 },
+    "inverse": { "stroke": "#4070a0", "strokeWidth": 1, "arrow": "-.->" },
+    "neutral": { "stroke": "#999",    "strokeWidth": 1 }
+  },
+  "paintBySemantic": true,
   "fontSize": 16
 }

--- a/themes/semantic-graph/power-direction-dark.json
+++ b/themes/semantic-graph/power-direction-dark.json
@@ -11,7 +11,8 @@
     "operator": { "shape": "hexagon", "fill": "#0f2540", "stroke": "#42a5f5", "color": "#bbdefb" },
     "function": { "shape": "hexagon", "fill": "#0f2540", "stroke": "#42a5f5", "color": "#bbdefb" },
     "relation": { "shape": "diamond", "fill": "#2e1b33", "stroke": "#ab47bc", "color": "#e1bee7" },
-    "result":   { "shape": "stadium", "fill": "#332a0b", "stroke": "#ffa726", "color": "#ffe0b2" }
+    "result":   { "shape": "stadium", "fill": "#332a0b", "stroke": "#ffa726", "color": "#ffe0b2" },
+    "annotation": { "shape": "circle",  "fill": "#131a2c", "stroke": "#4a5580", "color": "#b0bcd0" }
   },
   "operatorVariants": {
     "direct":   { "fill": "#3a1214", "stroke": "#ef5350", "color": "#ffcdd2", "strokeWidth": 3, "fontSize": 17 },

--- a/themes/semantic-graph/power-direction-light.json
+++ b/themes/semantic-graph/power-direction-light.json
@@ -11,7 +11,8 @@
     "operator": { "shape": "hexagon", "fill": "#e3f2fd", "stroke": "#42a5f5", "color": "#1565c0" },
     "function": { "shape": "hexagon", "fill": "#e3f2fd", "stroke": "#42a5f5", "color": "#1565c0" },
     "relation": { "shape": "diamond", "fill": "#f3e5f5", "stroke": "#ab47bc", "color": "#6a1b9a" },
-    "result":   { "shape": "stadium", "fill": "#fff8e1", "stroke": "#ffa726", "color": "#e65100" }
+    "result":   { "shape": "stadium", "fill": "#fff8e1", "stroke": "#ffa726", "color": "#e65100" },
+    "annotation": { "shape": "circle",  "fill": "#eef1f8", "stroke": "#7888a8", "color": "#3a4560" }
   },
   "operatorVariants": {
     "direct":  { "fill": "#ffebee", "stroke": "#ef5350", "color": "#c62828", "strokeWidth": 3, "fontSize": 17 },

--- a/themes/semantic-graph/power-direction-light.json
+++ b/themes/semantic-graph/power-direction-light.json
@@ -25,5 +25,6 @@
     "neutral":  { "stroke": "#777",    "strokeWidth": 2, "arrow": "-->" },
     "logical":  { "stroke": "#ab47bc", "strokeWidth": 2, "arrow": "-.->" }
   },
+  "paintBySemantic": true,
   "fontSize": 15
 }

--- a/themes/semantic-graph/power-flow-dark.json
+++ b/themes/semantic-graph/power-flow-dark.json
@@ -11,7 +11,8 @@
     "operator": { "shape": "hexagon", "fill": "#0f2540", "stroke": "#42a5f5", "color": "#bbdefb" },
     "function": { "shape": "hexagon", "fill": "#0f2540", "stroke": "#42a5f5", "color": "#bbdefb" },
     "relation": { "shape": "diamond", "fill": "#2e1b33", "stroke": "#ab47bc", "color": "#e1bee7" },
-    "result":   { "shape": "stadium", "fill": "#332a0b", "stroke": "#ffa726", "color": "#ffe0b2" }
+    "result":   { "shape": "stadium", "fill": "#332a0b", "stroke": "#ffa726", "color": "#ffe0b2" },
+    "annotation": { "shape": "circle",  "fill": "#131a2c", "stroke": "#4a5580", "color": "#b0bcd0" }
   },
   "edgeStyles": {
     "direct":  { "stroke": "#ef5350", "strokeWidth": 4 },

--- a/themes/semantic-graph/power-flow-light.json
+++ b/themes/semantic-graph/power-flow-light.json
@@ -11,7 +11,8 @@
     "operator": { "shape": "hexagon", "fill": "#e3f2fd", "stroke": "#42a5f5", "color": "#1565c0" },
     "function": { "shape": "hexagon", "fill": "#e3f2fd", "stroke": "#42a5f5", "color": "#1565c0" },
     "relation": { "shape": "diamond", "fill": "#f3e5f5", "stroke": "#ab47bc", "color": "#6a1b9a" },
-    "result":   { "shape": "stadium", "fill": "#fff8e1", "stroke": "#ffa726", "color": "#e65100" }
+    "result":   { "shape": "stadium", "fill": "#fff8e1", "stroke": "#ffa726", "color": "#e65100" },
+    "annotation": { "shape": "circle",  "fill": "#eef1f8", "stroke": "#7888a8", "color": "#3a4560" }
   },
   "edgeStyles": {
     "direct":  { "stroke": "#ef5350", "strokeWidth": 4 },

--- a/themes/semantic-graph/role-colored-dark.json
+++ b/themes/semantic-graph/role-colored-dark.json
@@ -14,6 +14,11 @@
     "result":   { "shape": "stadium", "fill": "#332a0b", "stroke": "#ffa726", "color": "#ffe0b2" },
     "annotation": { "shape": "circle",  "fill": "#131a2c", "stroke": "#4a5580", "color": "#b0bcd0" }
   },
-  "edgeStyle": { "stroke": "#aaa", "strokeWidth": 2 },
+  "edgeStyles": {
+    "direct":  { "stroke": "#ef5350", "strokeWidth": 3 },
+    "inverse": { "stroke": "#42a5f5", "strokeWidth": 1, "arrow": "-.->" },
+    "neutral": { "stroke": "#aaa",    "strokeWidth": 2 }
+  },
+  "paintBySemantic": true,
   "fontSize": 15
 }

--- a/themes/semantic-graph/role-colored-dark.json
+++ b/themes/semantic-graph/role-colored-dark.json
@@ -11,7 +11,8 @@
     "operator": { "shape": "hexagon", "fill": "#0f2540", "stroke": "#42a5f5", "color": "#bbdefb" },
     "function": { "shape": "hexagon", "fill": "#0f2540", "stroke": "#42a5f5", "color": "#bbdefb" },
     "relation": { "shape": "diamond", "fill": "#2e1b33", "stroke": "#ab47bc", "color": "#e1bee7" },
-    "result":   { "shape": "stadium", "fill": "#332a0b", "stroke": "#ffa726", "color": "#ffe0b2" }
+    "result":   { "shape": "stadium", "fill": "#332a0b", "stroke": "#ffa726", "color": "#ffe0b2" },
+    "annotation": { "shape": "circle",  "fill": "#131a2c", "stroke": "#4a5580", "color": "#b0bcd0" }
   },
   "edgeStyle": { "stroke": "#aaa", "strokeWidth": 2 },
   "fontSize": 15

--- a/themes/semantic-graph/role-colored-light.json
+++ b/themes/semantic-graph/role-colored-light.json
@@ -11,7 +11,8 @@
     "operator": { "shape": "hexagon", "fill": "#e3f2fd", "stroke": "#42a5f5", "color": "#1565c0" },
     "function": { "shape": "hexagon", "fill": "#e3f2fd", "stroke": "#42a5f5", "color": "#1565c0" },
     "relation": { "shape": "diamond", "fill": "#f3e5f5", "stroke": "#ab47bc", "color": "#6a1b9a" },
-    "result":   { "shape": "stadium", "fill": "#fff8e1", "stroke": "#ffa726", "color": "#e65100" }
+    "result":   { "shape": "stadium", "fill": "#fff8e1", "stroke": "#ffa726", "color": "#e65100" },
+    "annotation": { "shape": "circle",  "fill": "#eef1f8", "stroke": "#7888a8", "color": "#3a4560" }
   },
   "edgeStyle": { "stroke": "#777", "strokeWidth": 2 },
   "fontSize": 15

--- a/themes/semantic-graph/role-colored-light.json
+++ b/themes/semantic-graph/role-colored-light.json
@@ -14,6 +14,11 @@
     "result":   { "shape": "stadium", "fill": "#fff8e1", "stroke": "#ffa726", "color": "#e65100" },
     "annotation": { "shape": "circle",  "fill": "#eef1f8", "stroke": "#7888a8", "color": "#3a4560" }
   },
-  "edgeStyle": { "stroke": "#777", "strokeWidth": 2 },
+  "edgeStyles": {
+    "direct":  { "stroke": "#ef5350", "strokeWidth": 3 },
+    "inverse": { "stroke": "#42a5f5", "strokeWidth": 1, "arrow": "-.->" },
+    "neutral": { "stroke": "#777",    "strokeWidth": 2 }
+  },
+  "paintBySemantic": true,
   "fontSize": 15
 }


### PR DESCRIPTION
## Summary

- **Annotation overlay cards**: Render `annotation` nodes as themed bottom-stacked cards instead of graph nodes — font size matches info overlay (0.88em), background/border/color driven by `nodeStyles.annotation` from the active theme
- **Edge semantics legend**: Add a D3 edge legend (proportional / inversely proportional / structural) matching the existing Mermaid legend, with CSS arrow swatches using pseudo-elements
- **Skip annotations during enrichment**: Strip annotation nodes and their edges before Pydantic validation and Gemini enrichment (they carry free-text labels that exceed field limits and aren't meaningful to the enricher), re-attach to the result
- **Per-semantic edge styles for all themes**: Upgrade 6 themes from singular `edgeStyle` to per-semantic `edgeStyles` with `paintBySemantic: true` so the edge legend renders consistently

## Test plan

- [ ] Load an equation with parenthetical annotations — verify they render as themed cards below the graph, not as graph nodes
- [ ] Switch themes — verify annotation card colors match each theme's palette
- [ ] Verify edge legend appears in bottom-left corner with correct arrow styles per semantic type
- [ ] Trigger enrichment on a graph with annotations — verify enrichment succeeds and annotations survive the round-trip
- [ ] Run `pytest tests/test_latex_to_graph.py` — annotation extraction tests pass

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>