### PR TITLE
fix: remove htmlClass regex from semantic graph stripping

### DIFF
--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 |---|---|
-| **Branch** | `feat/dockable-semantic-graph` |
-| **Commit** | `6f2601c` |
-| **Date** | 2026-05-16 13:44:59 -0400 |
+| **Branch** | `codex/fix-htmlclass-redos` |
+| **Commit** | `1a3ddfe` |
+| **Date** | 2026-05-16 14:34:49 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [49536, 15568, 11573, 4219, 395, 137, 33]
+  bar [49536, 15568, 11596, 4219, 395, 137, 33]
 ```
 
 ## Summary by Language
@@ -28,7 +28,7 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  JSON                     41        49537        49536            0            1
  JavaScript               46        17999        15568          971         1460
- Python                   29        14999        11573         1722         1704
+ Python                   29        15029        11596         1724         1709
  CSS                       3         4581         4219          169          193
  Shell                     2          172          137           14           21
  BASH                      1           41           33            4            4
@@ -46,7 +46,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            11950         1475         7882         2593
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   181       100404        83568        10794         6042
+ Total                   181       100434        83591        10796         6047
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -131,9 +131,9 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Python                   29        14999        11573         1722         1704
+ Python                   29        15029        11596         1724         1709
 ─────────────────────────────────────────────────────────────────────────────────
- |ebench/algebench/server.py         2948         2357          346          245
+ |ebench/algebench/server.py         2958         2366          348          244
  |/scripts/latex_to_graph.py         2084         1557          366          161
  |sts/test_latex_to_graph.py         1833         1432          162          239
  |semantic_graph_enricher.py         1144          798          214          132
@@ -149,8 +149,8 @@ xychart-beta horizontal
  |ench/scripts/lint_scene.py          236          185           14           37
  |scripts/validate_schema.py          180          154            1           25
  |/scripts/assemble_scene.py          187          144            1           42
+ |graph_highlight_overlay.py          183          134           11           38
  |/tests/test_render_math.py          177          124           18           35
- |graph_highlight_overlay.py          163          120           11           32
  |h/models/semantic_graph.py          161          109           19           33
  |st_dot_notation_restore.py          156          107           19           30
  |h/algebench/agents/base.py          124          105            0           19
@@ -163,7 +163,7 @@ xychart-beta horizontal
  |lgebench/tests/__init__.py            0            0            0            0
  |h/tests/agents/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    29        14999        11573         1722         1704
+ Total                    29        15029        11596         1724         1709
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -172,5 +172,5 @@ xychart-beta horizontal
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
 | JavaScript (frontend) | 15568 | 57% |
-| Python (backend) | 11573 | 43% |
-| **Total** | **27141** | **100%** |
+| Python (backend) | 11596 | 43% |
+| **Total** | **27164** | **100%** |

--- a/server.py
+++ b/server.py
@@ -1186,9 +1186,6 @@ def _apply_highlights_to_graph(
         matched.setdefault("highlight", class_key)
 
 
-# Match any `\htmlClass{...}{body}` wrapper (may be nested) and peel it off.
-_HTML_CLASS_RE = re.compile(r"\\htmlClass\{[^}]*\}\{")
-
 def _strip_html_class(latex: str) -> str:
     """Remove `\\htmlClass{...}{...}` wrappers, keeping only the inner body.
 
@@ -1200,14 +1197,27 @@ def _strip_html_class(latex: str) -> str:
         return latex
     out = []
     i = 0
+    prefix = "\\htmlClass{"
     while i < len(latex):
-        m = _HTML_CLASS_RE.match(latex, i)
-        if not m:
+        # Keep this parser regex-free; CodeQL #31 flagged repeated regex
+        # matching here as a potential ReDoS risk.
+        # https://github.com/ibenian/algebench/security/code-scanning/31
+        if not latex.startswith(prefix, i):
             out.append(latex[i])
             i += 1
             continue
         # We're at `\htmlClass{class}{` — find matching `}` for the body.
-        i = m.end()
+        class_start = i + len(prefix)
+        class_end = latex.find("}", class_start)
+        if (
+            class_end == -1
+            or class_end + 1 >= len(latex)
+            or latex[class_end + 1] != "{"
+        ):
+            out.append(latex[i])
+            i += 1
+            continue
+        i = class_end + 2
         depth = 1
         while i < len(latex) and depth > 0:
             c = latex[i]

--- a/tests/test_graph_highlight_overlay.py
+++ b/tests/test_graph_highlight_overlay.py
@@ -24,6 +24,7 @@ from server import (  # noqa: E402  (path manipulation above)
     _apply_highlights_to_graph,
     _autofill_semantic_graphs,
     _extract_htmlclass_pairs,
+    _strip_html_class,
 )
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -161,3 +162,22 @@ def test_highlight_overlay_noop_when_no_highlights():
         assert "highlight" not in node
         # "color" may legitimately appear if role-based palettes ever attach
         # one, but the overlay itself should contribute nothing here.
+
+
+def test_strip_html_class_removes_wrappers_from_middle_of_math():
+    assert (
+        _strip_html_class(r"E = \htmlClass{hl-m}{m} \htmlClass{hl-c}{c}^2")
+        == r"E = m c^2"
+    )
+
+
+def test_strip_html_class_preserves_nested_latex_body():
+    assert (
+        _strip_html_class(r"E = \htmlClass{hl-kinetic}{\frac{1}{2} m v^2}")
+        == r"E = \frac{1}{2} m v^2"
+    )
+
+
+def test_strip_html_class_handles_malformed_wrapper_without_regex_backtracking():
+    bad = "\\htmlClass{" * 2000 + "x"
+    assert _strip_html_class(bad) == bad


### PR DESCRIPTION
## Summary

- Replaces the server-side `\htmlClass` wrapper regex with deterministic prefix parsing to avoid repeated regex matching on scene math.
- Preserves brace-depth parsing for nested LaTeX bodies used by semantic graph autofill.
- Adds regression coverage for middle-of-expression wrappers, nested bodies, and malformed repeated prefixes.

Addresses [Code scanning #31](https://github.com/ibenian/algebench/security/code-scanning/31).

## Test plan

- `./run.sh -m pytest tests/test_graph_highlight_overlay.py`
- `./run.sh -m pytest tests/`

🤖 Co-authored-by: Codex <codex@openai.com>