### PR TITLE
feat(graph): multi-node selection with Cmd+Click

### DIFF
--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -5,8 +5,8 @@
 | Field | Value |
 |---|---|
 | **Branch** | `feat/multi-node-selection` |
-| **Commit** | `900da30` |
-| **Date** | 2026-05-10 15:50:05 -0400 |
+| **Commit** | `3f6285c` |
+| **Date** | 2026-05-10 16:08:10 -0400 |
 
 ## Language Breakdown
 

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 |---|---|
-| **Branch** | `feat/236-right-click-pan` |
-| **Commit** | `d936824` |
-| **Date** | 2026-05-09 23:04:17 -0400 |
+| **Branch** | `feat/multi-node-selection` |
+| **Commit** | `6384274` |
+| **Date** | 2026-05-10 15:18:03 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [45735, 14943, 10689, 4130, 386, 137, 33]
+  bar [45735, 15074, 10689, 4150, 386, 137, 33]
 ```
 
 ## Summary by Language
@@ -27,9 +27,9 @@ xychart-beta horizontal
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  JSON                     40        45736        45735            0            1
- JavaScript               46        17235        14943          890         1402
+ JavaScript               46        17374        15074          888         1412
  Python                   29        13813        10689         1520         1604
- CSS                       3         4471         4130          156          185
+ CSS                       3         4493         4150          157          186
  Shell                     2          172          137           14           21
  BASH                      1           41           33            4            4
  Plain Text                1            9            0            9            0
@@ -46,7 +46,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            11945         1474         7878         2593
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   180        94529        78159        10494         5876
+ Total                   180        94690        78310        10493         5887
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -56,14 +56,14 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- JavaScript               46        17235        14943          890         1402
+ JavaScript               46        17374        15074          888         1412
 ─────────────────────────────────────────────────────────────────────────────────
- |bench/static/graph-view.js         1869         1415          319          135
+ |bench/static/graph-view.js         1977         1516          319          142
  |nch/static/json-browser.js         1403         1361            5           37
  |h/algebench/static/chat.js         1425         1160          113          152
  |lgebench/static/overlay.js         1168         1101           29           38
  |/algebench/static/proof.js         1109         1040           33           36
- |panel/d3-semantic-graph.js         1135          949           45          141
+ |panel/d3-semantic-graph.js         1166          979           43          144
  |nch/static/scene-loader.js          939          798           46           95
  |algebench/static/camera.js          760          646           20           94
  |cislunar-dynamics/index.js          611          546            8           57
@@ -105,10 +105,10 @@ xychart-beta horizontal
  |/static/objects/vectors.js           23           19            0            4
  |ch/static/objects/point.js           23           18            0            5
 ─────────────────────────────────────────────────────────────────────────────────
- CSS                       3         4471         4130          156          185
+ CSS                       3         4493         4150          157          186
 ─────────────────────────────────────────────────────────────────────────────────
  |algebench/static/style.css         4097         3793          144          160
- |anel/d3-semantic-graph.css          260          229           11           20
+ |anel/d3-semantic-graph.css          282          249           12           21
  |raph-panel/graph-panel.css          114          108            1            5
 ─────────────────────────────────────────────────────────────────────────────────
  HTML                      1          347          336            7            4
@@ -121,7 +121,7 @@ xychart-beta horizontal
  |islunar-dynamics/docs.json          122          122            0            0
  |tmospheric-entry/docs.json           41           41            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    53        22372        19728         1053         1591
+ Total                    53        22533        19879         1052         1602
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -171,6 +171,6 @@ xychart-beta horizontal
 
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
-| JavaScript (frontend) | 14943 | 58% |
+| JavaScript (frontend) | 15074 | 58% |
 | Python (backend) | 10689 | 42% |
-| **Total** | **25632** | **100%** |
+| **Total** | **25763** | **100%** |

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -5,8 +5,8 @@
 | Field | Value |
 |---|---|
 | **Branch** | `feat/multi-node-selection` |
-| **Commit** | `3f6285c` |
-| **Date** | 2026-05-10 16:08:10 -0400 |
+| **Commit** | `50e8370` |
+| **Date** | 2026-05-10 16:14:34 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [45735, 15076, 10689, 4150, 386, 137, 33]
+  bar [45735, 15079, 10689, 4150, 386, 137, 33]
 ```
 
 ## Summary by Language
@@ -27,7 +27,7 @@ xychart-beta horizontal
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  JSON                     40        45736        45735            0            1
- JavaScript               46        17376        15076          888         1412
+ JavaScript               46        17380        15079          888         1413
  Python                   29        13813        10689         1520         1604
  CSS                       3         4493         4150          157          186
  Shell                     2          172          137           14           21
@@ -46,7 +46,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            11945         1474         7878         2593
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   180        94692        78312        10493         5887
+ Total                   180        94696        78315        10493         5888
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -56,9 +56,9 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- JavaScript               46        17376        15076          888         1412
+ JavaScript               46        17380        15079          888         1413
 ─────────────────────────────────────────────────────────────────────────────────
- |bench/static/graph-view.js         1979         1518          319          142
+ |bench/static/graph-view.js         1983         1521          319          143
  |nch/static/json-browser.js         1403         1361            5           37
  |h/algebench/static/chat.js         1425         1160          113          152
  |lgebench/static/overlay.js         1168         1101           29           38
@@ -121,7 +121,7 @@ xychart-beta horizontal
  |islunar-dynamics/docs.json          122          122            0            0
  |tmospheric-entry/docs.json           41           41            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    53        22535        19881         1052         1602
+ Total                    53        22539        19884         1052         1603
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -171,6 +171,6 @@ xychart-beta horizontal
 
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
-| JavaScript (frontend) | 15076 | 58% |
+| JavaScript (frontend) | 15079 | 58% |
 | Python (backend) | 10689 | 42% |
-| **Total** | **25765** | **100%** |
+| **Total** | **25768** | **100%** |

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -5,8 +5,8 @@
 | Field | Value |
 |---|---|
 | **Branch** | `feat/multi-node-selection` |
-| **Commit** | `6384274` |
-| **Date** | 2026-05-10 15:18:03 -0400 |
+| **Commit** | `900da30` |
+| **Date** | 2026-05-10 15:50:05 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [45735, 15074, 10689, 4150, 386, 137, 33]
+  bar [45735, 15076, 10689, 4150, 386, 137, 33]
 ```
 
 ## Summary by Language
@@ -27,7 +27,7 @@ xychart-beta horizontal
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  JSON                     40        45736        45735            0            1
- JavaScript               46        17374        15074          888         1412
+ JavaScript               46        17376        15076          888         1412
  Python                   29        13813        10689         1520         1604
  CSS                       3         4493         4150          157          186
  Shell                     2          172          137           14           21
@@ -46,7 +46,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            11945         1474         7878         2593
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   180        94690        78310        10493         5887
+ Total                   180        94692        78312        10493         5887
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -56,9 +56,9 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- JavaScript               46        17374        15074          888         1412
+ JavaScript               46        17376        15076          888         1412
 ─────────────────────────────────────────────────────────────────────────────────
- |bench/static/graph-view.js         1977         1516          319          142
+ |bench/static/graph-view.js         1979         1518          319          142
  |nch/static/json-browser.js         1403         1361            5           37
  |h/algebench/static/chat.js         1425         1160          113          152
  |lgebench/static/overlay.js         1168         1101           29           38
@@ -121,7 +121,7 @@ xychart-beta horizontal
  |islunar-dynamics/docs.json          122          122            0            0
  |tmospheric-entry/docs.json           41           41            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    53        22533        19879         1052         1602
+ Total                    53        22535        19881         1052         1602
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -171,6 +171,6 @@ xychart-beta horizontal
 
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
-| JavaScript (frontend) | 15074 | 58% |
+| JavaScript (frontend) | 15076 | 58% |
 | Python (backend) | 10689 | 42% |
-| **Total** | **25763** | **100%** |
+| **Total** | **25765** | **100%** |

--- a/static/graph-panel/d3-semantic-graph.css
+++ b/static/graph-panel/d3-semantic-graph.css
@@ -108,6 +108,28 @@ svg.d3-semantic-graph {
     stroke-width: 2.5px;
 }
 
+/* Multi-selected node ring */
+.d3sg-node.selected .d3sg-var-bg {
+    stroke: #6df08e;
+    stroke-width: 2.5px;
+    filter: drop-shadow(0 0 6px rgba(109, 240, 142, 0.5));
+}
+.d3sg-node.selected .d3sg-op-bg {
+    stroke: #7ea8ff;
+    stroke-width: 2.5px;
+    filter: drop-shadow(0 0 6px rgba(126, 168, 255, 0.5));
+}
+.d3sg-node.selected .d3sg-tile-bg {
+    stroke: #7ea8ff;
+    stroke-width: 2.5px;
+    filter: drop-shadow(0 0 6px rgba(126, 168, 255, 0.5));
+}
+.d3sg-node.selected .d3sg-hit-target {
+    stroke: #7ea8ff !important;
+    stroke-width: 2px !important;
+    stroke-opacity: 0.6;
+}
+
 /* Annotation overlay — stacked at bottom of graph viewport */
 .d3sg-annotation-overlay {
     position: absolute;

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -202,6 +202,7 @@ export class D3SemanticGraphRenderer {
         this._positionById = new Map();
         this._lastInteractionId = null;
         this._activeNodeId = null;
+        this._selectedNodeIds = new Set();
         this._destroyed = false;
     }
 
@@ -238,11 +239,14 @@ export class D3SemanticGraphRenderer {
 
     selectNode(nodeId) {
         this._activeNodeId = nodeId;
+        this._selectedNodeIds.clear();
+        if (nodeId) this._selectedNodeIds.add(nodeId);
         this._applyHighlight();
     }
 
     clearSelection() {
         this._activeNodeId = null;
+        this._selectedNodeIds.clear();
         this._applyHighlight();
     }
 
@@ -250,10 +254,15 @@ export class D3SemanticGraphRenderer {
         return this._activeNodeId;
     }
 
+    get selectedNodes() {
+        return new Set(this._selectedNodeIds);
+    }
+
     saveState() {
         return {
             collapsed: new Set(this._collapsed),
             activeNodeId: this._activeNodeId,
+            selectedNodeIds: new Set(this._selectedNodeIds),
             positionById: new Map(this._positionById),
             zoomTransform: this._currentTransform,
         };
@@ -263,6 +272,7 @@ export class D3SemanticGraphRenderer {
         if (!snapshot) return;
         this._collapsed = new Set(snapshot.collapsed);
         this._activeNodeId = snapshot.activeNodeId;
+        this._selectedNodeIds = new Set(snapshot.selectedNodeIds || []);
         this._positionById = new Map(snapshot.positionById);
         if (snapshot.zoomTransform) this._currentTransform = snapshot.zoomTransform;
         this._needsInitialFit = false;
@@ -350,6 +360,7 @@ export class D3SemanticGraphRenderer {
             if (event.defaultPrevented) return;
             if (event.target === this._svg.node() || event.target.tagName === 'svg') {
                 this._activeNodeId = null;
+                this._selectedNodeIds.clear();
                 this._applyHighlight();
                 if (this.onBackgroundClick) this.onBackgroundClick();
             }
@@ -732,7 +743,7 @@ export class D3SemanticGraphRenderer {
             .style('cursor', d => this._isCollapsible(d) ? 'pointer' : 'default')
             .on('click', function (event, d) {
                 event.stopPropagation();
-                self._handleNodeClick(d);
+                self._handleNodeClick(d, event);
             })
             .on('mouseenter', function (event, d) {
                 if (self.onNodeHover) self.onNodeHover(d.data.id, d.data, this);
@@ -890,8 +901,9 @@ export class D3SemanticGraphRenderer {
         const isOp = kind === 'operator' || kind === 'relation' || kind === 'function';
         const base = isOp ? 'op' : 'var';
         const collapsed = d.data._collapsed ? ' collapsed' : '';
+        const selected = this._selectedNodeIds.has(d.data.id) ? ' selected' : '';
         const active = d.data.id === this._activeNodeId ? ' active' : '';
-        return `d3sg-node d3sg-${base}${collapsed}${active}`;
+        return `d3sg-node d3sg-${base}${collapsed}${selected}${active}`;
     }
 
     _isCollapsible(d) {
@@ -900,15 +912,34 @@ export class D3SemanticGraphRenderer {
             (d.data._childIds && d.data._childIds.length > 0);
     }
 
-    _handleNodeClick(d) {
+    _handleNodeClick(d, event) {
         const nodeId = d.data.id;
-        if (this._activeNodeId === nodeId) {
-            this._activeNodeId = null;
+        const multiSelect = event && (event.metaKey || event.ctrlKey);
+
+        if (multiSelect) {
+            if (this._selectedNodeIds.has(nodeId)) {
+                this._selectedNodeIds.delete(nodeId);
+                this._activeNodeId = this._selectedNodeIds.size
+                    ? [...this._selectedNodeIds].at(-1) : null;
+            } else {
+                this._selectedNodeIds.add(nodeId);
+                this._activeNodeId = nodeId;
+            }
         } else {
-            this._activeNodeId = nodeId;
+            if (this._selectedNodeIds.size <= 1 && this._activeNodeId === nodeId) {
+                this._activeNodeId = null;
+                this._selectedNodeIds.clear();
+            } else {
+                this._activeNodeId = nodeId;
+                this._selectedNodeIds.clear();
+                this._selectedNodeIds.add(nodeId);
+            }
         }
+
         this._applyHighlight();
-        if (this.onNodeClick) this.onNodeClick(nodeId, d.data);
+        if (this.onNodeClick) {
+            this.onNodeClick(nodeId, d.data, this._selectedNodeIds);
+        }
     }
 
     _handleChevronClick(d) {
@@ -1086,21 +1117,21 @@ export class D3SemanticGraphRenderer {
 
     _applyHighlight() {
         if (!this._svg) return;
-        const activeId = this._activeNodeId;
 
         this._nodeLayer.selectAll('g.d3sg-node')
             .attr('class', d => this._nodeClass(d));
 
-        if (!activeId) {
-            // Clear all dimming
+        if (!this._selectedNodeIds.size) {
             this._nodeLayer.selectAll('g.d3sg-node').style('opacity', 1);
             this._linkLayer.selectAll('path.d3sg-link').style('opacity', 1);
             this._labelLayer.selectAll('text.d3sg-edge-label').style('opacity', 1);
             return;
         }
 
-        // Find upstream nodes from active
-        const upstream = this._getUpstream(activeId);
+        const upstream = new Set();
+        for (const id of this._selectedNodeIds) {
+            for (const n of this._getUpstream(id)) upstream.add(n);
+        }
 
         this._nodeLayer.selectAll('g.d3sg-node').style('opacity', d =>
             upstream.has(d.data.id) ? 1 : 0.15

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -938,7 +938,7 @@ export class D3SemanticGraphRenderer {
 
         this._applyHighlight();
         if (this.onNodeClick) {
-            this.onNodeClick(nodeId, d.data, this._selectedNodeIds);
+            this.onNodeClick(nodeId, d.data, new Set(this._selectedNodeIds));
         }
     }
 

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -1134,15 +1134,15 @@ export class D3SemanticGraphRenderer {
         }
 
         this._nodeLayer.selectAll('g.d3sg-node').style('opacity', d =>
-            upstream.has(d.data.id) ? 1 : 0.15
+            upstream.has(d.data.id) ? 1 : 0.30
         );
 
         this._linkLayer.selectAll('path.d3sg-link').style('opacity', d =>
-            upstream.has(d.source.data.id) && upstream.has(d.target.data.id) ? 1 : 0.1
+            upstream.has(d.source.data.id) && upstream.has(d.target.data.id) ? 1 : 0.25
         );
 
         this._labelLayer.selectAll('text.d3sg-edge-label').style('opacity', d =>
-            upstream.has(d.source.data.id) && upstream.has(d.target.data.id) ? 1 : 0.1
+            upstream.has(d.source.data.id) && upstream.has(d.target.data.id) ? 1 : 0.25
         );
     }
 

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -970,26 +970,54 @@ function _showD3MultiInfoPanel(selectedIds, graph) {
     symbolEl.style.fontSize = '0.9em';
 
     fieldsEl.innerHTML = '';
-    for (const node of nodes) {
-        const row = document.createElement('div');
-        row.className = 'gp-field';
-        const k = document.createElement('span');
-        k.className = 'gp-key';
+    for (let i = 0; i < nodes.length; i++) {
+        const node = nodes[i];
+        if (i > 0) {
+            const sep = document.createElement('hr');
+            sep.className = 'gp-separator';
+            fieldsEl.appendChild(sep);
+        }
+        const symLine = document.createElement('div');
+        symLine.className = 'gp-symbol';
         const latex = node.latex || node.subexpr;
         if (latex && window.katex) {
             try {
-                window.katex.render(latex, k, { displayMode: false, throwOnError: false });
+                window.katex.render(latex, symLine, { displayMode: false, throwOnError: false });
             } catch (_) {
-                k.textContent = node.label || node.id;
+                symLine.textContent = node.label || node.id;
             }
         } else {
-            k.textContent = node.label || node.id;
+            symLine.textContent = node.label || node.id;
         }
-        const v = document.createElement('span');
-        v.className = 'gp-val';
-        v.textContent = [node.type, node.description].filter(Boolean).join(' — ');
-        row.append(k, v);
-        fieldsEl.appendChild(row);
+        fieldsEl.appendChild(symLine);
+        const FIELDS = [
+            ['label', 'Label'], ['type', 'Type'], ['role', 'Role'],
+            ['quantity', 'Quantity'], ['dimension', 'Dimension'],
+            ['unit', 'Unit'], ['value', 'Value'], ['op', 'Operation'],
+        ];
+        for (const [fkey, flabel] of FIELDS) {
+            if (!node[fkey]) continue;
+            const row = document.createElement('div');
+            row.className = 'gp-field';
+            const k = document.createElement('span');
+            k.className = 'gp-key';
+            k.textContent = flabel;
+            const v = document.createElement('span');
+            v.className = 'gp-val';
+            v.textContent = node[fkey];
+            row.append(k, v);
+            fieldsEl.appendChild(row);
+        }
+        if (node.description) {
+            const desc = document.createElement('div');
+            desc.className = 'gp-description';
+            if (typeof window.renderKaTeX === 'function') {
+                desc.innerHTML = window.renderKaTeX(node.description, false);
+            } else {
+                desc.textContent = node.description;
+            }
+            fieldsEl.appendChild(desc);
+        }
     }
 }
 

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -730,7 +730,7 @@ async function _renderWithD3(container, graph, step, key) {
     enrichGraphInBackground(graph, key, step);
 }
 
-function _buildD3NodeAskMessage(nodeId, graph) {
+function _buildD3NodeAskMessage(nodeId, graph, otherSelectedIds) {
     if (!nodeId || !graph) return 'Explain this graph node.';
     const node = (graph.nodes || []).find(n => n.id === nodeId);
     if (!node) return 'Explain this graph node.';
@@ -752,6 +752,19 @@ function _buildD3NodeAskMessage(nodeId, graph) {
     }
     if (incoming.length) lines.push(`Incoming: ${incoming.join(', ')}`);
     if (outgoing.length) lines.push(`Outgoing: ${outgoing.join(', ')}`);
+    if (otherSelectedIds && otherSelectedIds.length) {
+        const others = (graph.nodes || []).filter(n => otherSelectedIds.includes(n.id));
+        lines.push('');
+        lines.push('Also selected in the graph:');
+        for (const o of others) {
+            const parts = [`- ${o.label || o.id}`];
+            if (o.type) parts.push(`(${o.type})`);
+            if (o.description) parts.push(`— ${o.description}`);
+            lines.push(parts.join(' '));
+        }
+        lines.push('');
+        lines.push('Explain this node and how it relates to the other selected nodes.');
+    }
     return lines.join('\n');
 }
 
@@ -760,7 +773,13 @@ function _ensureD3NodeAskBtn() {
     const btn = makeAiAskButton(
         'ai-ask-btn graph-node-ai-btn',
         'Ask AI about this node',
-        () => _buildD3NodeAskMessage(_d3HoveredNodeId, _d3ActiveGraph),
+        () => {
+            const selected = _currentD3Renderer?.selectedNodes;
+            const others = selected && selected.size > 1
+                ? [...selected].filter(id => id !== _d3HoveredNodeId)
+                : [];
+            return _buildD3NodeAskMessage(_d3HoveredNodeId, _d3ActiveGraph, others);
+        },
     );
     btn.style.position = 'fixed';
     btn.style.opacity = '0';
@@ -819,7 +838,13 @@ function _showD3InfoPanel(nodeId, nodeData, graph) {
         const askBtn = makeAiAskButton(
             'ai-ask-btn graph-panel-ai-btn',
             'Ask AI about this node',
-            () => _buildD3NodeAskMessage(nodeId, graph),
+            () => {
+                const selected = _currentD3Renderer?.selectedNodes;
+                const others = selected && selected.size > 1
+                    ? [...selected].filter(id => id !== nodeId)
+                    : [];
+                return _buildD3NodeAskMessage(nodeId, graph, others);
+            },
         );
         header.appendChild(askBtn);
     }

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -683,8 +683,12 @@ async function _renderWithD3(container, graph, step, key) {
             direction: _currentDirection,
             labels: _currentLabels,
             theme: _currentTheme,
-            onNodeClick: (nodeId, nodeData) => {
-                _showD3InfoPanel(nodeId, nodeData, _d3ActiveGraph);
+            onNodeClick: (nodeId, nodeData, selectedIds) => {
+                if (selectedIds && selectedIds.size > 1) {
+                    _showD3MultiInfoPanel(selectedIds, _d3ActiveGraph);
+                } else {
+                    _showD3InfoPanel(nodeId, nodeData, _d3ActiveGraph);
+                }
             },
             onBackgroundClick: () => {
                 _hideD3InfoPanel();
@@ -877,6 +881,85 @@ function _hideD3InfoPanel() {
     const infoHost = document.getElementById('graph-info-panel-host');
     if (!infoHost) return;
     infoHost.innerHTML = '';
+}
+
+function _buildD3MultiNodeAskMessage(selectedIds, graph) {
+    if (!selectedIds || !selectedIds.size || !graph) return 'Explain these graph nodes.';
+    const nodes = (graph.nodes || []).filter(n => selectedIds.has(n.id));
+    if (!nodes.length) return 'Explain these graph nodes.';
+    const lines = [`Explain the relationship between these ${nodes.length} semantic graph nodes:`];
+    for (const node of nodes) {
+        const parts = [`- ${node.label || node.id}`];
+        if (node.type) parts.push(`(${node.type})`);
+        if (node.description) parts.push(`— ${node.description}`);
+        lines.push(parts.join(' '));
+    }
+    const connected = [];
+    for (const e of (graph.edges || [])) {
+        if (selectedIds.has(e.from) && selectedIds.has(e.to)) {
+            connected.push(`${e.from} → ${e.to}`);
+        }
+    }
+    if (connected.length) {
+        lines.push('Direct connections: ' + connected.join(', '));
+    }
+    return lines.join('\n');
+}
+
+function _showD3MultiInfoPanel(selectedIds, graph) {
+    const infoHost = document.getElementById('graph-info-panel-host');
+    if (!infoHost) return;
+    if (!selectedIds || !selectedIds.size) { _hideD3InfoPanel(); return; }
+
+    const nodes = (graph.nodes || []).filter(n => selectedIds.has(n.id));
+    infoHost.innerHTML = '';
+    const panel = buildInlineInfoPanel(infoHost);
+    if (!panel) return;
+
+    const h3 = panel.querySelector('h3');
+    if (h3 && !panel.querySelector('.graph-panel-ai-btn')) {
+        const header = document.createElement('div');
+        header.className = 'gp-header';
+        h3.replaceWith(header);
+        header.appendChild(h3);
+        const askBtn = makeAiAskButton(
+            'ai-ask-btn graph-panel-ai-btn',
+            'Ask AI about selected nodes',
+            () => _buildD3MultiNodeAskMessage(selectedIds, graph),
+        );
+        header.appendChild(askBtn);
+    }
+
+    const symbolEl = panel.querySelector('.gp-symbol');
+    const fieldsEl = panel.querySelector('.gp-fields');
+    if (!symbolEl || !fieldsEl) return;
+
+    symbolEl.textContent = `${nodes.length} nodes selected`;
+    symbolEl.style.opacity = '0.8';
+    symbolEl.style.fontSize = '0.9em';
+
+    fieldsEl.innerHTML = '';
+    for (const node of nodes) {
+        const row = document.createElement('div');
+        row.className = 'gp-field';
+        const k = document.createElement('span');
+        k.className = 'gp-key';
+        const latex = node.latex || node.subexpr;
+        if (latex && window.katex) {
+            try {
+                window.katex.render(latex, k, { displayMode: false, throwOnError: false });
+            } catch (_) {
+                k.textContent = node.label || node.id;
+            }
+        } else {
+            k.textContent = node.label || node.id;
+        }
+        const v = document.createElement('span');
+        v.className = 'gp-val';
+        v.textContent = node.type + (node.description ? ' — ' + node.description : '');
+        row.append(k, v);
+        fieldsEl.appendChild(row);
+    }
 }
 
 async function renderCurrentStepGraph(force = false) {

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -770,16 +770,23 @@ function _buildD3NodeAskMessage(nodeId, graph, otherSelectedIds) {
     return lines.join('\n');
 }
 
+function _getOtherContextNodes(targetNodeId) {
+    const selected = _currentD3Renderer?.selectedNodes;
+    if (selected && selected.size > 1) {
+        return [...selected].filter(id => id !== targetNodeId);
+    }
+    const active = _currentD3Renderer?.activeNode;
+    if (active && active !== targetNodeId) return [active];
+    return [];
+}
+
 function _ensureD3NodeAskBtn() {
     if (_d3NodeAskBtn) return _d3NodeAskBtn;
     const btn = makeAiAskButton(
         'ai-ask-btn graph-node-ai-btn',
         'Ask AI about this node',
         () => {
-            const selected = _currentD3Renderer?.selectedNodes;
-            const others = selected && selected.size > 1
-                ? [...selected].filter(id => id !== _d3HoveredNodeId)
-                : [];
+            const others = _getOtherContextNodes(_d3HoveredNodeId);
             return _buildD3NodeAskMessage(_d3HoveredNodeId, _d3ActiveGraph, others);
         },
     );
@@ -841,10 +848,7 @@ function _showD3InfoPanel(nodeId, nodeData, graph) {
             'ai-ask-btn graph-panel-ai-btn',
             'Ask AI about this node',
             () => {
-                const selected = _currentD3Renderer?.selectedNodes;
-                const others = selected && selected.size > 1
-                    ? [...selected].filter(id => id !== nodeId)
-                    : [];
+                const others = _getOtherContextNodes(nodeId);
                 return _buildD3NodeAskMessage(nodeId, graph, others);
             },
         );

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -684,7 +684,9 @@ async function _renderWithD3(container, graph, step, key) {
             labels: _currentLabels,
             theme: _currentTheme,
             onNodeClick: (nodeId, nodeData, selectedIds) => {
-                if (selectedIds && selectedIds.size > 1) {
+                if (!selectedIds || selectedIds.size === 0) {
+                    _hideD3InfoPanel();
+                } else if (selectedIds.size > 1) {
                     _showD3MultiInfoPanel(selectedIds, _d3ActiveGraph);
                 } else {
                     _showD3InfoPanel(nodeId, nodeData, _d3ActiveGraph);
@@ -981,7 +983,7 @@ function _showD3MultiInfoPanel(selectedIds, graph) {
         }
         const v = document.createElement('span');
         v.className = 'gp-val';
-        v.textContent = node.type + (node.description ? ' — ' + node.description : '');
+        v.textContent = [node.type, node.description].filter(Boolean).join(' — ');
         row.append(k, v);
         fieldsEl.appendChild(row);
     }

--- a/static/style.css
+++ b/static/style.css
@@ -4076,6 +4076,11 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 #graph-info-panel-host .graph-panel-info .gp-key {
     color: rgba(163, 172, 220, 0.6);
 }
+#graph-info-panel-host .graph-panel-info .gp-separator {
+    border: none;
+    border-top: 1px solid rgba(140, 155, 220, 0.2);
+    margin: 0.5rem 0;
+}
 #graph-info-panel-host .graph-panel-info .gp-close {
     color: rgba(176, 186, 229, 0.7);
 }


### PR DESCRIPTION
## Summary

- **Cmd+Click** toggles nodes into a multi-selection set with a glow effect (`drop-shadow`) distinct from the single-node active ring
- Highlights the **union of upstream dependencies** for all selected nodes simultaneously
- Info panel shows an aggregate "N nodes selected" view listing each node with KaTeX-rendered labels
- AI ask button on hover/info panel includes **other selected nodes as context**, prompting the AI to explain relationships between them
- Single click (no modifier) resets to single-node selection; background click clears all

Closes #246

## Test plan

- [ ] Open a scene with a semantic graph (e.g. graph-panel-demo, Schrödinger step)
- [ ] Single-click a node → info panel shows single node details, upstream highlighted
- [ ] Cmd+Click additional nodes → glow appears on all selected, upstream union highlighted, info panel shows "N nodes selected"
- [ ] Cmd+Click a selected node → deselects it
- [ ] Single-click (no Cmd) → clears multi-selection, selects only that node
- [ ] Click empty canvas → clears all selection
- [ ] Hover AI button on a node in multi-selection → prompt includes other selected nodes
- [ ] Navigate between proof steps → selection state persists per step

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>