### PR TITLE
fix(graph): split newline-separated LaTeX into independent statements

### DIFF
--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 |---|---|
-| **Branch** | `fix/braket-two-form-display` |
-| **Commit** | `95fe9b6` |
-| **Date** | 2026-05-15 06:00:02 -0400 |
+| **Branch** | `fix/253-newline-separated-latex` |
+| **Commit** | `f8a4a7b` |
+| **Date** | 2026-05-15 17:43:53 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [49521, 15313, 11500, 4163, 386, 137, 33]
+  bar [49521, 15313, 11561, 4163, 386, 137, 33]
 ```
 
 ## Summary by Language
@@ -28,7 +28,7 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  JSON                     41        49522        49521            0            1
  JavaScript               46        17690        15313          942         1435
- Python                   29        14885        11500         1691         1694
+ Python                   29        14966        11561         1694         1711
  CSS                       3         4506         4163          157          186
  Shell                     2          172          137           14           21
  BASH                      1           41           33            4            4
@@ -46,7 +46,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            11950         1475         7882         2593
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   181        99882        83160        10722         6000
+ Total                   181        99963        83221        10725         6017
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -131,11 +131,11 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Python                   29        14885        11500         1691         1694
+ Python                   29        14966        11561         1694         1711
 ─────────────────────────────────────────────────────────────────────────────────
  |ebench/algebench/server.py         2948         2357          346          245
- |/scripts/latex_to_graph.py         2020         1526          335          159
- |sts/test_latex_to_graph.py         1790         1396          162          232
+ |/scripts/latex_to_graph.py         2031         1533          338          160
+ |sts/test_latex_to_graph.py         1860         1450          162          248
  |semantic_graph_enricher.py         1144          798          214          132
  |semantic_graph_enricher.py          853          676          106           71
  |cripts/graph_to_mermaid.py          861          604          174           83
@@ -163,7 +163,7 @@ xychart-beta horizontal
  |lgebench/tests/__init__.py            0            0            0            0
  |h/tests/agents/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    29        14885        11500         1691         1694
+ Total                    29        14966        11561         1694         1711
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -171,6 +171,6 @@ xychart-beta horizontal
 
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
-| JavaScript (frontend) | 15313 | 57% |
-| Python (backend) | 11500 | 43% |
-| **Total** | **26813** | **100%** |
+| JavaScript (frontend) | 15313 | 56% |
+| Python (backend) | 11561 | 44% |
+| **Total** | **26874** | **100%** |

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -5,8 +5,8 @@
 | Field | Value |
 |---|---|
 | **Branch** | `fix/253-newline-separated-latex` |
-| **Commit** | `f8a4a7b` |
-| **Date** | 2026-05-15 17:43:53 -0400 |
+| **Commit** | `d9e23d3` |
+| **Date** | 2026-05-15 18:58:27 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [49521, 15313, 11561, 4163, 386, 137, 33]
+  bar [49521, 15313, 11582, 4163, 386, 137, 33]
 ```
 
 ## Summary by Language
@@ -28,7 +28,7 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  JSON                     41        49522        49521            0            1
  JavaScript               46        17690        15313          942         1435
- Python                   29        14966        11561         1694         1711
+ Python                   29        14991        11582         1695         1714
  CSS                       3         4506         4163          157          186
  Shell                     2          172          137           14           21
  BASH                      1           41           33            4            4
@@ -46,7 +46,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            11950         1475         7882         2593
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   181        99963        83221        10725         6017
+ Total                   181        99988        83242        10726         6020
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -131,11 +131,11 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Python                   29        14966        11561         1694         1711
+ Python                   29        14991        11582         1695         1714
 ─────────────────────────────────────────────────────────────────────────────────
  |ebench/algebench/server.py         2948         2357          346          245
- |/scripts/latex_to_graph.py         2031         1533          338          160
- |sts/test_latex_to_graph.py         1860         1450          162          248
+ |/scripts/latex_to_graph.py         2043         1544          339          160
+ |sts/test_latex_to_graph.py         1873         1460          162          251
  |semantic_graph_enricher.py         1144          798          214          132
  |semantic_graph_enricher.py          853          676          106           71
  |cripts/graph_to_mermaid.py          861          604          174           83
@@ -163,7 +163,7 @@ xychart-beta horizontal
  |lgebench/tests/__init__.py            0            0            0            0
  |h/tests/agents/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    29        14966        11561         1694         1711
+ Total                    29        14991        11582         1695         1714
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -172,5 +172,5 @@ xychart-beta horizontal
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
 | JavaScript (frontend) | 15313 | 56% |
-| Python (backend) | 11561 | 44% |
-| **Total** | **26874** | **100%** |
+| Python (backend) | 11582 | 44% |
+| **Total** | **26895** | **100%** |

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -1451,17 +1451,17 @@ def _split_on_top_level_newline(latex: str) -> list[str]:
     as **statement separators**.
 
     A ``\\`` is treated as a separator only when it sits at brace / paren /
-    bracket depth 0 — i.e. outside every ``{...}``, ``(...)``, ``[...]``
-    group.  Inside environments like ``\begin{cases}`` or matrices the
-    double-backslash is a row separator, not a statement separator, but
-    those environments are already wrapped in braces so the depth check
-    handles them automatically.
+    bracket depth 0 **and** outside any ``\begin{…}``/``\end{…}``
+    environment.  Inside environments like ``\begin{cases}``, matrices, or
+    ``align`` blocks the double-backslash is a row separator, not a
+    statement separator.
 
     Returns a list of trimmed, non-empty sub-expressions.  A single-element
     list means no top-level ``\\`` was found.
     """
     parts: list[str] = []
     depth = 0
+    env_depth = 0
     i = 0
     start = 0
     n = len(latex)
@@ -1474,7 +1474,19 @@ def _split_on_top_level_newline(latex: str) -> list[str]:
             if depth > 0:
                 depth -= 1
             i += 1
-        elif ch == "\\" and depth == 0:
+        elif ch == "\\" and i + 1 < n and latex[i + 1] != "\\":
+            # Check for \begin{...} / \end{...} to track environment depth.
+            rest = latex[i:]
+            if rest.startswith("\\begin{"):
+                env_depth += 1
+                i += 1
+            elif rest.startswith("\\end{"):
+                if env_depth > 0:
+                    env_depth -= 1
+                i += 1
+            else:
+                i += 1
+        elif ch == "\\" and depth == 0 and env_depth == 0:
             # Look for ``\\`` (two backslashes) that is NOT part of a
             # longer backslash-letter command.  We need exactly two
             # consecutive backslashes NOT followed by another backslash

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -1475,8 +1475,14 @@ def _split_on_top_level_newline(latex: str) -> list[str]:
                 depth -= 1
             i += 1
         elif ch == "\\" and depth == 0:
+            # Look for ``\\`` (two backslashes) that is NOT part of a
+            # longer backslash-letter command.  We need exactly two
+            # consecutive backslashes NOT followed by another backslash
+            # or a letter (which would make it ``\\\cmd``).
             if i + 1 < n and latex[i + 1] == "\\":
                 end_of_bs = i + 2
+                # Skip optional ``[...]`` spacing arg after ``\\``,
+                # e.g. ``\\[6pt]``
                 after = end_of_bs
                 while after < n and latex[after] in " \t":
                     after += 1
@@ -1898,11 +1904,16 @@ def latex_to_semantic_graph(latex: str, overrides: dict[str, dict[str, str]] | N
         _inject_annotations(graph, parenthetical_annotations)
         return graph
 
-    # A top-level comma now acts as a statement separator (preserves
-    # existing ``a = 1, b = 2`` behavior — multiple independent rooted
-    # statements, no synthetic ``and`` node). Pass only the user-supplied
-    # overrides; the recursive call re-derives text/compound placeholders
-    # per clause so they don't collide with parent-scoped ``Xi_{N}`` ids.
+    # No top-level relation.  Check for ``\\`` (LaTeX newline) first —
+    # it's a stronger separator than comma.  Then fall through to comma.
+    newline_clauses = _split_on_top_level_newline(latex)
+    if len(newline_clauses) > 1:
+        graph = _build_comma_separated_graph(
+            newline_clauses, overrides=user_overrides, domain=domain,
+        )
+        _inject_annotations(graph, parenthetical_annotations)
+        return graph
+
     clauses = _split_on_top_level_comma(latex)
     if len(clauses) > 1:
         graph = _build_comma_separated_graph(

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -14,6 +14,7 @@ from scripts.latex_to_graph import (
     parse_var_overrides,
     _preprocess_latex,
     _split_on_top_level_comma,
+    _split_on_top_level_newline,
     _extract_parenthetical_annotations,
     _inject_annotations,
     _collapse_braket_notation,
@@ -992,6 +993,75 @@ class TestCommaSplit:
         r"""``\\,`` — escaped backslash followed by a literal comma. The
         comma is NOT escaped, so the split should happen."""
         assert _split_on_top_level_comma(r"a \\, b") == [r"a \\", "b"]
+
+
+class TestNewlineSplit:
+    r"""Low-level splitting on ``\\`` (LaTeX line-break)."""
+
+    def test_no_newline_returns_single_clause(self):
+        assert _split_on_top_level_newline("x + y") == ["x + y"]
+
+    def test_top_level_newline_splits(self):
+        assert _split_on_top_level_newline(r"a = 1 \\ b = 2") == ["a = 1", "b = 2"]
+
+    def test_three_lines(self):
+        assert _split_on_top_level_newline(r"a \\ b \\ c") == ["a", "b", "c"]
+
+    def test_newline_inside_braces_not_split(self):
+        assert _split_on_top_level_newline(r"x = {1 \\ 2}") == [r"x = {1 \\ 2}"]
+
+    def test_newline_inside_parens_not_split(self):
+        assert _split_on_top_level_newline(r"(a \\ b)") == [r"(a \\ b)"]
+
+    def test_optional_spacing_arg_consumed(self):
+        r"""``\\[6pt]`` — the optional spacing argument must be consumed
+        and not leak into the next clause."""
+        assert _split_on_top_level_newline(r"x = 1 \\[6pt] y = 2") == [
+            "x = 1",
+            "y = 2",
+        ]
+
+    def test_single_backslash_not_split(self):
+        r"""A single ``\`` (LaTeX command prefix) must NOT trigger a split."""
+        assert _split_on_top_level_newline(r"\alpha + \beta") == [r"\alpha + \beta"]
+
+    def test_trailing_newline_no_empty_clause(self):
+        assert _split_on_top_level_newline(r"a = 1 \\") == ["a = 1"]
+
+    def test_leading_newline_no_empty_clause(self):
+        assert _split_on_top_level_newline(r"\\ b = 2") == ["b = 2"]
+
+
+class TestNewlineSeparatedClauses:
+    r"""Full graph behaviour for ``\\``-separated statements (issue #253)."""
+
+    def test_issue_253_two_equations(self):
+        r"""Two probability equations separated by ``\\`` must each produce
+        their own clause in the semantic graph."""
+        g = latex_to_semantic_graph(
+            r"p(0)=\lvert\langle 0\vert\psi\rangle\rvert^2"
+            r"=\cos^2\!\left(\frac{\theta}{2}\right)"
+            r" \\ "
+            r"p(1)=\lvert\langle 1\vert\psi\rangle\rvert^2"
+            r"=\sin^2\!\left(\frac{\theta}{2}\right)"
+        )
+        assert g["classification"]["kind"] == "statements"
+        assert g["classification"]["count"] == 2
+
+    def test_three_newline_separated_equations(self):
+        g = latex_to_semantic_graph(r"x = 1 \\ y = 2 \\ z = 3")
+        assert g["classification"]["kind"] == "statements"
+        assert g["classification"]["count"] == 3
+        assert _find_node(g, id="x") is not None
+        assert _find_node(g, id="y") is not None
+        assert _find_node(g, id="z") is not None
+
+    def test_newline_separated_shared_variable_dedup(self):
+        r"""Shared variables across ``\\``-separated clauses should dedup
+        to a single node, just like comma-separated clauses do."""
+        g = latex_to_semantic_graph(r"x = a + b \\ y = a + c")
+        a_nodes = [n for n in g["nodes"] if n.get("id") == "a"]
+        assert len(a_nodes) == 1, "shared variable 'a' should be a single node"
 
 
 class TestCommaSeparatedClauses:

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -1031,6 +1031,19 @@ class TestNewlineSplit:
     def test_leading_newline_no_empty_clause(self):
         assert _split_on_top_level_newline(r"\\ b = 2") == ["b = 2"]
 
+    def test_newline_inside_begin_cases_not_split(self):
+        latex = r"\begin{cases} a \\ b \end{cases}"
+        assert _split_on_top_level_newline(latex) == [latex]
+
+    def test_newline_inside_nested_environments_not_split(self):
+        latex = r"\begin{cases} \begin{matrix} x \\ y \end{matrix} \\ z \end{cases}"
+        assert _split_on_top_level_newline(latex) == [latex]
+
+    def test_newline_after_environment_does_split(self):
+        assert _split_on_top_level_newline(
+            r"\begin{cases} a \\ b \end{cases} \\ c = 1"
+        ) == [r"\begin{cases} a \\ b \end{cases}", "c = 1"]
+
 
 class TestNewlineSeparatedClauses:
     r"""Full graph behaviour for ``\\``-separated statements (issue #253)."""


### PR DESCRIPTION
## Summary
- Adds `_split_on_top_level_newline()` that splits on `\\` at brace depth 0, treating LaTeX line-breaks as statement separators
- Integrates the split into `latex_to_semantic_graph()` before the comma split (stronger separator precedence)
- Reuses existing `_build_comma_separated_graph()` for merging subgraphs with shared variable deduplication

Fixes #253

## Test plan
- [x] Issue's exact LaTeX input (`p(0)=... \\ p(1)=...`) now produces 2-clause graph
- [x] `\\[6pt]` optional spacing args consumed correctly
- [x] `\\` inside braces/parens not split (depth-aware)
- [x] Single `\` (command prefix) not confused for `\\`
- [x] Trailing/leading `\\` produce no empty clauses
- [x] Comma-separated and single expressions unchanged
- [x] Shared variables across `\\` clauses dedup to one node
- [x] All 355 tests pass

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>