### PR TITLE
fix(graph): braket parsing + two-form short/long label convention

### DIFF
--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 |---|---|
-| **Branch** | `fix/271-loc-report-merge-ours` |
-| **Commit** | `f836596` |
-| **Date** | 2026-05-15 05:37:58 -0400 |
+| **Branch** | `fix/braket-two-form-display` |
+| **Commit** | `c57e591` |
+| **Date** | 2026-05-15 05:42:19 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [49520, 15287, 10901, 4163, 386, 137, 33]
+  bar [49520, 15313, 11497, 4163, 386, 137, 33]
 ```
 
 ## Summary by Language
@@ -27,8 +27,8 @@ xychart-beta horizontal
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  JSON                     41        49521        49520            0            1
- JavaScript               46        17608        15287          891         1430
- Python                   29        14110        10901         1580         1629
+ JavaScript               46        17690        15313          942         1435
+ Python                   29        14878        11497         1687         1694
  CSS                       3         4506         4163          157          186
  Shell                     2          172          137           14           21
  BASH                      1           41           33            4            4
@@ -46,7 +46,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            11950         1475         7882         2593
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   181        99024        82534        10560         5930
+ Total                   181        99874        83156        10718         6000
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -56,21 +56,21 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- JavaScript               46        17608        15287          891         1430
+ JavaScript               46        17690        15313          942         1435
 ─────────────────────────────────────────────────────────────────────────────────
- |bench/static/graph-view.js         2011         1549          319          143
+ |bench/static/graph-view.js         2014         1549          322          143
  |nch/static/json-browser.js         1403         1361            5           37
  |h/algebench/static/chat.js         1425         1160          113          152
  |lgebench/static/overlay.js         1168         1101           29           38
  |/algebench/static/proof.js         1109         1040           33           36
- |panel/d3-semantic-graph.js         1201         1012           43          146
+ |panel/d3-semantic-graph.js         1272         1036           85          151
  |nch/static/scene-loader.js          939          798           46           95
  |algebench/static/camera.js          760          646           20           94
  |cislunar-dynamics/index.js          611          546            8           57
  |objects/animated-vector.js          533          487            3           43
  |lgebench/static/sliders.js          526          444           30           52
  |bench/static/follow-cam.js          455          417            5           33
- |graph-panel/graph-panel.js          534          408           81           45
+ |graph-panel/graph-panel.js          542          410           87           45
  |nch/algebench/static/ui.js          398          342           10           46
  |atmospheric-entry/index.js          373          335            8           30
  |h/algebench/static/expr.js          356          326           20           10
@@ -121,7 +121,7 @@ xychart-beta horizontal
  |islunar-dynamics/docs.json          122          122            0            0
  |tmospheric-entry/docs.json           41           41            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    53        22780        20105         1055         1620
+ Total                    53        22862        20131         1106         1625
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -131,11 +131,11 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Python                   29        14110        10901         1580         1629
+ Python                   29        14878        11497         1687         1694
 ─────────────────────────────────────────────────────────────────────────────────
- |ebench/algebench/server.py         2938         2352          341          245
- |sts/test_latex_to_graph.py         1575         1226          143          206
- |/scripts/latex_to_graph.py         1473         1105          248          120
+ |ebench/algebench/server.py         2948         2357          346          245
+ |/scripts/latex_to_graph.py         2013         1523          331          159
+ |sts/test_latex_to_graph.py         1790         1396          162          232
  |semantic_graph_enricher.py         1144          798          214          132
  |semantic_graph_enricher.py          853          676          106           71
  |cripts/graph_to_mermaid.py          861          604          174           83
@@ -151,8 +151,8 @@ xychart-beta horizontal
  |/scripts/assemble_scene.py          187          144            1           42
  |/tests/test_render_math.py          177          124           18           35
  |graph_highlight_overlay.py          163          120           11           32
+ |h/models/semantic_graph.py          161          109           19           33
  |st_dot_notation_restore.py          156          107           19           30
- |h/models/semantic_graph.py          158          106           19           33
  |h/algebench/agents/base.py          124          105            0           19
  |ents/test_schema_parity.py           75           57            0           18
  |t_semantic_graph_themes.py           69           51            0           18
@@ -163,7 +163,7 @@ xychart-beta horizontal
  |lgebench/tests/__init__.py            0            0            0            0
  |h/tests/agents/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    29        14110        10901         1580         1629
+ Total                    29        14878        11497         1687         1694
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -171,6 +171,6 @@ xychart-beta horizontal
 
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
-| JavaScript (frontend) | 15287 | 58% |
-| Python (backend) | 10901 | 42% |
-| **Total** | **26188** | **100%** |
+| JavaScript (frontend) | 15313 | 57% |
+| Python (backend) | 11497 | 43% |
+| **Total** | **26810** | **100%** |

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -5,8 +5,8 @@
 | Field | Value |
 |---|---|
 | **Branch** | `fix/braket-two-form-display` |
-| **Commit** | `c57e591` |
-| **Date** | 2026-05-15 05:42:19 -0400 |
+| **Commit** | `95fe9b6` |
+| **Date** | 2026-05-15 06:00:02 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [49520, 15313, 11497, 4163, 386, 137, 33]
+  bar [49521, 15313, 11500, 4163, 386, 137, 33]
 ```
 
 ## Summary by Language
@@ -26,9 +26,9 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- JSON                     41        49521        49520            0            1
+ JSON                     41        49522        49521            0            1
  JavaScript               46        17690        15313          942         1435
- Python                   29        14878        11497         1687         1694
+ Python                   29        14885        11500         1691         1694
  CSS                       3         4506         4163          157          186
  Shell                     2          172          137           14           21
  BASH                      1           41           33            4            4
@@ -46,7 +46,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            11950         1475         7882         2593
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   181        99874        83156        10718         6000
+ Total                   181        99882        83160        10722         6000
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -131,10 +131,10 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Python                   29        14878        11497         1687         1694
+ Python                   29        14885        11500         1691         1694
 ─────────────────────────────────────────────────────────────────────────────────
  |ebench/algebench/server.py         2948         2357          346          245
- |/scripts/latex_to_graph.py         2013         1523          331          159
+ |/scripts/latex_to_graph.py         2020         1526          335          159
  |sts/test_latex_to_graph.py         1790         1396          162          232
  |semantic_graph_enricher.py         1144          798          214          132
  |semantic_graph_enricher.py          853          676          106           71
@@ -163,7 +163,7 @@ xychart-beta horizontal
  |lgebench/tests/__init__.py            0            0            0            0
  |h/tests/agents/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    29        14878        11497         1687         1694
+ Total                    29        14885        11500         1691         1694
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -172,5 +172,5 @@ xychart-beta horizontal
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
 | JavaScript (frontend) | 15313 | 57% |
-| Python (backend) | 11497 | 43% |
-| **Total** | **26810** | **100%** |
+| Python (backend) | 11500 | 43% |
+| **Total** | **26813** | **100%** |

--- a/models/semantic_graph.py
+++ b/models/semantic_graph.py
@@ -24,6 +24,9 @@ NodeType = Literal[
     "expression",
     "text",
     "annotation",
+    "ket",
+    "bra",
+    "braket",
 ]
 
 Role = Literal[

--- a/schemas/semantic-graph.schema.json
+++ b/schemas/semantic-graph.schema.json
@@ -29,8 +29,8 @@
   "$defs": {
     "nodeType": {
       "type": "string",
-      "enum": ["scalar", "vector", "constant", "number", "operator", "function", "relation", "expression", "text", "annotation"],
-      "description": "The semantic role of the node."
+      "enum": ["scalar", "vector", "constant", "number", "operator", "function", "relation", "expression", "text", "annotation", "ket", "bra", "braket"],
+      "description": "The semantic role of the node. ``ket`` / ``bra`` are Dirac-notation state vectors (``|ψ⟩`` / ``⟨ψ|``); ``braket`` is reserved for legacy graphs — newer parses emit inner products as ``type=operator`` with ``op=inner_product``."
     },
     "operatorOp": {
       "type": "string",
@@ -38,7 +38,8 @@
         "add", "subtract", "multiply", "divide", "power", "equals", "negation",
         "derivative", "integral", "sum", "product",
         "sin", "cos", "tan", "log", "exp", "sqrt", "abs",
-        "arcsin", "arccos", "arctan"
+        "arcsin", "arccos", "arctan",
+        "inner_product"
       ],
       "description": "The mathematical operation this operator or function performs."
     },

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -514,13 +514,7 @@ class SemanticGraphBuilder:
         for name, attrs in self._overrides.items():
             if not _PLACEHOLDER_NAME_RE.fullmatch(name):
                 continue
-            # Prefer ``original_latex`` when present — only braket
-            # overrides set it.  Their ``latex`` is the *operator
-            # skeleton* (``\langle 0|\cdot\rangle``) used as the
-            # operator's own visual identity, but upstream subexprs
-            # (``|⟨0|ψ⟩|^2``, ``cos²(θ/2)``) need the full original
-            # form so the parent context reads as real mathematics.
-            real = attrs.get("original_latex") or attrs.get("latex")
+            real = attrs.get("latex")
             if not real:
                 continue
             # Preserve atomicity when the placeholder sits inside a
@@ -592,13 +586,11 @@ class SemanticGraphBuilder:
             # User overrides still win — authors can pin any property
             # (label, unit, ai_prompt, etc.) explicitly via ``\overrides{…}``.
             if name in self._overrides:
-                # ``bra_content`` / ``ket_content`` / ``original_latex``
-                # are internal metadata for braket operator construction
-                # — not valid graph-node attributes, so filter them out
+                # ``bra_content`` / ``ket_content`` are internal
+                # metadata for braket operand-wiring decisions — not
+                # valid graph-node attributes, so filter them out
                 # before merging.
-                _INTERNAL_OVERRIDE_KEYS = {
-                    "bra_content", "ket_content", "original_latex",
-                }
+                _INTERNAL_OVERRIDE_KEYS = {"bra_content", "ket_content"}
                 attrs.update({
                     k: v for k, v in self._overrides[name].items()
                     if k not in _INTERNAL_OVERRIDE_KEYS
@@ -635,13 +627,13 @@ class SemanticGraphBuilder:
                 and self._overrides[name].get("op") == "inner_product"
             ):
                 ovr = self._overrides[name]
-                # Preserve the original full LaTeX in subexpr so hover /
-                # details show ``⟨0|ψ⟩`` not ``⟨0|·⟩``.
+                # The braket's ``latex`` field already holds the full
+                # ``⟨bra|ket⟩`` — copy it to ``subexpr`` so upstream
+                # walkers and the details panel agree on what this
+                # node represents.
                 for n in self.nodes:
                     if n["id"] == node_id:
-                        original = ovr.get("original_latex")
-                        if original:
-                            n["subexpr"] = original
+                        n["subexpr"] = ovr["latex"]
                         break
                 for part_key, edge_role in (
                     ("bra_content", "lhs"),
@@ -870,16 +862,14 @@ class SemanticGraphBuilder:
             ket_label = sympy.latex(ket_arg.args[0]) if ket_arg.args else ""
             # The inner product is an *operator* like ``+`` or ``=`` —
             # ``op="inner_product"`` distinguishes it from other
-            # operators without inventing a separate type.  Skeleton
-            # uses ``\cdot`` for symbolic slots; the original full
-            # ``⟨bra|ket⟩`` lives in ``subexpr`` for hover/details.
-            skeleton = _braket_skeleton_latex(bra_label, ket_label)
+            # operators.  ``latex`` is the full ``⟨bra|ket⟩`` so the
+            # node and every upstream subexpression read as real math.
             full_latex = rf"\left\langle {bra_label}\middle|{ket_label}\right\rangle"
             self._add_node(
                 node_id,
                 type="operator",
                 op="inner_product",
-                latex=skeleton,
+                latex=full_latex,
                 subexpr=full_latex,
             )
             for inner_arg, edge_role in (
@@ -959,26 +949,6 @@ def _is_braket_constant_side(content: str) -> bool:
         return False
 
 
-def _braket_skeleton_latex(bra_content: str, ket_content: str) -> str:
-    r"""Build the braket *operator* LaTeX where symbolic slots show ``\cdot``
-    and constant slots show the constant verbatim.
-
-    Uses a plain ``|`` (not ``\middle|``) since the skeleton is rendered
-    without an enclosing ``\left … \right`` pair — KaTeX rejects bare
-    ``\middle`` outside such a pair and falls back to displaying the raw
-    source.
-
-    Examples:
-        ``⟨0|ψ⟩``  → ``\langle 0\,|\,\cdot\rangle``
-        ``⟨ψ|0⟩``  → ``\langle \cdot\,|\,0\rangle``
-        ``⟨x|y⟩``  → ``\langle \cdot\,|\,\cdot\rangle``
-        ``⟨0|1⟩``  → ``\langle 0\,|\,1\rangle``
-    """
-    bra_disp = bra_content if _is_braket_constant_side(bra_content) else r"\cdot"
-    ket_disp = ket_content if _is_braket_constant_side(ket_content) else r"\cdot"
-    return rf"\langle {bra_disp}\,|\,{ket_disp}\rangle"
-
-
 def _collapse_braket_notation(latex: str) -> tuple[str, dict[str, dict[str, str]]]:
     r"""Replace Dirac bra-ket notation with placeholder symbols before SymPy
     parsing.
@@ -1005,18 +975,20 @@ def _collapse_braket_notation(latex: str) -> tuple[str, dict[str, dict[str, str]
             seen[full] = idx
             bra_content = m.group(1).strip()
             ket_content = m.group(2).strip()
-            # The braket is an operator: its ``latex`` is the *operator
-            # skeleton* (``⟨0|·⟩``, ``⟨·|·⟩``, etc.) — symbolic operands
-            # appear as separate input nodes wired in by edges.  The
-            # original full LaTeX (``⟨0|ψ⟩``) is preserved in
-            # ``original_latex`` for the node's ``subexpr``.
+            # The braket is an operator with ``op="inner_product"`` —
+            # ``latex`` is the *full* original ``⟨bra|ket⟩`` so the
+            # node and every upstream subexpression read as real
+            # mathematics (``|⟨0|ψ⟩|²``, not ``|⟨0|·⟩|²``).
+            # ``bra_content`` / ``ket_content`` are kept so the
+            # placeholder-resolution path can decide which operands
+            # become input edges (symbolic) versus stay baked into
+            # the node label (constants like ``0``, ``1``).
             overrides[f"Phi_{{{idx}}}"] = {
-                "latex": _braket_skeleton_latex(bra_content, ket_content),
+                "latex": full,
                 "type": "operator",
                 "op": "inner_product",
                 "bra_content": bra_content,
                 "ket_content": ket_content,
-                "original_latex": full,
             }
         return rf"\Phi_{{{seen[full]}}}"
 

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -227,6 +227,118 @@ def _is_inverse_pow(expr: sympy.Basic) -> bool:
     return False
 
 
+# ---------------------------------------------------------------------------
+# Two-form display convention
+# ---------------------------------------------------------------------------
+# Every node carries two display forms:
+#
+#   * **short label** — compact symbol shown on the graph node itself
+#     (``\cos``, ``⟨0|·⟩``, ``|·|``, ``(·)²``, ``+``, ``=``).  Computed
+#     by ``node_short_label(node)``.
+#
+#   * **long label** — full applied form shown in the details panel,
+#     hover tooltip, TTS narration, and AI-enrichment context
+#     (``\cos(θ/2)``, ``⟨0|ψ⟩``, ``|⟨0|ψ⟩|²``).  Computed by
+#     ``node_long_label(node)``.
+#
+# Source-of-truth precedence:
+#
+#   short (op/rel/fn):  node.latex →  glyph(op, …)  →  op  →  id
+#   short (data):       node.latex →  node.label    →  id
+#   long  (any):        node.subexpr → node.latex   →  short label
+#
+# Both helpers are pure functions of the node dict — no UI logic
+# lives in the renderer; it just calls these.
+
+# Mirrors ``operatorGlyph`` in static/graph-panel/d3-semantic-graph.js.
+# Keep in sync.
+_OPERATOR_GLYPHS: dict[str, str] = {
+    "equals": "=", "greater_than": ">", "less_than": "<",
+    "greater_equal": "≥", "less_equal": "≤", "not_equal": "≠",
+    "multiply": "×", "add": "+", "subtract": "−",
+    "divide": "÷", "integral": "∫",
+    "implies": "⇒", "iff": "⇔",
+    "negation": "−", "not": "¬", "logical_not": "¬",
+    "conjunction": "∧", "disjunction": "∨",
+    "sum": "∑", "product": "∏", "limit": "lim",
+    "factorial": "!", "sqrt": "√(·)",
+    "log": "log", "logarithm": "log", "exp": "exp",
+    "sin": "sin", "cos": "cos", "tan": "tan",
+    "Abs": "|·|", "abs": "|·|",
+    "function": "f",
+}
+
+_SUPERSCRIPT_MAP: dict[str, str] = {
+    "0": "⁰", "1": "¹", "2": "²", "3": "³", "4": "⁴",
+    "5": "⁵", "6": "⁶", "7": "⁷", "8": "⁸", "9": "⁹",
+    "+": "⁺", "-": "⁻", "−": "⁻", "n": "ⁿ", "i": "ⁱ",
+}
+
+
+def _to_superscript(s: str) -> str:
+    return "".join(_SUPERSCRIPT_MAP.get(c, c) for c in str(s))
+
+
+def _operator_glyph(node: dict) -> str | None:
+    """Synthesize the compact glyph for an operator node from its ``op``.
+
+    Returns ``None`` when there is no derivable glyph (caller should
+    fall back to ``op`` or ``id``).
+    """
+    op = node.get("op")
+    if not op:
+        return None
+    if op == "power":
+        return f"(·){_to_superscript(node.get('exponent', 'n'))}"
+    if op in ("derivative", "partial_derivative"):
+        d = "∂" if op == "partial_derivative" else "d"
+        wrt = node.get("with_respect_to")
+        return f"{d}·/{d}{wrt}" if wrt else f"{d}·/{d}·"
+    return _OPERATOR_GLYPHS.get(op)
+
+
+_OP_KINDS: frozenset[str] = frozenset({"operator", "relation", "function"})
+
+
+def node_short_label(node: dict) -> str:
+    """Return the SHORT label — compact symbol for the graph node.
+
+    Operator / relation / function nodes resolve through the op-glyph
+    map (``=``, ``×``, ``(·)²``, ``|·|``, ``\\cos``…), with an
+    explicit parser-set ``latex`` taking precedence (e.g. ``⟨0|·⟩``
+    inner-product skeleton, ``|ψ⟩`` ket).  Data nodes (scalars,
+    vectors, numbers, constants…) use ``latex`` then ``label``.
+    Mirrors the structure of ``getNodeLabel`` in the JS renderer.
+
+    Precedence:
+        op/rel/fn:  latex → glyph(op, …) → op → id
+        data:       latex → label → id
+    """
+    if node.get("type") in _OP_KINDS:
+        if node.get("latex"):
+            return node["latex"]
+        glyph = _operator_glyph(node)
+        if glyph:
+            return glyph
+        return node.get("op") or node.get("id", "")
+    # Data nodes
+    if node.get("latex"):
+        return node["latex"]
+    if node.get("label"):
+        return node["label"]
+    return node.get("id", "")
+
+
+def node_long_label(node: dict) -> str:
+    """Return the LONG label — full applied form for the details panel.
+
+    Precedence: ``subexpr`` (full applied form set by parser via
+    ``_set_subexpr``) → ``latex`` (short label as fallback for
+    atomic symbols where the two coincide) → short label.
+    """
+    return node.get("subexpr") or node.get("latex") or node_short_label(node)
+
+
 class SemanticGraphBuilder:
     """Walks a SymPy expression tree and emits nodes + edges."""
 
@@ -514,7 +626,13 @@ class SemanticGraphBuilder:
         for name, attrs in self._overrides.items():
             if not _PLACEHOLDER_NAME_RE.fullmatch(name):
                 continue
-            real = attrs.get("latex")
+            # Prefer ``original_latex`` when present — only braket
+            # overrides set it.  Their ``latex`` is the compact
+            # skeleton (``⟨0|·⟩``) used as the node's display label,
+            # but upstream subexprs (``|⟨0|ψ⟩|^2``, ``=`` chains)
+            # need the full applied form so parents read as real
+            # mathematics.
+            real = attrs.get("original_latex") or attrs.get("latex")
             if not real:
                 continue
             # Preserve atomicity when the placeholder sits inside a
@@ -586,11 +704,13 @@ class SemanticGraphBuilder:
             # User overrides still win — authors can pin any property
             # (label, unit, ai_prompt, etc.) explicitly via ``\overrides{…}``.
             if name in self._overrides:
-                # ``bra_content`` / ``ket_content`` are internal
-                # metadata for braket operand-wiring decisions — not
-                # valid graph-node attributes, so filter them out
+                # ``bra_content`` / ``ket_content`` / ``original_latex``
+                # are internal metadata for braket operator construction
+                # — not valid graph-node attributes, so filter them out
                 # before merging.
-                _INTERNAL_OVERRIDE_KEYS = {"bra_content", "ket_content"}
+                _INTERNAL_OVERRIDE_KEYS = {
+                    "bra_content", "ket_content", "original_latex",
+                }
                 attrs.update({
                     k: v for k, v in self._overrides[name].items()
                     if k not in _INTERNAL_OVERRIDE_KEYS
@@ -627,13 +747,13 @@ class SemanticGraphBuilder:
                 and self._overrides[name].get("op") == "inner_product"
             ):
                 ovr = self._overrides[name]
-                # The braket's ``latex`` field already holds the full
-                # ``⟨bra|ket⟩`` — copy it to ``subexpr`` so upstream
-                # walkers and the details panel agree on what this
-                # node represents.
+                # ``latex`` on the node is the compact skeleton
+                # (``⟨0|·⟩``); set ``subexpr`` to the full
+                # ``⟨0|ψ⟩`` so the details panel / TTS / hover
+                # show the actual mathematics.
                 for n in self.nodes:
                     if n["id"] == node_id:
-                        n["subexpr"] = ovr["latex"]
+                        n["subexpr"] = ovr.get("original_latex", ovr["latex"])
                         break
                 for part_key, edge_role in (
                     ("bra_content", "lhs"),
@@ -862,14 +982,15 @@ class SemanticGraphBuilder:
             ket_label = sympy.latex(ket_arg.args[0]) if ket_arg.args else ""
             # The inner product is an *operator* like ``+`` or ``=`` —
             # ``op="inner_product"`` distinguishes it from other
-            # operators.  ``latex`` is the full ``⟨bra|ket⟩`` so the
-            # node and every upstream subexpression read as real math.
+            # operators.  ``latex`` is the compact skeleton (display
+            # label); ``subexpr`` is the full applied form (details).
+            skeleton = _braket_skeleton_latex(bra_label, ket_label)
             full_latex = rf"\left\langle {bra_label}\middle|{ket_label}\right\rangle"
             self._add_node(
                 node_id,
                 type="operator",
                 op="inner_product",
-                latex=full_latex,
+                latex=skeleton,
                 subexpr=full_latex,
             )
             for inner_arg, edge_role in (
@@ -949,6 +1070,24 @@ def _is_braket_constant_side(content: str) -> bool:
         return False
 
 
+def _braket_skeleton_latex(bra_content: str, ket_content: str) -> str:
+    r"""Build a *compact* braket label where symbolic slots show ``\cdot``.
+
+    Mirrors the convention used for ``|·|`` (Abs) and ``(·)²`` (power):
+    a compact operator-only form for the node label.  The full applied
+    form (``⟨0|ψ⟩``) lives in ``subexpr`` for hover / details / TTS.
+
+    Examples:
+        ``⟨0|ψ⟩``  → ``\langle 0\,|\,\cdot\rangle``   (constant bra, slot ket)
+        ``⟨ψ|0⟩``  → ``\langle \cdot\,|\,0\rangle``
+        ``⟨x|y⟩``  → ``\langle \cdot\,|\,\cdot\rangle``
+        ``⟨0|1⟩``  → ``\langle 0\,|\,1\rangle``       (both constant)
+    """
+    bra_disp = bra_content if _is_braket_constant_side(bra_content) else r"\cdot"
+    ket_disp = ket_content if _is_braket_constant_side(ket_content) else r"\cdot"
+    return rf"\langle {bra_disp}\,|\,{ket_disp}\rangle"
+
+
 def _collapse_braket_notation(latex: str) -> tuple[str, dict[str, dict[str, str]]]:
     r"""Replace Dirac bra-ket notation with placeholder symbols before SymPy
     parsing.
@@ -975,20 +1114,21 @@ def _collapse_braket_notation(latex: str) -> tuple[str, dict[str, dict[str, str]
             seen[full] = idx
             bra_content = m.group(1).strip()
             ket_content = m.group(2).strip()
-            # The braket is an operator with ``op="inner_product"`` —
-            # ``latex`` is the *full* original ``⟨bra|ket⟩`` so the
-            # node and every upstream subexpression read as real
-            # mathematics (``|⟨0|ψ⟩|²``, not ``|⟨0|·⟩|²``).
-            # ``bra_content`` / ``ket_content`` are kept so the
-            # placeholder-resolution path can decide which operands
-            # become input edges (symbolic) versus stay baked into
-            # the node label (constants like ``0``, ``1``).
+            # Two-form storage, mirroring how ``cos`` works: ``latex``
+            # is the compact operator-only skeleton (``⟨0|·⟩``) used
+            # as the node's display label; ``original_latex`` is the
+            # full ``⟨0|ψ⟩`` used both as the node's ``subexpr`` and
+            # as the substitution payload when upstream wrappers
+            # (``|⟨0|ψ⟩|²``, ``=``, …) reference this placeholder.
+            # ``bra_content`` / ``ket_content`` drive the constant-vs-
+            # symbolic edge-wiring decision in ``_walk_inner``.
             overrides[f"Phi_{{{idx}}}"] = {
-                "latex": full,
+                "latex": _braket_skeleton_latex(bra_content, ket_content),
                 "type": "operator",
                 "op": "inner_product",
                 "bra_content": bra_content,
                 "ket_content": ket_content,
+                "original_latex": full,
             }
         return rf"\Phi_{{{seen[full]}}}"
 

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -57,7 +57,7 @@ except ImportError:
           file=sys.stderr)
     sys.exit(1)
 
-from sympy.physics.quantum.state import Ket, Bra, KetBase, BraBase
+from sympy.physics.quantum.state import KetBase, BraBase
 from sympy.physics.quantum import InnerProduct
 
 
@@ -1919,10 +1919,17 @@ def latex_to_semantic_graph(latex: str, overrides: dict[str, dict[str, str]] | N
     if chained is not None:
         lhs_latex, rel_meta, rhs_latex = chained
         builder = SemanticGraphBuilder(overrides=overrides, latex_commands=latex_commands, original_latex=latex)
-        lhs_expr = parse_latex(lhs_latex)
-        lhs_id = builder._walk(lhs_expr)
-        rhs_expr = parse_latex(rhs_latex)
-        rhs_id = builder._walk(rhs_expr)
+        # Mirror the controlled-error pattern used by the relation
+        # branch above (line ~1858).  An unparsable side here would
+        # otherwise bubble up an opaque SymPy/ANTLR exception instead
+        # of the ``ValueError`` callers expect from this entry point.
+        try:
+            lhs_expr = parse_latex(lhs_latex)
+            lhs_id = builder._walk(lhs_expr)
+            rhs_expr = parse_latex(rhs_latex)
+            rhs_id = builder._walk(rhs_expr)
+        except Exception as exc:
+            raise ValueError(f"Failed to parse LaTeX: {exc}") from exc
         for node in builder.nodes:
             if node["id"] == lhs_id:
                 node["subexpr"] = builder._restore_placeholders(lhs_latex.strip())

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -514,7 +514,13 @@ class SemanticGraphBuilder:
         for name, attrs in self._overrides.items():
             if not _PLACEHOLDER_NAME_RE.fullmatch(name):
                 continue
-            real = attrs.get("latex")
+            # Prefer ``original_latex`` when present — only braket
+            # overrides set it.  Their ``latex`` is the *operator
+            # skeleton* (``\langle 0|\cdot\rangle``) used as the
+            # operator's own visual identity, but upstream subexprs
+            # (``|⟨0|ψ⟩|^2``, ``cos²(θ/2)``) need the full original
+            # form so the parent context reads as real mathematics.
+            real = attrs.get("original_latex") or attrs.get("latex")
             if not real:
                 continue
             # Preserve atomicity when the placeholder sits inside a

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -57,6 +57,9 @@ except ImportError:
           file=sys.stderr)
     sys.exit(1)
 
+from sympy.physics.quantum.state import Ket, Bra, KetBase, BraBase
+from sympy.physics.quantum import InnerProduct
+
 
 # ---------------------------------------------------------------------------
 # SI base dimensions
@@ -128,11 +131,12 @@ _ASYMMETRIC_OPS: set[str] = {
     "greater_than", "less_than", "greater_equal", "less_equal",
 }
 
-# Synthetic placeholder names emitted by ``_collapse_compound_symbols`` and
-# ``_collapse_text_commands``. Used to gate placeholder restoration so user
-# overrides keyed on real symbol names can never hit the substring-replace
-# path that would otherwise corrupt unrelated macros (\text, \tan, \left).
-_PLACEHOLDER_NAME_RE = re.compile(r"^(?:Theta|Xi)_\{\d+\}$")
+# Synthetic placeholder names emitted by ``_collapse_compound_symbols``,
+# ``_collapse_text_commands``, and ``_collapse_braket_notation``. Used to
+# gate placeholder restoration so user overrides keyed on real symbol names
+# can never hit the substring-replace path that would otherwise corrupt
+# unrelated macros (\text, \tan, \left).
+_PLACEHOLDER_NAME_RE = re.compile(r"^(?:Theta|Xi|Phi)_\{\d+\}$")
 
 # FUNCTION_MAP removed — the SymPy class name (``sin``, ``cos``, ``Abs``,
 # ``asin``, …) is used directly as the ``op`` field. Renames only mattered
@@ -582,7 +586,17 @@ class SemanticGraphBuilder:
             # User overrides still win — authors can pin any property
             # (label, unit, ai_prompt, etc.) explicitly via ``\overrides{…}``.
             if name in self._overrides:
-                attrs.update(self._overrides[name])
+                # ``bra_content`` / ``ket_content`` / ``original_latex``
+                # are internal metadata for braket operator construction
+                # — not valid graph-node attributes, so filter them out
+                # before merging.
+                _INTERNAL_OVERRIDE_KEYS = {
+                    "bra_content", "ket_content", "original_latex",
+                }
+                attrs.update({
+                    k: v for k, v in self._overrides[name].items()
+                    if k not in _INTERNAL_OVERRIDE_KEYS
+                })
             # For placeholder symbols whose override carries the real LaTeX
             # (e.g. compound symbols like ``\Delta t`` collapsed to
             # ``\Theta_{N}``), prefer the override's latex as the subexpr so
@@ -596,6 +610,49 @@ class SemanticGraphBuilder:
                 attrs["subexpr"] = self._overrides[name]["latex"]
             self._add_node(node_id, **attrs)
             self._seen_symbols[name] = node_id
+
+            # --- Wire symbolic operands into braket operator nodes ---
+            # The braket ``⟨bra|ket⟩`` is modeled as an *operator* node
+            # whose label (``\langle 0|\cdot\rangle``) shows constant
+            # basis labels verbatim and uses ``\cdot`` as a placeholder
+            # for symbolic slots.  Symbolic operands (``\psi``, ``x``)
+            # become child nodes wired in by edges; pure numeric
+            # operands (``0``, ``1``) stay baked into the label and have
+            # no edge.  Real variable names are NOT renamed by
+            # ``_build_comma_separated_graph._rename``, so a shared
+            # ``ψ`` that appears in both ``⟨0|ψ⟩`` and ``⟨1|ψ⟩`` across
+            # newline-separated clauses collapses into a single node —
+            # the cross-clause link the user expects.
+            if (
+                name.startswith("Phi_{")
+                and name in self._overrides
+                and self._overrides[name].get("op") == "inner_product"
+            ):
+                ovr = self._overrides[name]
+                # Preserve the original full LaTeX in subexpr so hover /
+                # details show ``⟨0|ψ⟩`` not ``⟨0|·⟩``.
+                for n in self.nodes:
+                    if n["id"] == node_id:
+                        original = ovr.get("original_latex")
+                        if original:
+                            n["subexpr"] = original
+                        break
+                for part_key, edge_role in (
+                    ("bra_content", "lhs"),
+                    ("ket_content", "rhs"),
+                ):
+                    content = ovr.get(part_key, "").strip()
+                    if not content or _is_braket_constant_side(content):
+                        continue
+                    # Parse the content through SymPy so existing dedup
+                    # (``_seen_symbols``) handles cross-braket sharing.
+                    try:
+                        inner_expr = parse_latex(content)
+                        child_id = self._walk(inner_expr)
+                        self._add_edge(child_id, node_id, role=edge_role)
+                    except Exception:
+                        pass  # graceful degradation — braket still works
+
             return node_id
 
         # --- Constants (pi, e, i, ∞) — check before Number since some are NumberSymbol ---
@@ -772,6 +829,66 @@ class SemanticGraphBuilder:
                 )
             return node_id
 
+        # --- Dirac notation: ket |ψ⟩, bra ⟨ψ|, inner product ⟨φ|ψ⟩ ---
+        if isinstance(expr, KetBase):
+            label_arg = expr.args[0] if expr.args else ""
+            label_latex = sympy.latex(label_arg)
+            node_id = self._next_id("ket")
+            ket_latex = rf"\left|{label_latex}\right\rangle"
+            self._add_node(
+                node_id,
+                type="ket",
+                latex=ket_latex,
+                subexpr=ket_latex,
+            )
+            return node_id
+
+        if isinstance(expr, BraBase):
+            label_arg = expr.args[0] if expr.args else ""
+            label_latex = sympy.latex(label_arg)
+            node_id = self._next_id("bra")
+            bra_latex = rf"\left\langle {label_latex}\right|"
+            self._add_node(
+                node_id,
+                type="bra",
+                latex=bra_latex,
+                subexpr=bra_latex,
+            )
+            return node_id
+
+        if isinstance(expr, InnerProduct):
+            node_id = self._next_id("braket")
+            bra_arg = expr.args[0]
+            ket_arg = expr.args[1]
+            bra_label = sympy.latex(bra_arg.args[0]) if bra_arg.args else ""
+            ket_label = sympy.latex(ket_arg.args[0]) if ket_arg.args else ""
+            # The inner product is an *operator* like ``+`` or ``=`` —
+            # ``op="inner_product"`` distinguishes it from other
+            # operators without inventing a separate type.  Skeleton
+            # uses ``\cdot`` for symbolic slots; the original full
+            # ``⟨bra|ket⟩`` lives in ``subexpr`` for hover/details.
+            skeleton = _braket_skeleton_latex(bra_label, ket_label)
+            full_latex = rf"\left\langle {bra_label}\middle|{ket_label}\right\rangle"
+            self._add_node(
+                node_id,
+                type="operator",
+                op="inner_product",
+                latex=skeleton,
+                subexpr=full_latex,
+            )
+            for inner_arg, edge_role in (
+                (bra_arg, "lhs"),
+                (ket_arg, "rhs"),
+            ):
+                if not inner_arg.args:
+                    continue
+                inner_label = inner_arg.args[0]
+                if isinstance(inner_label, Number):
+                    continue
+                child_id = self._walk(inner_label)
+                self._add_edge(child_id, node_id, role=edge_role)
+            return node_id
+
         # --- Fallback: treat as a generic node with children ---
         node_id = self._next_id("expr")
         self._add_node(node_id, type="expression", op=type(expr).__name__)
@@ -814,6 +931,99 @@ def _collapse_text_commands(latex: str) -> tuple[str, dict[str, dict[str, str]]]
         return rf"\Xi_{seen[content]}"
 
     rewritten = re.sub(r"\\text\{([^}]+)\}", repl, latex)
+    return rewritten, overrides
+
+
+def _is_braket_constant_side(content: str) -> bool:
+    """Decide whether the bra/ket content is a *constant* basis label
+    (``0``, ``1``, ``-1``) versus a *symbolic* operand (``\\psi``, ``x``).
+
+    Constants are baked into the braket operator's identity (its label
+    distinguishes ``\\langle 0|\\cdot\\rangle`` from ``\\langle 1|\\cdot\\rangle``);
+    symbolic operands become input nodes with edges flowing into the
+    operator. See the inner-product handling in ``_walk_inner``.
+    """
+    s = content.strip()
+    if not s:
+        return False
+    try:
+        float(s)
+        return True
+    except ValueError:
+        return False
+
+
+def _braket_skeleton_latex(bra_content: str, ket_content: str) -> str:
+    r"""Build the braket *operator* LaTeX where symbolic slots show ``\cdot``
+    and constant slots show the constant verbatim.
+
+    Uses a plain ``|`` (not ``\middle|``) since the skeleton is rendered
+    without an enclosing ``\left … \right`` pair — KaTeX rejects bare
+    ``\middle`` outside such a pair and falls back to displaying the raw
+    source.
+
+    Examples:
+        ``⟨0|ψ⟩``  → ``\langle 0\,|\,\cdot\rangle``
+        ``⟨ψ|0⟩``  → ``\langle \cdot\,|\,0\rangle``
+        ``⟨x|y⟩``  → ``\langle \cdot\,|\,\cdot\rangle``
+        ``⟨0|1⟩``  → ``\langle 0\,|\,1\rangle``
+    """
+    bra_disp = bra_content if _is_braket_constant_side(bra_content) else r"\cdot"
+    ket_disp = ket_content if _is_braket_constant_side(ket_content) else r"\cdot"
+    return rf"\langle {bra_disp}\,|\,{ket_disp}\rangle"
+
+
+def _collapse_braket_notation(latex: str) -> tuple[str, dict[str, dict[str, str]]]:
+    r"""Replace Dirac bra-ket notation with placeholder symbols before SymPy
+    parsing.
+
+    SymPy's ``parse_latex`` handles simple kets (``|\psi\rangle``) natively by
+    producing ``Ket`` objects, so those are left alone and handled in
+    ``_walk_inner``.  However inner products (``\langle\phi|\psi\rangle``) are
+    mis-parsed as ``Bra * Symbol`` — the closing ket is lost.
+
+    This function collapses braket inner-product patterns into ``\Phi_{N}``
+    placeholders so they survive parsing as atomic symbols.  The original LaTeX
+    is recorded as the placeholder's override for downstream rendering.
+
+    Returns ``(rewritten_latex, overrides)`` parallel to
+    ``_collapse_text_commands``.
+    """
+    overrides: dict[str, dict[str, str]] = {}
+    seen: dict[str, int] = {}
+
+    def _repl_braket(m: re.Match) -> str:
+        full = m.group(0)
+        if full not in seen:
+            idx = len(seen)
+            seen[full] = idx
+            bra_content = m.group(1).strip()
+            ket_content = m.group(2).strip()
+            # The braket is an operator: its ``latex`` is the *operator
+            # skeleton* (``⟨0|·⟩``, ``⟨·|·⟩``, etc.) — symbolic operands
+            # appear as separate input nodes wired in by edges.  The
+            # original full LaTeX (``⟨0|ψ⟩``) is preserved in
+            # ``original_latex`` for the node's ``subexpr``.
+            overrides[f"Phi_{{{idx}}}"] = {
+                "latex": _braket_skeleton_latex(bra_content, ket_content),
+                "type": "operator",
+                "op": "inner_product",
+                "bra_content": bra_content,
+                "ket_content": ket_content,
+                "original_latex": full,
+            }
+        return rf"\Phi_{{{seen[full]}}}"
+
+    # Inner product: \langle ... | ... \rangle  (with optional \left/\right)
+    # Content between delimiters: anything except unescaped pipe at depth 0.
+    braket_pat = (
+        r"(?:\\left\s*)?\\langle\s*"   # opening ⟨
+        r"([^|]*?)"                     # bra content (non-greedy)
+        r"\s*\|\s*"                     # middle |
+        r"([^|]*?)"                     # ket content (non-greedy)
+        r"\s*\\rangle(?:\s*\\right\s*\.)?"  # closing ⟩
+    )
+    rewritten = re.sub(braket_pat, _repl_braket, latex)
     return rewritten, overrides
 
 
@@ -947,6 +1157,62 @@ def _extract_parenthetical_annotations(latex: str) -> tuple[str, list[dict[str, 
     return latex, annotations
 
 
+def _normalize_latex(latex: str) -> str:
+    r"""Normalize LaTeX constructs that are valid LaTeX but alien to SymPy's
+    ``parse_latex``.
+
+    Runs **first** in the pipeline — before braket collapse, compound-symbol
+    collapse, text-command collapse, and preprocessing.  Transformations here
+    must be safe to apply unconditionally and must not depend on later stages.
+
+    Covers:
+
+    - ``\htmlClass{cls}{content}`` → ``content`` (KaTeX highlighting wrappers)
+    - ``\lvert``, ``\rvert``, ``\vert`` → ``|`` (SymPy only understands bare
+      pipe for absolute-value / bra-ket delimiters)
+    """
+    # Strip \htmlClass{...}{content} → content  (and \htmlId, \htmlData, \htmlStyle).
+    # Uses brace-balanced matching so nested braces in content are preserved.
+    _html_cmd = re.compile(r"\\html[A-Za-z]+")
+    parts: list[str] = []
+    i = 0
+    while i < len(latex):
+        m = _html_cmd.match(latex, i)
+        if m:
+            j = m.end()
+            # Skip first brace group {cls}
+            if j < len(latex) and latex[j] == "{":
+                depth = 1
+                j += 1
+                while j < len(latex) and depth > 0:
+                    if latex[j] == "{": depth += 1
+                    elif latex[j] == "}": depth -= 1
+                    j += 1
+            # Extract second brace group {content}, preserving nested braces
+            if j < len(latex) and latex[j] == "{":
+                depth = 1
+                j += 1
+                start = j
+                while j < len(latex) and depth > 0:
+                    if latex[j] == "{": depth += 1
+                    elif latex[j] == "}": depth -= 1
+                    j += 1
+                parts.append(latex[start:j - 1])
+            i = j
+        else:
+            parts.append(latex[i])
+            i += 1
+    latex = "".join(parts)
+
+    # Normalize vertical-bar commands to bare pipe so downstream stages
+    # (braket collapse, SymPy Abs parsing) see a uniform delimiter.
+    # Order matters: \lvert / \rvert first (longer), then \vert.
+    latex = re.sub(r"\\[lr]vert\b", "|", latex)
+    latex = re.sub(r"\\vert\b", "|", latex)
+
+    return latex
+
+
 def _preprocess_latex(latex: str) -> str:
     """Rewrite LaTeX patterns that SymPy's parse_latex doesn't handle natively.
 
@@ -1062,6 +1328,60 @@ def _classify_expression(expr: sympy.Basic) -> dict[str, Any]:
     return meta
 
 
+def _split_on_top_level_newline(latex: str) -> list[str]:
+    r"""Split *latex* on top-level ``\\`` (LaTeX line-break) tokens that act
+    as **statement separators**.
+
+    A ``\\`` is treated as a separator only when it sits at brace / paren /
+    bracket depth 0 — i.e. outside every ``{...}``, ``(...)``, ``[...]``
+    group.  Inside environments like ``\begin{cases}`` or matrices the
+    double-backslash is a row separator, not a statement separator, but
+    those environments are already wrapped in braces so the depth check
+    handles them automatically.
+
+    Returns a list of trimmed, non-empty sub-expressions.  A single-element
+    list means no top-level ``\\`` was found.
+    """
+    parts: list[str] = []
+    depth = 0
+    i = 0
+    start = 0
+    n = len(latex)
+    while i < n:
+        ch = latex[i]
+        if ch in "{([":
+            depth += 1
+            i += 1
+        elif ch in "})]":
+            if depth > 0:
+                depth -= 1
+            i += 1
+        elif ch == "\\" and depth == 0:
+            if i + 1 < n and latex[i + 1] == "\\":
+                end_of_bs = i + 2
+                after = end_of_bs
+                while after < n and latex[after] in " \t":
+                    after += 1
+                if after < n and latex[after] == "[":
+                    bracket_end = latex.find("]", after + 1)
+                    if bracket_end != -1:
+                        after = bracket_end + 1
+                    else:
+                        after = end_of_bs
+                else:
+                    after = end_of_bs
+                parts.append(latex[start:i])
+                start = after
+                i = after
+            else:
+                i += 1
+        else:
+            i += 1
+    parts.append(latex[start:])
+    nonempty = [p.strip() for p in parts if p.strip()]
+    return nonempty if nonempty else [latex]
+
+
 def _split_on_top_level_comma(latex: str) -> list[str]:
     r"""Detect whether any commas in *latex* act as **statement separators**
     and, if so, split the input into its separate statements.
@@ -1116,20 +1436,73 @@ def _split_on_top_level_comma(latex: str) -> list[str]:
 
 
 def _split_on_relation(latex: str) -> tuple[str, dict[str, str], str] | None:
-    """If *latex* contains a relation operator from RELATION_MAP, return
-    ``(lhs_latex, relation_meta, rhs_latex)``.  Returns ``None`` when no
-    relation is found."""
+    """If *latex* contains a top-level relation operator from RELATION_MAP,
+    return ``(lhs_latex, relation_meta, rhs_latex)``.  Returns ``None``
+    when no relation is found.
+
+    Only matches at brace/paren/bracket depth 0 so that operators
+    inside subscripts or fractions are ignored.
+    """
     best: tuple[int, str, dict[str, str]] | None = None
+    # Build depth map: depth[i] = nesting depth at position i.
+    n = len(latex)
+    depth = [0] * n
+    d = 0
+    for i in range(n):
+        if latex[i] in "{([":
+            d += 1
+        depth[i] = d
+        if latex[i] in "})]" and d > 0:
+            d -= 1
+            depth[i] = d
     for cmd, meta in RELATION_MAP:
-        idx = latex.find(cmd)
-        if idx != -1 and (best is None or idx < best[0]):
-            best = (idx, cmd, meta)
+        clen = len(cmd)
+        idx = 0
+        while idx <= n - clen:
+            pos = latex.find(cmd, idx)
+            if pos == -1:
+                break
+            if depth[pos] == 0:
+                if best is None or pos < best[0]:
+                    best = (pos, cmd, meta)
+                break
+            idx = pos + 1
     if best is not None:
         idx, cmd, meta = best
         lhs = latex[:idx].strip()
         rhs = latex[idx + len(cmd):].strip()
         if lhs and rhs:
             return lhs, meta, rhs
+    return None
+
+
+def _split_chained_equals(latex: str) -> tuple[str, dict[str, str], str] | None:
+    r"""Split on first ``=`` only when 2+ bare ``=`` exist at depth 0.
+
+    A single ``a = b`` is fine for SymPy (``Eq(a, b)``), but chained
+    ``a = b = c`` produces ``Eq(Eq(a, b), c)`` which evaluates to
+    ``BooleanFalse``.  Splitting on the first ``=`` yields LHS ``a``
+    and RHS ``b = c``; the RHS is parsed recursively as ``Eq(b, c)``.
+    """
+    n = len(latex)
+    d = 0
+    eq_positions: list[int] = []
+    for i in range(n):
+        ch = latex[i]
+        if ch in "{([":
+            d += 1
+        elif ch in "})]" and d > 0:
+            d -= 1
+        elif ch == "=" and d == 0:
+            eq_positions.append(i)
+    if len(eq_positions) < 2:
+        return None
+    first = eq_positions[0]
+    lhs = latex[:first].strip()
+    rhs = latex[first + 1:].strip()
+    if lhs and rhs:
+        meta = {"op": "equals", "label": "equals", "emoji": "="}
+        return lhs, meta, rhs
     return None
 
 
@@ -1215,7 +1588,7 @@ def _build_comma_separated_graph(
                 return nid
             if nid.startswith("__"):
                 return p + nid
-            if nid.startswith("Xi_{") or nid.startswith("Theta_{"):
+            if nid.startswith("Xi_{") or nid.startswith("Theta_{") or nid.startswith("Phi_{"):
                 return p + nid
             return nid
 
@@ -1285,23 +1658,38 @@ def latex_to_semantic_graph(latex: str, overrides: dict[str, dict[str, str]] | N
     relation node. Shared variables across clauses dedup to one node.
     """
     user_overrides = overrides
+    latex = _normalize_latex(latex)
     latex, parenthetical_annotations = _extract_parenthetical_annotations(latex)
-    compound_collapsed, compound_overrides = _collapse_compound_symbols(latex)
+
+    # ``\\`` (LaTeX newline) is the strongest separator — check before
+    # any other splitting or SymPy parsing.  Each clause is parsed
+    # independently via recursive ``latex_to_semantic_graph`` calls.
+    newline_clauses = _split_on_top_level_newline(latex)
+    if len(newline_clauses) > 1:
+        graph = _build_comma_separated_graph(
+            newline_clauses, overrides=user_overrides, domain=domain,
+        )
+        _inject_annotations(graph, parenthetical_annotations)
+        return graph
+
+    braket_collapsed, braket_overrides = _collapse_braket_notation(latex)
+    compound_collapsed, compound_overrides = _collapse_compound_symbols(braket_collapsed)
     collapsed, text_overrides = _collapse_text_commands(compound_collapsed)
     preprocessed = _preprocess_latex(collapsed)
     latex_commands = _extract_latex_commands(latex)
     # User-supplied overrides take precedence over auto-derived ones for
     # the same symbol name.
     merged_overrides: dict[str, dict[str, str]] = {
+        **braket_overrides,
         **compound_overrides,
         **text_overrides,
         **(user_overrides or {}),
     }
     overrides = merged_overrides
 
-    # Check for a top-level relation operator FIRST (before the comma
-    # split). When a relation is present, comma-joined clauses on either
-    # side are operand-level conjunctions — the comma scopes inside the
+    # Check for a top-level relation operator (before the comma split).
+    # When a relation is present, comma-joined clauses on either side are
+    # operand-level conjunctions — the comma scopes inside the
     # connective's operand, not above it. See #208: previously the comma
     # split ran first and orphaned the second RHS clause from the
     # ``\implies`` node.
@@ -1392,17 +1780,51 @@ def latex_to_semantic_graph(latex: str, overrides: dict[str, dict[str, str]] | N
         _inject_annotations(graph, parenthetical_annotations)
         return graph
 
-    # No top-level relation. A top-level comma now acts as a statement
-    # separator (preserves existing ``a = 1, b = 2`` behavior — multiple
-    # independent rooted statements, no synthetic ``and`` node). Pass
-    # only the user-supplied overrides; the recursive call re-derives
-    # text/compound placeholders per clause so they don't collide with
-    # parent-scoped ``Xi_{N}`` ids.
+    # A top-level comma now acts as a statement separator (preserves
+    # existing ``a = 1, b = 2`` behavior — multiple independent rooted
+    # statements, no synthetic ``and`` node). Pass only the user-supplied
+    # overrides; the recursive call re-derives text/compound placeholders
+    # per clause so they don't collide with parent-scoped ``Xi_{N}`` ids.
     clauses = _split_on_top_level_comma(latex)
     if len(clauses) > 1:
         graph = _build_comma_separated_graph(
             clauses, overrides=user_overrides, domain=domain,
         )
+        _inject_annotations(graph, parenthetical_annotations)
+        return graph
+
+    # Chained equals (``a = b = c``): SymPy produces
+    # ``Eq(Eq(a, b), c)`` → ``BooleanFalse``.  Split on the first ``=``
+    # only when 2+ bare ``=`` exist at depth 0.  Runs after comma split
+    # so ``a = 1, b = 2`` is correctly handled as independent clauses.
+    chained = _split_chained_equals(preprocessed)
+    if chained is not None:
+        lhs_latex, rel_meta, rhs_latex = chained
+        builder = SemanticGraphBuilder(overrides=overrides, latex_commands=latex_commands, original_latex=latex)
+        lhs_expr = parse_latex(lhs_latex)
+        lhs_id = builder._walk(lhs_expr)
+        rhs_expr = parse_latex(rhs_latex)
+        rhs_id = builder._walk(rhs_expr)
+        for node in builder.nodes:
+            if node["id"] == lhs_id:
+                node["subexpr"] = builder._restore_placeholders(lhs_latex.strip())
+            elif node["id"] == rhs_id:
+                node["subexpr"] = builder._restore_placeholders(rhs_latex.strip())
+        rel_id = builder._next_id(rel_meta["op"])
+        builder._add_node(rel_id, type="relation", subexpr=latex.strip(), **rel_meta)
+        builder._add_edge(lhs_id, rel_id)
+        builder._add_edge(rhs_id, rel_id)
+        graph = {"nodes": builder.nodes, "edges": builder.edges}
+        if lhs_expr is not None and rhs_expr is not None:
+            try:
+                combined = lhs_expr - rhs_expr
+            except TypeError:
+                combined = lhs_expr
+            graph["classification"] = _classify_expression(combined)
+        else:
+            graph["classification"] = {"kind": "algebraic"}
+        if domain:
+            graph["domain"] = domain
         _inject_annotations(graph, parenthetical_annotations)
         return graph
 

--- a/server.py
+++ b/server.py
@@ -852,6 +852,16 @@ def _derive_equation_chain_graph(latex: str) -> dict | None:
         if graph and early_annotations:
             _l2g._inject_annotations(graph, early_annotations)
         return graph
+    # ``\\`` (LaTeX newline) is a stronger separator than ``=``. If the
+    # expression contains top-level ``\\``, delegate to the single-expression
+    # parser whose pipeline splits on newlines first and handles each clause
+    # independently — otherwise the chain splitter would merge both clauses
+    # into one ``__equals`` node.
+    if r"\\" in latex:
+        graph = _derive_semantic_graph(latex)
+        if graph and early_annotations:
+            _l2g._inject_annotations(graph, early_annotations)
+        return graph
     sides = _split_equation_chain_sides(latex)
     if len(sides) <= 1:
         graph = _derive_semantic_graph(latex)

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -141,45 +141,92 @@ function inferEdgeSemantic(edge, nodeById) {
 
 // No tree conversion needed — dagre handles DAG layout directly.
 
-/**
- * Get the display label for a node, respecting label detail level.
- * @param {Object} node
- * @param {'minimal'|'description'|'full'} labelMode
- */
-function getNodeLabel(node, labelMode) {
-    if (node.type === 'operator' || node.type === 'relation' || node.type === 'function') {
-        return operatorGlyph(node);
-    }
-    const base = (labelMode === 'minimal')
-        ? (node.emoji || node.latex || node.label || node.id)
-        : (node.latex || node.label || node.id);
-    if (node.emoji && base !== node.emoji) return node.emoji + ' ' + base;
-    return base;
-}
+// ---------------------------------------------------------------------------
+// Two-form display convention — mirrors ``node_short_label`` /
+// ``node_long_label`` in ``scripts/latex_to_graph.py``.  Keep in sync.
+//
+// short (op/rel/fn):  node.latex →  glyph(op, …)  →  op  →  id
+// short (data):       node.latex →  node.label    →  id
+// long  (any):        node.subexpr → node.latex   →  short label
+//
+// Operator-glyph map mirrors ``_OPERATOR_GLYPHS`` in the Python parser.
+// ---------------------------------------------------------------------------
+
+const OPERATOR_GLYPHS = {
+    equals: '=', greater_than: '>', less_than: '<',
+    greater_equal: '≥', less_equal: '≤', not_equal: '≠',
+    multiply: '×', add: '+', subtract: '−',
+    divide: '÷', integral: '∫',
+    implies: '⇒', iff: '⇔',
+    negation: '−', not: '¬', logical_not: '¬',
+    conjunction: '∧', disjunction: '∨',
+    sum: '∑', product: '∏', limit: 'lim',
+    factorial: '!', sqrt: '√(·)',
+    log: 'log', logarithm: 'log', exp: 'exp',
+    sin: 'sin', cos: 'cos', tan: 'tan',
+    Abs: '|·|', abs: '|·|',
+    function: 'f',
+};
+
+const OP_KINDS = new Set(['operator', 'relation', 'function']);
 
 function operatorGlyph(node) {
-    const glyphs = {
-        equals: '=', greater_than: '>', less_than: '<',
-        greater_equal: '≥', less_equal: '≤', not_equal: '≠',
-        multiply: '×', add: '+', subtract: '−',
-        divide: '÷', integral: '∫',
-        implies: '⇒', iff: '⇔', negation: '−', not: '¬', logical_not: '¬', conjunction: '∧',
-        disjunction: '∨', sum: '∑', product: '∏', limit: 'lim',
-        factorial: '!', sqrt: '√(·)', log: 'log', logarithm: 'log',
-        exp: 'exp', sin: 'sin', cos: 'cos', tan: 'tan',
-        Abs: '|·|', abs: '|·|', function: 'f',
-    };
-    if (node.op === 'derivative' || node.op === 'partial_derivative') {
-        const d = node.op === 'partial_derivative' ? '∂' : 'd';
+    if (!node) return null;
+    const op = node.op;
+    if (!op) return null;
+    if (op === 'power') {
+        return `(·)${toSuperscript(node.exponent || 'n')}`;
+    }
+    if (op === 'derivative' || op === 'partial_derivative') {
+        const d = op === 'partial_derivative' ? '∂' : 'd';
         if (node.with_respect_to && (!node._childIds || node._childIds.length <= 1))
             return `${d}·/${d}${node.with_respect_to}`;
         return `${d}·/${d}·`;
     }
-    if (node.op === 'power') {
-        const exp = node.exponent || 'n';
-        return `(·)${toSuperscript(exp)}`;
+    return OPERATOR_GLYPHS[op] || null;
+}
+
+/**
+ * Compact symbol shown on the graph node itself.
+ * ``\cos``, ``⟨0|·⟩``, ``|·|``, ``(·)²``, ``+``, ``=``…
+ */
+export function nodeShortLabel(node) {
+    if (!node) return '';
+    if (OP_KINDS.has(node.type)) {
+        if (node.latex) return node.latex;
+        const g = operatorGlyph(node);
+        if (g) return g;
+        return node.op || node.id || '';
     }
-    return glyphs[node.op] || node.op || node.label || '?';
+    return node.latex || node.label || node.id || '';
+}
+
+/**
+ * Full applied form shown in the details panel / hover / TTS.
+ * ``\cos(θ/2)``, ``⟨0|ψ⟩``, ``|⟨0|ψ⟩|²``…
+ */
+export function nodeLongLabel(node) {
+    if (!node) return '';
+    return node.subexpr || node.latex || nodeShortLabel(node);
+}
+
+/**
+ * Get the display label for a node, respecting label detail level.
+ * Thin wrapper around ``nodeShortLabel`` that adds the emoji prefix
+ * for ``minimal`` label mode on data nodes.
+ *
+ * @param {Object} node
+ * @param {'minimal'|'description'|'full'} labelMode
+ */
+function getNodeLabel(node, labelMode) {
+    const short = nodeShortLabel(node);
+    if (OP_KINDS.has(node.type)) return short;
+    // Data nodes can prefix with emoji in minimal mode.
+    if (labelMode === 'minimal' && node.emoji) {
+        return short === node.emoji ? node.emoji : node.emoji + ' ' + short;
+    }
+    if (node.emoji && short !== node.emoji) return node.emoji + ' ' + short;
+    return short;
 }
 
 export class D3SemanticGraphRenderer {

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -78,7 +78,20 @@ const DEFAULT_EDGE_WIDTHS = {
     neutral: 1.4,
 };
 
-// Default node styles (fallback when theme has no nodeStyles)
+// Default node styles (fallback when theme has no nodeStyles).
+// Color families:
+//   green  — data (scalar / vector / constant / number / expression / text)
+//   blue   — computation (operator / function)
+//   purple — statements (relation)
+//   brown  — meta (annotation)
+//
+// Per-op variants (``sin`` vs ``cos``, ``inner_product`` vs ``+``,
+// etc.) are not styled here — they all inherit their type's colour.
+// Themes that want per-op distinction should add op-keyed entries to
+// their own ``nodeStyles`` block; those theme overrides take priority
+// in ``_nodeStyle``.  This keeps the default palette taxonomy-driven
+// (operator vs function vs data) and avoids singling out individual
+// ops in the built-in defaults.
 const DEFAULT_NODE_STYLES = {
     scalar:   { fill: '#1b3a1e', stroke: '#66bb6a', color: '#c8e6c9' },
     vector:   { fill: '#1b3a1e', stroke: '#66bb6a', color: '#c8e6c9' },
@@ -300,8 +313,19 @@ export class D3SemanticGraphRenderer {
 
     // ─── Theme helpers ─────────────────────────────────────────────────
 
-    _nodeStyle(nodeType) {
+    _nodeStyle(nodeOrType) {
+        // Accept either a bare type string (legacy callers) or a full
+        // node data object.  Defaults are taxonomy-driven only
+        // (operator / function / scalar / …) — no per-op specials.
+        // Themes that want per-op distinction (e.g. ``sin`` warmer
+        // than ``cos``) can opt in by adding op-keyed entries to
+        // their own ``nodeStyles`` block; we honour those when the
+        // node carries an ``op`` field.
+        const isNode = nodeOrType && typeof nodeOrType === 'object';
+        const nodeType = isNode ? nodeOrType.type : nodeOrType;
+        const op = isNode ? nodeOrType.op : null;
         const ts = this._theme?.nodeStyles;
+        if (op && ts && ts[op]) return ts[op];
         if (ts && ts[nodeType]) return ts[nodeType];
         return DEFAULT_NODE_STYLES[nodeType] || DEFAULT_NODE_STYLES.scalar;
     }
@@ -622,7 +646,7 @@ export class D3SemanticGraphRenderer {
 
     _nodeShape(d) {
         if (!d || !d.data) return { type: 'circle', r: 26 };
-        const style = this._nodeStyle(d.data.type);
+        const style = this._nodeStyle(d.data);
         const invisible = (!style.fill || style.fill === 'none') &&
                            (!style.stroke || style.stroke === 'none');
         if (d.data._collapsed) {
@@ -1037,7 +1061,7 @@ export class D3SemanticGraphRenderer {
         group.selectAll('*').remove();
         const data = d.data;
         const isOp = data.type === 'operator' || data.type === 'relation' || data.type === 'function';
-        const style = this._nodeStyle(data.type);
+        const style = this._nodeStyle(data);
 
         const invisible = (!style.fill || style.fill === 'none') &&
                            (!style.stroke || style.stroke === 'none');

--- a/static/graph-panel/graph-panel.js
+++ b/static/graph-panel/graph-panel.js
@@ -16,6 +16,7 @@
  */
 
 import { makeAiAskButton } from "/labels.js";
+import { nodeLongLabel } from "/graph-panel/d3-semantic-graph.js";
 
 const PANEL_FIELDS = [
   ["label", "Label"],
@@ -82,8 +83,12 @@ export class SemanticGraphPanel {
     for (const node of this.graph.nodes || []) {
       const sid = sanitize(node.id);
       const info = {};
+      // ``subexpr`` is included so ``nodeLongLabel(info)`` can resolve
+      // it; ``exponent`` / ``with_respect_to`` so ``operatorGlyph`` can
+      // synthesize ``(·)²`` / ``∂·/∂x`` short labels.
       for (const key of ["id", "type", "label", "description", "emoji", "op", "quantity",
-                          "dimension", "unit", "value", "role", "latex"]) {
+                          "dimension", "unit", "value", "role", "latex",
+                          "subexpr", "exponent", "with_respect_to"]) {
         if (node[key] !== undefined && node[key] !== null) info[key] = node[key];
       }
       this._nodeData[sid] = info;
@@ -231,7 +236,10 @@ export class SemanticGraphPanel {
     const emoji = data.emoji || "";
     const expr = this._subexprs[nodeId];
     const hasOwnLatex = !!data.latex;
-    const titleLatex = data.latex || (expr ? expr : null);
+    // Details panel shows the *long label* — the full applied form
+    // (``\cos(θ/2)``, ``⟨0|ψ⟩``, ``|⟨0|ψ⟩|²``).  ``nodeLongLabel``
+    // encapsulates the precedence (``subexpr → latex → short``).
+    const titleLatex = nodeLongLabel(data) || null;
     const titleText = data.id || "";
     const showEmoji = emoji && hasOwnLatex;
 

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -18,7 +18,7 @@
 
 import { state } from '/state.js';
 import { SemanticGraphPanel } from '/graph-panel/graph-panel.js';
-import { D3SemanticGraphRenderer } from '/graph-panel/d3-semantic-graph.js';
+import { D3SemanticGraphRenderer, nodeLongLabel } from '/graph-panel/d3-semantic-graph.js';
 import { makeAiAskButton, renderKaTeX } from '/labels.js';
 
 let _currentGraphPanel = null;
@@ -860,7 +860,10 @@ function _showD3InfoPanel(nodeId, nodeData, graph) {
     const fieldsEl = panel.querySelector('.gp-fields');
     if (!symbolEl || !fieldsEl) return;
 
-    const latex = fullNode.latex || fullNode.subexpr;
+    // Details panel shows the *long label* — full applied form
+    // (``\cos(θ/2)``, ``⟨0|ψ⟩``, ``|⟨0|ψ⟩|²``).  ``nodeLongLabel``
+    // encapsulates the precedence (``subexpr → latex → short``).
+    const latex = nodeLongLabel(fullNode);
     if (latex && window.katex) {
         try {
             const span = document.createElement('span');
@@ -979,7 +982,7 @@ function _showD3MultiInfoPanel(selectedIds, graph) {
         }
         const symLine = document.createElement('div');
         symLine.className = 'gp-symbol';
-        const latex = node.latex || node.subexpr;
+        const latex = nodeLongLabel(node);
         if (latex && window.katex) {
             try {
                 window.katex.render(latex, symLine, { displayMode: false, throwOnError: false });

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -1701,6 +1701,63 @@ class TestDiracNotation:
         psi_edges = [e for e in g["edges"] if e["from"] == "psi"]
         assert len(psi_edges) == 2, "ψ should connect to both brakets"
 
+    def test_braket_node_latex_is_full_form(self):
+        """The braket operator's ``latex`` is the full ``⟨bra|ket⟩``.
+
+        Regression: an earlier design rendered an "operator skeleton"
+        (``⟨0|·⟩``) on the node and stashed the full form elsewhere.
+        Two-form rendering forced upstream subexprs to know about a
+        separate ``original_latex`` field and made the node visually
+        disagree with its own description.  Now ``latex`` and
+        ``subexpr`` agree on the full braket.
+        """
+        g = latex_to_semantic_graph(r"\langle 0|\psi\rangle = c")
+        bk = next(n for n in g["nodes"] if n.get("op") == "inner_product")
+        assert bk["latex"] == r"\langle 0|\psi\rangle"
+        assert bk["subexpr"] == r"\langle 0|\psi\rangle"
+        assert "\\cdot" not in bk["latex"], "no operator-skeleton placeholders"
+
+    def test_braket_upstream_subexpr_has_full_braket(self):
+        """``|⟨0|ψ⟩|²`` — Abs / power / equals subexprs contain the full braket.
+
+        Regression: ``_restore_placeholders`` previously substituted a
+        skeleton (``⟨0|·⟩``) into upstream LaTeX, making parents read
+        ``|⟨0|·⟩|²`` instead of real math.
+        """
+        g = latex_to_semantic_graph(
+            r"p = \lvert\langle 0|\psi\rangle\rvert^2"
+        )
+        # Every operator/function whose subexpr involves the braket
+        # must contain the full ``\psi``, never a ``\cdot`` placeholder.
+        wrappers = [
+            n for n in g["nodes"]
+            if "langle" in (n.get("subexpr") or "")
+        ]
+        assert wrappers, "expected at least one wrapper node referencing the braket"
+        for n in wrappers:
+            sx = n["subexpr"]
+            assert r"\psi" in sx, f"node {n['id']} subexpr lost ψ: {sx!r}"
+            assert r"\cdot" not in sx, (
+                f"node {n['id']} subexpr leaks operator skeleton: {sx!r}"
+            )
+
+    def test_braket_edge_roles(self):
+        """Bra-side operands get ``role='lhs'``, ket-side ``role='rhs'``."""
+        g = latex_to_semantic_graph(r"\langle\phi|\psi\rangle = 0")
+        bk_id = next(n["id"] for n in g["nodes"] if n.get("op") == "inner_product")
+        edges = {e["from"]: e.get("role") for e in g["edges"] if e["to"] == bk_id}
+        assert edges.get("phi") == "lhs", f"phi should be bra (lhs): {edges}"
+        assert edges.get("psi") == "rhs", f"psi should be ket (rhs): {edges}"
+
+    def test_braket_pure_constants_have_no_operand_edges(self):
+        """``⟨0|1⟩`` — both sides constant → no operand edges into the braket."""
+        g = latex_to_semantic_graph(r"\langle 0|1\rangle = c")
+        bk_id = next(n["id"] for n in g["nodes"] if n.get("op") == "inner_product")
+        # Only the upstream ``=`` edge points away from the braket; nothing
+        # symbolic flows in.  Edges *to* the braket must be empty.
+        in_edges = [e for e in g["edges"] if e["to"] == bk_id]
+        assert in_edges == [], f"expected no operand edges, got {in_edges}"
+
     def test_ket_equation_has_equals(self):
         g = latex_to_semantic_graph(r"|\psi\rangle = |0\rangle")
         eq = _find_node(g, op="equals")

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -1592,11 +1592,21 @@ class TestBraketCollapse:
         # with ``op="inner_product"`` — not a separate type.
         assert overrides[key]["type"] == "operator"
         assert overrides[key]["op"] == "inner_product"
-        # ``latex`` is the full ``⟨bra|ket⟩`` so the node renders as
-        # real math (not an operator skeleton with ``\cdot`` slots).
-        assert overrides[key]["latex"] == r"\langle\phi|\psi\rangle"
+        # ``latex`` is the compact skeleton (node display label);
+        # ``original_latex`` is the full ⟨bra|ket⟩ used as the node's
+        # subexpr and as the substitution payload for upstream wrappers.
+        assert overrides[key]["latex"] == r"\langle \cdot\,|\,\cdot\rangle"
+        assert overrides[key]["original_latex"] == r"\langle\phi|\psi\rangle"
         assert overrides[key]["bra_content"] == r"\phi"
         assert overrides[key]["ket_content"] == r"\psi"
+
+    def test_braket_constant_kept_in_skeleton(self):
+        """Numeric basis labels stay verbatim in the operator skeleton."""
+        _, overrides = _collapse_braket_notation(r"\langle 0|\psi\rangle")
+        key = list(overrides.keys())[0]
+        # Bra is constant ``0`` (kept in label), ket is symbolic ``\psi`` (slot).
+        assert overrides[key]["latex"] == r"\langle 0\,|\,\cdot\rangle"
+        assert overrides[key]["original_latex"] == r"\langle 0|\psi\rangle"
 
     def test_braket_with_numbers(self):
         rewritten, overrides = _collapse_braket_notation(r"\langle 0|1\rangle")
@@ -1701,21 +1711,22 @@ class TestDiracNotation:
         psi_edges = [e for e in g["edges"] if e["from"] == "psi"]
         assert len(psi_edges) == 2, "ψ should connect to both brakets"
 
-    def test_braket_node_latex_is_full_form(self):
-        """The braket operator's ``latex`` is the full ``⟨bra|ket⟩``.
+    def test_braket_node_latex_is_compact_skeleton(self):
+        """Node label is the compact skeleton; subexpr carries the full form.
 
-        Regression: an earlier design rendered an "operator skeleton"
-        (``⟨0|·⟩``) on the node and stashed the full form elsewhere.
-        Two-form rendering forced upstream subexprs to know about a
-        separate ``original_latex`` field and made the node visually
-        disagree with its own description.  Now ``latex`` and
-        ``subexpr`` agree on the full braket.
+        Mirrors how ``cos`` works: the node displays a compact operator
+        symbol (``\\cos``, ``⟨0|·⟩``) while ``subexpr`` carries the full
+        applied form (``\\cos(θ/2)``, ``⟨0|ψ⟩``) for the details panel
+        and TTS narration.  Putting the full applied form in ``latex``
+        bloats the node label and breaks visual consistency with all
+        the other operators (``cos``, ``|·|``, ``(·)²``).
         """
         g = latex_to_semantic_graph(r"\langle 0|\psi\rangle = c")
         bk = next(n for n in g["nodes"] if n.get("op") == "inner_product")
-        assert bk["latex"] == r"\langle 0|\psi\rangle"
+        # Compact skeleton on the node label.
+        assert bk["latex"] == r"\langle 0\,|\,\cdot\rangle"
+        # Full applied form in subexpr — what the details panel shows.
         assert bk["subexpr"] == r"\langle 0|\psi\rangle"
-        assert "\\cdot" not in bk["latex"], "no operator-skeleton placeholders"
 
     def test_braket_upstream_subexpr_has_full_braket(self):
         """``|⟨0|ψ⟩|²`` — Abs / power / equals subexprs contain the full braket.

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -1592,19 +1592,11 @@ class TestBraketCollapse:
         # with ``op="inner_product"`` — not a separate type.
         assert overrides[key]["type"] == "operator"
         assert overrides[key]["op"] == "inner_product"
-        # ``latex`` is the *operator skeleton* with ``\cdot`` for symbolic
-        # slots — the original full braket lives in ``original_latex``.
-        assert overrides[key]["latex"] == r"\langle \cdot\,|\,\cdot\rangle"
-        assert overrides[key]["original_latex"] == r"\langle\phi|\psi\rangle"
+        # ``latex`` is the full ``⟨bra|ket⟩`` so the node renders as
+        # real math (not an operator skeleton with ``\cdot`` slots).
+        assert overrides[key]["latex"] == r"\langle\phi|\psi\rangle"
         assert overrides[key]["bra_content"] == r"\phi"
         assert overrides[key]["ket_content"] == r"\psi"
-
-    def test_braket_constant_kept_in_skeleton(self):
-        """Numeric basis labels stay verbatim in the operator skeleton."""
-        _, overrides = _collapse_braket_notation(r"\langle 0|\psi\rangle")
-        key = list(overrides.keys())[0]
-        # Bra is constant ``0`` (kept), ket is symbolic ``\psi`` (slot).
-        assert overrides[key]["latex"] == r"\langle 0\,|\,\cdot\rangle"
 
     def test_braket_with_numbers(self):
         rewritten, overrides = _collapse_braket_notation(r"\langle 0|1\rangle")

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -16,6 +16,7 @@ from scripts.latex_to_graph import (
     _split_on_top_level_comma,
     _extract_parenthetical_annotations,
     _inject_annotations,
+    _collapse_braket_notation,
 )
 
 
@@ -1573,3 +1574,157 @@ class TestParentheticalAnnotations:
         assert eq is not None, "equation should still parse correctly"
         anno = _find_node(g, type="annotation")
         assert anno is not None
+
+
+# ---------------------------------------------------------------------------
+# Dirac bra-ket notation (issue #211)
+# ---------------------------------------------------------------------------
+
+class TestBraketCollapse:
+    """Unit tests for _collapse_braket_notation()."""
+
+    def test_braket_inner_product(self):
+        rewritten, overrides = _collapse_braket_notation(r"\langle\phi|\psi\rangle")
+        assert len(overrides) == 1
+        key = list(overrides.keys())[0]
+        assert key.startswith("Phi_{")
+        # The inner product is an *operator* (like ``+`` or ``=``)
+        # with ``op="inner_product"`` — not a separate type.
+        assert overrides[key]["type"] == "operator"
+        assert overrides[key]["op"] == "inner_product"
+        # ``latex`` is the *operator skeleton* with ``\cdot`` for symbolic
+        # slots — the original full braket lives in ``original_latex``.
+        assert overrides[key]["latex"] == r"\langle \cdot\,|\,\cdot\rangle"
+        assert overrides[key]["original_latex"] == r"\langle\phi|\psi\rangle"
+        assert overrides[key]["bra_content"] == r"\phi"
+        assert overrides[key]["ket_content"] == r"\psi"
+
+    def test_braket_constant_kept_in_skeleton(self):
+        """Numeric basis labels stay verbatim in the operator skeleton."""
+        _, overrides = _collapse_braket_notation(r"\langle 0|\psi\rangle")
+        key = list(overrides.keys())[0]
+        # Bra is constant ``0`` (kept), ket is symbolic ``\psi`` (slot).
+        assert overrides[key]["latex"] == r"\langle 0\,|\,\cdot\rangle"
+
+    def test_braket_with_numbers(self):
+        rewritten, overrides = _collapse_braket_notation(r"\langle 0|1\rangle")
+        assert len(overrides) == 1
+        assert r"\Phi_{0}" in rewritten
+
+    def test_braket_dedup(self):
+        rewritten, overrides = _collapse_braket_notation(
+            r"\langle\phi|\psi\rangle + \langle\phi|\psi\rangle"
+        )
+        assert len(overrides) == 1, "same braket should dedup"
+
+    def test_no_braket_no_change(self):
+        latex = r"x + y = z"
+        rewritten, overrides = _collapse_braket_notation(latex)
+        assert rewritten == latex
+        assert len(overrides) == 0
+
+    def test_ket_not_collapsed(self):
+        """Standalone kets should NOT be collapsed — SymPy handles them."""
+        latex = r"|\psi\rangle"
+        rewritten, overrides = _collapse_braket_notation(latex)
+        assert rewritten == latex
+        assert len(overrides) == 0
+
+    def test_braket_inside_equation(self):
+        rewritten, overrides = _collapse_braket_notation(
+            r"\langle\phi|\psi\rangle = 0"
+        )
+        assert len(overrides) == 1
+        assert "= 0" in rewritten
+
+
+class TestDiracNotation:
+    """Integration tests for ket/bra/braket in semantic graphs."""
+
+    def test_issue_211_ket_equation(self):
+        """The exact LaTeX from issue #211 — kets should be atomic nodes."""
+        g = latex_to_semantic_graph(
+            r"|\psi\rangle = e^{i\gamma_\alpha}\left(r_\alpha|0\rangle "
+            r"+ r_\beta e^{i(\gamma_\beta - \gamma_\alpha)}|1\rangle\right)"
+        )
+        kets = [n for n in g["nodes"] if n["type"] == "ket"]
+        assert len(kets) == 3, f"expected 3 kets, got {len(kets)}"
+        eq = _find_node(g, op="equals")
+        assert eq is not None, "equation root should exist"
+        add = _find_node(g, op="add")
+        assert add is not None, "addition should exist"
+
+    def test_simple_ket(self):
+        g = latex_to_semantic_graph(r"|\psi\rangle")
+        kets = [n for n in g["nodes"] if n["type"] == "ket"]
+        assert len(kets) == 1
+        assert r"\rangle" in kets[0]["latex"]
+
+    def test_ket_addition(self):
+        g = latex_to_semantic_graph(r"|0\rangle + |1\rangle")
+        kets = [n for n in g["nodes"] if n["type"] == "ket"]
+        assert len(kets) == 2
+        add = _find_node(g, op="add")
+        assert add is not None
+
+    def test_bra_standalone(self):
+        g = latex_to_semantic_graph(r"\langle\phi|")
+        bras = [n for n in g["nodes"] if n["type"] == "bra"]
+        assert len(bras) == 1
+        assert r"\langle" in bras[0]["latex"]
+
+    def test_braket_inner_product_equation(self):
+        g = latex_to_semantic_graph(r"\langle\phi|\psi\rangle = 0")
+        # Inner product is an operator with ``op="inner_product"`` —
+        # filter by op so we don't pick up ``=`` or ``+`` operators.
+        brakets = [n for n in g["nodes"] if n.get("op") == "inner_product"]
+        assert len(brakets) == 1, "one inner product → one operator node"
+        # Symbolic operands are wired in via edges, not baked into the label.
+        bk = brakets[0]
+        assert bk["type"] == "operator"
+        bk_id = bk["id"]
+        operand_ids = {e["from"] for e in g["edges"] if e["to"] == bk_id}
+        assert "phi" in operand_ids and "psi" in operand_ids
+        eq = _find_node(g, op="equals")
+        assert eq is not None
+
+    def test_braket_constant_bra_is_baked_in(self):
+        """``⟨0|ψ⟩`` — the ``0`` stays in the operator label, not as an edge."""
+        g = latex_to_semantic_graph(r"\langle 0|\psi\rangle = c")
+        brakets = [n for n in g["nodes"] if n.get("op") == "inner_product"]
+        assert len(brakets) == 1
+        assert brakets[0]["type"] == "operator"
+        bk_id = brakets[0]["id"]
+        operand_ids = {e["from"] for e in g["edges"] if e["to"] == bk_id}
+        # Only ψ flows in. The constant ``0`` lives in the operator label.
+        assert operand_ids == {"psi"}, f"expected only psi, got {operand_ids}"
+
+    def test_braket_shared_psi_across_clauses(self):
+        """``⟨0|ψ⟩`` and ``⟨1|ψ⟩`` in two clauses share one ψ node."""
+        g = latex_to_semantic_graph(
+            r"a = \langle 0|\psi\rangle \\ b = \langle 1|\psi\rangle"
+        )
+        psi_nodes = [n for n in g["nodes"] if n["id"] == "psi"]
+        assert len(psi_nodes) == 1, "ψ should be a single shared node"
+        psi_edges = [e for e in g["edges"] if e["from"] == "psi"]
+        assert len(psi_edges) == 2, "ψ should connect to both brakets"
+
+    def test_ket_equation_has_equals(self):
+        g = latex_to_semantic_graph(r"|\psi\rangle = |0\rangle")
+        eq = _find_node(g, op="equals")
+        assert eq is not None
+        kets = [n for n in g["nodes"] if n["type"] == "ket"]
+        assert len(kets) == 2
+
+    def test_ket_with_subscript(self):
+        g = latex_to_semantic_graph(r"|\psi_n\rangle")
+        kets = [n for n in g["nodes"] if n["type"] == "ket"]
+        assert len(kets) == 1
+
+    def test_ket_coefficient_multiply(self):
+        """Coefficient × ket should produce multiply node."""
+        g = latex_to_semantic_graph(r"\alpha|0\rangle + \beta|1\rangle")
+        kets = [n for n in g["nodes"] if n["type"] == "ket"]
+        assert len(kets) == 2
+        muls = [n for n in g["nodes"] if n.get("op") == "multiply"]
+        assert len(muls) >= 2, "each coefficient×ket should be a multiply"


### PR DESCRIPTION
## Summary
- Fix Born's-rule rendering by treating ⟨bra|ket⟩ as an `operator` node with `op="inner_product"`; symbolic operands wire in as input edges, constants stay baked into the label
- Add `node_short_label` / `node_long_label` helpers in both Python and JS so the graph renderer and details panel ask the same question consistently
- Repair the long-form display in the D3 details panel (was preferring `latex` over `subexpr` in three separate places)

## Background
The Born's-rule step (`p(0)=|⟨0|ψ⟩|²=cos²(θ/2) \\ p(1)=|⟨1|ψ⟩|²=sin²(θ/2)`) was rendering as one collapsed `__equals` node and showing `⚠ Unsupported expression`. Tracing it surfaced several layered issues:

1. **`\\` newline-separator** was being missed by `server._derive_equation_chain_graph` — it greedily chained all `=` signs across the newline, merging both clauses.
2. **Braket placeholder collapsing** kept the same `Phi_{0}` index across clauses, so `_build_comma_separated_graph._rename` (which scopes per-clause IDs with a `c{i}_` prefix) needed to also recognize `Phi_{` placeholders.
3. **Upstream subexprs** (`|⟨0|ψ⟩|²`) were substituting the placeholder's operator skeleton (`⟨0|·⟩`) instead of the full ⟨bra|ket⟩, leaking incomplete math to AI enrichment / TTS / hover.
4. **JS details panel** preferred the short label (`latex`) over the long form (`subexpr`), so clicking the inner-product node showed `⟨0|·⟩` instead of `⟨0|ψ⟩`. The bug existed in three separate panel paths (Mermaid + D3 single-node + D3 multi-node).

## What this PR does

### Parser (`scripts/latex_to_graph.py`)
- Decompose `⟨bra|ket⟩` inner products: each becomes `type="operator", op="inner_product"`. Symbolic operands become child nodes wired via edges with `role="lhs"` / `"rhs"`. Numeric basis labels (`0`, `1`) stay baked into the operator's identity. Cross-clause variable dedup makes `⟨0|ψ⟩` and `⟨1|ψ⟩` share one `ψ` node.
- Operator `latex` = compact skeleton (`⟨0|·⟩`) for the graph label; `subexpr` = full applied form (`⟨0|ψ⟩`) for details / hover / TTS / AI context.
- `_restore_placeholders` substitutes the full ⟨bra|ket⟩ into upstream contexts (`|⟨0|ψ⟩|²`, `=` chains) via a new `original_latex` override field, so parents read as real mathematics.
- `\\` (LaTeX newline) routes through the single-expression pipeline in `server._derive_equation_chain_graph`, so newline-separated chains aren't merged.

### Two-form convention (`scripts/latex_to_graph.py`, `static/graph-panel/d3-semantic-graph.js`)
- `node_short_label(node)` / `node_long_label(node)` named helpers in Python; matching `nodeShortLabel` / `nodeLongLabel` exports in JS.
- Precedence:
  - **short** (op/rel/fn): `latex → glyph(op, …) → op → id`
  - **short** (data): `latex → label → id`
  - **long** (any): `subexpr → latex → short label`
- `_OPERATOR_GLYPHS` / `_SUPERSCRIPT_MAP` Python dicts mirror the JS so both surfaces produce identical short labels.
- All three details-panel paths (`graph-panel.js`, `graph-view.js` single + multi) now route through `nodeLongLabel`.

### Tests
- 4 new regression cases on `TestDiracNotation`: skeleton-as-label, full-braket subexpr, `lhs`/`rhs` edge roles, pure-constant `⟨0|1⟩` having no operand edges.
- 168 passed.

## Test plan
- [x] `pytest tests/test_latex_to_graph.py` — 168 passed
- [x] UI: `scenes/draft/quantum-states.json` → *Measurement Reads Latitude* → *Apply Born's rule* — renders the full graph; inner-product nodes show `⟨0|·⟩` / `⟨1|·⟩` and feed a shared `ψ` node
- [x] Details panel: clicking the inner product shows full `⟨0|ψ⟩` (long form), not the skeleton
- [x] Cos/sin/Abs nodes show full applied forms (`\cos(θ/2)`, `|⟨0|ψ⟩|`) in details panel

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>