### PR TITLE
feat(graph): right-click drag pan and trackpad scroll pan

### DIFF
--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -5,8 +5,8 @@
 | Field | Value |
 |---|---|
 | **Branch** | `feat/236-right-click-pan` |
-| **Commit** | `9f1c6c5` |
-| **Date** | 2026-05-09 22:45:08 -0400 |
+| **Commit** | `d936824` |
+| **Date** | 2026-05-09 23:04:17 -0400 |
 
 ## Language Breakdown
 
@@ -27,7 +27,7 @@ xychart-beta horizontal
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  JSON                     40        45736        45735            0            1
- JavaScript               46        17234        14943          889         1402
+ JavaScript               46        17235        14943          890         1402
  Python                   29        13813        10689         1520         1604
  CSS                       3         4471         4130          156          185
  Shell                     2          172          137           14           21
@@ -46,7 +46,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            11945         1474         7878         2593
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   180        94528        78159        10493         5876
+ Total                   180        94529        78159        10494         5876
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -56,14 +56,14 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- JavaScript               46        17234        14943          889         1402
+ JavaScript               46        17235        14943          890         1402
 ─────────────────────────────────────────────────────────────────────────────────
  |bench/static/graph-view.js         1869         1415          319          135
  |nch/static/json-browser.js         1403         1361            5           37
  |h/algebench/static/chat.js         1425         1160          113          152
  |lgebench/static/overlay.js         1168         1101           29           38
  |/algebench/static/proof.js         1109         1040           33           36
- |panel/d3-semantic-graph.js         1134          949           44          141
+ |panel/d3-semantic-graph.js         1135          949           45          141
  |nch/static/scene-loader.js          939          798           46           95
  |algebench/static/camera.js          760          646           20           94
  |cislunar-dynamics/index.js          611          546            8           57
@@ -121,7 +121,7 @@ xychart-beta horizontal
  |islunar-dynamics/docs.json          122          122            0            0
  |tmospheric-entry/docs.json           41           41            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    53        22371        19728         1052         1591
+ Total                    53        22372        19728         1053         1591
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 |---|---|
-| **Branch** | `fix/234-annotation-node-style` |
-| **Commit** | `ca9ae74` |
-| **Date** | 2026-05-09 21:08:56 -0400 |
+| **Branch** | `feat/236-right-click-pan` |
+| **Commit** | `9f1c6c5` |
+| **Date** | 2026-05-09 22:45:08 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [45734, 14925, 10686, 4129, 386, 137, 33]
+  bar [45735, 14943, 10689, 4130, 386, 137, 33]
 ```
 
 ## Summary by Language
@@ -26,10 +26,10 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- JSON                     40        45735        45734            0            1
- JavaScript               46        17211        14925          887         1399
- Python                   29        13810        10686         1520         1604
- CSS                       3         4470         4129          156          185
+ JSON                     40        45736        45735            0            1
+ JavaScript               46        17234        14943          889         1402
+ Python                   29        13813        10689         1520         1604
+ CSS                       3         4471         4130          156          185
  Shell                     2          172          137           14           21
  BASH                      1           41           33            4            4
  Plain Text                1            9            0            9            0
@@ -46,7 +46,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            11945         1474         7878         2593
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   180        94500        78136        10491         5873
+ Total                   180        94528        78159        10493         5876
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -56,14 +56,14 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- JavaScript               46        17211        14925          887         1399
+ JavaScript               46        17234        14943          889         1402
 ─────────────────────────────────────────────────────────────────────────────────
  |bench/static/graph-view.js         1869         1415          319          135
  |nch/static/json-browser.js         1403         1361            5           37
  |h/algebench/static/chat.js         1425         1160          113          152
  |lgebench/static/overlay.js         1168         1101           29           38
  |/algebench/static/proof.js         1109         1040           33           36
- |panel/d3-semantic-graph.js         1111          931           42          138
+ |panel/d3-semantic-graph.js         1134          949           44          141
  |nch/static/scene-loader.js          939          798           46           95
  |algebench/static/camera.js          760          646           20           94
  |cislunar-dynamics/index.js          611          546            8           57
@@ -105,10 +105,10 @@ xychart-beta horizontal
  |/static/objects/vectors.js           23           19            0            4
  |ch/static/objects/point.js           23           18            0            5
 ─────────────────────────────────────────────────────────────────────────────────
- CSS                       3         4470         4129          156          185
+ CSS                       3         4471         4130          156          185
 ─────────────────────────────────────────────────────────────────────────────────
  |algebench/static/style.css         4097         3793          144          160
- |anel/d3-semantic-graph.css          259          228           11           20
+ |anel/d3-semantic-graph.css          260          229           11           20
  |raph-panel/graph-panel.css          114          108            1            5
 ─────────────────────────────────────────────────────────────────────────────────
  HTML                      1          347          336            7            4
@@ -121,7 +121,7 @@ xychart-beta horizontal
  |islunar-dynamics/docs.json          122          122            0            0
  |tmospheric-entry/docs.json           41           41            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    53        22347        19709         1050         1588
+ Total                    53        22371        19728         1052         1591
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -131,11 +131,11 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Python                   29        13810        10686         1520         1604
+ Python                   29        13813        10689         1520         1604
 ─────────────────────────────────────────────────────────────────────────────────
  |ebench/algebench/server.py         2931         2349          337          245
  |sts/test_latex_to_graph.py         1491         1156          143          192
- |/scripts/latex_to_graph.py         1382         1037          228          117
+ |/scripts/latex_to_graph.py         1385         1040          228          117
  |semantic_graph_enricher.py         1106          762          214          130
  |semantic_graph_enricher.py          833          658          106           69
  |cripts/graph_to_mermaid.py          851          594          174           83
@@ -163,7 +163,7 @@ xychart-beta horizontal
  |lgebench/tests/__init__.py            0            0            0            0
  |h/tests/agents/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    29        13810        10686         1520         1604
+ Total                    29        13813        10689         1520         1604
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -171,6 +171,6 @@ xychart-beta horizontal
 
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
-| JavaScript (frontend) | 14925 | 58% |
-| Python (backend) | 10686 | 42% |
-| **Total** | **25611** | **100%** |
+| JavaScript (frontend) | 14943 | 58% |
+| Python (backend) | 10689 | 42% |
+| **Total** | **25632** | **100%** |

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -372,9 +372,10 @@ export class D3SemanticGraphRenderer {
         this._zoomBehavior = d3.zoom()
             .scaleExtent([ZOOM_MIN, ZOOM_MAX])
             .filter((event) => {
-                // Pinch (wheel + ctrlKey) → zoom; plain wheel (two-finger scroll) → handled separately as pan
-                if (event.type === 'wheel') return event.ctrlKey;
-                return !event.ctrlKey && (event.button === 0 || event.button === 2);
+                // Trackpad two-finger scroll (deltaMode 0) → handled separately as pan; let mouse wheel + pinch through
+                if (event.type === 'wheel') return event.ctrlKey || event.deltaMode !== 0;
+                // Allow touch/pointer events (button is 0 or undefined) and right-click (button 2)
+                return !event.ctrlKey && (event.button == null || event.button === 0 || event.button === 2);
             })
             .on('zoom', (event) => {
                 this._currentTransform = event.transform;
@@ -388,7 +389,7 @@ export class D3SemanticGraphRenderer {
 
         // Two-finger scroll → pan (pinch-to-zoom is handled by D3 zoom above)
         this._wheelPanHandler = (event) => {
-            if (event.ctrlKey) return;
+            if (event.ctrlKey || event.deltaMode !== 0) return;
             event.preventDefault();
             const t = this._currentTransform || d3.zoomIdentity;
             const nt = d3.zoomIdentity.translate(t.x - event.deltaX, t.y - event.deltaY).scale(t.k);

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -273,6 +273,9 @@ export class D3SemanticGraphRenderer {
         this._destroyed = true;
         if (this._svg && this._zoomBehavior) {
             this._svg.on('.zoom', null);
+            if (this._wheelPanHandler) {
+                this._svg.node().removeEventListener('wheel', this._wheelPanHandler);
+            }
         }
         this.container.innerHTML = '';
         this._svg = null;
@@ -340,6 +343,8 @@ export class D3SemanticGraphRenderer {
 
         this._setupZoom(d3);
 
+        this._svg.on('contextmenu', (event) => event.preventDefault());
+
         // Background click — only fire when not panning
         this._svg.on('click', (event) => {
             if (event.defaultPrevented) return;
@@ -366,6 +371,11 @@ export class D3SemanticGraphRenderer {
 
         this._zoomBehavior = d3.zoom()
             .scaleExtent([ZOOM_MIN, ZOOM_MAX])
+            .filter((event) => {
+                // Pinch (wheel + ctrlKey) → zoom; plain wheel (two-finger scroll) → handled separately as pan
+                if (event.type === 'wheel') return event.ctrlKey;
+                return !event.ctrlKey && (event.button === 0 || event.button === 2);
+            })
             .on('zoom', (event) => {
                 this._currentTransform = event.transform;
                 this._viewport.attr('transform', event.transform);
@@ -375,6 +385,16 @@ export class D3SemanticGraphRenderer {
             });
 
         this._svg.call(this._zoomBehavior);
+
+        // Two-finger scroll → pan (pinch-to-zoom is handled by D3 zoom above)
+        this._wheelPanHandler = (event) => {
+            if (event.ctrlKey) return;
+            event.preventDefault();
+            const t = this._currentTransform || d3.zoomIdentity;
+            const nt = d3.zoomIdentity.translate(t.x - event.deltaX, t.y - event.deltaY).scale(t.k);
+            this._svg.call(this._zoomBehavior.transform, nt);
+        };
+        this._svg.node().addEventListener('wheel', this._wheelPanHandler, { passive: false });
 
         // Restore saved transform if switching back to a step that had one
         if (this._currentTransform) {


### PR DESCRIPTION
## Summary

- Override D3 zoom filter to accept right-click (button 2) for panning, so users can pan even when dragging over nodes
- Remap trackpad two-finger scroll to pan instead of zoom, matching the 3D viewport behavior
- Preserve pinch-to-zoom via ctrlKey wheel events
- Suppress browser context menu on the graph SVG
- Clean up wheel event listener on destroy

Closes #236

## Test plan

- [ ] Right-click drag on graph background → pans viewport
- [ ] Right-click drag over nodes → pans viewport (not blocked by node interaction)
- [ ] Two-finger trackpad scroll → pans viewport (not zoom)
- [ ] Trackpad pinch → zooms in/out
- [ ] Left-click drag on background → still pans (unchanged)
- [ ] Left-click on node → still selects node (unchanged)
- [ ] No browser context menu appears on right-click in graph area
- [ ] Zoom percentage indicator updates correctly for all interactions

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>