### PR TITLE
feat: photons wavelength-energy lesson with semantic graph fixes

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -38,7 +38,7 @@
       "port": 5735
     },
     {
-      "name": "photons",
+      "name": "photons-wavelength-energy",
       "runtimeExecutable": "./algebench",
       "runtimeArgs": ["scenes/draft/photons-wavelength-energy.json", "--port", "5736", "--debug", "--server-only"],
       "port": 5736

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -36,6 +36,12 @@
       "runtimeExecutable": "./algebench",
       "runtimeArgs": ["scenes/draft/quantum-states.json", "--port", "5735", "--debug", "--server-only"],
       "port": 5735
+    },
+    {
+      "name": "photons",
+      "runtimeExecutable": "./algebench",
+      "runtimeArgs": ["scenes/draft/photons-wavelength-energy.json", "--port", "5736", "--debug", "--server-only"],
+      "port": 5736
     }
   ]
 }

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -5,8 +5,8 @@
 | Field | Value |
 |---|---|
 | **Branch** | `codex/photons-wavelength-energy-draft` |
-| **Commit** | `ae2d72c` |
-| **Date** | 2026-05-13 20:00:00 -0400 |
+| **Commit** | `e8cfff6` |
+| **Date** | 2026-05-13 20:04:55 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [49520, 15287, 10888, 4163, 386, 137, 33]
+  bar [49520, 15287, 10889, 4163, 386, 137, 33]
 ```
 
 ## Summary by Language
@@ -28,7 +28,7 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  JSON                     41        49521        49520            0            1
  JavaScript               46        17608        15287          891         1430
- Python                   29        14057        10888         1544         1625
+ Python                   29        14058        10889         1544         1625
  CSS                       3         4506         4163          157          186
  Shell                     2          172          137           14           21
  BASH                      1           41           33            4            4
@@ -46,7 +46,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            11945         1474         7878         2593
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   181        98966        82520        10520         5926
+ Total                   181        98967        82521        10520         5926
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -131,7 +131,7 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Python                   29        14057        10888         1544         1625
+ Python                   29        14058        10889         1544         1625
 ─────────────────────────────────────────────────────────────────────────────────
  |ebench/algebench/server.py         2938         2352          341          245
  |sts/test_latex_to_graph.py         1569         1221          143          205
@@ -140,7 +140,7 @@ xychart-beta horizontal
  |semantic_graph_enricher.py          853          676          106           71
  |cripts/graph_to_mermaid.py          861          604          174           83
  |h/algebench/agent_tools.py          610          522           35           53
- |ripts/audit_expressions.py          660          515           54           91
+ |ripts/audit_expressions.py          661          516           54           91
  |nch/scripts/render_math.py          509          469            4           36
  |cripts/validate_content.py          602          453           42          107
  |s/test_graph_to_mermaid.py          613          441           89           83
@@ -163,7 +163,7 @@ xychart-beta horizontal
  |lgebench/tests/__init__.py            0            0            0            0
  |h/tests/agents/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    29        14057        10888         1544         1625
+ Total                    29        14058        10889         1544         1625
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -172,5 +172,5 @@ xychart-beta horizontal
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
 | JavaScript (frontend) | 15287 | 58% |
-| Python (backend) | 10888 | 42% |
-| **Total** | **26175** | **100%** |
+| Python (backend) | 10889 | 42% |
+| **Total** | **26176** | **100%** |

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -5,8 +5,8 @@
 | Field | Value |
 |---|---|
 | **Branch** | `codex/photons-wavelength-energy-draft` |
-| **Commit** | `a9ca1c5` |
-| **Date** | 2026-05-12 23:10:09 -0400 |
+| **Commit** | `ae2d72c` |
+| **Date** | 2026-05-13 20:00:00 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [49516, 15281, 10872, 4163, 386, 137, 33]
+  bar [49520, 15287, 10888, 4163, 386, 137, 33]
 ```
 
 ## Summary by Language
@@ -26,9 +26,9 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- JSON                     41        49517        49516            0            1
- JavaScript               46        17597        15281          888         1428
- Python                   29        14031        10872         1535         1624
+ JSON                     41        49521        49520            0            1
+ JavaScript               46        17608        15287          891         1430
+ Python                   29        14057        10888         1544         1625
  CSS                       3         4506         4163          157          186
  Shell                     2          172          137           14           21
  BASH                      1           41           33            4            4
@@ -46,7 +46,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            11945         1474         7878         2593
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   181        98925        82494        10508         5923
+ Total                   181        98966        82520        10520         5926
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -56,7 +56,7 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- JavaScript               46        17597        15281          888         1428
+ JavaScript               46        17608        15287          891         1430
 ─────────────────────────────────────────────────────────────────────────────────
  |bench/static/graph-view.js         2011         1549          319          143
  |nch/static/json-browser.js         1403         1361            5           37
@@ -75,8 +75,8 @@ xychart-beta horizontal
  |atmospheric-entry/index.js          373          335            8           30
  |h/algebench/static/expr.js          356          326           20           10
  |bjects/animated-polygon.js          343          304            6           33
+ |/static/objects/polygon.js          328          285           12           31
  |/objects/animated-curve.js          319          284            2           33
- |/static/objects/polygon.js          318          280            9           29
  |algebench/static/labels.js          327          279           22           26
  |ins/astrodynamics/index.js          228          198           10           20
  |h/static/objects/skybox.js          225          196            3           26
@@ -94,7 +94,7 @@ xychart-beta horizontal
  |/static/context-browser.js           89           69            5           15
  |tatic/objects/ellipsoid.js           74           66            0            8
  |ic/objects/vector-field.js           72           64            0            8
- |nch/static/objects/text.js           67           58            0            9
+ |nch/static/objects/text.js           68           59            0            9
  |nch/static/objects/axis.js           62           56            0            6
  |algebench/static/coords.js           71           53           13            5
  |ch/static/objects/index.js           54           53            0            1
@@ -121,7 +121,7 @@ xychart-beta horizontal
  |islunar-dynamics/docs.json          122          122            0            0
  |tmospheric-entry/docs.json           41           41            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    53        22769        20099         1052         1618
+ Total                    53        22780        20105         1055         1620
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -131,11 +131,11 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Python                   29        14031        10872         1535         1624
+ Python                   29        14057        10888         1544         1625
 ─────────────────────────────────────────────────────────────────────────────────
  |ebench/algebench/server.py         2938         2352          341          245
  |sts/test_latex_to_graph.py         1569         1221          143          205
- |/scripts/latex_to_graph.py         1447         1089          239          119
+ |/scripts/latex_to_graph.py         1473         1105          248          120
  |semantic_graph_enricher.py         1144          798          214          132
  |semantic_graph_enricher.py          853          676          106           71
  |cripts/graph_to_mermaid.py          861          604          174           83
@@ -163,7 +163,7 @@ xychart-beta horizontal
  |lgebench/tests/__init__.py            0            0            0            0
  |h/tests/agents/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    29        14031        10872         1535         1624
+ Total                    29        14057        10888         1544         1625
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -171,6 +171,6 @@ xychart-beta horizontal
 
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
-| JavaScript (frontend) | 15281 | 58% |
-| Python (backend) | 10872 | 42% |
-| **Total** | **26153** | **100%** |
+| JavaScript (frontend) | 15287 | 58% |
+| Python (backend) | 10888 | 42% |
+| **Total** | **26175** | **100%** |

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -5,8 +5,8 @@
 | Field | Value |
 |---|---|
 | **Branch** | `codex/photons-wavelength-energy-draft` |
-| **Commit** | `fab05fc` |
-| **Date** | 2026-05-13 20:10:25 -0400 |
+| **Commit** | `88baeed` |
+| **Date** | 2026-05-13 22:10:07 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [49520, 15287, 10888, 4163, 386, 137, 33]
+  bar [49520, 15287, 10901, 4163, 386, 137, 33]
 ```
 
 ## Summary by Language
@@ -28,7 +28,7 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  JSON                     41        49521        49520            0            1
  JavaScript               46        17608        15287          891         1430
- Python                   29        14094        10888         1580         1626
+ Python                   29        14110        10901         1580         1629
  CSS                       3         4506         4163          157          186
  Shell                     2          172          137           14           21
  BASH                      1           41           33            4            4
@@ -46,7 +46,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            11945         1474         7878         2593
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   181        99003        82520        10556         5927
+ Total                   181        99019        82533        10556         5930
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -131,10 +131,10 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Python                   29        14094        10888         1580         1626
+ Python                   29        14110        10901         1580         1629
 ─────────────────────────────────────────────────────────────────────────────────
  |ebench/algebench/server.py         2938         2352          341          245
- |sts/test_latex_to_graph.py         1569         1221          143          205
+ |sts/test_latex_to_graph.py         1575         1226          143          206
  |/scripts/latex_to_graph.py         1473         1105          248          120
  |semantic_graph_enricher.py         1144          798          214          132
  |semantic_graph_enricher.py          853          676          106           71
@@ -151,9 +151,9 @@ xychart-beta horizontal
  |/scripts/assemble_scene.py          187          144            1           42
  |/tests/test_render_math.py          177          124           18           35
  |graph_highlight_overlay.py          163          120           11           32
+ |st_dot_notation_restore.py          156          107           19           30
  |h/models/semantic_graph.py          158          106           19           33
  |h/algebench/agents/base.py          124          105            0           19
- |st_dot_notation_restore.py          146           99           19           28
  |ents/test_schema_parity.py           75           57            0           18
  |t_semantic_graph_themes.py           69           51            0           18
  |ests/test_scene_schemas.py           66           50            0           16
@@ -163,7 +163,7 @@ xychart-beta horizontal
  |lgebench/tests/__init__.py            0            0            0            0
  |h/tests/agents/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    29        14094        10888         1580         1626
+ Total                    29        14110        10901         1580         1629
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -172,5 +172,5 @@ xychart-beta horizontal
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
 | JavaScript (frontend) | 15287 | 58% |
-| Python (backend) | 10888 | 42% |
-| **Total** | **26175** | **100%** |
+| Python (backend) | 10901 | 42% |
+| **Total** | **26188** | **100%** |

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 |---|---|
-| **Branch** | `fix/242-asymmetric-comparison-operators` |
-| **Commit** | `64090e7` |
-| **Date** | 2026-05-10 21:09:32 -0400 |
+| **Branch** | `codex/photons-wavelength-energy-draft` |
+| **Commit** | `a9ca1c5` |
+| **Date** | 2026-05-12 23:10:09 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [45812, 15139, 10842, 4164, 386, 137, 33]
+  bar [49516, 15281, 10872, 4163, 386, 137, 33]
 ```
 
 ## Summary by Language
@@ -26,10 +26,10 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- JSON                     40        45813        45812            0            1
- JavaScript               46        17442        15139          888         1415
- Python                   29        13985        10842         1520         1623
- CSS                       3         4507         4164          157          186
+ JSON                     41        49517        49516            0            1
+ JavaScript               46        17597        15281          888         1428
+ Python                   29        14031        10872         1535         1624
+ CSS                       3         4506         4163          157          186
  Shell                     2          172          137           14           21
  BASH                      1           41           33            4            4
  Plain Text                1            9            0            9            0
@@ -46,7 +46,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            11945         1474         7878         2593
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   180        95021        78619        10493         5909
+ Total                   181        98925        82494        10508         5923
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -56,14 +56,14 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- JavaScript               46        17442        15139          888         1415
+ JavaScript               46        17597        15281          888         1428
 ─────────────────────────────────────────────────────────────────────────────────
  |bench/static/graph-view.js         2011         1549          319          143
  |nch/static/json-browser.js         1403         1361            5           37
  |h/algebench/static/chat.js         1425         1160          113          152
  |lgebench/static/overlay.js         1168         1101           29           38
  |/algebench/static/proof.js         1109         1040           33           36
- |panel/d3-semantic-graph.js         1200         1011           43          146
+ |panel/d3-semantic-graph.js         1201         1012           43          146
  |nch/static/scene-loader.js          939          798           46           95
  |algebench/static/camera.js          760          646           20           94
  |cislunar-dynamics/index.js          611          546            8           57
@@ -76,10 +76,10 @@ xychart-beta horizontal
  |h/algebench/static/expr.js          356          326           20           10
  |bjects/animated-polygon.js          343          304            6           33
  |/objects/animated-curve.js          319          284            2           33
- |algebench/static/labels.js          323          275           22           26
+ |/static/objects/polygon.js          318          280            9           29
+ |algebench/static/labels.js          327          279           22           26
  |ins/astrodynamics/index.js          228          198           10           20
  |h/static/objects/skybox.js          225          196            3           26
- |/static/objects/polygon.js          187          161            8           18
  |jects/animated-cylinder.js          147          134            1           12
  |/objects/animated-point.js          148          132            1           15
  |h/algebench/static/main.js          152          124           19            9
@@ -94,20 +94,20 @@ xychart-beta horizontal
  |/static/context-browser.js           89           69            5           15
  |tatic/objects/ellipsoid.js           74           66            0            8
  |ic/objects/vector-field.js           72           64            0            8
+ |nch/static/objects/text.js           67           58            0            9
  |nch/static/objects/axis.js           62           56            0            6
  |algebench/static/coords.js           71           53           13            5
  |ch/static/objects/index.js           54           53            0            1
  |/static/objects/surface.js           52           48            0            4
  |ch/static/objects/plane.js           50           43            0            7
- |nch/static/objects/text.js           48           40            1            7
  |nch/static/objects/line.js           36           32            0            4
  |nch/static/objects/grid.js           33           30            0            3
  |/static/objects/vectors.js           23           19            0            4
  |ch/static/objects/point.js           23           18            0            5
 ─────────────────────────────────────────────────────────────────────────────────
- CSS                       3         4507         4164          157          186
+ CSS                       3         4506         4163          157          186
 ─────────────────────────────────────────────────────────────────────────────────
- |algebench/static/style.css         4102         3798          144          160
+ |algebench/static/style.css         4101         3797          144          160
  |anel/d3-semantic-graph.css          291          258           12           21
  |raph-panel/graph-panel.css          114          108            1            5
 ─────────────────────────────────────────────────────────────────────────────────
@@ -121,7 +121,7 @@ xychart-beta horizontal
  |islunar-dynamics/docs.json          122          122            0            0
  |tmospheric-entry/docs.json           41           41            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    53        22615        19958         1052         1605
+ Total                    53        22769        20099         1052         1618
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -131,11 +131,11 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Python                   29        13985        10842         1520         1623
+ Python                   29        14031        10872         1535         1624
 ─────────────────────────────────────────────────────────────────────────────────
- |ebench/algebench/server.py         2931         2349          337          245
+ |ebench/algebench/server.py         2938         2352          341          245
  |sts/test_latex_to_graph.py         1569         1221          143          205
- |/scripts/latex_to_graph.py         1408         1062          228          118
+ |/scripts/latex_to_graph.py         1447         1089          239          119
  |semantic_graph_enricher.py         1144          798          214          132
  |semantic_graph_enricher.py          853          676          106           71
  |cripts/graph_to_mermaid.py          861          604          174           83
@@ -163,7 +163,7 @@ xychart-beta horizontal
  |lgebench/tests/__init__.py            0            0            0            0
  |h/tests/agents/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    29        13985        10842         1520         1623
+ Total                    29        14031        10872         1535         1624
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -171,6 +171,6 @@ xychart-beta horizontal
 
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
-| JavaScript (frontend) | 15139 | 58% |
-| Python (backend) | 10842 | 42% |
-| **Total** | **25981** | **100%** |
+| JavaScript (frontend) | 15281 | 58% |
+| Python (backend) | 10872 | 42% |
+| **Total** | **26153** | **100%** |

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -5,8 +5,8 @@
 | Field | Value |
 |---|---|
 | **Branch** | `codex/photons-wavelength-energy-draft` |
-| **Commit** | `6fb7041` |
-| **Date** | 2026-05-13 20:07:01 -0400 |
+| **Commit** | `fab05fc` |
+| **Date** | 2026-05-13 20:10:25 -0400 |
 
 ## Language Breakdown
 
@@ -28,7 +28,7 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  JSON                     41        49521        49520            0            1
  JavaScript               46        17608        15287          891         1430
- Python                   29        14057        10888         1544         1625
+ Python                   29        14094        10888         1580         1626
  CSS                       3         4506         4163          157          186
  Shell                     2          172          137           14           21
  BASH                      1           41           33            4            4
@@ -46,7 +46,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            11945         1474         7878         2593
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   181        98966        82520        10520         5926
+ Total                   181        99003        82520        10556         5927
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -131,7 +131,7 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Python                   29        14057        10888         1544         1625
+ Python                   29        14094        10888         1580         1626
 ─────────────────────────────────────────────────────────────────────────────────
  |ebench/algebench/server.py         2938         2352          341          245
  |sts/test_latex_to_graph.py         1569         1221          143          205
@@ -140,7 +140,7 @@ xychart-beta horizontal
  |semantic_graph_enricher.py          853          676          106           71
  |cripts/graph_to_mermaid.py          861          604          174           83
  |h/algebench/agent_tools.py          610          522           35           53
- |ripts/audit_expressions.py          660          515           54           91
+ |ripts/audit_expressions.py          697          515           90           92
  |nch/scripts/render_math.py          509          469            4           36
  |cripts/validate_content.py          602          453           42          107
  |s/test_graph_to_mermaid.py          613          441           89           83
@@ -163,7 +163,7 @@ xychart-beta horizontal
  |lgebench/tests/__init__.py            0            0            0            0
  |h/tests/agents/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    29        14057        10888         1544         1625
+ Total                    29        14094        10888         1580         1626
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -5,8 +5,8 @@
 | Field | Value |
 |---|---|
 | **Branch** | `codex/photons-wavelength-energy-draft` |
-| **Commit** | `e8cfff6` |
-| **Date** | 2026-05-13 20:04:55 -0400 |
+| **Commit** | `6fb7041` |
+| **Date** | 2026-05-13 20:07:01 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [49520, 15287, 10889, 4163, 386, 137, 33]
+  bar [49520, 15287, 10888, 4163, 386, 137, 33]
 ```
 
 ## Summary by Language
@@ -28,7 +28,7 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  JSON                     41        49521        49520            0            1
  JavaScript               46        17608        15287          891         1430
- Python                   29        14058        10889         1544         1625
+ Python                   29        14057        10888         1544         1625
  CSS                       3         4506         4163          157          186
  Shell                     2          172          137           14           21
  BASH                      1           41           33            4            4
@@ -46,7 +46,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            11945         1474         7878         2593
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   181        98967        82521        10520         5926
+ Total                   181        98966        82520        10520         5926
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -131,7 +131,7 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Python                   29        14058        10889         1544         1625
+ Python                   29        14057        10888         1544         1625
 ─────────────────────────────────────────────────────────────────────────────────
  |ebench/algebench/server.py         2938         2352          341          245
  |sts/test_latex_to_graph.py         1569         1221          143          205
@@ -140,7 +140,7 @@ xychart-beta horizontal
  |semantic_graph_enricher.py          853          676          106           71
  |cripts/graph_to_mermaid.py          861          604          174           83
  |h/algebench/agent_tools.py          610          522           35           53
- |ripts/audit_expressions.py          661          516           54           91
+ |ripts/audit_expressions.py          660          515           54           91
  |nch/scripts/render_math.py          509          469            4           36
  |cripts/validate_content.py          602          453           42          107
  |s/test_graph_to_mermaid.py          613          441           89           83
@@ -163,7 +163,7 @@ xychart-beta horizontal
  |lgebench/tests/__init__.py            0            0            0            0
  |h/tests/agents/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    29        14058        10889         1544         1625
+ Total                    29        14057        10888         1544         1625
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -172,5 +172,5 @@ xychart-beta horizontal
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
 | JavaScript (frontend) | 15287 | 58% |
-| Python (backend) | 10889 | 42% |
-| **Total** | **26176** | **100%** |
+| Python (backend) | 10888 | 42% |
+| **Total** | **26175** | **100%** |

--- a/scenes/draft/photons-wavelength-energy.json
+++ b/scenes/draft/photons-wavelength-energy.json
@@ -1385,115 +1385,583 @@
           ]
         }
       ],
-      "proof": {
-        "id": "wave_kinematics",
-        "title": "From $x=vt$ to $c=f\\lambda$",
-        "technique": "derivation",
-        "goal": "Derive the wave relation $c=f\\lambda$ starting from the basic kinematic equation $x=vt$.",
-        "prompt": "Start from x=vt which every learner knows. Apply it to one wave cycle to get c=f*lambda. Emphasize this is the same formula, not a new law.",
-        "steps": [
-          {
-            "id": "basic_kinematics",
-            "type": "given",
-            "label": "Basic kinematics",
-            "math": "\\htmlClass{hl-dist}{x}=\\htmlClass{hl-speed}{v}\\cdot {}\\htmlClass{hl-time}{t}",
-            "highlights": {
-              "dist": {
-                "color": "cyan",
-                "label": "Distance travelled"
+      "proof": [
+        {
+          "id": "wave_kinematics",
+          "title": "From $x=vt$ to $c=f\\lambda$",
+          "technique": "derivation",
+          "goal": "Derive the wave relation $c=f\\lambda$ starting from the basic kinematic equation $x=vt$.",
+          "prompt": "Start from x=vt which every learner knows. Apply it to one wave cycle to get c=f*lambda. Emphasize this is the same formula, not a new law.",
+          "steps": [
+            {
+              "id": "basic_kinematics",
+              "type": "given",
+              "label": "Basic kinematics",
+              "math": "\\htmlClass{hl-dist}{x}=\\htmlClass{hl-speed}{v}\\cdot {}\\htmlClass{hl-time}{t}",
+              "highlights": {
+                "dist": {
+                  "color": "cyan",
+                  "label": "Distance travelled"
+                },
+                "speed": {
+                  "color": "orange",
+                  "label": "Speed"
+                },
+                "time": {
+                  "color": "yellow",
+                  "label": "Elapsed time"
+                }
               },
-              "speed": {
-                "color": "orange",
-                "label": "Speed"
-              },
-              "time": {
-                "color": "yellow",
-                "label": "Elapsed time"
-              }
+              "justification": "The fundamental kinematic relation for constant speed.",
+              "explanation": "Distance equals speed times time \u2014 the starting point for all wave relations.",
+              "prompt": "Start from the most basic formula the learner already knows.",
+              "sceneStep": 0
             },
-            "justification": "The fundamental kinematic relation for constant speed.",
-            "explanation": "Distance equals speed times time \u2014 the starting point for all wave relations.",
-            "prompt": "Start from the most basic formula the learner already knows.",
-            "sceneStep": 0
-          },
-          {
-            "id": "one_period",
-            "type": "step",
-            "label": "One period of a wave",
-            "math": "\\htmlClass{hl-wavelength}{\\lambda}=\\htmlClass{hl-speed}{c}\\cdot {}\\htmlClass{hl-period}{T}",
-            "highlights": {
-              "wavelength": {
-                "color": "cyan",
-                "label": "One wavelength (crest-to-crest)"
+            {
+              "id": "one_period",
+              "type": "step",
+              "label": "One period of a wave",
+              "math": "\\htmlClass{hl-wavelength}{\\lambda}=\\htmlClass{hl-speed}{c}\\cdot {}\\htmlClass{hl-period}{T}",
+              "highlights": {
+                "wavelength": {
+                  "color": "cyan",
+                  "label": "One wavelength (crest-to-crest)"
+                },
+                "speed": {
+                  "color": "orange",
+                  "label": "Wave speed (fixed at c)"
+                },
+                "period": {
+                  "color": "yellow",
+                  "label": "Period (time for one cycle)"
+                }
               },
-              "speed": {
-                "color": "orange",
-                "label": "Wave speed (fixed at c)"
-              },
-              "period": {
-                "color": "yellow",
-                "label": "Period (time for one cycle)"
-              }
+              "justification": "In one period $T$, the wave advances exactly one wavelength $\\lambda$. Set $x=\\lambda$, $v=c$, $t=T$.",
+              "explanation": "A crest travels one full wavelength in one period, so $\\lambda = c \\cdot T$.",
+              "prompt": "Connect x=vt to the wave: x becomes lambda, v becomes c, t becomes T.",
+              "sceneStep": 0
             },
-            "justification": "In one period $T$, the wave advances exactly one wavelength $\\lambda$. Set $x=\\lambda$, $v=c$, $t=T$.",
-            "explanation": "A crest travels one full wavelength in one period, so $\\lambda = c \\cdot T$.",
-            "prompt": "Connect x=vt to the wave: x becomes lambda, v becomes c, t becomes T.",
-            "sceneStep": 0
-          },
-          {
-            "id": "solve_for_f",
-            "type": "step",
-            "label": "Solve for frequency",
-            "math": "\\htmlClass{hl-freq}{f}=\\frac{1}{\\htmlClass{hl-period}{T}}=\\frac{\\htmlClass{hl-speed}{c}}{\\htmlClass{hl-wavelength}{\\lambda}}",
-            "highlights": {
-              "freq": {
-                "color": "green",
-                "label": "Frequency (cycles per second)"
+            {
+              "id": "solve_for_f",
+              "type": "step",
+              "label": "Solve for frequency",
+              "math": "\\htmlClass{hl-freq}{f}=\\frac{1}{\\htmlClass{hl-period}{T}}=\\frac{\\htmlClass{hl-speed}{c}}{\\htmlClass{hl-wavelength}{\\lambda}}",
+              "highlights": {
+                "freq": {
+                  "color": "green",
+                  "label": "Frequency (cycles per second)"
+                },
+                "period": {
+                  "color": "yellow",
+                  "label": "Period"
+                },
+                "speed": {
+                  "color": "orange",
+                  "label": "Wave speed"
+                },
+                "wavelength": {
+                  "color": "cyan",
+                  "label": "Wavelength"
+                }
               },
-              "period": {
-                "color": "yellow",
-                "label": "Period"
-              },
-              "speed": {
-                "color": "orange",
-                "label": "Wave speed"
-              },
-              "wavelength": {
-                "color": "cyan",
-                "label": "Wavelength"
-              }
+              "justification": "Frequency is the reciprocal of period: $f=1/T$. Substitute $T=\\lambda/c$.",
+              "explanation": "Rearranging gives the wave relation: frequency equals speed divided by wavelength.",
+              "prompt": "Show the algebra step by step: T = lambda/c, so f = 1/T = c/lambda.",
+              "sceneStep": 1
             },
-            "justification": "Frequency is the reciprocal of period: $f=1/T$. Substitute $T=\\lambda/c$.",
-            "explanation": "Rearranging gives the wave relation: frequency equals speed divided by wavelength.",
-            "prompt": "Show the algebra step by step: T = lambda/c, so f = 1/T = c/lambda.",
-            "sceneStep": 1
-          },
-          {
-            "id": "wave_equation",
-            "type": "conclusion",
-            "label": "The wave equation",
-            "math": "\\htmlClass{hl-speed}{c}=\\htmlClass{hl-freq}{f}\\,\\htmlClass{hl-wavelength}{\\lambda}",
-            "highlights": {
-              "speed": {
-                "color": "orange",
-                "label": "Wave speed"
+            {
+              "id": "wave_equation",
+              "type": "conclusion",
+              "label": "The wave equation",
+              "math": "\\htmlClass{hl-speed}{c}=\\htmlClass{hl-freq}{f}\\,\\htmlClass{hl-wavelength}{\\lambda}",
+              "highlights": {
+                "speed": {
+                  "color": "orange",
+                  "label": "Wave speed"
+                },
+                "freq": {
+                  "color": "green",
+                  "label": "Frequency"
+                },
+                "wavelength": {
+                  "color": "cyan",
+                  "label": "Wavelength"
+                }
               },
-              "freq": {
-                "color": "green",
-                "label": "Frequency"
+              "justification": "Multiply both sides of $f=c/\\lambda$ by $\\lambda$.",
+              "explanation": "This is just $x=vt$ applied to one cycle: speed equals frequency times wavelength.",
+              "prompt": "Emphasize that c = f lambda is not a new law \u2014 it is x = v t for one wave cycle.",
+              "sceneStep": 1
+            }
+          ]
+        },
+        {
+          "id": "em_wave_equation",
+          "title": "Maxwell to $\\vec{E}=E_0\\sin(kx-\\omega t)\\,\\hat{y}$",
+          "technique": "derivation",
+          "goal": "Derive the electromagnetic wave equation from Maxwell's equations and show that a sinusoidal $\\vec{E}$ field is a solution.",
+          "prompt": "Start from Maxwell's curl equations in free space. Take the curl of Faraday's law and use the vector identity to get the wave equation. Show the sinusoidal solution and extract the dispersion relation omega = ck.",
+          "steps": [
+            {
+              "id": "maxwell_faraday",
+              "type": "given",
+              "label": "Faraday's law (free space)",
+              "math": "\\htmlClass{hl-curl}{\\nabla\\times}\\htmlClass{hl-E}{\\vec{E}}=-\\htmlClass{hl-dtB}{\\frac{\\partial\\vec{B}}{\\partial t}}",
+              "highlights": {
+                "curl": {
+                  "color": "purple",
+                  "label": "Curl operator"
+                },
+                "E": {
+                  "color": "cyan",
+                  "label": "Electric field"
+                },
+                "dtB": {
+                  "color": "pink",
+                  "label": "Time rate of change of B"
+                }
               },
-              "wavelength": {
-                "color": "cyan",
-                "label": "Wavelength"
-              }
+              "justification": "One of Maxwell's four equations: a changing magnetic field induces a curling electric field.",
+              "explanation": "Faraday's law says a time-varying magnetic field creates a circulating electric field.",
+              "prompt": "Introduce Faraday's law as the starting point. This is one of Maxwell's four equations.",
+              "sceneStep": 0
             },
-            "justification": "Multiply both sides of $f=c/\\lambda$ by $\\lambda$.",
-            "explanation": "This is just $x=vt$ applied to one cycle: speed equals frequency times wavelength.",
-            "prompt": "Emphasize that c = f lambda is not a new law \u2014 it is x = v t for one wave cycle.",
-            "sceneStep": 1
-          }
-        ]
-      }
+            {
+              "id": "maxwell_ampere",
+              "type": "given",
+              "label": "Amp\u00e8re\u2013Maxwell law (free space)",
+              "math": "\\htmlClass{hl-curl}{\\nabla\\times}\\htmlClass{hl-B}{\\vec{B}}=\\htmlClass{hl-mu}{\\mu_0}\\htmlClass{hl-eps}{\\epsilon_0}\\htmlClass{hl-dtE}{\\frac{\\partial\\vec{E}}{\\partial t}}",
+              "highlights": {
+                "curl": {
+                  "color": "purple",
+                  "label": "Curl operator"
+                },
+                "B": {
+                  "color": "pink",
+                  "label": "Magnetic field"
+                },
+                "mu": {
+                  "color": "orange",
+                  "label": "Permeability of free space"
+                },
+                "eps": {
+                  "color": "yellow",
+                  "label": "Permittivity of free space"
+                },
+                "dtE": {
+                  "color": "cyan",
+                  "label": "Time rate of change of E"
+                }
+              },
+              "justification": "In free space (no currents), Amp\u00e8re's law with Maxwell's displacement current term.",
+              "explanation": "A time-varying electric field creates a curling magnetic field \u2014 Maxwell's crucial addition to Amp\u00e8re's law.",
+              "prompt": "Present the second curl equation. Note Maxwell's displacement current term is what makes waves possible.",
+              "sceneStep": 0
+            },
+            {
+              "id": "curl_of_curl",
+              "type": "step",
+              "label": "Take the curl of Faraday's law",
+              "math": "\\htmlClass{hl-curl}{\\nabla\\times(\\nabla\\times}\\htmlClass{hl-E}{\\vec{E}}\\htmlClass{hl-curl}{)}=-\\frac{\\partial}{\\partial t}(\\htmlClass{hl-curl}{\\nabla\\times}\\htmlClass{hl-B}{\\vec{B}})=-\\htmlClass{hl-mu}{\\mu_0}\\htmlClass{hl-eps}{\\epsilon_0}\\htmlClass{hl-d2E}{\\frac{\\partial^2\\vec{E}}{\\partial t^2}}",
+              "highlights": {
+                "curl": {
+                  "color": "purple",
+                  "label": "Curl operator"
+                },
+                "E": {
+                  "color": "cyan",
+                  "label": "Electric field"
+                },
+                "B": {
+                  "color": "pink",
+                  "label": "Magnetic field"
+                },
+                "mu": {
+                  "color": "orange",
+                  "label": "Permeability of free space"
+                },
+                "eps": {
+                  "color": "yellow",
+                  "label": "Permittivity of free space"
+                },
+                "d2E": {
+                  "color": "cyan",
+                  "label": "Second time derivative of E"
+                }
+              },
+              "justification": "Apply $\\nabla\\times$ to Faraday's law; on the right side, swap $\\nabla\\times$ with $\\partial/\\partial t$ and substitute Amp\u00e8re\u2013Maxwell.",
+              "explanation": "Taking the curl of both sides of Faraday's law and substituting the Amp\u00e8re\u2013Maxwell law eliminates $\\vec{B}$, leaving an equation in $\\vec{E}$ alone.",
+              "prompt": "This is the key step: curl of curl on the left, and on the right we substitute Amp\u00e8re\u2013Maxwell to eliminate B entirely.",
+              "sceneStep": 0
+            },
+            {
+              "id": "vector_identity",
+              "type": "step",
+              "label": "Apply the vector identity",
+              "math": "\\htmlClass{hl-grad}{\\nabla(\\underbrace{\\nabla\\cdot\\vec{E}}_{=\\,0})}-\\htmlClass{hl-lap}{\\nabla^2\\vec{E}}=-\\htmlClass{hl-mu}{\\mu_0}\\htmlClass{hl-eps}{\\epsilon_0}\\htmlClass{hl-d2E}{\\frac{\\partial^2\\vec{E}}{\\partial t^2}}",
+              "highlights": {
+                "grad": {
+                  "color": "green",
+                  "label": "Gradient of divergence (vanishes in free space)"
+                },
+                "lap": {
+                  "color": "cyan",
+                  "label": "Laplacian of E"
+                },
+                "mu": {
+                  "color": "orange",
+                  "label": "Permeability"
+                },
+                "eps": {
+                  "color": "yellow",
+                  "label": "Permittivity"
+                },
+                "d2E": {
+                  "color": "cyan",
+                  "label": "Second time derivative"
+                }
+              },
+              "justification": "The identity $\\nabla\\times(\\nabla\\times\\vec{E})=\\nabla(\\nabla\\cdot\\vec{E})-\\nabla^2\\vec{E}$. Gauss's law in free space gives $\\nabla\\cdot\\vec{E}=0$.",
+              "explanation": "The double-curl simplifies because in free space there are no charges, so the divergence of $\\vec{E}$ is zero.",
+              "prompt": "Use the standard vector identity. Gauss's law kills the first term, leaving just the Laplacian.",
+              "sceneStep": 0
+            },
+            {
+              "id": "wave_eq",
+              "type": "step",
+              "label": "The electromagnetic wave equation",
+              "math": "\\htmlClass{hl-lap}{\\nabla^2}\\htmlClass{hl-E}{\\vec{E}}=\\frac{1}{\\htmlClass{hl-c}{c}^2}\\htmlClass{hl-d2E}{\\frac{\\partial^2\\vec{E}}{\\partial t^2}},\\qquad \\htmlClass{hl-c}{c}=\\frac{1}{\\sqrt{\\htmlClass{hl-mu}{\\mu_0}\\htmlClass{hl-eps}{\\epsilon_0}}}",
+              "highlights": {
+                "lap": {
+                  "color": "purple",
+                  "label": "Laplacian (spatial second derivative)"
+                },
+                "E": {
+                  "color": "cyan",
+                  "label": "Electric field"
+                },
+                "c": {
+                  "color": "orange",
+                  "label": "Speed of light"
+                },
+                "d2E": {
+                  "color": "cyan",
+                  "label": "Second time derivative"
+                },
+                "mu": {
+                  "color": "orange",
+                  "label": "Permeability"
+                },
+                "eps": {
+                  "color": "yellow",
+                  "label": "Permittivity"
+                }
+              },
+              "justification": "Define $c^2=1/(\\mu_0\\epsilon_0)$ and rearrange. This is the standard wave equation.",
+              "explanation": "Maxwell's equations predict that $\\vec{E}$ satisfies a wave equation with speed $c=1/\\sqrt{\\mu_0\\epsilon_0}\\approx 3\\times 10^8$ m/s \u2014 the speed of light.",
+              "prompt": "This is the historic result: Maxwell's equations predict electromagnetic waves travelling at the speed of light. Light IS an electromagnetic wave.",
+              "sceneStep": 0
+            },
+            {
+              "id": "sinusoidal_ansatz",
+              "type": "step",
+              "label": "Try a sinusoidal solution",
+              "math": "\\htmlClass{hl-E}{E_y}=\\htmlClass{hl-amp}{E_0}\\sin(\\htmlClass{hl-k}{k}x-\\htmlClass{hl-omega}{\\omega}t)",
+              "highlights": {
+                "E": {
+                  "color": "cyan",
+                  "label": "y-component of electric field"
+                },
+                "amp": {
+                  "color": "green",
+                  "label": "Peak electric field amplitude"
+                },
+                "k": {
+                  "color": "yellow",
+                  "label": "Wave number (k = 2\u03c0/\u03bb)"
+                },
+                "omega": {
+                  "color": "orange",
+                  "label": "Angular frequency (\u03c9 = 2\u03c0f)"
+                }
+              },
+              "justification": "Substitute the simplest plane-wave ansatz propagating in the $x$-direction with $\\vec{E}$ polarized in $\\hat{y}$.",
+              "explanation": "We guess a sinusoidal form \u2014 a plane wave moving in the $x$-direction with the electric field oscillating in $y$.",
+              "prompt": "Try the simplest wave-like solution. The sine function naturally describes oscillations.",
+              "sceneStep": 0
+            },
+            {
+              "id": "dispersion",
+              "type": "step",
+              "label": "Dispersion relation",
+              "math": "\\htmlClass{hl-k}{k}^2=\\frac{\\htmlClass{hl-omega}{\\omega}^2}{\\htmlClass{hl-c}{c}^2}\\quad\\Longrightarrow\\quad \\htmlClass{hl-omega}{\\omega}=\\htmlClass{hl-c}{c}\\,\\htmlClass{hl-k}{k}",
+              "highlights": {
+                "k": {
+                  "color": "yellow",
+                  "label": "Wave number"
+                },
+                "omega": {
+                  "color": "orange",
+                  "label": "Angular frequency"
+                },
+                "c": {
+                  "color": "cyan",
+                  "label": "Speed of light"
+                }
+              },
+              "justification": "Substituting the ansatz: $\\partial^2 E_y/\\partial x^2=-k^2 E_y$ and $\\partial^2 E_y/\\partial t^2=-\\omega^2 E_y$. The wave equation gives $k^2=\\omega^2/c^2$.",
+              "explanation": "Plugging the sine into the wave equation forces $\\omega=ck$ \u2014 the frequency and wave number are locked together by the speed of light.",
+              "prompt": "Compute the second derivatives and substitute. The sine cancels, leaving the algebraic constraint omega = ck.",
+              "sceneStep": 0
+            },
+            {
+              "id": "E_solution",
+              "type": "conclusion",
+              "label": "The electric field of an EM wave",
+              "math": "\\htmlClass{hl-E}{\\vec{E}}=\\htmlClass{hl-amp}{E_0}\\sin(\\htmlClass{hl-k}{k}x-\\htmlClass{hl-omega}{\\omega}t)\\,\\htmlClass{hl-dir}{\\hat{y}}",
+              "highlights": {
+                "E": {
+                  "color": "cyan",
+                  "label": "Electric field vector"
+                },
+                "amp": {
+                  "color": "green",
+                  "label": "Peak amplitude"
+                },
+                "k": {
+                  "color": "yellow",
+                  "label": "k = 2\u03c0/\u03bb"
+                },
+                "omega": {
+                  "color": "orange",
+                  "label": "\u03c9 = 2\u03c0f = ck"
+                },
+                "dir": {
+                  "color": "pink",
+                  "label": "Polarization direction"
+                }
+              },
+              "justification": "The sinusoidal ansatz satisfies Maxwell's wave equation provided $\\omega=ck$. This is the wave shown in the 3D view.",
+              "explanation": "A sinusoidal electric field oscillating in $\\hat{y}$ and propagating in $\\hat{x}$ is a valid electromagnetic wave \u2014 exactly what the teal curve shows.",
+              "prompt": "This is the equation behind the visualization. The teal curve is E_0 sin(kx - \u03c9t) in the y-direction.",
+              "sceneStep": 4
+            }
+          ]
+        },
+        {
+          "id": "B_from_E",
+          "title": "Faraday's law: $\\vec{B}$ from $\\vec{E}$",
+          "technique": "derivation",
+          "goal": "Derive the magnetic field $\\vec{B}=\\frac{E_0}{c}\\sin(kx-\\omega t)\\,\\hat{z}$ from the electric field using Faraday's law.",
+          "prompt": "Start from the known E field solution and apply Faraday's law to derive B. Compute the curl component by component, integrate in time, and use omega=ck to get B=E/c.",
+          "steps": [
+            {
+              "id": "start_from_E",
+              "type": "given",
+              "label": "The known $\\vec{E}$ field",
+              "math": "\\htmlClass{hl-E}{\\vec{E}}=\\htmlClass{hl-amp}{E_0}\\sin(\\htmlClass{hl-k}{k}x-\\htmlClass{hl-omega}{\\omega}t)\\,\\htmlClass{hl-yhat}{\\hat{y}}",
+              "highlights": {
+                "E": {
+                  "color": "cyan",
+                  "label": "Electric field"
+                },
+                "amp": {
+                  "color": "green",
+                  "label": "Peak amplitude"
+                },
+                "k": {
+                  "color": "yellow",
+                  "label": "Wave number"
+                },
+                "omega": {
+                  "color": "orange",
+                  "label": "Angular frequency"
+                },
+                "yhat": {
+                  "color": "cyan",
+                  "label": "y-direction (polarization)"
+                }
+              },
+              "justification": "From the previous proof: this $\\vec{E}$ solves Maxwell's wave equation.",
+              "explanation": "We start with the electric field we already derived \u2014 now we use it to find the magnetic field.",
+              "prompt": "Recall the E field solution from the previous proof. Now we will find B.",
+              "sceneStep": 4
+            },
+            {
+              "id": "faraday_applied",
+              "type": "given",
+              "label": "Faraday's law",
+              "math": "\\htmlClass{hl-curl}{\\nabla\\times}\\htmlClass{hl-E}{\\vec{E}}=-\\htmlClass{hl-dtB}{\\frac{\\partial\\vec{B}}{\\partial t}}",
+              "highlights": {
+                "curl": {
+                  "color": "purple",
+                  "label": "Curl operator"
+                },
+                "E": {
+                  "color": "cyan",
+                  "label": "Electric field"
+                },
+                "dtB": {
+                  "color": "pink",
+                  "label": "Time derivative of B"
+                }
+              },
+              "justification": "Faraday's law connects the spatial variation of $\\vec{E}$ to the time variation of $\\vec{B}$.",
+              "explanation": "If $\\vec{E}$ varies in space, Faraday's law tells us $\\vec{B}$ must be changing in time.",
+              "prompt": "Faraday's law is the bridge: given E, it tells us what B must be.",
+              "sceneStep": 4
+            },
+            {
+              "id": "compute_curl",
+              "type": "step",
+              "label": "Compute the curl",
+              "math": "(\\htmlClass{hl-curl}{\\nabla\\times\\vec{E}})_z=\\frac{\\partial \\htmlClass{hl-Ey}{E_y}}{\\partial x}=\\htmlClass{hl-amp}{E_0}\\htmlClass{hl-k}{k}\\cos(\\htmlClass{hl-k}{k}x-\\htmlClass{hl-omega}{\\omega}t)",
+              "highlights": {
+                "curl": {
+                  "color": "purple",
+                  "label": "z-component of curl"
+                },
+                "Ey": {
+                  "color": "cyan",
+                  "label": "y-component of E"
+                },
+                "amp": {
+                  "color": "green",
+                  "label": "Amplitude"
+                },
+                "k": {
+                  "color": "yellow",
+                  "label": "Wave number"
+                },
+                "omega": {
+                  "color": "orange",
+                  "label": "Angular frequency"
+                }
+              },
+              "justification": "Since $\\vec{E}$ has only a $y$-component that depends on $x$, the only nonzero curl component is $\\partial E_y/\\partial x$ in the $\\hat{z}$ direction.",
+              "explanation": "The curl picks out how the $y$-field changes along $x$ \u2014 and points it in the $z$-direction. This is why $\\vec{B}$ will be in $\\hat{z}$.",
+              "prompt": "Only one component of the curl survives: dEy/dx gives a z-component. This determines the direction of B.",
+              "sceneStep": 4
+            },
+            {
+              "id": "faraday_z",
+              "type": "step",
+              "label": "Faraday's law, $z$-component",
+              "math": "-\\htmlClass{hl-dtBz}{\\frac{\\partial B_z}{\\partial t}}=\\htmlClass{hl-amp}{E_0}\\htmlClass{hl-k}{k}\\cos(\\htmlClass{hl-k}{k}x-\\htmlClass{hl-omega}{\\omega}t)",
+              "highlights": {
+                "dtBz": {
+                  "color": "pink",
+                  "label": "Time derivative of Bz"
+                },
+                "amp": {
+                  "color": "green",
+                  "label": "Amplitude"
+                },
+                "k": {
+                  "color": "yellow",
+                  "label": "Wave number"
+                },
+                "omega": {
+                  "color": "orange",
+                  "label": "Angular frequency"
+                }
+              },
+              "justification": "Equate the $z$-component of the curl to $-\\partial B_z/\\partial t$.",
+              "explanation": "Faraday's law now gives us a simple equation: the time derivative of $B_z$ equals $-E_0 k\\cos(kx-\\omega t)$.",
+              "prompt": "Write out the z-component of Faraday's law explicitly.",
+              "sceneStep": 4
+            },
+            {
+              "id": "integrate",
+              "type": "step",
+              "label": "Integrate in time",
+              "math": "\\htmlClass{hl-Bz}{B_z}=\\frac{\\htmlClass{hl-amp}{E_0}\\htmlClass{hl-k}{k}}{\\htmlClass{hl-omega}{\\omega}}\\sin(\\htmlClass{hl-k}{k}x-\\htmlClass{hl-omega}{\\omega}t)",
+              "highlights": {
+                "Bz": {
+                  "color": "pink",
+                  "label": "z-component of magnetic field"
+                },
+                "amp": {
+                  "color": "green",
+                  "label": "Amplitude"
+                },
+                "k": {
+                  "color": "yellow",
+                  "label": "Wave number"
+                },
+                "omega": {
+                  "color": "orange",
+                  "label": "Angular frequency"
+                }
+              },
+              "justification": "Integrate $-\\partial B_z/\\partial t$ with respect to $t$. The integral of $\\cos(kx-\\omega t)$ with respect to $t$ is $\\frac{1}{\\omega}\\sin(kx-\\omega t)$.",
+              "explanation": "Integrating the cosine in time gives back a sine \u2014 the magnetic field oscillates in phase with the electric field, with amplitude $E_0 k/\\omega$.",
+              "prompt": "Integrate both sides with respect to time. The cosine integrates to sine, picking up a factor of 1/omega.",
+              "sceneStep": 4
+            },
+            {
+              "id": "use_dispersion",
+              "type": "step",
+              "label": "Apply $\\omega=ck$",
+              "math": "\\frac{\\htmlClass{hl-k}{k}}{\\htmlClass{hl-omega}{\\omega}}=\\frac{\\htmlClass{hl-k}{k}}{\\htmlClass{hl-c}{c}\\,\\htmlClass{hl-k}{k}}=\\frac{1}{\\htmlClass{hl-c}{c}}",
+              "highlights": {
+                "k": {
+                  "color": "yellow",
+                  "label": "Wave number (cancels)"
+                },
+                "omega": {
+                  "color": "orange",
+                  "label": "Angular frequency"
+                },
+                "c": {
+                  "color": "cyan",
+                  "label": "Speed of light"
+                }
+              },
+              "justification": "The dispersion relation $\\omega=ck$ from the wave equation simplifies $k/\\omega$ to $1/c$.",
+              "explanation": "The ratio $k/\\omega$ collapses to $1/c$ \u2014 the wave number and frequency are locked together by the speed of light.",
+              "prompt": "This is where the dispersion relation omega=ck pays off. The k cancels beautifully.",
+              "sceneStep": 4
+            },
+            {
+              "id": "B_solution",
+              "type": "conclusion",
+              "label": "The magnetic field of an EM wave",
+              "math": "\\htmlClass{hl-B}{\\vec{B}}=\\frac{\\htmlClass{hl-amp}{E_0}}{\\htmlClass{hl-c}{c}}\\sin(\\htmlClass{hl-k}{k}x-\\htmlClass{hl-omega}{\\omega}t)\\,\\htmlClass{hl-zhat}{\\hat{z}}",
+              "highlights": {
+                "B": {
+                  "color": "pink",
+                  "label": "Magnetic field vector"
+                },
+                "amp": {
+                  "color": "green",
+                  "label": "Electric field amplitude"
+                },
+                "c": {
+                  "color": "cyan",
+                  "label": "Speed of light"
+                },
+                "k": {
+                  "color": "yellow",
+                  "label": "k = 2\u03c0/\u03bb"
+                },
+                "omega": {
+                  "color": "orange",
+                  "label": "\u03c9 = 2\u03c0f"
+                },
+                "zhat": {
+                  "color": "pink",
+                  "label": "z-direction (\u22a5 to E and propagation)"
+                }
+              },
+              "justification": "Substitute $k/\\omega=1/c$. The magnetic field is perpendicular to $\\vec{E}$ and to the propagation direction, with magnitude $B_0=E_0/c$.",
+              "explanation": "$\\vec{B}$ oscillates in $\\hat{z}$, perpendicular to both $\\vec{E}$ (in $\\hat{y}$) and propagation (in $\\hat{x}$). Its amplitude is $E_0/c$ \u2014 about $3\\times 10^{-9}$ times smaller in SI units, which is why $\\vec{E}$ dominates interactions with matter.",
+              "prompt": "This is the red curve in the 3D view. B is perpendicular to E, in phase, and c times smaller. That's why we usually only need to think about E.",
+              "sceneStep": 4
+            }
+          ]
+        }
+      ]
     },
     {
       "title": "One Photon Energy vs Light Intensity",

--- a/scenes/draft/photons-wavelength-energy.json
+++ b/scenes/draft/photons-wavelength-energy.json
@@ -7,30 +7,79 @@
       "markdown": "# Light as a Wave\n\nClassical electromagnetism treats light as a wave moving at speed $c$ in vacuum. The basic kinematic link is\n\n$$c=f\\lambda.$$\n\nIf $c$ is fixed, wavelength and frequency must trade off:\n\n$$f=\\frac{c}{\\lambda}.$$\n\nA longer wavelength means fewer crests pass a point each second. This part is continuous: in free space, a photon can have any wavelength allowed by the source and propagation conditions.\n\n## The historical pressure\n\nAt the turn of the twentieth century, classical blackbody theory led to the ultraviolet catastrophe: it predicted runaway short-wavelength emission. Planck's resolution was to make exchange of energy discrete, in units proportional to frequency. That idea became the first step toward quantum mechanics.\n\nReferences: https://en.wikipedia.org/wiki/Quantum and https://en.wikipedia.org/wiki/Photon_energy",
       "prompt": "Teach the wave kinematics first. Keep the distinction clear: c = f lambda is a wave relation, while E = hf is the quantum energy relation introduced next. Emphasize that stretching wavelength lowers frequency for fixed c.",
       "functions": [
-        {"name": "photonEnergy", "args": ["lambda"], "expr": "1/lambda"},
-        {"name": "freq", "args": ["lambda"], "expr": "1/lambda"}
+        {
+          "name": "photonEnergy",
+          "args": [
+            "lambda"
+          ],
+          "expr": "1/lambda"
+        },
+        {
+          "name": "freq",
+          "args": [
+            "lambda"
+          ],
+          "expr": "1/lambda"
+        }
       ],
       "range": [
-        [-6, 6],
-        [-6, 6],
-        [-6, 6]
+        [
+          -6,
+          6
+        ],
+        [
+          -6,
+          6
+        ],
+        [
+          -6,
+          6
+        ]
       ],
-      "scale": [1, 1, 1],
+      "scale": [
+        1,
+        1,
+        1
+      ],
       "camera": {
-        "position": [0, 1, 12],
-        "target": [0, 1, 0]
+        "position": [
+          -1,
+          1,
+          13
+        ],
+        "target": [
+          -1,
+          1,
+          0
+        ]
       },
       "views": [
         {
           "name": "Wave",
-          "position": [0, 1, 12],
-          "target": [0, 1, 0],
+          "position": [
+            0,
+            1,
+            12
+          ],
+          "target": [
+            0,
+            1,
+            0
+          ],
           "description": "Face-on wave view"
         },
         {
           "name": "Iso",
-          "position": [6, 5, 10],
-          "target": [0, 1, 0],
+          "position": [
+            6,
+            5,
+            10
+          ],
+          "target": [
+            0,
+            1,
+            0
+          ],
           "description": "Three-dimensional context"
         }
       ],
@@ -38,7 +87,18 @@
         {
           "id": "s0_wave_axis",
           "type": "line",
-          "points": [[0, 0, 0], [6, 0, 0]],
+          "points": [
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              6,
+              0,
+              0
+            ]
+          ],
           "color": "#555e6a",
           "width": 1,
           "legendGroup": "$\\text{EM wave}$"
@@ -47,8 +107,15 @@
           "id": "s0_grid",
           "type": "grid",
           "plane": "xy",
-          "range": [-6, 6],
-          "color": [0.28, 0.32, 0.38],
+          "range": [
+            -6,
+            6
+          ],
+          "color": [
+            0.28,
+            0.32,
+            0.38
+          ],
           "opacity": 0.12,
           "divisions": 12
         }
@@ -62,10 +129,10 @@
             {
               "id": "lambda",
               "label": "$\\lambda$",
-              "min": 1,
-              "max": 5,
+              "min": 0.8,
+              "max": 10,
               "step": 0.1,
-              "default": 2.4
+              "default": 2
             }
           ],
           "add": [
@@ -75,7 +142,10 @@
               "x": "t",
               "y": "sin(2*pi*t/lambda)",
               "z": "0",
-              "range": [0, 6],
+              "range": [
+                0,
+                6
+              ],
               "samples": 200,
               "color": "#2f9e9b",
               "width": 4,
@@ -85,8 +155,16 @@
               "id": "s0_lambda_span",
               "type": "animated_line",
               "points": [
-                ["lambda/2", "0", "0"],
-                ["lambda/2 + lambda", "0", "0"]
+                [
+                  "lambda/2",
+                  "0",
+                  "0"
+                ],
+                [
+                  "lambda/2 + lambda",
+                  "0",
+                  "0"
+                ]
               ],
               "color": "#f0b84b",
               "width": 5,
@@ -96,8 +174,16 @@
               "id": "s0_tick_left",
               "type": "animated_line",
               "points": [
-                ["lambda/2", "-1.6", "0"],
-                ["lambda/2", "1.6", "0"]
+                [
+                  "lambda/2",
+                  "-1.6",
+                  "0"
+                ],
+                [
+                  "lambda/2",
+                  "1.6",
+                  "0"
+                ]
               ],
               "color": "#f0b84b",
               "width": 1,
@@ -108,8 +194,16 @@
               "id": "s0_tick_right",
               "type": "animated_line",
               "points": [
-                ["lambda/2 + lambda", "-1.6", "0"],
-                ["lambda/2 + lambda", "1.6", "0"]
+                [
+                  "lambda/2 + lambda",
+                  "-1.6",
+                  "0"
+                ],
+                [
+                  "lambda/2 + lambda",
+                  "1.6",
+                  "0"
+                ]
               ],
               "color": "#f0b84b",
               "width": 1,
@@ -120,7 +214,11 @@
               "id": "s0_wave_title",
               "type": "text",
               "text": "$\\text{EM wave}$",
-              "position": [3, -0.6, 0],
+              "position": [
+                3,
+                -0.6,
+                0
+              ],
               "color": "#2f9e9b",
               "size": 15,
               "label": "$\\text{EM wave}$"
@@ -142,7 +240,18 @@
             {
               "id": "s0_chart_lambda_axis",
               "type": "line",
-              "points": [[-5.5, 0, 0], [-0.5, 0, 0]],
+              "points": [
+                [
+                  -5.5,
+                  0,
+                  0
+                ],
+                [
+                  -0.5,
+                  0,
+                  0
+                ]
+              ],
               "color": "#555e6a",
               "width": 1,
               "legendGroup": "$f=c/\\lambda$"
@@ -150,7 +259,18 @@
             {
               "id": "s0_chart_f_axis",
               "type": "line",
-              "points": [[-5.5, 0, 0], [-5.5, 3.5, 0]],
+              "points": [
+                [
+                  -5.5,
+                  0,
+                  0
+                ],
+                [
+                  -5.5,
+                  3.5,
+                  0
+                ]
+              ],
               "color": "#555e6a",
               "width": 1,
               "legendGroup": "$f=c/\\lambda$"
@@ -159,7 +279,11 @@
               "id": "s0_chart_label_lambda",
               "type": "text",
               "text": "$\\lambda$",
-              "position": [-0.3, -0.3, 0],
+              "position": [
+                -0.3,
+                -0.3,
+                0
+              ],
               "color": "#f0b84b",
               "size": 16,
               "legendGroup": "$f=c/\\lambda$"
@@ -168,7 +292,11 @@
               "id": "s0_chart_label_f",
               "type": "text",
               "text": "$f$",
-              "position": [-5.9, 3.6, 0],
+              "position": [
+                -5.9,
+                3.6,
+                0
+              ],
               "color": "#6ec6ff",
               "size": 16,
               "legendGroup": "$f=c/\\lambda$"
@@ -176,10 +304,13 @@
             {
               "id": "s0_chart_curve",
               "type": "parametric_curve",
-              "x": "t - 6",
+              "x": "t * 0.5 - 5.5",
               "y": "3/t",
               "z": "0",
-              "range": [0.8, 5.5],
+              "range": [
+                0.8,
+                10
+              ],
               "samples": 120,
               "color": "#6ec6ff",
               "width": 3,
@@ -188,7 +319,11 @@
             {
               "id": "s0_chart_dot",
               "type": "animated_point",
-              "positionExpr": ["lambda - 6", "3/lambda", "0"],
+              "positionExpr": [
+                "lambda * 0.5 - 5.5",
+                "3/lambda",
+                "0"
+              ],
               "color": "#ffffff",
               "radius": 0.12
             },
@@ -196,8 +331,16 @@
               "id": "s0_chart_vline",
               "type": "animated_line",
               "points": [
-                ["lambda - 6", "0", "0"],
-                ["lambda - 6", "3/lambda", "0"]
+                [
+                  "lambda * 0.5 - 5.5",
+                  "0",
+                  "0"
+                ],
+                [
+                  "lambda * 0.5 - 5.5",
+                  "3/lambda",
+                  "0"
+                ]
               ],
               "color": "#f0b84b",
               "width": 1,
@@ -208,8 +351,16 @@
               "id": "s0_chart_hline",
               "type": "animated_line",
               "points": [
-                ["-5.5", "3/lambda", "0"],
-                ["lambda - 6", "3/lambda", "0"]
+                [
+                  "-5.5",
+                  "3/lambda",
+                  "0"
+                ],
+                [
+                  "lambda * 0.5 - 5.5",
+                  "3/lambda",
+                  "0"
+                ]
               ],
               "color": "#6ec6ff",
               "width": 1,
@@ -220,7 +371,11 @@
               "id": "s0_chart_title",
               "type": "text",
               "text": "$f=c/\\lambda$",
-              "position": [-3, -0.6, 0],
+              "position": [
+                -3,
+                -0.6,
+                0
+              ],
               "color": "#6ec6ff",
               "size": 15,
               "label": "$f=c/\\lambda$"
@@ -236,7 +391,7 @@
         },
         {
           "title": "The crisis of the infinite",
-          "description": "Classical prediction: short wavelengths run away. Planck's resolution: energy comes in quanta. Blackbody radiation forced a deeper idea — energy exchange is quantized.",
+          "description": "Classical prediction: short wavelengths run away. Planck's resolution: energy comes in quanta. Blackbody radiation forced a deeper idea \u2014 energy exchange is quantized.",
           "prompt": "Frame the ultraviolet catastrophe as the reason the energy rule had to change. Avoid overclaiming: Planck quantized exchange of energy, not simply spatial wavelength.",
           "remove": [
             {
@@ -265,97 +420,469 @@
             {
               "id": "s0_spec_01",
               "type": "polygon",
-              "vertices": [[-6.1,0,0],[-5.7,0,0],[-5.7,0.35,0],[-6.1,0.35,0]],
+              "vertices": [
+                [
+                  -7.3,
+                  0.0,
+                  0
+                ],
+                [
+                  -6.9,
+                  0.0,
+                  0
+                ],
+                [
+                  -6.9,
+                  0.35,
+                  0
+                ],
+                [
+                  -7.3,
+                  0.35,
+                  0
+                ]
+              ],
               "color": "#990000",
               "opacity": 0.9,
-              "shader": {"shininess": 40, "emissive": "#220000"},
+              "shader": {
+                "shininess": 40,
+                "emissive": "#220000"
+              },
               "legendGroup": "visible spectrum"
             },
             {
               "id": "s0_spec_02",
               "type": "polygon",
-              "vertices": [[-6.1,0.35,0],[-5.7,0.35,0],[-5.7,0.7,0],[-6.1,0.7,0]],
+              "vertices": [
+                [
+                  -7.3,
+                  0.35,
+                  0
+                ],
+                [
+                  -6.9,
+                  0.35,
+                  0
+                ],
+                [
+                  -6.9,
+                  0.7,
+                  0
+                ],
+                [
+                  -7.3,
+                  0.7,
+                  0
+                ]
+              ],
               "color": "#CC1100",
               "opacity": 0.9,
-              "shader": {"shininess": 40, "emissive": "#2a0400"},
+              "shader": {
+                "shininess": 40,
+                "emissive": "#2a0400"
+              },
               "legendGroup": "visible spectrum"
             },
             {
               "id": "s0_spec_03",
               "type": "polygon",
-              "vertices": [[-6.1,0.7,0],[-5.7,0.7,0],[-5.7,1.05,0],[-6.1,1.05,0]],
+              "vertices": [
+                [
+                  -7.3,
+                  0.7,
+                  0
+                ],
+                [
+                  -6.9,
+                  0.7,
+                  0
+                ],
+                [
+                  -6.9,
+                  1.05,
+                  0
+                ],
+                [
+                  -7.3,
+                  1.05,
+                  0
+                ]
+              ],
               "color": "#FF5500",
               "opacity": 0.9,
-              "shader": {"shininess": 40, "emissive": "#331100"},
+              "shader": {
+                "shininess": 40,
+                "emissive": "#331100"
+              },
               "legendGroup": "visible spectrum"
             },
             {
               "id": "s0_spec_04",
               "type": "polygon",
-              "vertices": [[-6.1,1.05,0],[-5.7,1.05,0],[-5.7,1.4,0],[-6.1,1.4,0]],
+              "vertices": [
+                [
+                  -7.3,
+                  1.05,
+                  0
+                ],
+                [
+                  -6.9,
+                  1.05,
+                  0
+                ],
+                [
+                  -6.9,
+                  1.4,
+                  0
+                ],
+                [
+                  -7.3,
+                  1.4,
+                  0
+                ]
+              ],
               "color": "#FFAA00",
               "opacity": 0.9,
-              "shader": {"shininess": 40, "emissive": "#332200"},
+              "shader": {
+                "shininess": 40,
+                "emissive": "#332200"
+              },
               "legendGroup": "visible spectrum"
             },
             {
               "id": "s0_spec_05",
               "type": "polygon",
-              "vertices": [[-6.1,1.4,0],[-5.7,1.4,0],[-5.7,1.75,0],[-6.1,1.75,0]],
+              "vertices": [
+                [
+                  -7.3,
+                  1.4,
+                  0
+                ],
+                [
+                  -6.9,
+                  1.4,
+                  0
+                ],
+                [
+                  -6.9,
+                  1.75,
+                  0
+                ],
+                [
+                  -7.3,
+                  1.75,
+                  0
+                ]
+              ],
               "color": "#CCDD00",
               "opacity": 0.9,
-              "shader": {"shininess": 40, "emissive": "#2a2d00"},
+              "shader": {
+                "shininess": 40,
+                "emissive": "#2a2d00"
+              },
               "legendGroup": "visible spectrum"
             },
             {
               "id": "s0_spec_06",
               "type": "polygon",
-              "vertices": [[-6.1,1.75,0],[-5.7,1.75,0],[-5.7,2.1,0],[-6.1,2.1,0]],
+              "vertices": [
+                [
+                  -7.3,
+                  1.75,
+                  0
+                ],
+                [
+                  -6.9,
+                  1.75,
+                  0
+                ],
+                [
+                  -6.9,
+                  2.1,
+                  0
+                ],
+                [
+                  -7.3,
+                  2.1,
+                  0
+                ]
+              ],
               "color": "#22CC44",
               "opacity": 0.9,
-              "shader": {"shininess": 40, "emissive": "#062a0e"},
+              "shader": {
+                "shininess": 40,
+                "emissive": "#062a0e"
+              },
               "legendGroup": "visible spectrum"
             },
             {
               "id": "s0_spec_07",
               "type": "polygon",
-              "vertices": [[-6.1,2.1,0],[-5.7,2.1,0],[-5.7,2.45,0],[-6.1,2.45,0]],
+              "vertices": [
+                [
+                  -7.3,
+                  2.1,
+                  0
+                ],
+                [
+                  -6.9,
+                  2.1,
+                  0
+                ],
+                [
+                  -6.9,
+                  2.45,
+                  0
+                ],
+                [
+                  -7.3,
+                  2.45,
+                  0
+                ]
+              ],
               "color": "#00BBCC",
               "opacity": 0.9,
-              "shader": {"shininess": 40, "emissive": "#00262a"},
+              "shader": {
+                "shininess": 40,
+                "emissive": "#00262a"
+              },
               "legendGroup": "visible spectrum"
             },
             {
               "id": "s0_spec_08",
               "type": "polygon",
-              "vertices": [[-6.1,2.45,0],[-5.7,2.45,0],[-5.7,2.8,0],[-6.1,2.8,0]],
+              "vertices": [
+                [
+                  -7.3,
+                  2.45,
+                  0
+                ],
+                [
+                  -6.9,
+                  2.45,
+                  0
+                ],
+                [
+                  -6.9,
+                  2.8,
+                  0
+                ],
+                [
+                  -7.3,
+                  2.8,
+                  0
+                ]
+              ],
               "color": "#0066FF",
               "opacity": 0.9,
-              "shader": {"shininess": 40, "emissive": "#001533"},
+              "shader": {
+                "shininess": 40,
+                "emissive": "#001533"
+              },
               "legendGroup": "visible spectrum"
             },
             {
               "id": "s0_spec_09",
               "type": "polygon",
-              "vertices": [[-6.1,2.8,0],[-5.7,2.8,0],[-5.7,3.15,0],[-6.1,3.15,0]],
+              "vertices": [
+                [
+                  -7.3,
+                  2.8,
+                  0
+                ],
+                [
+                  -6.9,
+                  2.8,
+                  0
+                ],
+                [
+                  -6.9,
+                  3.15,
+                  0
+                ],
+                [
+                  -7.3,
+                  3.15,
+                  0
+                ]
+              ],
               "color": "#4400DD",
               "opacity": 0.9,
-              "shader": {"shininess": 40, "emissive": "#0e002e"},
+              "shader": {
+                "shininess": 40,
+                "emissive": "#0e002e"
+              },
               "legendGroup": "visible spectrum"
             },
             {
               "id": "s0_spec_10",
               "type": "polygon",
-              "vertices": [[-6.1,3.15,0],[-5.7,3.15,0],[-5.7,3.5,0],[-6.1,3.5,0]],
+              "vertices": [
+                [
+                  -7.3,
+                  3.15,
+                  0
+                ],
+                [
+                  -6.9,
+                  3.15,
+                  0
+                ],
+                [
+                  -6.9,
+                  3.5,
+                  0
+                ],
+                [
+                  -7.3,
+                  3.5,
+                  0
+                ]
+              ],
               "color": "#8B00FF",
               "opacity": 0.9,
-              "shader": {"shininess": 40, "emissive": "#1c0033"},
+              "shader": {
+                "shininess": 40,
+                "emissive": "#1c0033"
+              },
+              "legendGroup": "visible spectrum"
+            },
+            {
+              "id": "s0_gradient",
+              "type": "polygon",
+              "vertices": [
+                [
+                  -6.8,
+                  0.0,
+                  0
+                ],
+                [
+                  -6.4,
+                  0.0,
+                  0
+                ],
+                [
+                  -6.4,
+                  3.5,
+                  0
+                ],
+                [
+                  -6.8,
+                  3.5,
+                  0
+                ]
+              ],
+              "opacity": 0.95,
+              "shader": {
+                "type": "basic"
+              },
+              "gradient": {
+                "direction": "y",
+                "stops": [
+                  {
+                    "t": 0.0,
+                    "color": "#990000"
+                  },
+                  {
+                    "t": 0.05,
+                    "color": "#990000"
+                  },
+                  {
+                    "t": 0.1,
+                    "color": "#CC1100"
+                  },
+                  {
+                    "t": 0.15,
+                    "color": "#CC1100"
+                  },
+                  {
+                    "t": 0.2,
+                    "color": "#FF5500"
+                  },
+                  {
+                    "t": 0.25,
+                    "color": "#FF5500"
+                  },
+                  {
+                    "t": 0.3,
+                    "color": "#FFAA00"
+                  },
+                  {
+                    "t": 0.35,
+                    "color": "#FFAA00"
+                  },
+                  {
+                    "t": 0.4,
+                    "color": "#CCDD00"
+                  },
+                  {
+                    "t": 0.45,
+                    "color": "#CCDD00"
+                  },
+                  {
+                    "t": 0.5,
+                    "color": "#22CC44"
+                  },
+                  {
+                    "t": 0.55,
+                    "color": "#22CC44"
+                  },
+                  {
+                    "t": 0.6,
+                    "color": "#00BBCC"
+                  },
+                  {
+                    "t": 0.65,
+                    "color": "#00BBCC"
+                  },
+                  {
+                    "t": 0.7,
+                    "color": "#0066FF"
+                  },
+                  {
+                    "t": 0.75,
+                    "color": "#0066FF"
+                  },
+                  {
+                    "t": 0.8,
+                    "color": "#4400DD"
+                  },
+                  {
+                    "t": 0.85,
+                    "color": "#4400DD"
+                  },
+                  {
+                    "t": 0.9,
+                    "color": "#8B00FF"
+                  },
+                  {
+                    "t": 0.95,
+                    "color": "#8B00FF"
+                  },
+                  {
+                    "t": 1.0,
+                    "color": "#8B00FF"
+                  }
+                ],
+                "segments": 70
+              },
               "legendGroup": "visible spectrum"
             },
             {
               "id": "s0_spec_indicator",
               "type": "animated_line",
-              "points": [["-6.25","3/lambda","0"],["-5.55","3/lambda","0"]],
+              "points": [
+                [
+                  "-7.45",
+                  "3/lambda",
+                  "0.1"
+                ],
+                [
+                  "-6.25",
+                  "3/lambda",
+                  "0.1"
+                ]
+              ],
               "color": "#ffffff",
               "width": 3,
               "label": "current $f$"
@@ -363,7 +890,11 @@
             {
               "id": "s0_spec_dot",
               "type": "animated_point",
-              "positionExpr": ["-5.9", "3/lambda", "0"],
+              "positionExpr": [
+                "-7.1",
+                "3/lambda",
+                "0.1"
+              ],
               "color": "#ffffff",
               "radius": 0.1,
               "legendGroup": "current $f$"
@@ -372,7 +903,11 @@
               "id": "s0_clabel_red",
               "type": "text",
               "text": "red",
-              "position": [-6.55, 0.17, 0],
+              "position": [
+                -7.75,
+                0.17,
+                0
+              ],
               "color": "#CC1100",
               "size": 10,
               "legendGroup": "visible spectrum"
@@ -381,7 +916,11 @@
               "id": "s0_clabel_orange",
               "type": "text",
               "text": "orange",
-              "position": [-6.55, 0.87, 0],
+              "position": [
+                -7.75,
+                0.87,
+                0
+              ],
               "color": "#FF5500",
               "size": 10,
               "legendGroup": "visible spectrum"
@@ -390,7 +929,11 @@
               "id": "s0_clabel_yellow",
               "type": "text",
               "text": "yellow",
-              "position": [-6.55, 1.22, 0],
+              "position": [
+                -7.75,
+                1.22,
+                0
+              ],
               "color": "#FFAA00",
               "size": 10,
               "legendGroup": "visible spectrum"
@@ -399,7 +942,11 @@
               "id": "s0_clabel_green",
               "type": "text",
               "text": "green",
-              "position": [-6.55, 1.92, 0],
+              "position": [
+                -7.75,
+                1.92,
+                0
+              ],
               "color": "#22CC44",
               "size": 10,
               "legendGroup": "visible spectrum"
@@ -408,7 +955,11 @@
               "id": "s0_clabel_cyan",
               "type": "text",
               "text": "cyan",
-              "position": [-6.55, 2.27, 0],
+              "position": [
+                -7.75,
+                2.27,
+                0
+              ],
               "color": "#00BBCC",
               "size": 10,
               "legendGroup": "visible spectrum"
@@ -417,7 +968,11 @@
               "id": "s0_clabel_blue",
               "type": "text",
               "text": "blue",
-              "position": [-6.55, 2.62, 0],
+              "position": [
+                -7.75,
+                2.62,
+                0
+              ],
               "color": "#0066FF",
               "size": 10,
               "legendGroup": "visible spectrum"
@@ -426,27 +981,39 @@
               "id": "s0_clabel_violet",
               "type": "text",
               "text": "violet",
-              "position": [-6.55, 3.32, 0],
+              "position": [
+                -7.75,
+                3.32,
+                0
+              ],
               "color": "#8B00FF",
               "size": 10,
               "legendGroup": "visible spectrum"
             },
             {
               "id": "s0_nm_red",
-              "type": "text",
               "text": "$700\\,\\text{nm}$",
-              "position": [-6.55, -0.25, 0],
+              "position": [
+                -7.75,
+                -0.25,
+                0
+              ],
               "color": "#CC1100",
               "size": 11,
+              "type": "text",
               "legendGroup": "visible spectrum"
             },
             {
               "id": "s0_nm_violet",
-              "type": "text",
               "text": "$380\\,\\text{nm}$",
-              "position": [-6.55, 3.6, 0],
+              "position": [
+                -7.75,
+                3.6,
+                0
+              ],
               "color": "#8B00FF",
               "size": 11,
+              "type": "text",
               "legendGroup": "visible spectrum"
             }
           ],
@@ -464,7 +1031,7 @@
             {
               "id": "s0_wavelength_info",
               "position": "top-left",
-              "content": "**Wavelength → frequency**\n\n$$f=\\frac{c}{\\lambda}$$\n\n| $\\lambda$ (nm) | $f$ (THz) | Color |\n|---|---|---|\n| 380 | 789 | violet |\n| 480 | 625 | cyan |\n| 550 | 545 | green |\n| 600 | 500 | orange |\n| 700 | 428 | red |"
+              "content": "**Wavelength \u2192 frequency**\n\n$$f=\\frac{c}{\\lambda}$$\n\n| $\\lambda$ (nm) | $f$ (THz) | Color |\n|---|---|---|\n| 380 | 789 | violet |\n| 480 | 625 | cyan |\n| 550 | 545 | green |\n| 600 | 500 | orange |\n| 700 | 428 | red |"
             }
           ]
         }
@@ -482,12 +1049,21 @@
             "label": "Basic kinematics",
             "math": "\\htmlClass{hl-dist}{x}=\\htmlClass{hl-speed}{v}\\cdot {}\\htmlClass{hl-time}{t}",
             "highlights": {
-              "dist": {"color": "cyan", "label": "Distance travelled"},
-              "speed": {"color": "orange", "label": "Speed"},
-              "time": {"color": "yellow", "label": "Elapsed time"}
+              "dist": {
+                "color": "cyan",
+                "label": "Distance travelled"
+              },
+              "speed": {
+                "color": "orange",
+                "label": "Speed"
+              },
+              "time": {
+                "color": "yellow",
+                "label": "Elapsed time"
+              }
             },
             "justification": "The fundamental kinematic relation for constant speed.",
-            "explanation": "Distance equals speed times time — the starting point for all wave relations.",
+            "explanation": "Distance equals speed times time \u2014 the starting point for all wave relations.",
             "prompt": "Start from the most basic formula the learner already knows.",
             "sceneStep": 0
           },
@@ -497,9 +1073,18 @@
             "label": "One period of a wave",
             "math": "\\htmlClass{hl-wavelength}{\\lambda}=\\htmlClass{hl-speed}{c}\\cdot {}\\htmlClass{hl-period}{T}",
             "highlights": {
-              "wavelength": {"color": "cyan", "label": "One wavelength (crest-to-crest)"},
-              "speed": {"color": "orange", "label": "Wave speed (fixed at c)"},
-              "period": {"color": "yellow", "label": "Period (time for one cycle)"}
+              "wavelength": {
+                "color": "cyan",
+                "label": "One wavelength (crest-to-crest)"
+              },
+              "speed": {
+                "color": "orange",
+                "label": "Wave speed (fixed at c)"
+              },
+              "period": {
+                "color": "yellow",
+                "label": "Period (time for one cycle)"
+              }
             },
             "justification": "In one period $T$, the wave advances exactly one wavelength $\\lambda$. Set $x=\\lambda$, $v=c$, $t=T$.",
             "explanation": "A crest travels one full wavelength in one period, so $\\lambda = c \\cdot T$.",
@@ -512,10 +1097,22 @@
             "label": "Solve for frequency",
             "math": "\\htmlClass{hl-freq}{f}=\\frac{1}{\\htmlClass{hl-period}{T}}=\\frac{\\htmlClass{hl-speed}{c}}{\\htmlClass{hl-wavelength}{\\lambda}}",
             "highlights": {
-              "freq": {"color": "green", "label": "Frequency (cycles per second)"},
-              "period": {"color": "yellow", "label": "Period"},
-              "speed": {"color": "orange", "label": "Wave speed"},
-              "wavelength": {"color": "cyan", "label": "Wavelength"}
+              "freq": {
+                "color": "green",
+                "label": "Frequency (cycles per second)"
+              },
+              "period": {
+                "color": "yellow",
+                "label": "Period"
+              },
+              "speed": {
+                "color": "orange",
+                "label": "Wave speed"
+              },
+              "wavelength": {
+                "color": "cyan",
+                "label": "Wavelength"
+              }
             },
             "justification": "Frequency is the reciprocal of period: $f=1/T$. Substitute $T=\\lambda/c$.",
             "explanation": "Rearranging gives the wave relation: frequency equals speed divided by wavelength.",
@@ -528,13 +1125,22 @@
             "label": "The wave equation",
             "math": "\\htmlClass{hl-speed}{c}=\\htmlClass{hl-freq}{f}\\,\\htmlClass{hl-wavelength}{\\lambda}",
             "highlights": {
-              "speed": {"color": "orange", "label": "Wave speed"},
-              "freq": {"color": "green", "label": "Frequency"},
-              "wavelength": {"color": "cyan", "label": "Wavelength"}
+              "speed": {
+                "color": "orange",
+                "label": "Wave speed"
+              },
+              "freq": {
+                "color": "green",
+                "label": "Frequency"
+              },
+              "wavelength": {
+                "color": "cyan",
+                "label": "Wavelength"
+              }
             },
             "justification": "Multiply both sides of $f=c/\\lambda$ by $\\lambda$.",
             "explanation": "This is just $x=vt$ applied to one cycle: speed equals frequency times wavelength.",
-            "prompt": "Emphasize that c = f lambda is not a new law — it is x = v t for one wave cycle.",
+            "prompt": "Emphasize that c = f lambda is not a new law \u2014 it is x = v t for one wave cycle.",
             "sceneStep": 1
           }
         ]
@@ -546,25 +1152,58 @@
       "markdown": "# Photon Energy\n\nThe Planck-Einstein relation is\n\n$$E=hf=\\frac{hc}{\\lambda}.$$\n\nA shorter-wavelength blue photon has more energy than a longer-wavelength red photon. But that statement is about **one photon**.\n\nA beam's total delivered energy also depends on photon count:\n\n$$E_{\\text{total}}=Nhf.$$\n\nSo the useful correction is:\n\n- Blue photon: higher energy per photon than red.\n- Many red photons: can carry more total energy than one blue photon.\n- Intensity: mainly photon number flux.\n- Color/frequency: energy per photon.",
       "prompt": "Correct the common misconception directly. Say: one blue photon has more energy than one red photon, but many red photons can carry more total energy. Separate energy per photon from photon count/intensity.",
       "range": [
-        [-5, 5],
-        [-1, 7],
-        [-3, 3]
+        [
+          -5,
+          5
+        ],
+        [
+          -1,
+          7
+        ],
+        [
+          -3,
+          3
+        ]
       ],
       "camera": {
-        "position": [0, 0, 10],
-        "target": [0, 3, 0]
+        "position": [
+          0,
+          0,
+          10
+        ],
+        "target": [
+          0,
+          3,
+          0
+        ]
       },
       "views": [
         {
           "name": "Bars",
-          "position": [0, 0, 10],
-          "target": [0, 3, 0],
+          "position": [
+            0,
+            0,
+            10
+          ],
+          "target": [
+            0,
+            3,
+            0
+          ],
           "description": "Energy comparison"
         },
         {
           "name": "Iso",
-          "position": [6, 5, 8],
-          "target": [0, 2.5, 0],
+          "position": [
+            6,
+            5,
+            8
+          ],
+          "target": [
+            0,
+            2.5,
+            0
+          ],
           "description": "Perspective view"
         }
       ],
@@ -573,7 +1212,10 @@
           "id": "s1_y_axis",
           "type": "axis",
           "axis": "y",
-          "range": [0, 7],
+          "range": [
+            0,
+            7
+          ],
           "color": "#9aa4ad",
           "width": 1.2,
           "label": "$E$"
@@ -582,8 +1224,15 @@
           "id": "s1_grid",
           "type": "grid",
           "plane": "xy",
-          "range": [-5, 7],
-          "color": [0.25, 0.29, 0.34],
+          "range": [
+            -5,
+            7
+          ],
+          "color": [
+            0.25,
+            0.29,
+            0.34
+          ],
           "opacity": 0.14,
           "divisions": 12
         }
@@ -598,10 +1247,26 @@
               "id": "s1_red_bar",
               "type": "polygon",
               "vertices": [
-                [-3.4, 0, 0],
-                [-2.4, 0, 0],
-                [-2.4, 1, 0],
-                [-3.4, 1, 0]
+                [
+                  -3.4,
+                  0,
+                  0
+                ],
+                [
+                  -2.4,
+                  0,
+                  0
+                ],
+                [
+                  -2.4,
+                  1,
+                  0
+                ],
+                [
+                  -3.4,
+                  1,
+                  0
+                ]
               ],
               "color": "#d84a3a",
               "opacity": 0.75,
@@ -613,10 +1278,26 @@
               "id": "s1_blue_bar",
               "type": "polygon",
               "vertices": [
-                [1.8, 0, 0],
-                [2.8, 0, 0],
-                [2.8, 2.5, 0],
-                [1.8, 2.5, 0]
+                [
+                  1.8,
+                  0,
+                  0
+                ],
+                [
+                  2.8,
+                  0,
+                  0
+                ],
+                [
+                  2.8,
+                  2.5,
+                  0
+                ],
+                [
+                  1.8,
+                  2.5,
+                  0
+                ]
               ],
               "color": "#3c8cff",
               "opacity": 0.75,
@@ -628,7 +1309,11 @@
               "id": "s1_red_label",
               "type": "text",
               "text": "$E_R=hf_R$",
-              "position": [-3.75, 1.35, 0],
+              "position": [
+                -3.75,
+                1.35,
+                0
+              ],
               "color": "#ff9a8f",
               "size": 15
             },
@@ -636,7 +1321,11 @@
               "id": "s1_blue_label",
               "type": "text",
               "text": "$E_B=hf_B$",
-              "position": [1.45, 2.85, 0],
+              "position": [
+                1.45,
+                2.85,
+                0
+              ],
               "color": "#9dccff",
               "size": 15
             }
@@ -673,10 +1362,26 @@
               "id": "s1_red_total",
               "type": "animated_polygon",
               "vertices": [
-                ["-0.6", "0", "0"],
-                ["0.4", "0", "0"],
-                ["0.4", "Nred", "0"],
-                ["-0.6", "Nred", "0"]
+                [
+                  "-0.6",
+                  "0",
+                  "0"
+                ],
+                [
+                  "0.4",
+                  "0",
+                  "0"
+                ],
+                [
+                  "0.4",
+                  "Nred",
+                  "0"
+                ],
+                [
+                  "-0.6",
+                  "Nred",
+                  "0"
+                ]
               ],
               "color": "#d84a3a",
               "opacity": 0.45,
@@ -688,7 +1393,11 @@
               "id": "s1_total_label",
               "type": "text",
               "text": "$E_{total}=Nhf$",
-              "position": [-0.9, 6.35, 0],
+              "position": [
+                -0.9,
+                6.35,
+                0
+              ],
               "color": "#f0b84b",
               "size": 16
             }
@@ -710,7 +1419,11 @@
               "id": "s1_frequency_axis_text",
               "type": "text",
               "text": "frequency: energy per photon",
-              "position": [-4.45, 5.8, 0],
+              "position": [
+                -4.45,
+                5.8,
+                0
+              ],
               "color": "#6ec6ff",
               "size": 15
             },
@@ -718,7 +1431,11 @@
               "id": "s1_intensity_axis_text",
               "type": "text",
               "text": "intensity: photon arrival rate",
-              "position": [-4.45, 5.35, 0],
+              "position": [
+                -4.45,
+                5.35,
+                0
+              ],
               "color": "#7bd389",
               "size": 15
             }
@@ -745,9 +1462,18 @@
             "label": "Single photon energy",
             "math": "\\htmlClass{hl-energy}{E}=\\htmlClass{hl-planck}{h}\\htmlClass{hl-freq}{f}",
             "highlights": {
-              "energy": {"color": "orange", "label": "Energy of one photon"},
-              "planck": {"color": "yellow", "label": "Planck constant"},
-              "freq": {"color": "cyan", "label": "Frequency"}
+              "energy": {
+                "color": "orange",
+                "label": "Energy of one photon"
+              },
+              "planck": {
+                "color": "yellow",
+                "label": "Planck constant"
+              },
+              "freq": {
+                "color": "cyan",
+                "label": "Frequency"
+              }
             },
             "justification": "Planck-Einstein relation.",
             "explanation": "Each photon carries energy proportional to its frequency.",
@@ -759,9 +1485,18 @@
             "label": "N identical photons",
             "math": "\\htmlClass{hl-total}{E_{total}}=\\htmlClass{hl-count}{N}\\cdot {}\\htmlClass{hl-energy}{hf}",
             "highlights": {
-              "total": {"color": "green", "label": "Total beam energy"},
-              "count": {"color": "magenta", "label": "Photon count"},
-              "energy": {"color": "orange", "label": "Energy per photon"}
+              "total": {
+                "color": "green",
+                "label": "Total beam energy"
+              },
+              "count": {
+                "color": "magenta",
+                "label": "Photon count"
+              },
+              "energy": {
+                "color": "orange",
+                "label": "Energy per photon"
+              }
             },
             "justification": "Photon energies add independently.",
             "explanation": "Total energy scales linearly with photon count.",
@@ -785,25 +1520,58 @@
       "markdown": "# Continuous vs Discrete Wavelengths\n\nFree photons in open space can have a continuous range of wavelengths. Discrete spectra appear when a system is constrained.\n\nThe simplest analogy is a standing wave in a box of length $L$. If the wave must vanish at both walls, only waves that fit are allowed:\n\n$$L=n\\frac{\\lambda}{2},\\qquad n=1,2,3,\\ldots$$\n\nFor a nonrelativistic particle in a box, the energy levels scale as\n\n$$E_n=\\frac{n^2h^2}{8mL^2}.$$\n\nSo a useful correction is: the allowed wavelengths scale like $1/n$, but the particle-in-a-box energies scale like $n^2$, not like $n$.\n\nAtoms are more complicated than a literal box, but the same structural idea survives: boundary conditions and allowed quantum states produce discrete emission lines.",
       "prompt": "Teach quantization as a boundary-condition effect. Make clear that free photons are not forced into a discrete wavelength ladder; confinement or bound-state structure creates discreteness.",
       "range": [
-        [-0.5, 6.5],
-        [-2.5, 3.5],
-        [-2, 2]
+        [
+          -0.5,
+          6.5
+        ],
+        [
+          -2.5,
+          3.5
+        ],
+        [
+          -2,
+          2
+        ]
       ],
       "camera": {
-        "position": [3, 0.4, 9],
-        "target": [3, 0.2, 0]
+        "position": [
+          3,
+          0.4,
+          9
+        ],
+        "target": [
+          3,
+          0.2,
+          0
+        ]
       },
       "views": [
         {
           "name": "Box",
-          "position": [3, 0.4, 9],
-          "target": [3, 0.2, 0],
+          "position": [
+            3,
+            0.4,
+            9
+          ],
+          "target": [
+            3,
+            0.2,
+            0
+          ],
           "description": "Standing-wave view"
         },
         {
           "name": "Energy",
-          "position": [6, 4, 8],
-          "target": [3, 1, 0],
+          "position": [
+            6,
+            4,
+            8
+          ],
+          "target": [
+            3,
+            1,
+            0
+          ],
           "description": "Energy-level view"
         }
       ],
@@ -812,7 +1580,10 @@
           "id": "s2_box_axis",
           "type": "axis",
           "axis": "x",
-          "range": [0, 6],
+          "range": [
+            0,
+            6
+          ],
           "color": "#d04f4f",
           "width": 1.5,
           "label": "$x$"
@@ -821,8 +1592,15 @@
           "id": "s2_grid",
           "type": "grid",
           "plane": "xy",
-          "range": [-1, 6],
-          "color": [0.25, 0.29, 0.34],
+          "range": [
+            -1,
+            6
+          ],
+          "color": [
+            0.25,
+            0.29,
+            0.34
+          ],
           "opacity": 0.14,
           "divisions": 12
         },
@@ -830,8 +1608,16 @@
           "id": "s2_left_wall",
           "type": "line",
           "points": [
-            [0, -2, 0],
-            [0, 2, 0]
+            [
+              0,
+              -2,
+              0
+            ],
+            [
+              0,
+              2,
+              0
+            ]
           ],
           "color": "#d8dee9",
           "width": 5,
@@ -841,8 +1627,16 @@
           "id": "s2_right_wall",
           "type": "animated_line",
           "points": [
-            ["L", "-2", "0"],
-            ["L", "2", "0"]
+            [
+              "L",
+              "-2",
+              "0"
+            ],
+            [
+              "L",
+              "2",
+              "0"
+            ]
           ],
           "color": "#d8dee9",
           "width": 5,
@@ -859,8 +1653,16 @@
               "id": "s2_spectrum_line",
               "type": "line",
               "points": [
-                [0.4, 2.6, 0],
-                [5.6, 2.6, 0]
+                [
+                  0.4,
+                  2.6,
+                  0
+                ],
+                [
+                  5.6,
+                  2.6,
+                  0
+                ]
               ],
               "color": "#8bd3dd",
               "width": 8,
@@ -870,7 +1672,11 @@
               "id": "s2_spectrum_label",
               "type": "text",
               "text": "free photons: continuum",
-              "position": [1.55, 3.0, 0],
+              "position": [
+                1.55,
+                3.0,
+                0
+              ],
               "color": "#8bd3dd",
               "size": 15
             }
@@ -917,7 +1723,10 @@
               "x": "t",
               "y": "1.25*sin(n*pi*t/L)",
               "z": "0",
-              "range": [0, 6],
+              "range": [
+                0,
+                6
+              ],
               "samples": 240,
               "color": "#f0b84b",
               "width": 4,
@@ -927,7 +1736,11 @@
               "id": "s2_fit_text",
               "type": "text",
               "text": "$L=n\\lambda/2$",
-              "position": [0.5, -2.25, 0],
+              "position": [
+                0.5,
+                -2.25,
+                0
+              ],
               "color": "#f0b84b",
               "size": 16
             }
@@ -949,8 +1762,16 @@
               "id": "s2_e1",
               "type": "line",
               "points": [
-                [4.2, 0.25, 0],
-                [5.7, 0.25, 0]
+                [
+                  4.2,
+                  0.25,
+                  0
+                ],
+                [
+                  5.7,
+                  0.25,
+                  0
+                ]
               ],
               "color": "#7bd389",
               "width": 3,
@@ -960,8 +1781,16 @@
               "id": "s2_e2",
               "type": "line",
               "points": [
-                [4.2, 1.0, 0],
-                [5.7, 1.0, 0]
+                [
+                  4.2,
+                  1.0,
+                  0
+                ],
+                [
+                  5.7,
+                  1.0,
+                  0
+                ]
               ],
               "color": "#7bd389",
               "width": 3,
@@ -971,8 +1800,16 @@
               "id": "s2_e3",
               "type": "line",
               "points": [
-                [4.2, 2.25, 0],
-                [5.7, 2.25, 0]
+                [
+                  4.2,
+                  2.25,
+                  0
+                ],
+                [
+                  5.7,
+                  2.25,
+                  0
+                ]
               ],
               "color": "#7bd389",
               "width": 3,
@@ -995,8 +1832,16 @@
             {
               "id": "s2_transition",
               "type": "vector",
-              "from": [5.95, 2.25, 0],
-              "to": [5.95, 0.25, 0],
+              "from": [
+                5.95,
+                2.25,
+                0
+              ],
+              "to": [
+                5.95,
+                0.25,
+                0
+              ],
               "color": "#ff7b72",
               "width": 4,
               "label": "$E_{photon}$"
@@ -1007,7 +1852,10 @@
               "x": "0.35*t + 0.4",
               "y": "-1.15 + 0.25*sin(2*pi*t)",
               "z": "0",
-              "range": [0, 10],
+              "range": [
+                0,
+                10
+              ],
               "samples": 160,
               "color": "#6ec6ff",
               "width": 3,
@@ -1030,26 +1878,63 @@
       "markdown": "# Spreading vs Stretching\n\nThis is the most important distinction in the lesson.\n\n## Spreading\n\nA beam or wave packet expands over a larger area. The same photon energy is distributed across a larger cross-section, so intensity drops. Energy per photon stays the same.\n\n## Stretching\n\nThe wavelength itself grows. Since\n\n$$E=\\frac{hc}{\\lambda},$$\n\nstretching the wavelength lowers the energy per photon.\n\nRedshift is a stretching effect. Doppler redshift comes from relative motion. Gravitational redshift comes from climbing out of a gravitational field. Cosmological redshift is described by\n\n$$\\lambda_{obs}=\\lambda_{em}(1+z).$$\n\nIn expanding spacetime, local conservation laws still hold, but a single global total energy for the universe is not generally well-defined.",
       "prompt": "Make the distinction crisp: spreading changes intensity, stretching changes photon energy. For cosmological redshift, say global total energy is not generally well-defined in GR rather than saying energy disappears.",
       "range": [
-        [-5, 5],
-        [-5, 5],
-        [-5, 5]
+        [
+          -5,
+          5
+        ],
+        [
+          -5,
+          5
+        ],
+        [
+          -5,
+          5
+        ]
       ],
-      "scale": [1, 1, 1],
+      "scale": [
+        1,
+        1,
+        1
+      ],
       "camera": {
-        "position": [0, 0, 10],
-        "target": [0, 0.5, 0]
+        "position": [
+          0,
+          0,
+          10
+        ],
+        "target": [
+          0,
+          0.5,
+          0
+        ]
       },
       "views": [
         {
           "name": "Face On",
-          "position": [0, 0, 10],
-          "target": [0, 0.5, 0],
+          "position": [
+            0,
+            0,
+            10
+          ],
+          "target": [
+            0,
+            0.5,
+            0
+          ],
           "description": "Compare spreading and stretching"
         },
         {
           "name": "Iso",
-          "position": [5, 4, 8],
-          "target": [0, 0.5, 0],
+          "position": [
+            5,
+            4,
+            8
+          ],
+          "target": [
+            0,
+            0.5,
+            0
+          ],
           "description": "Perspective view"
         }
       ],
@@ -1058,8 +1943,15 @@
           "id": "s3_grid",
           "type": "grid",
           "plane": "xy",
-          "range": [-5, 5],
-          "color": [0.25, 0.29, 0.34],
+          "range": [
+            -5,
+            5
+          ],
+          "color": [
+            0.25,
+            0.29,
+            0.34
+          ],
           "opacity": 0.14,
           "divisions": 10
         },
@@ -1067,8 +1959,16 @@
           "id": "s3_midline",
           "type": "line",
           "points": [
-            [0, -3, 0],
-            [0, 4, 0]
+            [
+              0,
+              -3,
+              0
+            ],
+            [
+              0,
+              4,
+              0
+            ]
           ],
           "color": "#4b5563",
           "width": 2
@@ -1096,7 +1996,10 @@
               "x": "-2.5 + R*cos(t)",
               "y": "0.2 + R*sin(t)",
               "z": "0",
-              "range": [0, 6.283185307179586],
+              "range": [
+                0,
+                6.283185307179586
+              ],
               "samples": 160,
               "color": "#7bd389",
               "width": 3,
@@ -1105,7 +2008,11 @@
             {
               "id": "s3_spread_center",
               "type": "animated_point",
-              "expr": ["-2.5", "0.2", "0"],
+              "expr": [
+                "-2.5",
+                "0.2",
+                "0"
+              ],
               "color": "#7bd389",
               "size": 10,
               "label": "$E=hf$"
@@ -1114,7 +2021,11 @@
               "id": "s3_spread_text",
               "type": "text",
               "text": "spreading: dimmer",
-              "position": [-4.6, 3.25, 0],
+              "position": [
+                -4.6,
+                3.25,
+                0
+              ],
               "color": "#7bd389",
               "size": 16
             }
@@ -1148,7 +2059,10 @@
               "x": "1.1 + 0.7*t",
               "y": "0.2 + 0.55*sin(2*pi*t/(1+zshift))",
               "z": "0",
-              "range": [0, 6],
+              "range": [
+                0,
+                6
+              ],
               "samples": 200,
               "color": "#ff7b72",
               "width": 4,
@@ -1158,8 +2072,16 @@
               "id": "s3_energy_bar_bg",
               "type": "line",
               "points": [
-                [4.25, -2.2, 0],
-                [4.25, 2.2, 0]
+                [
+                  4.25,
+                  -2.2,
+                  0
+                ],
+                [
+                  4.25,
+                  2.2,
+                  0
+                ]
               ],
               "color": "#3b4652",
               "width": 9,
@@ -1169,8 +2091,16 @@
               "id": "s3_energy_bar",
               "type": "animated_line",
               "points": [
-                ["4.25", "-2.2", "0"],
-                ["4.25", "-2.2 + 4.4/(1+zshift)", "0"]
+                [
+                  "4.25",
+                  "-2.2",
+                  "0"
+                ],
+                [
+                  "4.25",
+                  "-2.2 + 4.4/(1+zshift)",
+                  "0"
+                ]
               ],
               "color": "#f0b84b",
               "width": 9,
@@ -1194,7 +2124,11 @@
               "id": "s3_gr_note",
               "type": "text",
               "text": "local conservation: yes",
-              "position": [-4.55, -2.15, 0],
+              "position": [
+                -4.55,
+                -2.15,
+                0
+              ],
               "color": "#7bd389",
               "size": 15
             },
@@ -1202,7 +2136,11 @@
               "id": "s3_global_note",
               "type": "text",
               "text": "global total energy: not generally defined",
-              "position": [-4.55, -2.55, 0],
+              "position": [
+                -4.55,
+                -2.55,
+                0
+              ],
               "color": "#f0b84b",
               "size": 15
             }
@@ -1229,9 +2167,18 @@
             "label": "Redshift relation",
             "math": "\\htmlClass{hl-obs}{\\lambda_{obs}}=\\htmlClass{hl-em}{\\lambda_{em}}(1+\\htmlClass{hl-z}{z})",
             "highlights": {
-              "obs": {"color": "orange", "label": "Observed wavelength"},
-              "em": {"color": "cyan", "label": "Emitted wavelength"},
-              "z": {"color": "yellow", "label": "Redshift parameter"}
+              "obs": {
+                "color": "orange",
+                "label": "Observed wavelength"
+              },
+              "em": {
+                "color": "cyan",
+                "label": "Emitted wavelength"
+              },
+              "z": {
+                "color": "yellow",
+                "label": "Redshift parameter"
+              }
             },
             "justification": "Definition of cosmological redshift.",
             "explanation": "Space expansion stretches the wavelength by a factor $(1+z)$.",
@@ -1243,10 +2190,22 @@
             "label": "Substitute into $E=hc/\\lambda$",
             "math": "\\htmlClass{hl-eobs}{E_{obs}}=\\frac{hc}{\\htmlClass{hl-obs}{\\lambda_{obs}}}=\\frac{hc}{\\htmlClass{hl-em}{\\lambda_{em}}(1+\\htmlClass{hl-z}{z})}",
             "highlights": {
-              "eobs": {"color": "green", "label": "Observed energy"},
-              "obs": {"color": "orange", "label": "Observed wavelength"},
-              "em": {"color": "cyan", "label": "Emitted wavelength"},
-              "z": {"color": "yellow", "label": "Redshift parameter"}
+              "eobs": {
+                "color": "green",
+                "label": "Observed energy"
+              },
+              "obs": {
+                "color": "orange",
+                "label": "Observed wavelength"
+              },
+              "em": {
+                "color": "cyan",
+                "label": "Emitted wavelength"
+              },
+              "z": {
+                "color": "yellow",
+                "label": "Redshift parameter"
+              }
             },
             "justification": "Replace $\\lambda_{obs}$ with the redshift expression.",
             "explanation": "The longer wavelength means less energy per photon.",
@@ -1258,9 +2217,18 @@
             "label": "Redshifted energy",
             "math": "\\htmlClass{hl-eobs}{E_{obs}}=\\frac{\\htmlClass{hl-eem}{E_{em}}}{1+\\htmlClass{hl-z}{z}}",
             "highlights": {
-              "eobs": {"color": "green", "label": "Observed energy"},
-              "eem": {"color": "cyan", "label": "Emitted energy"},
-              "z": {"color": "yellow", "label": "Redshift parameter"}
+              "eobs": {
+                "color": "green",
+                "label": "Observed energy"
+              },
+              "eem": {
+                "color": "cyan",
+                "label": "Emitted energy"
+              },
+              "z": {
+                "color": "yellow",
+                "label": "Redshift parameter"
+              }
             },
             "justification": "Recognize $hc/\\lambda_{em}=E_{em}$.",
             "explanation": "Stretching lowers energy per photon by exactly the redshift factor.",
@@ -1275,26 +2243,63 @@
       "markdown": "# What Is a Photon?\n\nA photon is a quantized excitation of the electromagnetic field. It is not a tiny classical ball and not a classical water wave.\n\nThe useful synthesis is a wave packet:\n\n$$\\Psi(x,t)=\\int A(k)e^{i(kx-\\omega t)}\\,dk.$$\n\nBefore detection, the quantum state can be spatially spread out. Detection is localized and all-or-nothing: a detector either records an interaction or it does not.\n\nA careful wording is:\n\n- Before measurement: spread-out quantum state or probability amplitude.\n- At measurement: localized detection event.\n- Measurement updates the quantum state description.\n\nThis avoids the misleading picture of a physical classical wave instantly collapsing across the universe.",
       "prompt": "Use cautious quantum language. Say the photon is a quantized field excitation, described by a state that can be spatially spread out, with localized detection. Avoid implying a classical physical wave literally collapses.",
       "range": [
-        [-6, 6],
-        [-6, 6],
-        [-6, 6]
+        [
+          -6,
+          6
+        ],
+        [
+          -6,
+          6
+        ],
+        [
+          -6,
+          6
+        ]
       ],
-      "scale": [1, 1, 1],
+      "scale": [
+        1,
+        1,
+        1
+      ],
       "camera": {
-        "position": [0, 0, 9],
-        "target": [0, 0, 0]
+        "position": [
+          0,
+          0,
+          9
+        ],
+        "target": [
+          0,
+          0,
+          0
+        ]
       },
       "views": [
         {
           "name": "Packet",
-          "position": [0, 0, 9],
-          "target": [0, 0, 0],
+          "position": [
+            0,
+            0,
+            9
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
           "description": "Wave-packet view"
         },
         {
           "name": "Iso",
-          "position": [6, 4, 7],
-          "target": [0, 0, 0],
+          "position": [
+            6,
+            4,
+            7
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
           "description": "Perspective view"
         }
       ],
@@ -1303,7 +2308,10 @@
           "id": "s4_x_axis",
           "type": "axis",
           "axis": "x",
-          "range": [-6, 6],
+          "range": [
+            -6,
+            6
+          ],
           "color": "#d04f4f",
           "width": 1.2,
           "label": "$x$"
@@ -1312,8 +2320,15 @@
           "id": "s4_grid",
           "type": "grid",
           "plane": "xy",
-          "range": [-6, 6],
-          "color": [0.25, 0.29, 0.34],
+          "range": [
+            -6,
+            6
+          ],
+          "color": [
+            0.25,
+            0.29,
+            0.34
+          ],
           "opacity": 0.14,
           "divisions": 12
         }
@@ -1340,7 +2355,10 @@
               "x": "t",
               "y": "exp(-(t*t)/(2*sigma*sigma))*cos(7*t)",
               "z": "0",
-              "range": [-6, 6],
+              "range": [
+                -6,
+                6
+              ],
               "samples": 320,
               "color": "#6ec6ff",
               "width": 4,
@@ -1352,7 +2370,10 @@
               "x": "t",
               "y": "exp(-(t*t)/(2*sigma*sigma))",
               "z": "0",
-              "range": [-6, 6],
+              "range": [
+                -6,
+                6
+              ],
               "samples": 240,
               "color": "#f0b84b",
               "width": 2,
@@ -1365,7 +2386,10 @@
               "x": "t",
               "y": "-exp(-(t*t)/(2*sigma*sigma))",
               "z": "0",
-              "range": [-6, 6],
+              "range": [
+                -6,
+                6
+              ],
               "samples": 240,
               "color": "#f0b84b",
               "width": 2,
@@ -1390,8 +2414,16 @@
               "id": "s4_detector",
               "type": "line",
               "points": [
-                [2.6, -2.1, 0],
-                [2.6, 2.1, 0]
+                [
+                  2.6,
+                  -2.1,
+                  0
+                ],
+                [
+                  2.6,
+                  2.1,
+                  0
+                ]
               ],
               "color": "#ff7b72",
               "width": 5,
@@ -1400,7 +2432,11 @@
             {
               "id": "s4_click",
               "type": "point",
-              "position": [2.6, 0.25, 0],
+              "position": [
+                2.6,
+                0.25,
+                0
+              ],
               "color": "#ff7b72",
               "size": 18,
               "label": "click"
@@ -1409,7 +2445,11 @@
               "id": "s4_detection_text",
               "type": "text",
               "text": "localized interaction",
-              "position": [2.85, 1.85, 0],
+              "position": [
+                2.85,
+                1.85,
+                0
+              ],
               "color": "#ff7b72",
               "size": 15
             }
@@ -1436,7 +2476,11 @@
               "id": "s4_summary_1",
               "type": "text",
               "text": "quantized excitation",
-              "position": [-5.2, 2.2, 0],
+              "position": [
+                -5.2,
+                2.2,
+                0
+              ],
               "color": "#6ec6ff",
               "size": 16
             },
@@ -1444,7 +2488,11 @@
               "id": "s4_summary_2",
               "type": "text",
               "text": "continuous wavelength in free space",
-              "position": [-5.2, 1.75, 0],
+              "position": [
+                -5.2,
+                1.75,
+                0
+              ],
               "color": "#8bd3dd",
               "size": 16
             },
@@ -1452,7 +2500,11 @@
               "id": "s4_summary_3",
               "type": "text",
               "text": "discrete spectra from constraints",
-              "position": [-5.2, 1.3, 0],
+              "position": [
+                -5.2,
+                1.3,
+                0
+              ],
               "color": "#7bd389",
               "size": 16
             },
@@ -1460,7 +2512,11 @@
               "id": "s4_summary_4",
               "type": "text",
               "text": "$E=hf=hc/\\lambda$",
-              "position": [-5.2, 0.85, 0],
+              "position": [
+                -5.2,
+                0.85,
+                0
+              ],
               "color": "#f0b84b",
               "size": 18
             }
@@ -1481,26 +2537,63 @@
       "markdown": "# Black Holes and the Limits of the Picture\n\nNear a black hole, intuition based on ordinary wave packets becomes unreliable.\n\nCorrect statements:\n\n- Falling photons can blueshift for local observers.\n- Photon energy contributes to the black hole's mass-energy when absorbed.\n- Photons do not become little classical balls compressed to a mathematical point.\n- Singularities are not fully described by established quantum theory and general relativity together.\n\nThe honest ending is that black holes point toward quantum gravity, which remains unsolved.",
       "prompt": "Use this as a careful epilogue. State what is known without pretending the lesson solves quantum gravity. Correct the idea that photons literally collapse into a point.",
       "range": [
-        [-5, 5],
-        [-5, 5],
-        [-5, 5]
+        [
+          -5,
+          5
+        ],
+        [
+          -5,
+          5
+        ],
+        [
+          -5,
+          5
+        ]
       ],
-      "scale": [1, 1, 1],
+      "scale": [
+        1,
+        1,
+        1
+      ],
       "camera": {
-        "position": [0, 2, 9],
-        "target": [0, 0, 0]
+        "position": [
+          0,
+          2,
+          9
+        ],
+        "target": [
+          0,
+          0,
+          0
+        ]
       },
       "views": [
         {
           "name": "Face On",
-          "position": [0, 2, 9],
-          "target": [0, 0, 0],
+          "position": [
+            0,
+            2,
+            9
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
           "description": "Black-hole sketch"
         },
         {
           "name": "Iso",
-          "position": [5, 4, 8],
-          "target": [0, 0, 0],
+          "position": [
+            5,
+            4,
+            8
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
           "description": "Perspective view"
         }
       ],
@@ -1509,8 +2602,15 @@
           "id": "s5_grid",
           "type": "grid",
           "plane": "xy",
-          "range": [-5, 5],
-          "color": [0.18, 0.2, 0.25],
+          "range": [
+            -5,
+            5
+          ],
+          "color": [
+            0.18,
+            0.2,
+            0.25
+          ],
           "opacity": 0.14,
           "divisions": 10
         },
@@ -1520,7 +2620,10 @@
           "x": "1.3*cos(t)",
           "y": "1.3*sin(t)",
           "z": "0",
-          "range": [0, 6.283185307179586],
+          "range": [
+            0,
+            6.283185307179586
+          ],
           "samples": 180,
           "color": "#9aa4ad",
           "width": 4,
@@ -1529,7 +2632,11 @@
         {
           "id": "s5_dark_core",
           "type": "sphere",
-          "center": [0, 0, 0],
+          "center": [
+            0,
+            0,
+            0
+          ],
           "radius": 1.2,
           "color": "#050507",
           "opacity": 0.92,
@@ -1558,7 +2665,10 @@
               "x": "-4 + 4*t",
               "y": "2.4 - 2.1*t + 0.25*sin((4+grav*4)*pi*t)",
               "z": "0",
-              "range": [0, 1],
+              "range": [
+                0,
+                1
+              ],
               "samples": 200,
               "color": "#6ec6ff",
               "width": 4,
@@ -1568,7 +2678,11 @@
               "id": "s5_blue_note",
               "type": "text",
               "text": "falling: local blueshift",
-              "position": [-4.55, 3.15, 0],
+              "position": [
+                -4.55,
+                3.15,
+                0
+              ],
               "color": "#6ec6ff",
               "size": 16
             }
@@ -1592,7 +2706,10 @@
               "x": "1.55*cos(t)",
               "y": "1.55*sin(t)",
               "z": "0",
-              "range": [0, 6.283185307179586],
+              "range": [
+                0,
+                6.283185307179586
+              ],
               "samples": 180,
               "color": "#f0b84b",
               "width": 2,
@@ -1602,7 +2719,11 @@
               "id": "s5_energy_note",
               "type": "text",
               "text": "$\\Delta M=E/c^2$",
-              "position": [1.9, -1.9, 0],
+              "position": [
+                1.9,
+                -1.9,
+                0
+              ],
               "color": "#f0b84b",
               "size": 17
             }
@@ -1624,7 +2745,11 @@
               "id": "s5_limit_text",
               "type": "text",
               "text": "singularity physics: unresolved",
-              "position": [-4.45, -3.05, 0],
+              "position": [
+                -4.45,
+                -3.05,
+                0
+              ],
               "color": "#ff7b72",
               "size": 16
             },
@@ -1632,7 +2757,11 @@
               "id": "s5_qg_text",
               "type": "text",
               "text": "requires quantum gravity",
-              "position": [-4.45, -3.5, 0],
+              "position": [
+                -4.45,
+                -3.5,
+                0
+              ],
               "color": "#f0b84b",
               "size": 16
             }

--- a/scenes/draft/photons-wavelength-energy.json
+++ b/scenes/draft/photons-wavelength-energy.json
@@ -4,7 +4,7 @@
     {
       "title": "Light as a Wave: $c=f\\lambda$",
       "description": "Start with the classical wave picture: stretching wavelength lowers frequency when the wave speed is fixed.",
-      "markdown": "# Light as a Wave\n\nClassical electromagnetism treats light as a wave moving at speed $c$ in vacuum. The basic kinematic link is\n\n$$c=f\\lambda.$$\n\nIf $c$ is fixed, wavelength and frequency must trade off:\n\n$$f=\\frac{c}{\\lambda}.$$\n\nA longer wavelength means fewer crests pass a point each second. This part is continuous: in free space, a photon can have any wavelength allowed by the source and propagation conditions.\n\n## The historical pressure\n\nAt the turn of the twentieth century, classical blackbody theory led to the ultraviolet catastrophe: it predicted runaway short-wavelength emission. Planck's resolution was to make exchange of energy discrete, in units proportional to frequency. That idea became the first step toward quantum mechanics.\n\nReferences: https://en.wikipedia.org/wiki/Quantum and https://en.wikipedia.org/wiki/Photon_energy",
+      "markdown": "# Light as a Wave\n\nClassical electromagnetism treats light as a wave moving at speed $c$ in vacuum. The basic kinematic link is\n\n$$c=f\\lambda.$$\n\nIf $c$ is fixed, wavelength and frequency must trade off:\n\n$$f=\\frac{c}{\\lambda}.$$\n\nA longer wavelength means fewer crests pass a point each second. This part is continuous: in free space, a photon can have any wavelength allowed by the source and propagation conditions.\n\n## What this wave is — and what it is not\n\nThe sine wave shown here represents the **electric field** component of a classical electromagnetic wave: $E_y(x,t)=A\\sin(kx-\\omega t)$, described by Maxwell's equations.\n\nA real EM wave has **two fields** oscillating in phase, perpendicular to each other and to the propagation direction:\n\n- **Electric field** $\\vec{E}$: shown here as the sine wave in the $y$-direction.\n- **Magnetic field** $\\vec{B}$: oscillates in the $z$-direction (perpendicular to the screen), with magnitude $B=E/c$.\n\nWe show only the electric field because it is the component that does most of the work on charged matter — it drives electron oscillations, photoelectric ejection, and detector responses. The magnetic component is always present but $c$ times smaller in SI units.\n\nThis wave does not depict a single photon. In quantum terms it corresponds to a **coherent state** — a huge number of photons all sharing the same frequency, direction, and phase, like a laser beam or a radio signal. The amplitude $A$ is the peak electric field strength. A brighter beam has a larger $A$, which means more photons per second, not more energetic photons.\n\nA single photon is one quantum excitation of the field mode. It has definite energy $E=hf$ and momentum $p=h/\\lambda$, but it does not have a definite classical electric field value. To depict a single photon, you would show a localized **wave packet** — a few oscillations that taper off — not an infinite plane wave.\n\nThe quantum content of this scene is the relation $E=hf$: the wave's energy is not continuous but comes in discrete packets, each carrying energy proportional to frequency. The wave picture gives wavelength and frequency; quantization gives the energy rule.\n\n## The historical pressure\n\nAt the turn of the twentieth century, classical blackbody theory led to the ultraviolet catastrophe: it predicted runaway short-wavelength emission. Planck's resolution was to make exchange of energy discrete, in units proportional to frequency. That idea became the first step toward quantum mechanics.\n\nReferences: https://en.wikipedia.org/wiki/Quantum and https://en.wikipedia.org/wiki/Photon_energy",
       "prompt": "Teach the wave kinematics first. Keep the distinction clear: c = f lambda is a wave relation, while E = hf is the quantum energy relation introduced next. Emphasize that stretching wavelength lowers frequency for fixed c.",
       "functions": [
         {
@@ -1314,6 +1314,73 @@
               "id": "s0_wavelength_info",
               "position": "top-left",
               "content": "**Wavelength \u2192 frequency**\n\n$$f=\\frac{c}{\\lambda}$$\n\n| $\\lambda$ (nm) | $f$ (THz) | Color |\n|---|---|---|\n| 380 | 789 | violet |\n| 480 | 625 | cyan |\n| 550 | 545 | green |\n| 600 | 500 | orange |\n| 700 | 428 | red |"
+            }
+          ]
+        },
+        {
+          "title": "The full picture: $\\vec{E}$ and $\\vec{B}$",
+          "description": "An electromagnetic wave has two perpendicular oscillating fields. Until now we showed only the electric field $\\vec{E}$ (in $y$). The magnetic field $\\vec{B}$ oscillates in $z$, perpendicular to both $\\vec{E}$ and the propagation direction. Switch to the Iso view to see both components in 3D.",
+          "prompt": "Reveal the magnetic field component oscillating in the z-direction. Explain that every EM wave has both E and B perpendicular to each other and to the propagation direction. We showed only E because it dominates interactions with charged matter. Note B = E/c in SI units; we exaggerate B visually for clarity.",
+          "camera": {
+            "position": [6, 5, 10],
+            "target": [0, 1, 0]
+          },
+          "remove": [
+            { "type": "info" },
+            { "id": "s0_wave_title" }
+          ],
+          "add": [
+            {
+              "id": "s0_B_wave",
+              "type": "parametric_curve",
+              "x": "t",
+              "y": "0",
+              "z": "sin(2*pi*t/lambda)",
+              "range": [0, 12],
+              "samples": 300,
+              "color": "#e85d75",
+              "width": 4,
+              "label": "$\\vec{B}$ (magnetic)"
+            },
+            {
+              "id": "s0_z_ref",
+              "type": "line",
+              "points": [[0, 0, 0], [0, 0, 2]],
+              "color": "#555e6a",
+              "width": 1,
+              "opacity": 0.4,
+              "legendGroup": "$\\vec{B}$ (magnetic)"
+            },
+            {
+              "id": "s0_E_field_label",
+              "type": "text",
+              "text": "$\\vec{E}$ (electric)",
+              "position": [1, 1.4, 0],
+              "color": "#2f9e9b",
+              "size": 16
+            },
+            {
+              "id": "s0_B_field_label",
+              "type": "text",
+              "text": "$\\vec{B}$ (magnetic)",
+              "position": [1, 0, 1.4],
+              "color": "#e85d75",
+              "size": 16
+            },
+            {
+              "id": "s0_prop_label",
+              "type": "text",
+              "text": "propagation $\\rightarrow$",
+              "position": [10, -0.5, 0],
+              "color": "#9aa4ad",
+              "size": 14
+            }
+          ],
+          "info": [
+            {
+              "id": "s0_eb_info",
+              "position": "top-right",
+              "content": "**Complete EM wave**\n\n$$\\vec{E}=E_0\\sin(kx-\\omega t)\\,\\hat{y}$$\n\n$$\\vec{B}=\\frac{E_0}{c}\\sin(kx-\\omega t)\\,\\hat{z}$$\n\n$\\vec{E}\\perp\\vec{B}\\perp\\hat{x}$\n\nPrevious steps showed only $\\vec{E}$ because it dominates interactions with charged matter."
             }
           ]
         }

--- a/scenes/draft/photons-wavelength-energy.json
+++ b/scenes/draft/photons-wavelength-energy.json
@@ -1218,7 +1218,7 @@
           ],
           "color": "#9aa4ad",
           "width": 1.2,
-          "label": "$E$"
+          "label": "$E\\;(\\text{eV})$"
         },
         {
           "id": "s1_grid",
@@ -1240,8 +1240,8 @@
       "steps": [
         {
           "title": "Energy per photon",
-          "description": "Set red photon energy to 1 unit and blue photon energy to 2.5 units. The blue photon is larger per photon because $E=hf$.",
-          "prompt": "Introduce this as scaled units, not real electron-volts. Keep the proportional relationship central.",
+          "description": "A red photon ($\\lambda=700$ nm) carries $1.77$ eV; a blue photon ($\\lambda=450$ nm) carries $2.76$ eV. The blue photon has more energy because $E=hf$.",
+          "prompt": "Emphasize that energy per photon is set by frequency. Use the eV numbers on the bars to ground the comparison.",
           "add": [
             {
               "id": "s1_red_bar",
@@ -1259,12 +1259,12 @@
                 ],
                 [
                   -2.4,
-                  1,
+                  1.77,
                   0
                 ],
                 [
                   -3.4,
-                  1,
+                  1.77,
                   0
                 ]
               ],
@@ -1290,12 +1290,12 @@
                 ],
                 [
                   2.8,
-                  2.5,
+                  2.76,
                   0
                 ],
                 [
                   1.8,
-                  2.5,
+                  2.76,
                   0
                 ]
               ],
@@ -1311,11 +1311,35 @@
               "text": "$E_R=hf_R$",
               "position": [
                 -3.75,
-                1.35,
+                2.15,
                 0
               ],
               "color": "#ff9a8f",
               "size": 15
+            },
+            {
+              "id": "s1_red_ev",
+              "type": "text",
+              "text": "$1.77\\;\\text{eV}$",
+              "position": [
+                -3.5,
+                0.85,
+                0
+              ],
+              "color": "#ff9a8f",
+              "size": 14
+            },
+            {
+              "id": "s1_red_wl",
+              "type": "text",
+              "text": "$\\lambda=700\\;\\text{nm}$",
+              "position": [
+                -3.55,
+                -0.45,
+                0
+              ],
+              "color": "#ff9a8f",
+              "size": 12
             },
             {
               "id": "s1_blue_label",
@@ -1323,11 +1347,35 @@
               "text": "$E_B=hf_B$",
               "position": [
                 1.45,
-                2.85,
+                3.15,
                 0
               ],
               "color": "#9dccff",
               "size": 15
+            },
+            {
+              "id": "s1_blue_ev",
+              "type": "text",
+              "text": "$2.76\\;\\text{eV}$",
+              "position": [
+                1.7,
+                1.35,
+                0
+              ],
+              "color": "#9dccff",
+              "size": 14
+            },
+            {
+              "id": "s1_blue_wl",
+              "type": "text",
+              "text": "$\\lambda=450\\;\\text{nm}$",
+              "position": [
+                1.65,
+                -0.45,
+                0
+              ],
+              "color": "#9dccff",
+              "size": 12
             }
           ],
           "info": [
@@ -1352,9 +1400,9 @@
               "id": "Nred",
               "label": "$N_{red}$",
               "min": 1,
-              "max": 6,
+              "max": 4,
               "step": 1,
-              "default": 4
+              "default": 2
             }
           ],
           "add": [
@@ -1374,12 +1422,12 @@
                 ],
                 [
                   "0.4",
-                  "Nred",
+                  "Nred * 1.77",
                   "0"
                 ],
                 [
                   "-0.6",
-                  "Nred",
+                  "Nred * 1.77",
                   "0"
                 ]
               ],

--- a/scenes/draft/photons-wavelength-energy.json
+++ b/scenes/draft/photons-wavelength-energy.json
@@ -420,6 +420,21 @@
               "legendGroup": "scale"
             },
             {
+              "id": "s0_scale_lambda_nm",
+              "type": "text",
+              "text": "$200\\;\\text{nm}$",
+              "position": [
+                "lambda + 0.6",
+                "-1.6",
+                "0"
+              ],
+              "color": "#f0b84b",
+              "size": 12,
+              "textExpr": "lambda * 100",
+              "textFormat": "$%d\\;\\text{nm}$",
+              "legendGroup": "scale"
+            },
+            {
               "id": "s0_scale_origin_tick",
               "type": "line",
               "points": [
@@ -482,12 +497,13 @@
               "type": "text",
               "text": "influenza virus $\\sim\\!100$ nm",
               "position": [
-                1.3,
+                -0.15,
                 -2.2,
                 0
               ],
               "color": "#e85d75",
-              "size": 11,
+              "size": 10,
+              "cssClass": "label-3d label-right",
               "legendGroup": "scale"
             },
             {
@@ -533,12 +549,13 @@
               "type": "text",
               "text": "bacteriophage $\\sim\\!200$ nm",
               "position": [
-                2.3,
+                -0.15,
                 -2.8,
                 0
               ],
               "color": "#7fba5c",
-              "size": 11,
+              "size": 10,
+              "cssClass": "label-3d label-right",
               "legendGroup": "scale"
             },
             {
@@ -584,12 +601,13 @@
               "type": "text",
               "text": "Mycoplasma $\\sim\\!300$ nm",
               "position": [
-                3.3,
+                -0.15,
                 -3.4,
                 0
               ],
               "color": "#5cb8e8",
-              "size": 11,
+              "size": 10,
+              "cssClass": "label-3d label-right",
               "legendGroup": "scale"
             },
             {
@@ -635,12 +653,13 @@
               "type": "text",
               "text": "$\\textit{E.\\,coli}$ width $\\sim\\!500$ nm",
               "position": [
-                5.3,
+                -0.15,
                 -4.0,
                 0
               ],
               "color": "#c49be8",
-              "size": 11,
+              "size": 10,
+              "cssClass": "label-3d label-right",
               "legendGroup": "scale"
             }
           ],

--- a/scenes/draft/photons-wavelength-energy.json
+++ b/scenes/draft/photons-wavelength-energy.json
@@ -234,8 +234,8 @@
         },
         {
           "title": "Frequency falls as wavelength grows",
-          "description": "With $c$ fixed, the frequency scales like $1/\\lambda$. The same speed is carried by wider or tighter waves.",
-          "prompt": "Use the slider to compare short and long wavelengths. Ask the learner what happens to f when lambda doubles.",
+          "description": "With $c$ fixed, the frequency scales like $1/\\lambda$. The scale bars below compare $\\lambda$ to nanoscale objects: visible light wavelengths are on the order of viruses and bacteria.",
+          "prompt": "Use the slider to compare short and long wavelengths. Ask the learner what happens to f when lambda doubles. Draw attention to the scale bars: when lambda is around 1, the wavelength is about the size of a flu virus; at lambda 5, it matches the width of an E. coli bacterium. Visible light lives in this extraordinary nanoscale world.",
           "add": [
             {
               "id": "s0_chart_lambda_axis",
@@ -379,6 +379,269 @@
               "color": "#6ec6ff",
               "size": 15,
               "label": "$f=c/\\lambda$"
+            },
+            {
+              "id": "s0_scale_lambda",
+              "type": "animated_line",
+              "points": [
+                [
+                  "0",
+                  "-1.6",
+                  "0"
+                ],
+                [
+                  "lambda",
+                  "-1.6",
+                  "0"
+                ]
+              ],
+              "color": "#f0b84b",
+              "width": 5,
+              "label": "$\\lambda$",
+              "legendGroup": "scale"
+            },
+            {
+              "id": "s0_scale_lambda_tick",
+              "type": "animated_line",
+              "points": [
+                [
+                  "lambda",
+                  "-1.4",
+                  "0"
+                ],
+                [
+                  "lambda",
+                  "-1.8",
+                  "0"
+                ]
+              ],
+              "color": "#f0b84b",
+              "width": 2,
+              "legendGroup": "scale"
+            },
+            {
+              "id": "s0_scale_origin_tick",
+              "type": "line",
+              "points": [
+                [
+                  0,
+                  -1.4,
+                  0
+                ],
+                [
+                  0,
+                  -4.0,
+                  0
+                ]
+              ],
+              "color": "#666666",
+              "width": 1,
+              "opacity": 0.4,
+              "legendGroup": "scale"
+            },
+            {
+              "id": "s0_scale_flu",
+              "type": "line",
+              "points": [
+                [
+                  0,
+                  -2.2,
+                  0
+                ],
+                [
+                  1,
+                  -2.2,
+                  0
+                ]
+              ],
+              "color": "#e85d75",
+              "width": 4,
+              "legendGroup": "scale"
+            },
+            {
+              "id": "s0_scale_flu_tick",
+              "type": "line",
+              "points": [
+                [
+                  1,
+                  -2.05,
+                  0
+                ],
+                [
+                  1,
+                  -2.35,
+                  0
+                ]
+              ],
+              "color": "#e85d75",
+              "width": 2,
+              "legendGroup": "scale"
+            },
+            {
+              "id": "s0_scale_flu_label",
+              "type": "text",
+              "text": "influenza virus $\\sim\\!100$ nm",
+              "position": [
+                1.3,
+                -2.2,
+                0
+              ],
+              "color": "#e85d75",
+              "size": 11,
+              "legendGroup": "scale"
+            },
+            {
+              "id": "s0_scale_phage",
+              "type": "line",
+              "points": [
+                [
+                  0,
+                  -2.8,
+                  0
+                ],
+                [
+                  2,
+                  -2.8,
+                  0
+                ]
+              ],
+              "color": "#7fba5c",
+              "width": 4,
+              "legendGroup": "scale"
+            },
+            {
+              "id": "s0_scale_phage_tick",
+              "type": "line",
+              "points": [
+                [
+                  2,
+                  -2.65,
+                  0
+                ],
+                [
+                  2,
+                  -2.95,
+                  0
+                ]
+              ],
+              "color": "#7fba5c",
+              "width": 2,
+              "legendGroup": "scale"
+            },
+            {
+              "id": "s0_scale_phage_label",
+              "type": "text",
+              "text": "bacteriophage $\\sim\\!200$ nm",
+              "position": [
+                2.3,
+                -2.8,
+                0
+              ],
+              "color": "#7fba5c",
+              "size": 11,
+              "legendGroup": "scale"
+            },
+            {
+              "id": "s0_scale_myco",
+              "type": "line",
+              "points": [
+                [
+                  0,
+                  -3.4,
+                  0
+                ],
+                [
+                  3,
+                  -3.4,
+                  0
+                ]
+              ],
+              "color": "#5cb8e8",
+              "width": 4,
+              "legendGroup": "scale"
+            },
+            {
+              "id": "s0_scale_myco_tick",
+              "type": "line",
+              "points": [
+                [
+                  3,
+                  -3.25,
+                  0
+                ],
+                [
+                  3,
+                  -3.55,
+                  0
+                ]
+              ],
+              "color": "#5cb8e8",
+              "width": 2,
+              "legendGroup": "scale"
+            },
+            {
+              "id": "s0_scale_myco_label",
+              "type": "text",
+              "text": "Mycoplasma $\\sim\\!300$ nm",
+              "position": [
+                3.3,
+                -3.4,
+                0
+              ],
+              "color": "#5cb8e8",
+              "size": 11,
+              "legendGroup": "scale"
+            },
+            {
+              "id": "s0_scale_ecoli",
+              "type": "line",
+              "points": [
+                [
+                  0,
+                  -4.0,
+                  0
+                ],
+                [
+                  5,
+                  -4.0,
+                  0
+                ]
+              ],
+              "color": "#c49be8",
+              "width": 4,
+              "legendGroup": "scale"
+            },
+            {
+              "id": "s0_scale_ecoli_tick",
+              "type": "line",
+              "points": [
+                [
+                  5,
+                  -3.85,
+                  0
+                ],
+                [
+                  5,
+                  -4.15,
+                  0
+                ]
+              ],
+              "color": "#c49be8",
+              "width": 2,
+              "legendGroup": "scale"
+            },
+            {
+              "id": "s0_scale_ecoli_label",
+              "type": "text",
+              "text": "$\\textit{E.\\,coli}$ width $\\sim\\!500$ nm",
+              "position": [
+                5.3,
+                -4.0,
+                0
+              ],
+              "color": "#c49be8",
+              "size": 11,
+              "legendGroup": "scale"
             }
           ],
           "info": [
@@ -409,8 +672,8 @@
         },
         {
           "title": "Visible light: real wavelengths",
-          "description": "Map the abstract $\\lambda$ to real wavelengths. The vertical spectrum bar shows how frequency maps to color.",
-          "prompt": "Show how the abstract wavelength maps to visible light. The vertical color bar next to the f-axis shows the direct mapping: higher frequency means shorter wavelength and bluer color. Emphasize that our eyes only see a tiny slice of the full EM spectrum.",
+          "description": "Map the abstract $\\lambda$ to real wavelengths. The vertical spectrum bar shows how frequency maps to color. Note: the wave's amplitude represents the peak electric field strength, not its energy or wavelength\u2014amplitude depends on intensity (how many photons), not on color.",
+          "prompt": "Show how the abstract wavelength maps to visible light. The vertical color bar next to the f-axis shows the direct mapping: higher frequency means shorter wavelength and bluer color. Emphasize that our eyes only see a tiny slice of the full EM spectrum. Point out that the amplitude of the wave is the electric field strength and is independent of wavelength\u2014it depends on the light's intensity, not its color. A dim blue beam and a dim red beam have the same small amplitude; a bright red beam has a large amplitude.",
           "remove": [
             {
               "type": "info"

--- a/scenes/draft/photons-wavelength-energy.json
+++ b/scenes/draft/photons-wavelength-energy.json
@@ -1,0 +1,1217 @@
+{
+  "title": "Photons, Wavelength, and Energy: The Quantized Ripple",
+  "scenes": [
+    {
+      "title": "Light as a Wave: $c=f\\lambda$",
+      "description": "Start with the classical wave picture: stretching wavelength lowers frequency when the wave speed is fixed.",
+      "markdown": "# Light as a Wave\n\nClassical electromagnetism treats light as a wave moving at speed $c$ in vacuum. The basic kinematic link is\n\n$$c=f\\lambda.$$\n\nIf $c$ is fixed, wavelength and frequency must trade off:\n\n$$f=\\frac{c}{\\lambda}.$$\n\nA longer wavelength means fewer crests pass a point each second. This part is continuous: in free space, a photon can have any wavelength allowed by the source and propagation conditions.\n\n## The historical pressure\n\nAt the turn of the twentieth century, classical blackbody theory led to the ultraviolet catastrophe: it predicted runaway short-wavelength emission. Planck's resolution was to make exchange of energy discrete, in units proportional to frequency. That idea became the first step toward quantum mechanics.\n\nReferences: https://en.wikipedia.org/wiki/Quantum and https://en.wikipedia.org/wiki/Photon_energy",
+      "prompt": "Teach the wave kinematics first. Keep the distinction clear: c = f lambda is a wave relation, while E = hf is the quantum energy relation introduced next. Emphasize that stretching wavelength lowers frequency for fixed c.",
+      "range": [
+        [-6, 6],
+        [-2.8, 2.8],
+        [-2.8, 2.8]
+      ],
+      "camera": {
+        "position": [0, 0, 9],
+        "target": [0, 0, 0]
+      },
+      "views": [
+        {
+          "name": "Wave",
+          "position": [0, 0, 9],
+          "target": [0, 0, 0],
+          "description": "Face-on wave view"
+        },
+        {
+          "name": "Iso",
+          "position": [6, 4, 7],
+          "target": [0, 0, 0],
+          "description": "Three-dimensional context"
+        }
+      ],
+      "elements": [
+        {
+          "id": "s0_x_axis",
+          "type": "axis",
+          "axis": "x",
+          "range": [-6, 6],
+          "color": "#d04f4f",
+          "width": 1.5,
+          "label": "$x$"
+        },
+        {
+          "id": "s0_grid",
+          "type": "grid",
+          "plane": "xy",
+          "range": [-6, 6],
+          "color": [0.28, 0.32, 0.38],
+          "opacity": 0.16,
+          "divisions": 12
+        }
+      ],
+      "steps": [
+        {
+          "title": "A travelling ripple",
+          "description": "A sinusoidal wave gives the first mental model: a spatially spread disturbance with a wavelength $\\lambda$.",
+          "prompt": "Introduce wavelength as crest-to-crest spacing. Do not talk about photons as tiny balls.",
+          "sliders": [
+            {
+              "id": "lambda",
+              "label": "$\\lambda$",
+              "min": 1,
+              "max": 5,
+              "step": 0.1,
+              "default": 2.4
+            }
+          ],
+          "add": [
+            {
+              "id": "s0_wave",
+              "type": "parametric_curve",
+              "x": "t",
+              "y": "sin(2*pi*t/lambda)",
+              "z": "0",
+              "range": [-6, 6],
+              "samples": 240,
+              "color": "#2f9e9b",
+              "width": 4,
+              "label": "$\\text{electric-field ripple}$"
+            },
+            {
+              "id": "s0_lambda_span",
+              "type": "animated_line",
+              "points": [
+                ["-lambda/2", "-1.55", "0"],
+                ["lambda/2", "-1.55", "0"]
+              ],
+              "color": "#f0b84b",
+              "width": 5,
+              "label": "$\\lambda$"
+            },
+            {
+              "id": "s0_lambda_label",
+              "type": "text",
+              "text": "$\\lambda$",
+              "position": [0, -1.9, 0],
+              "color": "#f0b84b",
+              "label": "$\\lambda$",
+              "size": 18
+            }
+          ],
+          "info": [
+            {
+              "id": "s0_wave_info",
+              "position": "top-right",
+              "content": "$$c=f\\lambda$$\nFor fixed $c$, increasing $\\lambda$ decreases $f$."
+            }
+          ]
+        },
+        {
+          "title": "Frequency falls as wavelength grows",
+          "description": "With $c$ fixed, the frequency scales like $1/\\lambda$. The same speed is carried by wider or tighter ripples.",
+          "prompt": "Use the slider to compare short and long wavelengths. Ask the learner what happens to f when lambda doubles.",
+          "add": [
+            {
+              "id": "s0_freq_bar_bg",
+              "type": "line",
+              "points": [
+                [4.5, -1.8, 0],
+                [4.5, 1.8, 0]
+              ],
+              "color": "#3b4652",
+              "width": 10
+            },
+            {
+              "id": "s0_freq_bar",
+              "type": "animated_line",
+              "points": [
+                ["4.5", "-1.8", "0"],
+                ["4.5", "-1.8 + 3.6/lambda", "0"]
+              ],
+              "color": "#6ec6ff",
+              "width": 10,
+              "label": "$f\\propto 1/\\lambda$"
+            },
+            {
+              "id": "s0_freq_label",
+              "type": "text",
+              "text": "$f=c/\\lambda$",
+              "position": [3.35, 2.05, 0],
+              "color": "#6ec6ff",
+              "label": "$f\\propto 1/\\lambda$",
+              "size": 16
+            }
+          ],
+          "info": [
+            {
+              "id": "s0_kinematic_info",
+              "position": "bottom-right",
+              "content": "**Kinematic link**\n\nStretch the wave: fewer peaks pass per second.\n\n$$f=\\frac{c}{\\lambda}$$"
+            }
+          ]
+        },
+        {
+          "title": "The crisis of the infinite",
+          "description": "Classical theory could treat wavelengths continuously, but blackbody radiation forced a deeper idea: energy exchange is quantized.",
+          "prompt": "Frame the ultraviolet catastrophe as the reason the energy rule had to change. Avoid overclaiming: Planck quantized exchange of energy, not simply spatial wavelength.",
+          "remove": [
+            {
+              "type": "info"
+            }
+          ],
+          "add": [
+            {
+              "id": "s0_uv_warning",
+              "type": "text",
+              "text": "Classical prediction: short wavelengths run away",
+              "position": [-3.5, 2.1, 0],
+              "color": "#ff6b6b",
+              "size": 16
+            },
+            {
+              "id": "s0_planck_text",
+              "type": "text",
+              "text": "Planck: energy comes in quanta",
+              "position": [-3.5, 1.62, 0],
+              "color": "#f0b84b",
+              "size": 16
+            }
+          ],
+          "info": [
+            {
+              "id": "s0_planck_info",
+              "position": "top-right",
+              "content": "**Planck's move**\n\nEnergy exchange is not arbitrary:\n\n$$E=hf$$\n\nThis is the bridge from the wave picture to photons."
+            }
+          ]
+        }
+      ],
+      "proof": {
+        "id": "wave_kinematics",
+        "title": "Why $f=c/\\lambda$",
+        "technique": "derivation",
+        "goal": "Show that a wave moving at speed $c$ with wavelength $\\lambda$ has frequency $f=c/\\lambda$.",
+        "prompt": "Keep this proof short and physical: speed is distance per time, and one period advances one wavelength.",
+        "steps": [
+          {
+            "id": "period_distance",
+            "type": "given",
+            "label": "One period",
+            "math": "\\text{distance in one period}=\\lambda",
+            "justification": "By definition, one period carries one crest spacing past a fixed point.",
+            "explanation": "A crest advances by exactly one wavelength in one full cycle.",
+            "prompt": "Tie the algebra to the moving crest.",
+            "sceneStep": 0
+          },
+          {
+            "id": "speed_period",
+            "type": "step",
+            "label": "Speed",
+            "math": "c=\\frac{\\lambda}{T}",
+            "justification": "Speed equals distance divided by time.",
+            "explanation": "The wave travels one wavelength in one period $T$.",
+            "prompt": "Ask what happens if T is small.",
+            "sceneStep": 1
+          },
+          {
+            "id": "frequency_result",
+            "type": "conclusion",
+            "label": "Frequency",
+            "math": "f=\\frac{1}{T}=\\frac{c}{\\lambda}",
+            "justification": "Frequency is the reciprocal of period.",
+            "explanation": "This gives the kinematic relation $c=f\\lambda$.",
+            "prompt": "Connect the result to the wavelength slider.",
+            "sceneStep": 1
+          }
+        ]
+      }
+    },
+    {
+      "title": "One Photon Energy vs Light Intensity",
+      "description": "The energy of one photon depends on frequency; intensity depends on how many photons arrive.",
+      "markdown": "# Photon Energy\n\nThe Planck-Einstein relation is\n\n$$E=hf=\\frac{hc}{\\lambda}.$$\n\nA shorter-wavelength blue photon has more energy than a longer-wavelength red photon. But that statement is about **one photon**.\n\nA beam's total delivered energy also depends on photon count:\n\n$$E_{\\text{total}}=Nhf.$$\n\nSo the useful correction is:\n\n- Blue photon: higher energy per photon than red.\n- Many red photons: can carry more total energy than one blue photon.\n- Intensity: mainly photon number flux.\n- Color/frequency: energy per photon.",
+      "prompt": "Correct the common misconception directly. Say: one blue photon has more energy than one red photon, but many red photons can carry more total energy. Separate energy per photon from photon count/intensity.",
+      "range": [
+        [-5, 5],
+        [-1, 7],
+        [-3, 3]
+      ],
+      "camera": {
+        "position": [0, 0, 10],
+        "target": [0, 3, 0]
+      },
+      "views": [
+        {
+          "name": "Bars",
+          "position": [0, 0, 10],
+          "target": [0, 3, 0],
+          "description": "Energy comparison"
+        },
+        {
+          "name": "Iso",
+          "position": [6, 5, 8],
+          "target": [0, 2.5, 0],
+          "description": "Perspective view"
+        }
+      ],
+      "elements": [
+        {
+          "id": "s1_y_axis",
+          "type": "axis",
+          "axis": "y",
+          "range": [0, 7],
+          "color": "#9aa4ad",
+          "width": 1.2,
+          "label": "$E$"
+        },
+        {
+          "id": "s1_grid",
+          "type": "grid",
+          "plane": "xy",
+          "range": [-5, 7],
+          "color": [0.25, 0.29, 0.34],
+          "opacity": 0.14,
+          "divisions": 12
+        }
+      ],
+      "steps": [
+        {
+          "title": "Energy per photon",
+          "description": "Set red photon energy to 1 unit and blue photon energy to 2.5 units. The blue photon is larger per photon because $E=hf$.",
+          "prompt": "Introduce this as scaled units, not real electron-volts. Keep the proportional relationship central.",
+          "add": [
+            {
+              "id": "s1_red_bar",
+              "type": "polygon",
+              "vertices": [
+                [-3.4, 0, 0],
+                [-2.4, 0, 0],
+                [-2.4, 1, 0],
+                [-3.4, 1, 0]
+              ],
+              "color": "#d84a3a",
+              "opacity": 0.75,
+              "outlineColor": "#ff9a8f",
+              "outlineWidth": 1.2,
+              "label": "one red photon"
+            },
+            {
+              "id": "s1_blue_bar",
+              "type": "polygon",
+              "vertices": [
+                [1.8, 0, 0],
+                [2.8, 0, 0],
+                [2.8, 2.5, 0],
+                [1.8, 2.5, 0]
+              ],
+              "color": "#3c8cff",
+              "opacity": 0.75,
+              "outlineColor": "#9dccff",
+              "outlineWidth": 1.2,
+              "label": "one blue photon"
+            },
+            {
+              "id": "s1_red_label",
+              "type": "text",
+              "text": "$E_R=hf_R$",
+              "position": [-3.75, 1.35, 0],
+              "color": "#ff9a8f",
+              "size": 15
+            },
+            {
+              "id": "s1_blue_label",
+              "type": "text",
+              "text": "$E_B=hf_B$",
+              "position": [1.45, 2.85, 0],
+              "color": "#9dccff",
+              "size": 15
+            }
+          ],
+          "info": [
+            {
+              "id": "s1_per_photon_info",
+              "position": "top-right",
+              "content": "$$E_B>E_R$$\nwhen $f_B>f_R$.\n\nThis compares **one photon to one photon**."
+            }
+          ]
+        },
+        {
+          "title": "Photon count changes total energy",
+          "description": "Use the red photon count slider. Many lower-energy photons can exceed the energy of one higher-energy photon.",
+          "prompt": "Let the learner move N_red. Emphasize that intensity is count per area per time, while frequency sets energy per photon.",
+          "remove": [
+            {
+              "id": "s1_per_photon_info"
+            }
+          ],
+          "sliders": [
+            {
+              "id": "Nred",
+              "label": "$N_{red}$",
+              "min": 1,
+              "max": 6,
+              "step": 1,
+              "default": 4
+            }
+          ],
+          "add": [
+            {
+              "id": "s1_red_total",
+              "type": "animated_polygon",
+              "vertices": [
+                ["-0.6", "0", "0"],
+                ["0.4", "0", "0"],
+                ["0.4", "Nred", "0"],
+                ["-0.6", "Nred", "0"]
+              ],
+              "color": "#d84a3a",
+              "opacity": 0.45,
+              "outlineColor": "#ffd0ca",
+              "outlineWidth": 1.3,
+              "label": "$N_{red}E_R$"
+            },
+            {
+              "id": "s1_total_label",
+              "type": "text",
+              "text": "$E_{total}=Nhf$",
+              "position": [-0.9, 6.35, 0],
+              "color": "#f0b84b",
+              "size": 16
+            }
+          ],
+          "info": [
+            {
+              "id": "s1_count_info",
+              "position": "top-right",
+              "content": "**Correct comparison**\n\nA blue photon has more energy than a red photon.\n\nBut $N$ red photons carry\n\n$$E_{total}=Nhf_R.$$\n\nFor large enough $N$, that total can exceed one blue photon."
+            }
+          ]
+        },
+        {
+          "title": "Color is not brightness",
+          "description": "Frequency controls energy per photon. Photon number controls intensity. The two knobs are different.",
+          "prompt": "Finish by separating two axes: frequency/color and intensity/count. Mention that real beams also involve area and time.",
+          "add": [
+            {
+              "id": "s1_frequency_axis_text",
+              "type": "text",
+              "text": "frequency: energy per photon",
+              "position": [-4.45, 5.8, 0],
+              "color": "#6ec6ff",
+              "size": 15
+            },
+            {
+              "id": "s1_intensity_axis_text",
+              "type": "text",
+              "text": "intensity: photon arrival rate",
+              "position": [-4.45, 5.35, 0],
+              "color": "#7bd389",
+              "size": 15
+            }
+          ],
+          "info": [
+            {
+              "id": "s1_distinction_info",
+              "position": "bottom-right",
+              "content": "| Quantity | Meaning |\n|---|---|\n| $f$ | energy per photon |\n| $N$ | number of photons |\n| intensity | photon flux and total power |"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "When Wavelengths Become Discrete",
+      "description": "Free waves can vary continuously; constrained waves must fit boundary conditions.",
+      "markdown": "# Continuous vs Discrete Wavelengths\n\nFree photons in open space can have a continuous range of wavelengths. Discrete spectra appear when a system is constrained.\n\nThe simplest analogy is a standing wave in a box of length $L$. If the wave must vanish at both walls, only waves that fit are allowed:\n\n$$L=n\\frac{\\lambda}{2},\\qquad n=1,2,3,\\ldots$$\n\nFor a nonrelativistic particle in a box, the energy levels scale as\n\n$$E_n=\\frac{n^2h^2}{8mL^2}.$$\n\nSo a useful correction is: the allowed wavelengths scale like $1/n$, but the particle-in-a-box energies scale like $n^2$, not like $n$.\n\nAtoms are more complicated than a literal box, but the same structural idea survives: boundary conditions and allowed quantum states produce discrete emission lines.",
+      "prompt": "Teach quantization as a boundary-condition effect. Make clear that free photons are not forced into a discrete wavelength ladder; confinement or bound-state structure creates discreteness.",
+      "range": [
+        [-0.5, 6.5],
+        [-2.5, 3.5],
+        [-2, 2]
+      ],
+      "camera": {
+        "position": [3, 0.4, 9],
+        "target": [3, 0.2, 0]
+      },
+      "views": [
+        {
+          "name": "Box",
+          "position": [3, 0.4, 9],
+          "target": [3, 0.2, 0],
+          "description": "Standing-wave view"
+        },
+        {
+          "name": "Energy",
+          "position": [6, 4, 8],
+          "target": [3, 1, 0],
+          "description": "Energy-level view"
+        }
+      ],
+      "elements": [
+        {
+          "id": "s2_box_axis",
+          "type": "axis",
+          "axis": "x",
+          "range": [0, 6],
+          "color": "#d04f4f",
+          "width": 1.5,
+          "label": "$x$"
+        },
+        {
+          "id": "s2_grid",
+          "type": "grid",
+          "plane": "xy",
+          "range": [-1, 6],
+          "color": [0.25, 0.29, 0.34],
+          "opacity": 0.14,
+          "divisions": 12
+        },
+        {
+          "id": "s2_left_wall",
+          "type": "line",
+          "points": [
+            [0, -2, 0],
+            [0, 2, 0]
+          ],
+          "color": "#d8dee9",
+          "width": 5,
+          "label": "wall"
+        },
+        {
+          "id": "s2_right_wall",
+          "type": "line",
+          "points": [
+            [6, -2, 0],
+            [6, 2, 0]
+          ],
+          "color": "#d8dee9",
+          "width": 5,
+          "legendGroup": "wall"
+        }
+      ],
+      "steps": [
+        {
+          "title": "A free spectrum is continuous",
+          "description": "Without boundary conditions selecting modes, wavelength can vary continuously.",
+          "prompt": "Start from the contrast: free space permits a continuum. Bound systems create a ladder.",
+          "add": [
+            {
+              "id": "s2_spectrum_line",
+              "type": "line",
+              "points": [
+                [0.4, 2.6, 0],
+                [5.6, 2.6, 0]
+              ],
+              "color": "#8bd3dd",
+              "width": 8,
+              "label": "continuous spectrum"
+            },
+            {
+              "id": "s2_spectrum_label",
+              "type": "text",
+              "text": "free photons: continuum",
+              "position": [1.55, 3.0, 0],
+              "color": "#8bd3dd",
+              "size": 15
+            }
+          ],
+          "info": [
+            {
+              "id": "s2_continuum_info",
+              "position": "top-right",
+              "content": "**Free system**\n\nNo wall condition forces a specific wavelength ladder.\n\nWavelength is continuous in the ideal free-space model."
+            }
+          ]
+        },
+        {
+          "title": "Boundary conditions pick standing waves",
+          "description": "The wave must have nodes at both walls, so only integer half-wavelengths fit: $L=n\\lambda/2$.",
+          "prompt": "Use the n slider to show exactly fitting waves. The walls require zero amplitude at both ends.",
+          "remove": [
+            {
+              "id": "s2_continuum_info"
+            }
+          ],
+          "sliders": [
+            {
+              "id": "n",
+              "label": "$n$",
+              "min": 1,
+              "max": 5,
+              "step": 1,
+              "default": 2
+            }
+          ],
+          "add": [
+            {
+              "id": "s2_standing_wave",
+              "type": "parametric_curve",
+              "x": "t",
+              "y": "1.25*sin(n*pi*t/6)",
+              "z": "0",
+              "range": [0, 6],
+              "samples": 240,
+              "color": "#f0b84b",
+              "width": 4,
+              "label": "$\\psi_n(x)$"
+            },
+            {
+              "id": "s2_fit_text",
+              "type": "text",
+              "text": "$L=n\\lambda/2$",
+              "position": [0.5, -2.25, 0],
+              "color": "#f0b84b",
+              "size": 16
+            }
+          ],
+          "info": [
+            {
+              "id": "s2_fit_info",
+              "position": "top-right",
+              "content": "**Allowed wavelengths**\n\n$$L=n\\frac{\\lambda}{2}$$\n\n$$\\lambda_n=\\frac{2L}{n}$$"
+            }
+          ]
+        },
+        {
+          "title": "Energy scales as $n^2$",
+          "description": "For the particle-in-a-box model, the energy ladder is quadratic: $E_n\\propto n^2$.",
+          "prompt": "Correct the linear-energy misconception. Explain that momentum scales like n, and kinetic energy goes like p^2.",
+          "add": [
+            {
+              "id": "s2_e1",
+              "type": "line",
+              "points": [
+                [4.2, 0.25, 0],
+                [5.7, 0.25, 0]
+              ],
+              "color": "#7bd389",
+              "width": 3,
+              "label": "$E_1$"
+            },
+            {
+              "id": "s2_e2",
+              "type": "line",
+              "points": [
+                [4.2, 1.0, 0],
+                [5.7, 1.0, 0]
+              ],
+              "color": "#7bd389",
+              "width": 3,
+              "label": "$E_2=4E_1$"
+            },
+            {
+              "id": "s2_e3",
+              "type": "line",
+              "points": [
+                [4.2, 2.25, 0],
+                [5.7, 2.25, 0]
+              ],
+              "color": "#7bd389",
+              "width": 3,
+              "label": "$E_3=9E_1$"
+            }
+          ],
+          "info": [
+            {
+              "id": "s2_energy_info",
+              "position": "bottom-right",
+              "content": "**Correction**\n\nNot $E_n=nhc/(2L)$ for a massive particle in a box.\n\nInstead:\n\n$$E_n=\\frac{n^2h^2}{8mL^2}$$"
+            }
+          ]
+        },
+        {
+          "title": "Emission lines are energy differences",
+          "description": "Atoms emit photons when electrons move between allowed energy levels: $E_{photon}=E_{high}-E_{low}$.",
+          "prompt": "Use this as the bridge from box analogy to atomic spectra. Avoid saying atoms are literal boxes.",
+          "add": [
+            {
+              "id": "s2_transition",
+              "type": "vector",
+              "from": [5.95, 2.25, 0],
+              "to": [5.95, 0.25, 0],
+              "color": "#ff7b72",
+              "width": 4,
+              "label": "$E_{photon}$"
+            },
+            {
+              "id": "s2_photon_line",
+              "type": "parametric_curve",
+              "x": "0.35*t + 0.4",
+              "y": "-1.15 + 0.25*sin(2*pi*t)",
+              "z": "0",
+              "range": [0, 10],
+              "samples": 160,
+              "color": "#6ec6ff",
+              "width": 3,
+              "label": "emitted photon"
+            }
+          ],
+          "info": [
+            {
+              "id": "s2_atomic_info",
+              "position": "top-right",
+              "content": "**Atomic emission**\n\n$$E_{photon}=E_{high}-E_{low}$$\n\nDiscrete energy levels create spectral lines."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Spreading Is Not Stretching",
+      "description": "A wave packet can spread through space while each photon's energy stays fixed; redshift changes energy per photon.",
+      "markdown": "# Spreading vs Stretching\n\nThis is the most important distinction in the lesson.\n\n## Spreading\n\nA beam or wave packet expands over a larger area. The same photon energy is distributed across a larger cross-section, so intensity drops. Energy per photon stays the same.\n\n## Stretching\n\nThe wavelength itself grows. Since\n\n$$E=\\frac{hc}{\\lambda},$$\n\nstretching the wavelength lowers the energy per photon.\n\nRedshift is a stretching effect. Doppler redshift comes from relative motion. Gravitational redshift comes from climbing out of a gravitational field. Cosmological redshift is described by\n\n$$\\lambda_{obs}=\\lambda_{em}(1+z).$$\n\nIn expanding spacetime, local conservation laws still hold, but a single global total energy for the universe is not generally well-defined.",
+      "prompt": "Make the distinction crisp: spreading changes intensity, stretching changes photon energy. For cosmological redshift, say global total energy is not generally well-defined in GR rather than saying energy disappears.",
+      "range": [
+        [-5, 5],
+        [-3, 4],
+        [-3, 3]
+      ],
+      "camera": {
+        "position": [0, 0, 10],
+        "target": [0, 0.5, 0]
+      },
+      "views": [
+        {
+          "name": "Face On",
+          "position": [0, 0, 10],
+          "target": [0, 0.5, 0],
+          "description": "Compare spreading and stretching"
+        },
+        {
+          "name": "Iso",
+          "position": [5, 4, 8],
+          "target": [0, 0.5, 0],
+          "description": "Perspective view"
+        }
+      ],
+      "elements": [
+        {
+          "id": "s3_grid",
+          "type": "grid",
+          "plane": "xy",
+          "range": [-5, 5],
+          "color": [0.25, 0.29, 0.34],
+          "opacity": 0.14,
+          "divisions": 10
+        },
+        {
+          "id": "s3_midline",
+          "type": "line",
+          "points": [
+            [0, -3, 0],
+            [0, 4, 0]
+          ],
+          "color": "#4b5563",
+          "width": 2
+        }
+      ],
+      "steps": [
+        {
+          "title": "Spreading dims the beam",
+          "description": "Move the radius slider. The footprint grows, so intensity drops, but the photon energy label stays unchanged.",
+          "prompt": "Explain inverse-area intuition without over-formalizing it. Energy per photon is unchanged by spreading alone.",
+          "sliders": [
+            {
+              "id": "R",
+              "label": "$R$",
+              "min": 0.8,
+              "max": 2.6,
+              "step": 0.1,
+              "default": 1.5
+            }
+          ],
+          "add": [
+            {
+              "id": "s3_spread_circle",
+              "type": "parametric_curve",
+              "x": "-2.5 + R*cos(t)",
+              "y": "0.2 + R*sin(t)",
+              "z": "0",
+              "range": [0, 6.283185307179586],
+              "samples": 160,
+              "color": "#7bd389",
+              "width": 3,
+              "label": "beam footprint"
+            },
+            {
+              "id": "s3_spread_center",
+              "type": "animated_point",
+              "expr": ["-2.5", "0.2", "0"],
+              "color": "#7bd389",
+              "size": 10,
+              "label": "$E=hf$"
+            },
+            {
+              "id": "s3_spread_text",
+              "type": "text",
+              "text": "spreading: dimmer",
+              "position": [-4.6, 3.25, 0],
+              "color": "#7bd389",
+              "size": 16
+            }
+          ],
+          "info": [
+            {
+              "id": "s3_spread_info",
+              "position": "top-left",
+              "content": "**Spreading**\n\nBigger footprint means lower intensity.\n\nEnergy per photon remains $E=hf$."
+            }
+          ]
+        },
+        {
+          "title": "Stretching lowers photon energy",
+          "description": "Redshift increases wavelength. The wave becomes longer and $E=hc/\\lambda$ decreases.",
+          "prompt": "Use the z slider to show wavelength stretching. Emphasize energy per photon, not photon count.",
+          "sliders": [
+            {
+              "id": "zshift",
+              "label": "$z$",
+              "min": 0,
+              "max": 2,
+              "step": 0.05,
+              "default": 0.6
+            }
+          ],
+          "add": [
+            {
+              "id": "s3_redshift_wave",
+              "type": "parametric_curve",
+              "x": "1.1 + 0.7*t",
+              "y": "0.2 + 0.55*sin(2*pi*t/(1+zshift))",
+              "z": "0",
+              "range": [0, 6],
+              "samples": 200,
+              "color": "#ff7b72",
+              "width": 4,
+              "label": "$\\lambda_{obs}=\\lambda_{em}(1+z)$"
+            },
+            {
+              "id": "s3_energy_bar_bg",
+              "type": "line",
+              "points": [
+                [4.25, -2.2, 0],
+                [4.25, 2.2, 0]
+              ],
+              "color": "#3b4652",
+              "width": 9
+            },
+            {
+              "id": "s3_energy_bar",
+              "type": "animated_line",
+              "points": [
+                ["4.25", "-2.2", "0"],
+                ["4.25", "-2.2 + 4.4/(1+zshift)", "0"]
+              ],
+              "color": "#f0b84b",
+              "width": 9,
+              "label": "$E\\propto 1/(1+z)$"
+            }
+          ],
+          "info": [
+            {
+              "id": "s3_stretch_info",
+              "position": "top-right",
+              "content": "**Stretching**\n\n$$\\lambda_{obs}=\\lambda_{em}(1+z)$$\n\n$$E_{obs}=\\frac{E_{em}}{1+z}$$"
+            }
+          ]
+        },
+        {
+          "title": "Cosmological caution",
+          "description": "In expanding spacetime, local conservation remains meaningful. A global total energy for the whole universe is not generally well-defined.",
+          "prompt": "State the GR caveat carefully. Avoid saying the energy simply disappears.",
+          "add": [
+            {
+              "id": "s3_gr_note",
+              "type": "text",
+              "text": "local conservation: yes",
+              "position": [-4.55, -2.15, 0],
+              "color": "#7bd389",
+              "size": 15
+            },
+            {
+              "id": "s3_global_note",
+              "type": "text",
+              "text": "global total energy: not generally defined",
+              "position": [-4.55, -2.55, 0],
+              "color": "#f0b84b",
+              "size": 15
+            }
+          ],
+          "info": [
+            {
+              "id": "s3_energy_conservation_info",
+              "position": "bottom-right",
+              "content": "**Better statement**\n\nNot: energy disappears.\n\nInstead: in general relativity, a global total energy for an expanding universe is not generally well-defined."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Photon as Wave Packet and Detection Event",
+      "description": "A photon is a quantum excitation: spread out in possibility, localized in interaction.",
+      "markdown": "# What Is a Photon?\n\nA photon is a quantized excitation of the electromagnetic field. It is not a tiny classical ball and not a classical water wave.\n\nThe useful synthesis is a wave packet:\n\n$$\\Psi(x,t)=\\int A(k)e^{i(kx-\\omega t)}\\,dk.$$\n\nBefore detection, the quantum state can be spatially spread out. Detection is localized and all-or-nothing: a detector either records an interaction or it does not.\n\nA careful wording is:\n\n- Before measurement: spread-out quantum state or probability amplitude.\n- At measurement: localized detection event.\n- Measurement updates the quantum state description.\n\nThis avoids the misleading picture of a physical classical wave instantly collapsing across the universe.",
+      "prompt": "Use cautious quantum language. Say the photon is a quantized field excitation, described by a state that can be spatially spread out, with localized detection. Avoid implying a classical physical wave literally collapses.",
+      "range": [
+        [-6, 6],
+        [-2.8, 2.8],
+        [-2.8, 2.8]
+      ],
+      "camera": {
+        "position": [0, 0, 9],
+        "target": [0, 0, 0]
+      },
+      "views": [
+        {
+          "name": "Packet",
+          "position": [0, 0, 9],
+          "target": [0, 0, 0],
+          "description": "Wave-packet view"
+        },
+        {
+          "name": "Iso",
+          "position": [6, 4, 7],
+          "target": [0, 0, 0],
+          "description": "Perspective view"
+        }
+      ],
+      "elements": [
+        {
+          "id": "s4_x_axis",
+          "type": "axis",
+          "axis": "x",
+          "range": [-6, 6],
+          "color": "#d04f4f",
+          "width": 1.2,
+          "label": "$x$"
+        },
+        {
+          "id": "s4_grid",
+          "type": "grid",
+          "plane": "xy",
+          "range": [-6, 6],
+          "color": [0.25, 0.29, 0.34],
+          "opacity": 0.14,
+          "divisions": 12
+        }
+      ],
+      "steps": [
+        {
+          "title": "A localized packet is built from many waves",
+          "description": "A packet is made by superposing many wave numbers $k$. Narrower packets require a broader spread of wavelengths.",
+          "prompt": "Introduce superposition qualitatively. This is a conceptual visualization, not a full photon field calculation.",
+          "sliders": [
+            {
+              "id": "sigma",
+              "label": "$\\sigma$",
+              "min": 0.8,
+              "max": 2.6,
+              "step": 0.1,
+              "default": 1.4
+            }
+          ],
+          "add": [
+            {
+              "id": "s4_packet",
+              "type": "parametric_curve",
+              "x": "t",
+              "y": "exp(-(t*t)/(2*sigma*sigma))*cos(7*t)",
+              "z": "0",
+              "range": [-6, 6],
+              "samples": 320,
+              "color": "#6ec6ff",
+              "width": 4,
+              "label": "$\\Psi(x)$"
+            },
+            {
+              "id": "s4_envelope_pos",
+              "type": "parametric_curve",
+              "x": "t",
+              "y": "exp(-(t*t)/(2*sigma*sigma))",
+              "z": "0",
+              "range": [-6, 6],
+              "samples": 240,
+              "color": "#f0b84b",
+              "width": 2,
+              "opacity": 0.65,
+              "label": "packet envelope"
+            },
+            {
+              "id": "s4_envelope_neg",
+              "type": "parametric_curve",
+              "x": "t",
+              "y": "-exp(-(t*t)/(2*sigma*sigma))",
+              "z": "0",
+              "range": [-6, 6],
+              "samples": 240,
+              "color": "#f0b84b",
+              "width": 2,
+              "opacity": 0.65,
+              "legendGroup": "packet envelope"
+            }
+          ],
+          "info": [
+            {
+              "id": "s4_packet_info",
+              "position": "top-right",
+              "content": "$$\\Psi(x,t)=\\int A(k)e^{i(kx-\\omega t)}\\,dk$$\n\nA packet is spread out, but not infinitely uniform."
+            }
+          ]
+        },
+        {
+          "title": "Detection is localized",
+          "description": "The spread-out state predicts probabilities. The detector records a localized event.",
+          "prompt": "Use the detector point to distinguish state description from detection event.",
+          "add": [
+            {
+              "id": "s4_detector",
+              "type": "line",
+              "points": [
+                [2.6, -2.1, 0],
+                [2.6, 2.1, 0]
+              ],
+              "color": "#ff7b72",
+              "width": 5,
+              "label": "detector"
+            },
+            {
+              "id": "s4_click",
+              "type": "point",
+              "position": [2.6, 0.25, 0],
+              "color": "#ff7b72",
+              "size": 18,
+              "label": "click"
+            },
+            {
+              "id": "s4_detection_text",
+              "type": "text",
+              "text": "localized interaction",
+              "position": [2.85, 1.85, 0],
+              "color": "#ff7b72",
+              "size": 15
+            }
+          ],
+          "info": [
+            {
+              "id": "s4_detection_info",
+              "position": "bottom-right",
+              "content": "**Photon detection**\n\nSpread-out state.\n\nLocalized interaction.\n\nAll-or-nothing detector click."
+            }
+          ]
+        },
+        {
+          "title": "The final mental model",
+          "description": "A photon is spread out in possibility and localized in interaction. Wave and particle are incomplete classical metaphors.",
+          "prompt": "Close the lesson with the core insight. Invite questions about particle in a box, atomic orbitals, or black holes as next topics.",
+          "remove": [
+            {
+              "type": "info"
+            }
+          ],
+          "add": [
+            {
+              "id": "s4_summary_1",
+              "type": "text",
+              "text": "quantized excitation",
+              "position": [-5.2, 2.2, 0],
+              "color": "#6ec6ff",
+              "size": 16
+            },
+            {
+              "id": "s4_summary_2",
+              "type": "text",
+              "text": "continuous wavelength in free space",
+              "position": [-5.2, 1.75, 0],
+              "color": "#8bd3dd",
+              "size": 16
+            },
+            {
+              "id": "s4_summary_3",
+              "type": "text",
+              "text": "discrete spectra from constraints",
+              "position": [-5.2, 1.3, 0],
+              "color": "#7bd389",
+              "size": 16
+            },
+            {
+              "id": "s4_summary_4",
+              "type": "text",
+              "text": "$E=hf=hc/\\lambda$",
+              "position": [-5.2, 0.85, 0],
+              "color": "#f0b84b",
+              "size": 18
+            }
+          ],
+          "info": [
+            {
+              "id": "s4_summary_info",
+              "position": "top-right",
+              "content": "**Core insight**\n\nA photon is not a tiny ball flying through space.\n\nIt is a quantum entity: spread out in possibility, localized in interaction."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Where Intuition Breaks: Black Holes",
+      "description": "Extreme gravity sharpens the lesson: photon energy depends on observer and spacetime, and singularities require unfinished physics.",
+      "markdown": "# Black Holes and the Limits of the Picture\n\nNear a black hole, intuition based on ordinary wave packets becomes unreliable.\n\nCorrect statements:\n\n- Falling photons can blueshift for local observers.\n- Photon energy contributes to the black hole's mass-energy when absorbed.\n- Photons do not become little classical balls compressed to a mathematical point.\n- Singularities are not fully described by established quantum theory and general relativity together.\n\nThe honest ending is that black holes point toward quantum gravity, which remains unsolved.",
+      "prompt": "Use this as a careful epilogue. State what is known without pretending the lesson solves quantum gravity. Correct the idea that photons literally collapse into a point.",
+      "range": [
+        [-5, 5],
+        [-4, 4],
+        [-4, 4]
+      ],
+      "camera": {
+        "position": [0, 2, 9],
+        "target": [0, 0, 0]
+      },
+      "views": [
+        {
+          "name": "Face On",
+          "position": [0, 2, 9],
+          "target": [0, 0, 0],
+          "description": "Black-hole sketch"
+        },
+        {
+          "name": "Iso",
+          "position": [5, 4, 8],
+          "target": [0, 0, 0],
+          "description": "Perspective view"
+        }
+      ],
+      "elements": [
+        {
+          "id": "s5_grid",
+          "type": "grid",
+          "plane": "xy",
+          "range": [-5, 5],
+          "color": [0.18, 0.2, 0.25],
+          "opacity": 0.14,
+          "divisions": 10
+        },
+        {
+          "id": "s5_horizon",
+          "type": "parametric_curve",
+          "x": "1.3*cos(t)",
+          "y": "1.3*sin(t)",
+          "z": "0",
+          "range": [0, 6.283185307179586],
+          "samples": 180,
+          "color": "#9aa4ad",
+          "width": 4,
+          "label": "event horizon"
+        },
+        {
+          "id": "s5_dark_core",
+          "type": "sphere",
+          "center": [0, 0, 0],
+          "radius": 1.2,
+          "color": "#050507",
+          "opacity": 0.92,
+          "label": "black hole"
+        }
+      ],
+      "steps": [
+        {
+          "title": "Falling light blueshifts locally",
+          "description": "A falling photon can be measured with increasing frequency by local observers deeper in the gravitational field.",
+          "prompt": "State observer dependence. Do not imply there is one universal photon energy in curved spacetime.",
+          "add": [
+            {
+              "id": "s5_photon_path",
+              "type": "parametric_curve",
+              "x": "-4 + 4*t",
+              "y": "2.4 - 2.1*t + 0.25*sin(8*pi*t)",
+              "z": "0",
+              "range": [0, 1],
+              "samples": 160,
+              "color": "#6ec6ff",
+              "width": 4,
+              "label": "incoming photon"
+            },
+            {
+              "id": "s5_blue_note",
+              "type": "text",
+              "text": "falling: local blueshift",
+              "position": [-4.55, 3.15, 0],
+              "color": "#6ec6ff",
+              "size": 16
+            }
+          ],
+          "info": [
+            {
+              "id": "s5_blueshift_info",
+              "position": "top-right",
+              "content": "**Near strong gravity**\n\nObserved photon frequency depends on observer and spacetime geometry.\n\nFalling photons can blueshift locally."
+            }
+          ]
+        },
+        {
+          "title": "Absorbed energy changes the black hole",
+          "description": "If the photon is absorbed, its energy contributes to the black hole's mass-energy.",
+          "prompt": "Make this conservative: absorbed energy contributes to mass-energy. Avoid details of horizon thermodynamics.",
+          "add": [
+            {
+              "id": "s5_mass_ring",
+              "type": "parametric_curve",
+              "x": "1.55*cos(t)",
+              "y": "1.55*sin(t)",
+              "z": "0",
+              "range": [0, 6.283185307179586],
+              "samples": 180,
+              "color": "#f0b84b",
+              "width": 2,
+              "label": "mass-energy increases"
+            },
+            {
+              "id": "s5_energy_note",
+              "type": "text",
+              "text": "$\\Delta M=E/c^2$",
+              "position": [1.9, -1.9, 0],
+              "color": "#f0b84b",
+              "size": 17
+            }
+          ],
+          "info": [
+            {
+              "id": "s5_absorb_info",
+              "position": "bottom-right",
+              "content": "**Absorption**\n\nPhoton energy is not ignored.\n\nAbsorbed energy contributes to black-hole mass-energy."
+            }
+          ]
+        },
+        {
+          "title": "Do not overextend the picture",
+          "description": "Photons do not literally collapse into a classical point. The singularity problem needs quantum gravity.",
+          "prompt": "Close by acknowledging the unsolved part. Use this as a boundary on the model, not a mystery flourish.",
+          "add": [
+            {
+              "id": "s5_limit_text",
+              "type": "text",
+              "text": "singularity physics: unresolved",
+              "position": [-4.45, -3.05, 0],
+              "color": "#ff7b72",
+              "size": 16
+            },
+            {
+              "id": "s5_qg_text",
+              "type": "text",
+              "text": "requires quantum gravity",
+              "position": [-4.45, -3.5, 0],
+              "color": "#f0b84b",
+              "size": 16
+            }
+          ],
+          "info": [
+            {
+              "id": "s5_limits_info",
+              "position": "top-left",
+              "content": "**Model boundary**\n\nNot: photons collapse into one physical point.\n\nBetter: established physics becomes incomplete at singularities."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scenes/draft/photons-wavelength-energy.json
+++ b/scenes/draft/photons-wavelength-energy.json
@@ -6,11 +6,16 @@
       "description": "Start with the classical wave picture: stretching wavelength lowers frequency when the wave speed is fixed.",
       "markdown": "# Light as a Wave\n\nClassical electromagnetism treats light as a wave moving at speed $c$ in vacuum. The basic kinematic link is\n\n$$c=f\\lambda.$$\n\nIf $c$ is fixed, wavelength and frequency must trade off:\n\n$$f=\\frac{c}{\\lambda}.$$\n\nA longer wavelength means fewer crests pass a point each second. This part is continuous: in free space, a photon can have any wavelength allowed by the source and propagation conditions.\n\n## The historical pressure\n\nAt the turn of the twentieth century, classical blackbody theory led to the ultraviolet catastrophe: it predicted runaway short-wavelength emission. Planck's resolution was to make exchange of energy discrete, in units proportional to frequency. That idea became the first step toward quantum mechanics.\n\nReferences: https://en.wikipedia.org/wiki/Quantum and https://en.wikipedia.org/wiki/Photon_energy",
       "prompt": "Teach the wave kinematics first. Keep the distinction clear: c = f lambda is a wave relation, while E = hf is the quantum energy relation introduced next. Emphasize that stretching wavelength lowers frequency for fixed c.",
+      "functions": [
+        {"name": "photonEnergy", "args": ["lambda"], "expr": "1/lambda"},
+        {"name": "freq", "args": ["lambda"], "expr": "1/lambda"}
+      ],
       "range": [
         [-6, 6],
-        [-2.8, 2.8],
-        [-2.8, 2.8]
+        [-6, 6],
+        [-6, 6]
       ],
+      "scale": [1, 1, 1],
       "camera": {
         "position": [0, 0, 9],
         "target": [0, 0, 0]
@@ -94,7 +99,7 @@
               "text": "$\\lambda$",
               "position": [0, -1.9, 0],
               "color": "#f0b84b",
-              "label": "$\\lambda$",
+              "legendGroup": "$\\lambda$",
               "size": 18
             }
           ],
@@ -119,14 +124,15 @@
                 [4.5, 1.8, 0]
               ],
               "color": "#3b4652",
-              "width": 10
+              "width": 10,
+              "legendGroup": "$f\\propto 1/\\lambda$"
             },
             {
               "id": "s0_freq_bar",
               "type": "animated_line",
               "points": [
                 ["4.5", "-1.8", "0"],
-                ["4.5", "-1.8 + 3.6/lambda", "0"]
+                ["4.5", "-1.8 + 3.6*(1/lambda)/(1/1)", "0"]
               ],
               "color": "#6ec6ff",
               "width": 10,
@@ -197,7 +203,10 @@
             "id": "period_distance",
             "type": "given",
             "label": "One period",
-            "math": "\\text{distance in one period}=\\lambda",
+            "math": "\\text{distance in one period}=\\htmlClass{hl-wavelength}{\\lambda}",
+            "highlights": {
+              "wavelength": {"color": "cyan", "label": "Crest-to-crest spacing"}
+            },
             "justification": "By definition, one period carries one crest spacing past a fixed point.",
             "explanation": "A crest advances by exactly one wavelength in one full cycle.",
             "prompt": "Tie the algebra to the moving crest.",
@@ -207,7 +216,12 @@
             "id": "speed_period",
             "type": "step",
             "label": "Speed",
-            "math": "c=\\frac{\\lambda}{T}",
+            "math": "\\htmlClass{hl-speed}{c}=\\frac{\\htmlClass{hl-wavelength}{\\lambda}}{\\htmlClass{hl-period}{T}}",
+            "highlights": {
+              "speed": {"color": "orange", "label": "Wave speed (fixed)"},
+              "wavelength": {"color": "cyan", "label": "Wavelength"},
+              "period": {"color": "yellow", "label": "Period"}
+            },
             "justification": "Speed equals distance divided by time.",
             "explanation": "The wave travels one wavelength in one period $T$.",
             "prompt": "Ask what happens if T is small.",
@@ -217,7 +231,13 @@
             "id": "frequency_result",
             "type": "conclusion",
             "label": "Frequency",
-            "math": "f=\\frac{1}{T}=\\frac{c}{\\lambda}",
+            "math": "\\htmlClass{hl-freq}{f}=\\frac{1}{\\htmlClass{hl-period}{T}}=\\frac{\\htmlClass{hl-speed}{c}}{\\htmlClass{hl-wavelength}{\\lambda}}",
+            "highlights": {
+              "freq": {"color": "green", "label": "Frequency"},
+              "period": {"color": "yellow", "label": "Period"},
+              "speed": {"color": "orange", "label": "Wave speed"},
+              "wavelength": {"color": "cyan", "label": "Wavelength"}
+            },
             "justification": "Frequency is the reciprocal of period.",
             "explanation": "This gives the kinematic relation $c=f\\lambda$.",
             "prompt": "Connect the result to the wavelength slider.",
@@ -417,7 +437,53 @@
             }
           ]
         }
-      ]
+      ],
+      "proof": {
+        "id": "total_energy",
+        "title": "Total energy of $N$ photons",
+        "technique": "derivation",
+        "goal": "Show that $N$ identical photons of frequency $f$ carry total energy $E_{total}=Nhf$.",
+        "prompt": "Keep this derivation simple. The key insight is linearity: each photon independently carries $hf$.",
+        "steps": [
+          {
+            "id": "single_photon",
+            "type": "given",
+            "label": "Single photon energy",
+            "math": "\\htmlClass{hl-energy}{E}=\\htmlClass{hl-planck}{h}\\htmlClass{hl-freq}{f}",
+            "highlights": {
+              "energy": {"color": "orange", "label": "Energy of one photon"},
+              "planck": {"color": "yellow", "label": "Planck constant"},
+              "freq": {"color": "cyan", "label": "Frequency"}
+            },
+            "justification": "Planck-Einstein relation.",
+            "explanation": "Each photon carries energy proportional to its frequency.",
+            "sceneStep": 0
+          },
+          {
+            "id": "n_photons",
+            "type": "step",
+            "label": "N identical photons",
+            "math": "\\htmlClass{hl-total}{E_{total}}=\\htmlClass{hl-count}{N}\\cdot\\htmlClass{hl-energy}{hf}",
+            "highlights": {
+              "total": {"color": "green", "label": "Total beam energy"},
+              "count": {"color": "magenta", "label": "Photon count"},
+              "energy": {"color": "orange", "label": "Energy per photon"}
+            },
+            "justification": "Photon energies add independently.",
+            "explanation": "Total energy scales linearly with photon count.",
+            "sceneStep": 1
+          },
+          {
+            "id": "intensity_distinction",
+            "type": "conclusion",
+            "label": "Intensity vs color",
+            "math": "\\text{intensity}\\propto N,\\quad \\text{color}\\propto f",
+            "justification": "Frequency sets energy per photon; count sets total energy.",
+            "explanation": "Brightness and color are independent controls.",
+            "sceneStep": 2
+          }
+        ]
+      }
     },
     {
       "title": "When Wavelengths Become Discrete",
@@ -479,10 +545,10 @@
         },
         {
           "id": "s2_right_wall",
-          "type": "line",
+          "type": "animated_line",
           "points": [
-            [6, -2, 0],
-            [6, 2, 0]
+            ["L", "-2", "0"],
+            ["L", "2", "0"]
           ],
           "color": "#d8dee9",
           "width": 5,
@@ -540,6 +606,14 @@
               "max": 5,
               "step": 1,
               "default": 2
+            },
+            {
+              "id": "L",
+              "label": "$L$ (box length)",
+              "min": 3,
+              "max": 6,
+              "step": 0.5,
+              "default": 6
             }
           ],
           "add": [
@@ -547,7 +621,7 @@
               "id": "s2_standing_wave",
               "type": "parametric_curve",
               "x": "t",
-              "y": "1.25*sin(n*pi*t/6)",
+              "y": "1.25*sin(n*pi*t/L)",
               "z": "0",
               "range": [0, 6],
               "samples": 240,
@@ -663,9 +737,10 @@
       "prompt": "Make the distinction crisp: spreading changes intensity, stretching changes photon energy. For cosmological redshift, say global total energy is not generally well-defined in GR rather than saying energy disappears.",
       "range": [
         [-5, 5],
-        [-3, 4],
-        [-3, 3]
+        [-5, 5],
+        [-5, 5]
       ],
+      "scale": [1, 1, 1],
       "camera": {
         "position": [0, 0, 10],
         "target": [0, 0.5, 0]
@@ -713,7 +788,7 @@
           "sliders": [
             {
               "id": "R",
-              "label": "$R$",
+              "label": "$R$ (beam radius)",
               "min": 0.8,
               "max": 2.6,
               "step": 0.1,
@@ -793,7 +868,8 @@
                 [4.25, 2.2, 0]
               ],
               "color": "#3b4652",
-              "width": 9
+              "width": 9,
+              "legendGroup": "$E\\propto 1/(1+z)$"
             },
             {
               "id": "s3_energy_bar",
@@ -845,7 +921,59 @@
             }
           ]
         }
-      ]
+      ],
+      "proof": {
+        "id": "redshift_energy",
+        "title": "Redshifted photon energy",
+        "technique": "derivation",
+        "goal": "Show that cosmological redshift reduces photon energy: $E_{obs}=E_{em}/(1+z)$.",
+        "prompt": "Derive from the wavelength relation and E = hc/lambda. Keep it algebraic.",
+        "steps": [
+          {
+            "id": "redshift_def",
+            "type": "given",
+            "label": "Redshift relation",
+            "math": "\\htmlClass{hl-obs}{\\lambda_{obs}}=\\htmlClass{hl-em}{\\lambda_{em}}(1+\\htmlClass{hl-z}{z})",
+            "highlights": {
+              "obs": {"color": "orange", "label": "Observed wavelength"},
+              "em": {"color": "cyan", "label": "Emitted wavelength"},
+              "z": {"color": "yellow", "label": "Redshift parameter"}
+            },
+            "justification": "Definition of cosmological redshift.",
+            "explanation": "Space expansion stretches the wavelength by a factor $(1+z)$.",
+            "sceneStep": 1
+          },
+          {
+            "id": "energy_substitution",
+            "type": "step",
+            "label": "Substitute into $E=hc/\\lambda$",
+            "math": "\\htmlClass{hl-eobs}{E_{obs}}=\\frac{hc}{\\htmlClass{hl-obs}{\\lambda_{obs}}}=\\frac{hc}{\\htmlClass{hl-em}{\\lambda_{em}}(1+\\htmlClass{hl-z}{z})}",
+            "highlights": {
+              "eobs": {"color": "green", "label": "Observed energy"},
+              "obs": {"color": "orange", "label": "Observed wavelength"},
+              "em": {"color": "cyan", "label": "Emitted wavelength"},
+              "z": {"color": "yellow", "label": "Redshift parameter"}
+            },
+            "justification": "Replace $\\lambda_{obs}$ with the redshift expression.",
+            "explanation": "The longer wavelength means less energy per photon.",
+            "sceneStep": 1
+          },
+          {
+            "id": "energy_result",
+            "type": "conclusion",
+            "label": "Redshifted energy",
+            "math": "\\htmlClass{hl-eobs}{E_{obs}}=\\frac{\\htmlClass{hl-eem}{E_{em}}}{1+\\htmlClass{hl-z}{z}}",
+            "highlights": {
+              "eobs": {"color": "green", "label": "Observed energy"},
+              "eem": {"color": "cyan", "label": "Emitted energy"},
+              "z": {"color": "yellow", "label": "Redshift parameter"}
+            },
+            "justification": "Recognize $hc/\\lambda_{em}=E_{em}$.",
+            "explanation": "Stretching lowers energy per photon by exactly the redshift factor.",
+            "sceneStep": 1
+          }
+        ]
+      }
     },
     {
       "title": "Photon as Wave Packet and Detection Event",
@@ -854,9 +982,10 @@
       "prompt": "Use cautious quantum language. Say the photon is a quantized field excitation, described by a state that can be spatially spread out, with localized detection. Avoid implying a classical physical wave literally collapses.",
       "range": [
         [-6, 6],
-        [-2.8, 2.8],
-        [-2.8, 2.8]
+        [-6, 6],
+        [-6, 6]
       ],
+      "scale": [1, 1, 1],
       "camera": {
         "position": [0, 0, 9],
         "target": [0, 0, 0]
@@ -1059,9 +1188,10 @@
       "prompt": "Use this as a careful epilogue. State what is known without pretending the lesson solves quantum gravity. Correct the idea that photons literally collapse into a point.",
       "range": [
         [-5, 5],
-        [-4, 4],
-        [-4, 4]
+        [-5, 5],
+        [-5, 5]
       ],
+      "scale": [1, 1, 1],
       "camera": {
         "position": [0, 2, 9],
         "target": [0, 0, 0]
@@ -1117,15 +1247,25 @@
           "title": "Falling light blueshifts locally",
           "description": "A falling photon can be measured with increasing frequency by local observers deeper in the gravitational field.",
           "prompt": "State observer dependence. Do not imply there is one universal photon energy in curved spacetime.",
+          "sliders": [
+            {
+              "id": "grav",
+              "label": "$g$ (gravity strength)",
+              "min": 1,
+              "max": 4,
+              "step": 0.1,
+              "default": 2
+            }
+          ],
           "add": [
             {
               "id": "s5_photon_path",
               "type": "parametric_curve",
               "x": "-4 + 4*t",
-              "y": "2.4 - 2.1*t + 0.25*sin(8*pi*t)",
+              "y": "2.4 - 2.1*t + 0.25*sin((4+grav*4)*pi*t)",
               "z": "0",
               "range": [0, 1],
-              "samples": 160,
+              "samples": 200,
               "color": "#6ec6ff",
               "width": 4,
               "label": "incoming photon"

--- a/scenes/draft/photons-wavelength-energy.json
+++ b/scenes/draft/photons-wavelength-energy.json
@@ -129,7 +129,7 @@
             {
               "id": "lambda",
               "label": "$\\lambda$",
-              "min": 0.8,
+              "min": 0.1,
               "max": 10,
               "step": 0.1,
               "default": 2
@@ -503,7 +503,7 @@
               ],
               "color": "#e85d75",
               "size": 10,
-              "cssClass": "label-3d label-right",
+              "align": "right",
               "legendGroup": "scale"
             },
             {
@@ -555,7 +555,7 @@
               ],
               "color": "#7fba5c",
               "size": 10,
-              "cssClass": "label-3d label-right",
+              "align": "right",
               "legendGroup": "scale"
             },
             {
@@ -607,7 +607,7 @@
               ],
               "color": "#5cb8e8",
               "size": 10,
-              "cssClass": "label-3d label-right",
+              "align": "right",
               "legendGroup": "scale"
             },
             {
@@ -659,7 +659,7 @@
               ],
               "color": "#c49be8",
               "size": 10,
-              "cssClass": "label-3d label-right",
+              "align": "right",
               "legendGroup": "scale"
             }
           ],

--- a/scenes/draft/photons-wavelength-energy.json
+++ b/scenes/draft/photons-wavelength-energy.json
@@ -94,7 +94,7 @@
               0
             ],
             [
-              6,
+              12,
               0,
               0
             ]
@@ -144,9 +144,9 @@
               "z": "0",
               "range": [
                 0,
-                6
+                12
               ],
-              "samples": 200,
+              "samples": 300,
               "color": "#2f9e9b",
               "width": 4,
               "legendGroup": "$\\text{EM wave}$"

--- a/scenes/draft/photons-wavelength-energy.json
+++ b/scenes/draft/photons-wavelength-energy.json
@@ -17,32 +17,31 @@
       ],
       "scale": [1, 1, 1],
       "camera": {
-        "position": [0, 0, 9],
-        "target": [0, 0, 0]
+        "position": [0, 1, 12],
+        "target": [0, 1, 0]
       },
       "views": [
         {
           "name": "Wave",
-          "position": [0, 0, 9],
-          "target": [0, 0, 0],
+          "position": [0, 1, 12],
+          "target": [0, 1, 0],
           "description": "Face-on wave view"
         },
         {
           "name": "Iso",
-          "position": [6, 4, 7],
-          "target": [0, 0, 0],
+          "position": [6, 5, 10],
+          "target": [0, 1, 0],
           "description": "Three-dimensional context"
         }
       ],
       "elements": [
         {
-          "id": "s0_x_axis",
-          "type": "axis",
-          "axis": "x",
-          "range": [-6, 6],
-          "color": "#d04f4f",
-          "width": 1.5,
-          "label": "$x$"
+          "id": "s0_wave_axis",
+          "type": "line",
+          "points": [[0, 0, 0], [6, 0, 0]],
+          "color": "#555e6a",
+          "width": 1,
+          "legendGroup": "$\\text{EM wave}$"
         },
         {
           "id": "s0_grid",
@@ -50,14 +49,14 @@
           "plane": "xy",
           "range": [-6, 6],
           "color": [0.28, 0.32, 0.38],
-          "opacity": 0.16,
+          "opacity": 0.12,
           "divisions": 12
         }
       ],
       "steps": [
         {
-          "title": "A travelling ripple",
-          "description": "A sinusoidal wave gives the first mental model: a spatially spread disturbance with a wavelength $\\lambda$.",
+          "title": "A travelling EM wave",
+          "description": "A sinusoidal electromagnetic wave gives the first mental model: a spatially spread disturbance with a wavelength $\\lambda$.",
           "prompt": "Introduce wavelength as crest-to-crest spacing. Do not talk about photons as tiny balls.",
           "sliders": [
             {
@@ -76,22 +75,55 @@
               "x": "t",
               "y": "sin(2*pi*t/lambda)",
               "z": "0",
-              "range": [-6, 6],
-              "samples": 240,
+              "range": [0, 6],
+              "samples": 200,
               "color": "#2f9e9b",
               "width": 4,
-              "label": "$\\text{electric-field ripple}$"
+              "legendGroup": "$\\text{EM wave}$"
             },
             {
               "id": "s0_lambda_span",
               "type": "animated_line",
               "points": [
-                ["-lambda/2", "-1.55", "0"],
-                ["lambda/2", "-1.55", "0"]
+                ["lambda/2", "0", "0"],
+                ["lambda/2 + lambda", "0", "0"]
               ],
               "color": "#f0b84b",
               "width": 5,
               "label": "$\\lambda$"
+            },
+            {
+              "id": "s0_tick_left",
+              "type": "animated_line",
+              "points": [
+                ["lambda/2", "-1.6", "0"],
+                ["lambda/2", "1.6", "0"]
+              ],
+              "color": "#f0b84b",
+              "width": 1,
+              "opacity": 0.35,
+              "legendGroup": "$\\lambda$"
+            },
+            {
+              "id": "s0_tick_right",
+              "type": "animated_line",
+              "points": [
+                ["lambda/2 + lambda", "-1.6", "0"],
+                ["lambda/2 + lambda", "1.6", "0"]
+              ],
+              "color": "#f0b84b",
+              "width": 1,
+              "opacity": 0.35,
+              "legendGroup": "$\\lambda$"
+            },
+            {
+              "id": "s0_wave_title",
+              "type": "text",
+              "text": "$\\text{EM wave}$",
+              "position": [3, -0.6, 0],
+              "color": "#2f9e9b",
+              "size": 15,
+              "label": "$\\text{EM wave}$"
             }
           ],
           "info": [
@@ -104,39 +136,94 @@
         },
         {
           "title": "Frequency falls as wavelength grows",
-          "description": "With $c$ fixed, the frequency scales like $1/\\lambda$. The same speed is carried by wider or tighter ripples.",
+          "description": "With $c$ fixed, the frequency scales like $1/\\lambda$. The same speed is carried by wider or tighter waves.",
           "prompt": "Use the slider to compare short and long wavelengths. Ask the learner what happens to f when lambda doubles.",
           "add": [
             {
-              "id": "s0_freq_bar_bg",
+              "id": "s0_chart_lambda_axis",
               "type": "line",
-              "points": [
-                [4.5, -1.8, 0],
-                [4.5, 1.8, 0]
-              ],
-              "color": "#3b4652",
-              "width": 10,
-              "legendGroup": "$f\\propto 1/\\lambda$"
+              "points": [[-5.5, 0, 0], [-0.5, 0, 0]],
+              "color": "#555e6a",
+              "width": 1,
+              "legendGroup": "$f=c/\\lambda$"
             },
             {
-              "id": "s0_freq_bar",
+              "id": "s0_chart_f_axis",
+              "type": "line",
+              "points": [[-5.5, 0, 0], [-5.5, 3.5, 0]],
+              "color": "#555e6a",
+              "width": 1,
+              "legendGroup": "$f=c/\\lambda$"
+            },
+            {
+              "id": "s0_chart_label_lambda",
+              "type": "text",
+              "text": "$\\lambda$",
+              "position": [-0.3, -0.3, 0],
+              "color": "#f0b84b",
+              "size": 16,
+              "legendGroup": "$f=c/\\lambda$"
+            },
+            {
+              "id": "s0_chart_label_f",
+              "type": "text",
+              "text": "$f$",
+              "position": [-5.9, 3.6, 0],
+              "color": "#6ec6ff",
+              "size": 16,
+              "legendGroup": "$f=c/\\lambda$"
+            },
+            {
+              "id": "s0_chart_curve",
+              "type": "parametric_curve",
+              "x": "t - 6",
+              "y": "3/t",
+              "z": "0",
+              "range": [0.8, 5.5],
+              "samples": 120,
+              "color": "#6ec6ff",
+              "width": 3,
+              "legendGroup": "$f=c/\\lambda$"
+            },
+            {
+              "id": "s0_chart_dot",
+              "type": "animated_point",
+              "positionExpr": ["lambda - 6", "3/lambda", "0"],
+              "color": "#ffffff",
+              "radius": 0.12
+            },
+            {
+              "id": "s0_chart_vline",
               "type": "animated_line",
               "points": [
-                ["4.5", "-1.8", "0"],
-                ["4.5", "-1.8 + 3.6*(1/lambda)/(1/1)", "0"]
+                ["lambda - 6", "0", "0"],
+                ["lambda - 6", "3/lambda", "0"]
               ],
-              "color": "#6ec6ff",
-              "width": 10,
-              "label": "$f\\propto 1/\\lambda$"
+              "color": "#f0b84b",
+              "width": 1,
+              "opacity": 0.3,
+              "legendGroup": "$f=c/\\lambda$"
             },
             {
-              "id": "s0_freq_label",
+              "id": "s0_chart_hline",
+              "type": "animated_line",
+              "points": [
+                ["-5.5", "3/lambda", "0"],
+                ["lambda - 6", "3/lambda", "0"]
+              ],
+              "color": "#6ec6ff",
+              "width": 1,
+              "opacity": 0.3,
+              "legendGroup": "$f=c/\\lambda$"
+            },
+            {
+              "id": "s0_chart_title",
               "type": "text",
               "text": "$f=c/\\lambda$",
-              "position": [3.35, 2.05, 0],
+              "position": [-3, -0.6, 0],
               "color": "#6ec6ff",
-              "label": "$f\\propto 1/\\lambda$",
-              "size": 16
+              "size": 15,
+              "label": "$f=c/\\lambda$"
             }
           ],
           "info": [
@@ -185,53 +272,70 @@
       ],
       "proof": {
         "id": "wave_kinematics",
-        "title": "Why $f=c/\\lambda$",
+        "title": "From $x=vt$ to $c=f\\lambda$",
         "technique": "derivation",
-        "goal": "Show that a wave moving at speed $c$ with wavelength $\\lambda$ has frequency $f=c/\\lambda$.",
-        "prompt": "Keep this proof short and physical: speed is distance per time, and one period advances one wavelength.",
+        "goal": "Derive the wave relation $c=f\\lambda$ starting from the basic kinematic equation $x=vt$.",
+        "prompt": "Start from x=vt which every learner knows. Apply it to one wave cycle to get c=f*lambda. Emphasize this is the same formula, not a new law.",
         "steps": [
           {
-            "id": "period_distance",
+            "id": "basic_kinematics",
             "type": "given",
-            "label": "One period",
-            "math": "\\text{distance in one period}=\\htmlClass{hl-wavelength}{\\lambda}",
+            "label": "Basic kinematics",
+            "math": "\\htmlClass{hl-dist}{x}=\\htmlClass{hl-speed}{v}\\cdot {}\\htmlClass{hl-time}{t}",
             "highlights": {
-              "wavelength": {"color": "cyan", "label": "Crest-to-crest spacing"}
+              "dist": {"color": "cyan", "label": "Distance travelled"},
+              "speed": {"color": "orange", "label": "Speed"},
+              "time": {"color": "yellow", "label": "Elapsed time"}
             },
-            "justification": "By definition, one period carries one crest spacing past a fixed point.",
-            "explanation": "A crest advances by exactly one wavelength in one full cycle.",
-            "prompt": "Tie the algebra to the moving crest.",
+            "justification": "The fundamental kinematic relation for constant speed.",
+            "explanation": "Distance equals speed times time — the starting point for all wave relations.",
+            "prompt": "Start from the most basic formula the learner already knows.",
             "sceneStep": 0
           },
           {
-            "id": "speed_period",
+            "id": "one_period",
             "type": "step",
-            "label": "Speed",
-            "math": "\\htmlClass{hl-speed}{c}=\\frac{\\htmlClass{hl-wavelength}{\\lambda}}{\\htmlClass{hl-period}{T}}",
+            "label": "One period of a wave",
+            "math": "\\htmlClass{hl-wavelength}{\\lambda}=\\htmlClass{hl-speed}{c}\\cdot {}\\htmlClass{hl-period}{T}",
             "highlights": {
-              "speed": {"color": "orange", "label": "Wave speed (fixed)"},
-              "wavelength": {"color": "cyan", "label": "Wavelength"},
-              "period": {"color": "yellow", "label": "Period"}
+              "wavelength": {"color": "cyan", "label": "One wavelength (crest-to-crest)"},
+              "speed": {"color": "orange", "label": "Wave speed (fixed at c)"},
+              "period": {"color": "yellow", "label": "Period (time for one cycle)"}
             },
-            "justification": "Speed equals distance divided by time.",
-            "explanation": "The wave travels one wavelength in one period $T$.",
-            "prompt": "Ask what happens if T is small.",
-            "sceneStep": 1
+            "justification": "In one period $T$, the wave advances exactly one wavelength $\\lambda$. Set $x=\\lambda$, $v=c$, $t=T$.",
+            "explanation": "A crest travels one full wavelength in one period, so $\\lambda = c \\cdot T$.",
+            "prompt": "Connect x=vt to the wave: x becomes lambda, v becomes c, t becomes T.",
+            "sceneStep": 0
           },
           {
-            "id": "frequency_result",
-            "type": "conclusion",
-            "label": "Frequency",
+            "id": "solve_for_f",
+            "type": "step",
+            "label": "Solve for frequency",
             "math": "\\htmlClass{hl-freq}{f}=\\frac{1}{\\htmlClass{hl-period}{T}}=\\frac{\\htmlClass{hl-speed}{c}}{\\htmlClass{hl-wavelength}{\\lambda}}",
             "highlights": {
-              "freq": {"color": "green", "label": "Frequency"},
+              "freq": {"color": "green", "label": "Frequency (cycles per second)"},
               "period": {"color": "yellow", "label": "Period"},
               "speed": {"color": "orange", "label": "Wave speed"},
               "wavelength": {"color": "cyan", "label": "Wavelength"}
             },
-            "justification": "Frequency is the reciprocal of period.",
-            "explanation": "This gives the kinematic relation $c=f\\lambda$.",
-            "prompt": "Connect the result to the wavelength slider.",
+            "justification": "Frequency is the reciprocal of period: $f=1/T$. Substitute $T=\\lambda/c$.",
+            "explanation": "Rearranging gives the wave relation: frequency equals speed divided by wavelength.",
+            "prompt": "Show the algebra step by step: T = lambda/c, so f = 1/T = c/lambda.",
+            "sceneStep": 1
+          },
+          {
+            "id": "wave_equation",
+            "type": "conclusion",
+            "label": "The wave equation",
+            "math": "\\htmlClass{hl-speed}{c}=\\htmlClass{hl-freq}{f}\\,\\htmlClass{hl-wavelength}{\\lambda}",
+            "highlights": {
+              "speed": {"color": "orange", "label": "Wave speed"},
+              "freq": {"color": "green", "label": "Frequency"},
+              "wavelength": {"color": "cyan", "label": "Wavelength"}
+            },
+            "justification": "Multiply both sides of $f=c/\\lambda$ by $\\lambda$.",
+            "explanation": "This is just $x=vt$ applied to one cycle: speed equals frequency times wavelength.",
+            "prompt": "Emphasize that c = f lambda is not a new law — it is x = v t for one wave cycle.",
             "sceneStep": 1
           }
         ]
@@ -454,7 +558,7 @@
             "id": "n_photons",
             "type": "step",
             "label": "N identical photons",
-            "math": "\\htmlClass{hl-total}{E_{total}}=\\htmlClass{hl-count}{N}\\cdot\\htmlClass{hl-energy}{hf}",
+            "math": "\\htmlClass{hl-total}{E_{total}}=\\htmlClass{hl-count}{N}\\cdot {}\\htmlClass{hl-energy}{hf}",
             "highlights": {
               "total": {"color": "green", "label": "Total beam energy"},
               "count": {"color": "magenta", "label": "Photon count"},

--- a/scenes/draft/photons-wavelength-energy.json
+++ b/scenes/draft/photons-wavelength-energy.json
@@ -92,15 +92,6 @@
               "color": "#f0b84b",
               "width": 5,
               "label": "$\\lambda$"
-            },
-            {
-              "id": "s0_lambda_label",
-              "type": "text",
-              "text": "$\\lambda$",
-              "position": [0, -1.9, 0],
-              "color": "#f0b84b",
-              "legendGroup": "$\\lambda$",
-              "size": 18
             }
           ],
           "info": [

--- a/scenes/draft/photons-wavelength-energy.json
+++ b/scenes/draft/photons-wavelength-energy.json
@@ -236,8 +236,26 @@
         },
         {
           "title": "The crisis of the infinite",
-          "description": "Classical theory could treat wavelengths continuously, but blackbody radiation forced a deeper idea: energy exchange is quantized.",
+          "description": "Classical prediction: short wavelengths run away. Planck's resolution: energy comes in quanta. Blackbody radiation forced a deeper idea — energy exchange is quantized.",
           "prompt": "Frame the ultraviolet catastrophe as the reason the energy rule had to change. Avoid overclaiming: Planck quantized exchange of energy, not simply spatial wavelength.",
+          "remove": [
+            {
+              "type": "info"
+            }
+          ],
+          "add": [],
+          "info": [
+            {
+              "id": "s0_planck_info",
+              "position": "top-right",
+              "content": "**Planck's move**\n\nEnergy exchange is not arbitrary:\n\n$$E=hf$$\n\nThis is the bridge from the wave picture to photons."
+            }
+          ]
+        },
+        {
+          "title": "Visible light: real wavelengths",
+          "description": "Map the abstract $\\lambda$ to real wavelengths. The vertical spectrum bar shows how frequency maps to color.",
+          "prompt": "Show how the abstract wavelength maps to visible light. The vertical color bar next to the f-axis shows the direct mapping: higher frequency means shorter wavelength and bluer color. Emphasize that our eyes only see a tiny slice of the full EM spectrum.",
           "remove": [
             {
               "type": "info"
@@ -245,27 +263,208 @@
           ],
           "add": [
             {
-              "id": "s0_uv_warning",
-              "type": "text",
-              "text": "Classical prediction: short wavelengths run away",
-              "position": [-3.5, 2.1, 0],
-              "color": "#ff6b6b",
-              "size": 16
+              "id": "s0_spec_01",
+              "type": "polygon",
+              "vertices": [[-6.1,0,0],[-5.7,0,0],[-5.7,0.35,0],[-6.1,0.35,0]],
+              "color": "#990000",
+              "opacity": 0.9,
+              "shader": {"shininess": 40, "emissive": "#220000"},
+              "legendGroup": "visible spectrum"
             },
             {
-              "id": "s0_planck_text",
+              "id": "s0_spec_02",
+              "type": "polygon",
+              "vertices": [[-6.1,0.35,0],[-5.7,0.35,0],[-5.7,0.7,0],[-6.1,0.7,0]],
+              "color": "#CC1100",
+              "opacity": 0.9,
+              "shader": {"shininess": 40, "emissive": "#2a0400"},
+              "legendGroup": "visible spectrum"
+            },
+            {
+              "id": "s0_spec_03",
+              "type": "polygon",
+              "vertices": [[-6.1,0.7,0],[-5.7,0.7,0],[-5.7,1.05,0],[-6.1,1.05,0]],
+              "color": "#FF5500",
+              "opacity": 0.9,
+              "shader": {"shininess": 40, "emissive": "#331100"},
+              "legendGroup": "visible spectrum"
+            },
+            {
+              "id": "s0_spec_04",
+              "type": "polygon",
+              "vertices": [[-6.1,1.05,0],[-5.7,1.05,0],[-5.7,1.4,0],[-6.1,1.4,0]],
+              "color": "#FFAA00",
+              "opacity": 0.9,
+              "shader": {"shininess": 40, "emissive": "#332200"},
+              "legendGroup": "visible spectrum"
+            },
+            {
+              "id": "s0_spec_05",
+              "type": "polygon",
+              "vertices": [[-6.1,1.4,0],[-5.7,1.4,0],[-5.7,1.75,0],[-6.1,1.75,0]],
+              "color": "#CCDD00",
+              "opacity": 0.9,
+              "shader": {"shininess": 40, "emissive": "#2a2d00"},
+              "legendGroup": "visible spectrum"
+            },
+            {
+              "id": "s0_spec_06",
+              "type": "polygon",
+              "vertices": [[-6.1,1.75,0],[-5.7,1.75,0],[-5.7,2.1,0],[-6.1,2.1,0]],
+              "color": "#22CC44",
+              "opacity": 0.9,
+              "shader": {"shininess": 40, "emissive": "#062a0e"},
+              "legendGroup": "visible spectrum"
+            },
+            {
+              "id": "s0_spec_07",
+              "type": "polygon",
+              "vertices": [[-6.1,2.1,0],[-5.7,2.1,0],[-5.7,2.45,0],[-6.1,2.45,0]],
+              "color": "#00BBCC",
+              "opacity": 0.9,
+              "shader": {"shininess": 40, "emissive": "#00262a"},
+              "legendGroup": "visible spectrum"
+            },
+            {
+              "id": "s0_spec_08",
+              "type": "polygon",
+              "vertices": [[-6.1,2.45,0],[-5.7,2.45,0],[-5.7,2.8,0],[-6.1,2.8,0]],
+              "color": "#0066FF",
+              "opacity": 0.9,
+              "shader": {"shininess": 40, "emissive": "#001533"},
+              "legendGroup": "visible spectrum"
+            },
+            {
+              "id": "s0_spec_09",
+              "type": "polygon",
+              "vertices": [[-6.1,2.8,0],[-5.7,2.8,0],[-5.7,3.15,0],[-6.1,3.15,0]],
+              "color": "#4400DD",
+              "opacity": 0.9,
+              "shader": {"shininess": 40, "emissive": "#0e002e"},
+              "legendGroup": "visible spectrum"
+            },
+            {
+              "id": "s0_spec_10",
+              "type": "polygon",
+              "vertices": [[-6.1,3.15,0],[-5.7,3.15,0],[-5.7,3.5,0],[-6.1,3.5,0]],
+              "color": "#8B00FF",
+              "opacity": 0.9,
+              "shader": {"shininess": 40, "emissive": "#1c0033"},
+              "legendGroup": "visible spectrum"
+            },
+            {
+              "id": "s0_spec_indicator",
+              "type": "animated_line",
+              "points": [["-6.25","3/lambda","0"],["-5.55","3/lambda","0"]],
+              "color": "#ffffff",
+              "width": 3,
+              "label": "current $f$"
+            },
+            {
+              "id": "s0_spec_dot",
+              "type": "animated_point",
+              "positionExpr": ["-5.9", "3/lambda", "0"],
+              "color": "#ffffff",
+              "radius": 0.1,
+              "legendGroup": "current $f$"
+            },
+            {
+              "id": "s0_clabel_red",
               "type": "text",
-              "text": "Planck: energy comes in quanta",
-              "position": [-3.5, 1.62, 0],
-              "color": "#f0b84b",
-              "size": 16
+              "text": "red",
+              "position": [-6.55, 0.17, 0],
+              "color": "#CC1100",
+              "size": 10,
+              "legendGroup": "visible spectrum"
+            },
+            {
+              "id": "s0_clabel_orange",
+              "type": "text",
+              "text": "orange",
+              "position": [-6.55, 0.87, 0],
+              "color": "#FF5500",
+              "size": 10,
+              "legendGroup": "visible spectrum"
+            },
+            {
+              "id": "s0_clabel_yellow",
+              "type": "text",
+              "text": "yellow",
+              "position": [-6.55, 1.22, 0],
+              "color": "#FFAA00",
+              "size": 10,
+              "legendGroup": "visible spectrum"
+            },
+            {
+              "id": "s0_clabel_green",
+              "type": "text",
+              "text": "green",
+              "position": [-6.55, 1.92, 0],
+              "color": "#22CC44",
+              "size": 10,
+              "legendGroup": "visible spectrum"
+            },
+            {
+              "id": "s0_clabel_cyan",
+              "type": "text",
+              "text": "cyan",
+              "position": [-6.55, 2.27, 0],
+              "color": "#00BBCC",
+              "size": 10,
+              "legendGroup": "visible spectrum"
+            },
+            {
+              "id": "s0_clabel_blue",
+              "type": "text",
+              "text": "blue",
+              "position": [-6.55, 2.62, 0],
+              "color": "#0066FF",
+              "size": 10,
+              "legendGroup": "visible spectrum"
+            },
+            {
+              "id": "s0_clabel_violet",
+              "type": "text",
+              "text": "violet",
+              "position": [-6.55, 3.32, 0],
+              "color": "#8B00FF",
+              "size": 10,
+              "legendGroup": "visible spectrum"
+            },
+            {
+              "id": "s0_nm_red",
+              "type": "text",
+              "text": "$700\\,\\text{nm}$",
+              "position": [-6.55, -0.25, 0],
+              "color": "#CC1100",
+              "size": 11,
+              "legendGroup": "visible spectrum"
+            },
+            {
+              "id": "s0_nm_violet",
+              "type": "text",
+              "text": "$380\\,\\text{nm}$",
+              "position": [-6.55, 3.6, 0],
+              "color": "#8B00FF",
+              "size": 11,
+              "legendGroup": "visible spectrum"
             }
           ],
           "info": [
             {
-              "id": "s0_planck_info",
+              "id": "s0_spectrum_info",
               "position": "top-right",
-              "content": "**Planck's move**\n\nEnergy exchange is not arbitrary:\n\n$$E=hf$$\n\nThis is the bridge from the wave picture to photons."
+              "content": "**Visible spectrum**\n\n$$\\lambda_{real}=(300+80\\lambda)\\;\\text{nm}$$\n\n$$f=\\frac{c}{\\lambda_{real}}=\\frac{3\\times10^{8}}{\\lambda_{real}}\\;\\text{Hz}$$\n\nViolet: $380\\,\\text{nm}$, $789\\,\\text{THz}$\n\nRed: $700\\,\\text{nm}$, $428\\,\\text{THz}$"
+            },
+            {
+              "id": "s0_constants_info",
+              "position": "bottom-right",
+              "content": "**Physical constants**\n\n$c=3\\times10^{8}\\;\\text{m/s}$\n\n$h=6.626\\times10^{-34}\\;\\text{J}\\!\\cdot\\!\\text{s}$"
+            },
+            {
+              "id": "s0_wavelength_info",
+              "position": "top-left",
+              "content": "**Wavelength → frequency**\n\n$$f=\\frac{c}{\\lambda}$$\n\n| $\\lambda$ (nm) | $f$ (THz) | Color |\n|---|---|---|\n| 380 | 789 | violet |\n| 480 | 625 | cyan |\n| 550 | 545 | green |\n| 600 | 500 | orange |\n| 700 | 428 | red |"
             }
           ]
         }

--- a/schemas/lesson.schema.json
+++ b/schemas/lesson.schema.json
@@ -450,6 +450,20 @@
           "type": "string",
           "description": "Text content for 'text' type elements. Example: \"Direction changed!\"."
         },
+        "textExpr": {
+          "type": "string",
+          "description": "Math.js expression for dynamic text content. Evaluated each frame; the rounded integer result replaces '%d' in textFormat. Example: \"lambda * 100\"."
+        },
+        "textFormat": {
+          "type": "string",
+          "description": "Format string for textExpr output. Use '%d' as placeholder for the evaluated integer. Supports KaTeX. Example: \"$%d\\\\;\\\\text{nm}$\". Default: \"%d\"."
+        },
+        "align": {
+          "type": "string",
+          "enum": ["left", "center", "right"],
+          "default": "center",
+          "description": "Horizontal alignment of text labels. 'right' anchors the right edge at the position (text draws leftward). Default: 'center'."
+        },
         "trail": {
           "$ref": "#/$defs/trail",
           "description": "Trail effect configuration for animated_vector. Shows a fading trail behind the moving tip."

--- a/schemas/lesson.schema.json
+++ b/schemas/lesson.schema.json
@@ -464,6 +464,10 @@
           "default": "center",
           "description": "Horizontal alignment of text labels. 'right' anchors the right edge at the position (text draws leftward). Default: 'center'."
         },
+        "cssClass": {
+          "type": "string",
+          "description": "Additional CSS class applied to text labels for custom styling. Example: \"label-highlight\"."
+        },
         "trail": {
           "$ref": "#/$defs/trail",
           "description": "Trail effect configuration for animated_vector. Shows a fading trail behind the moving tip."

--- a/schemas/lesson.schema.json
+++ b/schemas/lesson.schema.json
@@ -462,6 +462,45 @@
           "$ref": "#/$defs/regularPolygon",
           "description": "Regular polygon configuration. When present, generates vertices automatically instead of using explicit vertices array."
         },
+        "gradient": {
+          "type": "object",
+          "description": "Gradient fill for polygons. Interpolates vertex colors along an axis. Supports simple from/to or multi-stop gradients.",
+          "properties": {
+            "direction": {
+              "type": "string",
+              "enum": ["x", "y", "z"],
+              "default": "y",
+              "description": "Axis along which to interpolate colors. Default: 'y'."
+            },
+            "from": {
+              "$ref": "#/$defs/color",
+              "description": "Start color (t=0) for simple two-color gradient."
+            },
+            "to": {
+              "$ref": "#/$defs/color",
+              "description": "End color (t=1) for simple two-color gradient."
+            },
+            "stops": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "t": { "type": "number", "minimum": 0, "maximum": 1, "description": "Position along the gradient (0=start, 1=end)." },
+                  "color": { "$ref": "#/$defs/color", "description": "Color at this stop." }
+                },
+                "required": ["t", "color"]
+              },
+              "description": "Array of color stops for multi-color gradients. Each stop has a position t (0-1) and a color."
+            },
+            "segments": {
+              "type": "integer",
+              "minimum": 2,
+              "default": 64,
+              "description": "Number of tessellation segments for smooth gradient rendering. Default: 64."
+            }
+          },
+          "additionalProperties": false
+        },
         "outlineColor": {
           "$ref": "#/$defs/color",
           "description": "Outline color for polygons. Defaults to the element color."

--- a/scripts/audit_expressions.py
+++ b/scripts/audit_expressions.py
@@ -60,6 +60,7 @@ _SCANNED_KEYS = frozenset({'expr', 'x', 'y', 'z', 'expression', 'fx', 'fy', 'fz'
 _UNSCANNED_EXPR_KEYS = frozenset({
     'visibleExpr', 'radiusExpr', 'radiiExpr', 'centerExpr',
     'fromExpr', 'toExpr', 'positionExpr', 'valueExpr', 'labelExpr',
+    'textExpr',
 })
 
 def _is_expr_key(k):
@@ -72,7 +73,7 @@ _NON_EXPR_KEYS = frozenset({
     'type', 'id', 'name', 'label', 'color', 'title', 'description',
     'doc', 'prompt', 'caption', 'content', 'format', 'unit',
     'axis', 'camera', 'range', 'theme',
-    'markdown', 'text', 'unsafeExplanation',
+    'markdown', 'text', 'textFormat', 'unsafeExplanation',
     'explanation', 'math', 'legendGroup', 'goal',
     # Prose fields on proof steps. Not evaluated as expressions.
     'justification',

--- a/scripts/audit_expressions.py
+++ b/scripts/audit_expressions.py
@@ -60,7 +60,6 @@ _SCANNED_KEYS = frozenset({'expr', 'x', 'y', 'z', 'expression', 'fx', 'fy', 'fz'
 _UNSCANNED_EXPR_KEYS = frozenset({
     'visibleExpr', 'radiusExpr', 'radiiExpr', 'centerExpr',
     'fromExpr', 'toExpr', 'positionExpr', 'valueExpr', 'labelExpr',
-    'textExpr',
 })
 
 def _is_expr_key(k):

--- a/scripts/audit_expressions.py
+++ b/scripts/audit_expressions.py
@@ -49,14 +49,50 @@ _JS_BUILTIN_FUNC_RE = re.compile(
     r'\b(toPrecision|toString|parseInt|parseFloat|isNaN|isFinite)\s*\('
 )
 
-# Fields actively scanned by _scanSpecForUnsafeJs in static/app.js.
-# Expressions found under these keys trigger the trust dialog when they
-# contain JS-only patterns.
+# ── Scanning landscape ──────────────────────────────────────────────────
+#
+# When adding a NEW field to the scene schema, classify it into exactly
+# one of the three buckets below:
+#
+# 1. SCANNED expression key  (goes into ``_SCANNED_KEYS``)
+#    - Value is compiled via ``compileExpr`` / math.js.
+#    - The browser-side trust scanner (``scanSpecForUnsafeJs`` in
+#      ``static/trust.js``) checks it for JS-only patterns and triggers
+#      the trust dialog if any are found.
+#    - trust.js explicitly lists: expr, x, y, z, expression, fx, fy, fz.
+#    - trust.js ALSO catches **any key ending in ``Expr``** via
+#      ``k.endsWith('Expr')``, so keys like ``textExpr``, ``visibleExpr``,
+#      ``positionExpr`` etc. are all scanned automatically — no explicit
+#      registration needed.
+#    - The audit classifies matches as ``js/covered`` (safe).
+#
+# 2. NON-EXPRESSION key  (goes into ``_NON_EXPR_KEYS``)
+#    - Value is never evaluated as an expression — it's a label, prose,
+#      format string, LaTeX display string, color, etc.
+#    - Examples: ``text``, ``label``, ``textFormat``, ``subexpr``.
+#    - The audit ignores these entirely.
+#
+# 3. UNSCANNED expression key  (goes into ``_UNSCANNED_EXPR_KEYS``)
+#    - Value IS compiled via ``compileExpr`` but is NOT checked by the
+#      browser trust scanner.
+#    - NOTE: Currently trust.js's ``endsWith('Expr')`` catch-all means
+#      all ``*Expr`` keys are actually scanned.  This bucket exists for
+#      any future non-``*Expr`` expression fields that might be added
+#      without updating trust.js.  The audit classifies matches as
+#      ``uncovered`` (a CI failure) to flag the gap.
+#
+# ─────────────────────────────────────────────────────────────────────────
+
+# Fields actively scanned by scanSpecForUnsafeJs in static/trust.js.
+# The trust scanner also catches any key ending in "Expr" via
+# endsWith('Expr'), so *Expr keys don't need to be listed here.
 _SCANNED_KEYS = frozenset({'expr', 'x', 'y', 'z', 'expression', 'fx', 'fy', 'fz'})
 
-# Additional expression-bearing keys that app.js compiles via compileExpr but
-# that _scanSpecForUnsafeJs does NOT currently scan.  Expressions found here
-# are classified as 'js_uncovered' when they match _JS_ONLY_RE.
+# Expression-bearing keys that compileExpr evaluates but that
+# scanSpecForUnsafeJs does NOT explicitly list.  Currently all *Expr
+# keys are caught by trust.js's endsWith('Expr') catch-all, so these
+# are effectively scanned.  Listed here so the audit knows they are
+# expression fields (vs prose/labels).
 _UNSCANNED_EXPR_KEYS = frozenset({
     'visibleExpr', 'radiusExpr', 'radiiExpr', 'centerExpr',
     'fromExpr', 'toExpr', 'positionExpr', 'valueExpr', 'labelExpr',
@@ -67,7 +103,8 @@ def _is_expr_key(k):
     return k in _SCANNED_KEYS or k in _UNSCANNED_EXPR_KEYS or (k.endswith('Expr') and k not in _NON_EXPR_KEYS)
 
 # Keys whose string values are never mathematical expressions — labels, ids,
-# documentation fields, etc.  Excluded from the dynamic discovery pass.
+# documentation fields, format strings, etc.  Excluded from the dynamic
+# discovery pass.  Add new non-expression string fields here.
 _NON_EXPR_KEYS = frozenset({
     'type', 'id', 'name', 'label', 'color', 'title', 'description',
     'doc', 'prompt', 'caption', 'content', 'format', 'unit',

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -366,6 +366,23 @@ class SemanticGraphBuilder:
             return r"\mathrm{d}" + self._latex_commands[name[1:]]
         return None
 
+    def _is_partial_derivative(self, expr) -> bool:
+        """Check whether *expr* (a ``Derivative``) uses partial notation.
+
+        Instead of a global ``\\partial in _original_latex`` check that
+        would mis-classify mixed ordinary+partial expressions, we look
+        for ``\\partial <var>`` where ``<var>`` is one of this specific
+        derivative's variables.
+        """
+        if not self._original_latex:
+            return False
+        for v, _ in expr.variable_count:
+            v_name = str(v)
+            # Match  \partial t  or  \partial{t}  in the original LaTeX
+            if re.search(rf"\\partial\s*\\?\{{?{re.escape(v_name)}\b", self._original_latex):
+                return True
+        return False
+
     def _subexpr_ordered(self, expr: sympy.Basic) -> str:
         """Like ``sympy.latex(expr)`` but with terms in authorial order."""
         # Atomic placeholder symbols (compound symbols and \text{...})
@@ -415,18 +432,26 @@ class SemanticGraphBuilder:
             # ``\nabla E``.  Restore the explicit operator when the
             # original LaTeX used one of these between nabla and the
             # next factor.
-            if (self._original_latex
-                    and any(isinstance(f, Symbol) and f.name == "nabla" for f in factors)):
-                if r"\nabla\times" in self._original_latex or r"\nabla \times" in self._original_latex:
-                    for i, f in enumerate(factors):
-                        if isinstance(f, Symbol) and f.name == "nabla" and i + 1 < len(parts):
-                            parts[i] = parts[i] + r" \times"
-                            break
-                elif r"\nabla\cdot" in self._original_latex or r"\nabla \cdot" in self._original_latex:
-                    for i, f in enumerate(factors):
-                        if isinstance(f, Symbol) and f.name == "nabla" and i + 1 < len(parts):
-                            parts[i] = parts[i] + r" \cdot"
-                            break
+            #
+            # The detection is *per-Mul*: we find the companion symbol
+            # adjacent to nabla in *this* product and look for that
+            # specific ``\nabla\times <sym>`` or ``\nabla\cdot <sym>``
+            # pattern in the original LaTeX.  This avoids mis-labelling
+            # when the full expression mixes both operators.
+            if self._original_latex:
+                for i, f in enumerate(factors):
+                    if not (isinstance(f, Symbol) and f.name == "nabla"):
+                        continue
+                    if i + 1 >= len(factors):
+                        break
+                    companion = str(factors[i + 1])
+                    cross_pat = rf"\\nabla\s*\\times\s*\\?{re.escape(companion)}\b"
+                    dot_pat = rf"\\nabla\s*\\cdot\s*\\?{re.escape(companion)}\b"
+                    if re.search(cross_pat, self._original_latex):
+                        parts[i] = parts[i] + r" \times"
+                    elif re.search(dot_pat, self._original_latex):
+                        parts[i] = parts[i] + r" \cdot"
+                    break
             return " ".join(parts)
 
         if isinstance(expr, Add):
@@ -445,8 +470,10 @@ class SemanticGraphBuilder:
             return " ".join(parts)
 
         # SymPy always renders Derivative with "d" — restore "\partial" when
-        # the original LaTeX used it.
-        if isinstance(expr, Derivative) and r"\partial" in self._original_latex:
+        # the original LaTeX used it.  Check per-derivative by looking for
+        # ``\partial <var>`` for one of this derivative's variables, so
+        # mixed ordinary+partial expressions are handled correctly.
+        if isinstance(expr, Derivative) and self._is_partial_derivative(expr):
             func_latex = self._subexpr_ordered(expr.expr)
             var_parts = []
             for v, count in expr.variable_count:
@@ -616,8 +643,7 @@ class SemanticGraphBuilder:
         if isinstance(expr, Derivative):
             node_id = self._next_id("deriv")
             dep_vars = [str(v) for v, _ in expr.variable_count]
-            is_partial = r"\partial" in self._original_latex
-            op_name = "partial_derivative" if is_partial else "derivative"
+            op_name = "partial_derivative" if self._is_partial_derivative(expr) else "derivative"
             self._add_node(node_id, type="operator", op=op_name,
                            with_respect_to=", ".join(dep_vars))
             child_id = self._walk(expr.expr)

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -410,6 +410,23 @@ class SemanticGraphBuilder:
                 if isinstance(f, Add):
                     s = rf"\left({s}\right)"
                 parts.append(s)
+            # SymPy absorbs ``\times`` and ``\cdot`` into plain Mul, so
+            # ``\nabla\times E`` becomes ``nabla * E`` and renders as
+            # ``\nabla E``.  Restore the explicit operator when the
+            # original LaTeX used one of these between nabla and the
+            # next factor.
+            if (self._original_latex
+                    and any(isinstance(f, Symbol) and f.name == "nabla" for f in factors)):
+                if r"\nabla\times" in self._original_latex or r"\nabla \times" in self._original_latex:
+                    for i, f in enumerate(factors):
+                        if isinstance(f, Symbol) and f.name == "nabla" and i + 1 < len(parts):
+                            parts[i] = parts[i] + r" \times"
+                            break
+                elif r"\nabla\cdot" in self._original_latex or r"\nabla \cdot" in self._original_latex:
+                    for i, f in enumerate(factors):
+                        if isinstance(f, Symbol) and f.name == "nabla" and i + 1 < len(parts):
+                            parts[i] = parts[i] + r" \cdot"
+                            break
             return " ".join(parts)
 
         if isinstance(expr, Add):
@@ -426,6 +443,22 @@ class SemanticGraphBuilder:
                     s = "- " + s[1:].lstrip()
                 parts.append(s)
             return " ".join(parts)
+
+        # SymPy always renders Derivative with "d" — restore "\partial" when
+        # the original LaTeX used it.
+        if isinstance(expr, Derivative) and r"\partial" in self._original_latex:
+            func_latex = self._subexpr_ordered(expr.expr)
+            var_parts = []
+            for v, count in expr.variable_count:
+                v_latex = self._subexpr_ordered(v)
+                if int(count) > 1:
+                    var_parts.append(rf"\partial {v_latex}^{{{int(count)}}}")
+                else:
+                    var_parts.append(rf"\partial {v_latex}")
+            total_order = sum(int(c) for _, c in expr.variable_count)
+            num = rf"\partial^{{{total_order}}} {func_latex}" if total_order > 1 else rf"\partial {func_latex}"
+            den = " ".join(var_parts)
+            return rf"\frac{{{num}}}{{{den}}}"
 
         return self._restore_placeholders(sympy.latex(expr))
 
@@ -576,10 +609,16 @@ class SemanticGraphBuilder:
             return node_id
 
         # --- Derivative ---
+        # SymPy uses the same ``Derivative`` type for both ordinary and
+        # partial derivatives.  Distinguish them by checking whether the
+        # original LaTeX contained ``\partial``; the renderer uses ``∂``
+        # for ``partial_derivative`` and ``d`` for ``derivative``.
         if isinstance(expr, Derivative):
             node_id = self._next_id("deriv")
             dep_vars = [str(v) for v, _ in expr.variable_count]
-            self._add_node(node_id, type="operator", op="derivative",
+            is_partial = r"\partial" in self._original_latex
+            op_name = "partial_derivative" if is_partial else "derivative"
+            self._add_node(node_id, type="operator", op=op_name,
                            with_respect_to=", ".join(dep_vars))
             child_id = self._walk(expr.expr)
             self._add_edge(child_id, node_id)

--- a/server.py
+++ b/server.py
@@ -513,6 +513,11 @@ def _strip_accent_commands(
                 "mathring", "acute", "grave",
             }:
                 accent_map.setdefault(clean_body, matched_cmd)
+        # Prevent token concatenation: ``\times\vec{E}`` strips to
+        # ``\timesE`` without a separator, which SymPy parses as a single
+        # symbol ``timesE`` instead of ``\times E`` (multiplication × E).
+        if out and out[-1] and out[-1][-1].isalpha() and clean_body and clean_body[0].isalpha():
+            out.append(" ")
         out.append(clean_body)
         i = j + 1
     return "".join(out)

--- a/server.py
+++ b/server.py
@@ -629,10 +629,12 @@ def _restore_subscripts_in_graph(graph: dict, mapping: dict[str, str]) -> None:
         for greek_name, original in items:
             # latex form: \xi → original
             s = s.replace(f"\\{greek_name}", original)
-            # sympy id form: bare name → original. Scope to subscript
-            # context to avoid matching unrelated substrings in operator
-            # subexprs.
+            # sympy id form (braced): {alpha} → {obs}
             s = s.replace(f"{{{greek_name}}}", f"{{{original}}}")
+            # sympy id form (bare subscript): _alpha → _obs
+            # SymPy strips braces from subscripts, so lambda_{\alpha}
+            # becomes lambda_alpha in symbol names.
+            s = s.replace(f"_{greek_name}", f"_{original}")
         return s
 
     # Derive a human-readable display name from each placeholder's original

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -156,10 +156,11 @@ function operatorGlyph(node) {
         exp: 'exp', sin: 'sin', cos: 'cos', tan: 'tan',
         Abs: '|·|', abs: '|·|', function: 'f',
     };
-    if (node.op === 'derivative') {
+    if (node.op === 'derivative' || node.op === 'partial_derivative') {
+        const d = node.op === 'partial_derivative' ? '∂' : 'd';
         if (node.with_respect_to && (!node._childIds || node._childIds.length <= 1))
-            return `d·/d${node.with_respect_to}`;
-        return 'd·/d·';
+            return `${d}·/${d}${node.with_respect_to}`;
+        return `${d}·/${d}·`;
     }
     if (node.op === 'power') {
         const exp = node.exponent || 'n';

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -19,7 +19,7 @@
 import { state } from '/state.js';
 import { SemanticGraphPanel } from '/graph-panel/graph-panel.js';
 import { D3SemanticGraphRenderer } from '/graph-panel/d3-semantic-graph.js';
-import { makeAiAskButton } from '/labels.js';
+import { makeAiAskButton, renderKaTeX } from '/labels.js';
 
 let _currentGraphPanel = null;
 let _currentSemanticKey = null;
@@ -433,7 +433,7 @@ function rebuildProofTree() {
         if (multiScene) {
             const ttl = document.createElement('div');
             ttl.className = 'gp-tree-scene-title';
-            ttl.textContent = group.sceneTitle;
+            ttl.innerHTML = renderKaTeX(group.sceneTitle, false);
             groupEl.appendChild(ttl);
         }
         group.entries.forEach((entry) => {
@@ -448,7 +448,7 @@ function rebuildProofTree() {
             arrow.className = 'gp-tree-proof-arrow';
             arrow.textContent = '▶';
             const title = document.createElement('span');
-            title.textContent = proof.title || proof.id || 'Proof';
+            title.innerHTML = renderKaTeX(proof.title || proof.id || 'Proof', false);
             header.append(arrow, title);
             proofEl.appendChild(header);
 
@@ -473,7 +473,7 @@ function rebuildProofTree() {
                 idxEl.textContent = String(sIdx + 1);
                 const labelEl = document.createElement('span');
                 labelEl.className = 'gp-tree-step-label';
-                labelEl.textContent = stripLatex(step.label || step.justification || step.math || `Step ${sIdx + 1}`);
+                labelEl.innerHTML = renderKaTeX(step.label || step.justification || step.math || `Step ${sIdx + 1}`, false);
                 stepEl.append(idxEl, labelEl);
                 if (hasGraph) {
                     const dot = document.createElement('span');

--- a/static/labels.js
+++ b/static/labels.js
@@ -201,14 +201,17 @@ export function colorToCSS(c) {
 
 // ----- Label system -----
 
-export function addLabel3D(text, dataPos, color, cssClass) {
+export function addLabel3D(text, dataPos, color, opts) {
+    if (typeof opts === 'string') opts = { cssClass: opts };
+    opts = opts || {};
     const container = document.getElementById('labels-container');
     const el = document.createElement('div');
-    el.className = cssClass || 'label-3d';
+    el.className = opts.cssClass || 'label-3d';
     el.innerHTML = renderKaTeX(text, false);
     if (color) el.style.color = colorToCSS(color);
     container.appendChild(el);
-    const entry = { el, dataPos: dataPos.slice(), screenX: null, screenY: null, forceHidden: false };
+    const align = opts.align || 'center';
+    const entry = { el, dataPos: dataPos.slice(), screenX: null, screenY: null, forceHidden: false, align };
     state.labels.push(entry);
     return entry;
 }
@@ -243,7 +246,8 @@ export function updateLabels() {
             lbl.screenY += (targetY - lbl.screenY) * alpha;
         }
         const s = state.displayParams.labelScale;
-        lbl.el.style.transform = `translate(${lbl.screenX}px, ${lbl.screenY}px) translate(-50%, -50%)${s !== 1 ? ' scale(' + s + ')' : ''}`;
+        const ax = lbl.align === 'right' ? '-100%' : lbl.align === 'left' ? '0%' : '-50%';
+        lbl.el.style.transform = `translate(${lbl.screenX}px, ${lbl.screenY}px) translate(${ax}, -50%)${s !== 1 ? ' scale(' + s + ')' : ''}`;
         lbl.el.style.opacity = visible ? state.displayParams.labelOpacity : '0';
     }
 }

--- a/static/objects/polygon.js
+++ b/static/objects/polygon.js
@@ -91,7 +91,13 @@ function _buildGradientSlab(wVerts, gradient, halfThick, normal) {
     const tValues = wVerts.map(v => v[axis]);
     const tMin = Math.min(...tValues);
     const tMax = Math.max(...tValues);
-    const tRange = tMax - tMin || 1;
+
+    // All vertices share the same coordinate on the gradient axis —
+    // slicing would produce empty geometry.  Fall back to a solid fill
+    // using the color at t=0.
+    if (tMax - tMin < 1e-9) return null;
+
+    const tRange = tMax - tMin;
 
     const n = wVerts.length;
     const edges = [];
@@ -238,12 +244,13 @@ export function renderPolygon(el, view) {
     }
 
     const geom = new THREE.BufferGeometry();
-    const hasGradient = !!el.gradient;
+    const gradResult = el.gradient
+        ? _buildGradientSlab(wVerts, el.gradient, baseHalf * state.displayParams.planeScale, normal)
+        : null;
+    const hasGradient = !!gradResult;
     if (hasGradient) {
-        const { positions: gPos, colors: gCol } = _buildGradientSlab(
-            wVerts, el.gradient, baseHalf * state.displayParams.planeScale, normal);
-        geom.setAttribute('position', new THREE.Float32BufferAttribute(gPos, 3));
-        geom.setAttribute('color', new THREE.Float32BufferAttribute(gCol, 3));
+        geom.setAttribute('position', new THREE.Float32BufferAttribute(gradResult.positions, 3));
+        geom.setAttribute('color', new THREE.Float32BufferAttribute(gradResult.colors, 3));
     } else {
         const { positions, uvData } = buildSlabGeometry(baseHalf * state.displayParams.planeScale);
         geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
@@ -289,7 +296,10 @@ export function renderPolygon(el, view) {
     mesh.userData.wVerts = wVerts;
     mesh.userData.normal = normal.clone();
     mesh.userData.buildSlab = hasGradient
-        ? (halfThick) => _buildGradientSlab(wVerts, el.gradient, halfThick, normal).positions
+        ? (halfThick) => {
+            const g = _buildGradientSlab(wVerts, el.gradient, halfThick, normal);
+            return g ? g.positions : buildSlabGeometry(halfThick).positions;
+        }
         : (halfThick) => buildSlabGeometry(halfThick).positions;
     const _serial = el.renderOrder !== undefined ? el.renderOrder : state._planeMeshSerial++;
     mesh.renderOrder = _serial;

--- a/static/objects/polygon.js
+++ b/static/objects/polygon.js
@@ -51,6 +51,126 @@ function _computePlaneUVs(wVerts, normal) {
     return proj.map(([u, v]) => [(u - minU) / scale, (v - minV) / scale]);
 }
 
+// ── Gradient support: per-vertex color interpolation along an axis ──
+
+function _buildGradientColorFn(gradient) {
+    if (gradient.stops && gradient.stops.length > 0) {
+        const stops = gradient.stops.slice().sort((a, b) => a.t - b.t);
+        const parsed = stops.map(s => ({ t: s.t, c: parseColor(s.color) }));
+        return (t) => {
+            if (t <= parsed[0].t) return parsed[0].c.slice();
+            if (t >= parsed[parsed.length - 1].t) return parsed[parsed.length - 1].c.slice();
+            for (let i = 0; i < parsed.length - 1; i++) {
+                if (t <= parsed[i + 1].t) {
+                    const f = (t - parsed[i].t) / (parsed[i + 1].t - parsed[i].t);
+                    return [
+                        parsed[i].c[0] + f * (parsed[i + 1].c[0] - parsed[i].c[0]),
+                        parsed[i].c[1] + f * (parsed[i + 1].c[1] - parsed[i].c[1]),
+                        parsed[i].c[2] + f * (parsed[i + 1].c[2] - parsed[i].c[2]),
+                    ];
+                }
+            }
+            return parsed[parsed.length - 1].c.slice();
+        };
+    }
+    const c0 = parseColor(gradient.from || '#ff0000');
+    const c1 = parseColor(gradient.to || '#0000ff');
+    return (t) => [
+        c0[0] + t * (c1[0] - c0[0]),
+        c0[1] + t * (c1[1] - c0[1]),
+        c0[2] + t * (c1[2] - c0[2]),
+    ];
+}
+
+function _buildGradientSlab(wVerts, gradient, halfThick, normal) {
+    const dir = gradient.direction || 'y';
+    const axis = dir === 'x' ? 0 : dir === 'z' ? 2 : 1;
+    const segments = gradient.segments || 64;
+    const getColor = _buildGradientColorFn(gradient);
+
+    const tValues = wVerts.map(v => v[axis]);
+    const tMin = Math.min(...tValues);
+    const tMax = Math.max(...tValues);
+    const tRange = tMax - tMin || 1;
+
+    const n = wVerts.length;
+    const edges = [];
+    for (let i = 0; i < n; i++) {
+        const j = (i + 1) % n;
+        edges.push({
+            w0: wVerts[i], w1: wVerts[j],
+            t0: (tValues[i] - tMin) / tRange,
+            t1: (tValues[j] - tMin) / tRange,
+        });
+    }
+
+    function sliceAt(t) {
+        const pts = [];
+        for (const e of edges) {
+            const lo = Math.min(e.t0, e.t1), hi = Math.max(e.t0, e.t1);
+            if (t < lo - 1e-9 || t > hi + 1e-9) continue;
+            const dt = e.t1 - e.t0;
+            if (Math.abs(dt) < 1e-9) {
+                pts.push(e.w0.slice(), e.w1.slice());
+            } else {
+                const f = (t - e.t0) / dt;
+                pts.push([
+                    e.w0[0] + f * (e.w1[0] - e.w0[0]),
+                    e.w0[1] + f * (e.w1[1] - e.w0[1]),
+                    e.w0[2] + f * (e.w1[2] - e.w0[2]),
+                ]);
+            }
+        }
+        const unique = [];
+        for (const p of pts) {
+            if (!unique.some(u =>
+                Math.abs(u[0]-p[0]) < 1e-9 &&
+                Math.abs(u[1]-p[1]) < 1e-9 &&
+                Math.abs(u[2]-p[2]) < 1e-9))
+                unique.push(p);
+        }
+        const sa = axis === 0 ? 1 : 0;
+        unique.sort((a, b) => a[sa] - b[sa]);
+        return unique;
+    }
+
+    const positions = [];
+    const vertColors = [];
+    const off = (v, s) => [
+        v[0] + normal.x * halfThick * s,
+        v[1] + normal.y * halfThick * s,
+        v[2] + normal.z * halfThick * s,
+    ];
+
+    for (let s = 0; s < segments; s++) {
+        const tBot = s / segments;
+        const tTop = (s + 1) / segments;
+        const bp = sliceAt(tBot);
+        const tp = sliceAt(tTop);
+        if (bp.length < 2 || tp.length < 2) continue;
+
+        const cB = getColor(tBot);
+        const cT = getColor(tTop);
+        const bL = bp[0], bR = bp[bp.length - 1];
+        const tL = tp[0], tR = tp[tp.length - 1];
+
+        for (const sign of [1, -1]) {
+            const o = (v) => off(v, sign);
+            if (sign === 1) {
+                positions.push(...o(bL), ...o(bR), ...o(tR));
+                positions.push(...o(bL), ...o(tR), ...o(tL));
+            } else {
+                positions.push(...o(bL), ...o(tR), ...o(bR));
+                positions.push(...o(bL), ...o(tL), ...o(tR));
+            }
+            vertColors.push(...cB, ...cB, ...cT);
+            vertColors.push(...cB, ...cT, ...cT);
+        }
+    }
+
+    return { positions, colors: vertColors };
+}
+
 export function renderPolygon(el, view) {
     const color = parseColor(el.color || '#aa66ff');
     const opacity = el.opacity !== undefined ? el.opacity : 0.5;
@@ -118,18 +238,27 @@ export function renderPolygon(el, view) {
     }
 
     const geom = new THREE.BufferGeometry();
-    const { positions, uvData } = buildSlabGeometry(baseHalf * state.displayParams.planeScale);
-    geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
-    if (uvData) geom.setAttribute('uv', new THREE.Float32BufferAttribute(uvData, 2));
+    const hasGradient = !!el.gradient;
+    if (hasGradient) {
+        const { positions: gPos, colors: gCol } = _buildGradientSlab(
+            wVerts, el.gradient, baseHalf * state.displayParams.planeScale, normal);
+        geom.setAttribute('position', new THREE.Float32BufferAttribute(gPos, 3));
+        geom.setAttribute('color', new THREE.Float32BufferAttribute(gCol, 3));
+    } else {
+        const { positions, uvData } = buildSlabGeometry(baseHalf * state.displayParams.planeScale);
+        geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+        if (uvData) geom.setAttribute('uv', new THREE.Float32BufferAttribute(uvData, 2));
+    }
     geom.computeVertexNormals();
 
     const baseMatOpts = {
-        color: new THREE.Color(...color),
+        color: hasGradient ? new THREE.Color(1, 1, 1) : new THREE.Color(...color),
         opacity: state.displayParams.planeOpacity,
         transparent: true,
         side: THREE.DoubleSide,
         depthWrite: false,
     };
+    if (hasGradient) baseMatOpts.vertexColors = true;
 
     let mat;
     if (sh.type === 'basic') {
@@ -159,7 +288,9 @@ export function renderPolygon(el, view) {
     mesh.userData.baseHalf = baseHalf;
     mesh.userData.wVerts = wVerts;
     mesh.userData.normal = normal.clone();
-    mesh.userData.buildSlab = (halfThick) => buildSlabGeometry(halfThick).positions;
+    mesh.userData.buildSlab = hasGradient
+        ? (halfThick) => _buildGradientSlab(wVerts, el.gradient, halfThick, normal).positions
+        : (halfThick) => buildSlabGeometry(halfThick).positions;
     const _serial = el.renderOrder !== undefined ? el.renderOrder : state._planeMeshSerial++;
     mesh.renderOrder = _serial;
     mesh.position.z = el.depthZ !== undefined ? el.depthZ : _serial * 0.0002;

--- a/static/objects/text.js
+++ b/static/objects/text.js
@@ -20,7 +20,7 @@ export function renderText(el, view) {
             return null;
         }
 
-        const labelOpts = { align: el.align };
+        const labelOpts = { align: el.align, cssClass: el.cssClass };
         const labelEl = addLabel3D(text, initPos, color, labelOpts);
         const startTime = state.sceneStartTime;
 
@@ -61,7 +61,7 @@ export function renderText(el, view) {
 
     const position = el.position || el.at || [0, 0, 0];
 
-    const labelOpts = { align: el.align };
+    const labelOpts = { align: el.align, cssClass: el.cssClass };
     addLabel3D(text, position, color, labelOpts);
 
     return { type: 'text', color, label: text };

--- a/static/objects/text.js
+++ b/static/objects/text.js
@@ -1,4 +1,4 @@
-import { parseColor, addLabel3D } from '/labels.js';
+import { parseColor, addLabel3D, renderKaTeX } from '/labels.js';
 import { compileExpr, evalExpr } from '/expr.js';
 import { state } from '/state.js';
 
@@ -20,8 +20,17 @@ export function renderText(el, view) {
             return null;
         }
 
-        const labelEl = addLabel3D(text, initPos, color);
+        const cssClass = el.cssClass || undefined;
+        const labelEl = addLabel3D(text, initPos, color, cssClass);
         const startTime = state.sceneStartTime;
+
+        let textExprFn = null;
+        const textFormat = el.textFormat || '%d';
+        if (el.textExpr) {
+            try { textExprFn = compileExpr(el.textExpr); } catch (_e) { /* ignore */ }
+        }
+        let prevTextVal = null;
+
         state.activeAnimUpdaters.push({
             animState: { stopped: false },
             updateFrame(nowMs) {
@@ -31,8 +40,17 @@ export function renderText(el, view) {
                     labelEl.dataPos[0] = p[0];
                     labelEl.dataPos[1] = p[1];
                     labelEl.dataPos[2] = p[2];
-                } catch (_err) {
-                    // keep previous label position on evaluation failure
+                } catch (_err) {}
+                if (textExprFn) {
+                    try {
+                        const raw = evalExpr(textExprFn, tSec);
+                        const rounded = Math.round(raw);
+                        if (rounded !== prevTextVal) {
+                            prevTextVal = rounded;
+                            const formatted = textFormat.replace('%d', rounded);
+                            labelEl.el.innerHTML = renderKaTeX(formatted, false);
+                        }
+                    } catch (_err) {}
                 }
             },
         });
@@ -42,7 +60,8 @@ export function renderText(el, view) {
 
     const position = el.position || el.at || [0, 0, 0];
 
-    addLabel3D(text, position, color);
+    const cssClass = el.cssClass || undefined;
+    addLabel3D(text, position, color, cssClass);
 
     return { type: 'text', color, label: text };
 }

--- a/static/objects/text.js
+++ b/static/objects/text.js
@@ -20,8 +20,8 @@ export function renderText(el, view) {
             return null;
         }
 
-        const cssClass = el.cssClass || undefined;
-        const labelEl = addLabel3D(text, initPos, color, cssClass);
+        const labelOpts = { align: el.align };
+        const labelEl = addLabel3D(text, initPos, color, labelOpts);
         const startTime = state.sceneStartTime;
 
         let textExprFn = null;
@@ -60,8 +60,8 @@ export function renderText(el, view) {
 
     const position = el.position || el.at || [0, 0, 0];
 
-    const cssClass = el.cssClass || undefined;
-    addLabel3D(text, position, color, cssClass);
+    const labelOpts = { align: el.align };
+    addLabel3D(text, position, color, labelOpts);
 
     return { type: 'text', color, label: text };
 }

--- a/static/objects/text.js
+++ b/static/objects/text.js
@@ -44,6 +44,7 @@ export function renderText(el, view) {
                 if (textExprFn) {
                     try {
                         const raw = evalExpr(textExprFn, tSec);
+                        if (!Number.isFinite(raw)) return;
                         const rounded = Math.round(raw);
                         if (rounded !== prevTextVal) {
                             prevTextVal = rounded;

--- a/static/style.css
+++ b/static/style.css
@@ -888,6 +888,7 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     will-change: transform, opacity;
 }
 
+.label-3d.label-right { transform: translate(-100%, -50%); }
 .label-3d .katex { font-size: 1em; }
 .label-axis { font-size: 18px; font-weight: bold; }
 

--- a/static/style.css
+++ b/static/style.css
@@ -888,7 +888,6 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     will-change: transform, opacity;
 }
 
-.label-3d.label-right { transform: translate(-100%, -50%); }
 .label-3d .katex { font-size: 1em; }
 .label-axis { font-size: 18px; font-weight: bold; }
 

--- a/static/style.css
+++ b/static/style.css
@@ -3520,7 +3520,6 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     font-size: 0.68rem;
     font-weight: 700;
     letter-spacing: 0.14em;
-    text-transform: uppercase;
     color: rgba(176, 186, 229, 0.6);
     padding: 6px 4px;
 }

--- a/tests/test_dot_notation_restore.py
+++ b/tests/test_dot_notation_restore.py
@@ -15,7 +15,7 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from server import _re_sub_literal, _restore_dot_notation, _derive_semantic_graph  # noqa: E402
+from server import _re_sub_literal, _restore_dot_notation, _derive_semantic_graph, _strip_accent_commands  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -129,6 +129,16 @@ class TestIssue185Repro:
         ids = {node["id"] for node in g["nodes"]}
         assert r"q_{\text{lunar}}" in ids
         assert r"q_{\text{LEO}}" in ids
+
+    def test_accent_strip_prevents_token_concatenation(self):
+        """``\\times\\vec{E}`` must strip to ``\\times E``, not ``\\timesE``."""
+        result = _strip_accent_commands(r"\times\vec{E}")
+        assert result == r"\times E"
+
+    def test_accent_strip_no_space_after_non_alpha(self):
+        """No extra space when preceding char is not alphabetic."""
+        result = _strip_accent_commands(r"(\vec{F})")
+        assert result == "(F)"
 
     def test_dotted_subexprs_use_dot_command(self):
         g = _derive_semantic_graph(self.LATEX)

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -613,7 +613,7 @@ class TestComplexFormulas:
         g = latex_to_semantic_graph(
             r"\frac{\partial^2 u}{\partial t^2} = c^2 \frac{\partial^2 u}{\partial x^2}"
         )
-        derivs = _find_nodes(g, type="operator", op="derivative")
+        derivs = _find_nodes(g, type="operator", op="partial_derivative")
         assert len(derivs) == 2
         wrt_vars = {d["with_respect_to"] for d in derivs}
         assert "t" in wrt_vars
@@ -1308,7 +1308,7 @@ class TestCompoundSymbols:
     def test_partial_derivative_still_parses(self):
         """``\\partial`` must NOT be collapsed — derivatives still need it."""
         g = latex_to_semantic_graph(r"\frac{\partial u}{\partial x} = 0")
-        derivs = _find_nodes(g, type="operator", op="derivative")
+        derivs = _find_nodes(g, type="operator", op="partial_derivative")
         assert derivs, (
             "\\partial u / \\partial x should still be recognized as a "
             "derivative, not a fraction of compound symbols"

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -285,6 +285,12 @@ class TestDerivatives:
         result = _preprocess_latex(r"\frac{\partial^{3} u}{\partial x^{3}}")
         assert result.count(r"\frac") == 3
 
+    def test_ordinary_derivative_not_partial(self):
+        """d/dt must stay op='derivative', not 'partial_derivative'."""
+        g = latex_to_semantic_graph(r"\frac{d v}{d t}")
+        assert _find_node(g, type="operator", op="derivative") is not None
+        assert _find_node(g, type="operator", op="partial_derivative") is None
+
 
 # ---------------------------------------------------------------------------
 # Relation operators (proportional, implies, iff, maps_to, approximately)


### PR DESCRIPTION
## Summary

- Add comprehensive photons, wavelength, and energy interactive lesson with multiple steps covering EM spectrum, wave properties, and Maxwell's equations
- Add native gradient support for polygon objects with vertex colors
- Add dynamic `textExpr`, right-aligned labels, `align` property, and `cssClass` support for text features
- Fix LaTeX rendering in Math panel titles with KaTeX
- Fix semantic graph: restore `\nabla\times` and `\nabla\cdot` operators in subexpr fields (SymPy absorbs these into plain `Mul`)
- Fix semantic graph: distinguish `\partial` (partial derivative) from ordinary `d` derivative using `∂` glyph
- Fix accent stripping token concatenation (`\times\vec{E}` → `\times E` instead of `\timesE`)

## Key changes

### Lesson content
- 15-step photons lesson covering visible spectrum, wavelength-frequency relationship, EM waves, and Maxwell's equation proofs
- Nanoscale comparison bars, side-by-side charts, 3D magnetic field visualization

### Semantic graph pipeline
- `_subexpr_ordered()` now restores `\times`/`\cdot` after nabla when original LaTeX used them
- `_subexpr_ordered()` renders `\partial` instead of `d` for partial derivatives  
- `_walk_inner()` sets `op="partial_derivative"` vs `op="derivative"` based on original LaTeX
- D3 graph renderer uses `∂` glyph for partial derivative operators
- `_strip_accent_commands()` inserts space to prevent token concatenation

## Test plan
- [x] All 340 tests pass
- [x] Verified nabla × E renders correctly in browser preview
- [x] Verified partial derivative shows ∂ glyph in D3 graph

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>