### PR TITLE
fix(security): prevent stack trace exposure in API error responses

### DIFF
--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 |---|---|
-| **Branch** | `fix/code-scanning-32-xss-dom` |
-| **Commit** | `b02484a` |
-| **Date** | 2026-05-16 22:57:50 -0400 |
+| **Branch** | `fix/code-scanning-stack-trace-exposure` |
+| **Commit** | `534dff1` |
+| **Date** | 2026-05-16 23:07:31 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [49536, 15572, 11740, 4219, 395, 137, 33]
+  bar [49536, 15572, 11745, 4219, 395, 137, 33]
 ```
 
 ## Summary by Language
@@ -28,7 +28,7 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  JSON                     41        49537        49536            0            1
  JavaScript               46        18003        15572          971         1460
- Python                   31        15213        11740         1724         1749
+ Python                   31        15218        11745         1724         1749
  CSS                       3         4581         4219          169          193
  Shell                     2          172          137           14           21
  BASH                      1           41           33            4            4
@@ -47,7 +47,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            12036         1501         7938         2597
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   183       100708        83765        10852         6091
+ Total                   183       100713        83770        10852         6091
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -132,9 +132,9 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Python                   31        15213        11740         1724         1749
+ Python                   31        15218        11745         1724         1749
 ─────────────────────────────────────────────────────────────────────────────────
- |ebench/algebench/server.py         2991         2397          348          246
+ |ebench/algebench/server.py         2996         2402          348          246
  |/scripts/latex_to_graph.py         2084         1557          366          161
  |sts/test_latex_to_graph.py         1833         1432          162          239
  |semantic_graph_enricher.py         1144          798          214          132
@@ -166,7 +166,7 @@ xychart-beta horizontal
  |lgebench/tests/__init__.py            0            0            0            0
  |h/tests/agents/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    31        15213        11740         1724         1749
+ Total                    31        15218        11745         1724         1749
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -175,5 +175,5 @@ xychart-beta horizontal
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
 | JavaScript (frontend) | 15572 | 57% |
-| Python (backend) | 11740 | 43% |
-| **Total** | **27312** | **100%** |
+| Python (backend) | 11745 | 43% |
+| **Total** | **27317** | **100%** |

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -5,8 +5,8 @@
 | Field | Value |
 |---|---|
 | **Branch** | `fix/code-scanning-stack-trace-exposure` |
-| **Commit** | `534dff1` |
-| **Date** | 2026-05-16 23:07:31 -0400 |
+| **Commit** | `f58ec65` |
+| **Date** | 2026-05-16 23:27:20 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [49536, 15572, 11745, 4219, 395, 137, 33]
+  bar [49536, 15572, 11751, 4219, 395, 137, 33]
 ```
 
 ## Summary by Language
@@ -28,7 +28,7 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  JSON                     41        49537        49536            0            1
  JavaScript               46        18003        15572          971         1460
- Python                   31        15218        11745         1724         1749
+ Python                   31        15224        11751         1724         1749
  CSS                       3         4581         4219          169          193
  Shell                     2          172          137           14           21
  BASH                      1           41           33            4            4
@@ -47,7 +47,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            12036         1501         7938         2597
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   183       100713        83770        10852         6091
+ Total                   183       100719        83776        10852         6091
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -132,9 +132,9 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Python                   31        15218        11745         1724         1749
+ Python                   31        15224        11751         1724         1749
 ─────────────────────────────────────────────────────────────────────────────────
- |ebench/algebench/server.py         2996         2402          348          246
+ |ebench/algebench/server.py         3002         2408          348          246
  |/scripts/latex_to_graph.py         2084         1557          366          161
  |sts/test_latex_to_graph.py         1833         1432          162          239
  |semantic_graph_enricher.py         1144          798          214          132
@@ -166,7 +166,7 @@ xychart-beta horizontal
  |lgebench/tests/__init__.py            0            0            0            0
  |h/tests/agents/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    31        15218        11745         1724         1749
+ Total                    31        15224        11751         1724         1749
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -174,6 +174,6 @@ xychart-beta horizontal
 
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
-| JavaScript (frontend) | 15572 | 57% |
-| Python (backend) | 11745 | 43% |
-| **Total** | **27317** | **100%** |
+| JavaScript (frontend) | 15572 | 56% |
+| Python (backend) | 11751 | 44% |
+| **Total** | **27323** | **100%** |

--- a/server.py
+++ b/server.py
@@ -2292,7 +2292,8 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
                     themes.append({"name": name, "mode": "light"})
             return JSONResponse({"themes": themes})
         except Exception as e:
-            return JSONResponse({"error": str(e), "themes": []}, status_code=500)
+            print(f"   ❌ /api/graph/themes: {e}", flush=True)
+            return JSONResponse({"error": "internal error loading themes", "themes": []}, status_code=500)
 
     @fastapp.get("/api/graph/theme/{name}")
     async def get_graph_theme(name: str):
@@ -2307,7 +2308,8 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
         except FileNotFoundError:
             return JSONResponse({"error": f"theme '{name}' not found"}, status_code=404)
         except Exception as e:
-            return JSONResponse({"error": str(e)}, status_code=500)
+            print(f"   ❌ /api/graph/theme: {e}", flush=True)
+            return JSONResponse({"error": "internal error loading theme"}, status_code=500)
 
     class MermaidRenderRequest(BaseModel):
         graph: dict = {}
@@ -2337,7 +2339,7 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
         except Exception as e:
             import traceback
             print(f"   ❌ /api/graph/from-latex: {e}\n{traceback.format_exc()}")
-            return JSONResponse({"error": str(e)}, status_code=400)
+            return JSONResponse({"error": "failed to derive semantic graph from LaTeX"}, status_code=400)
 
     class GraphEnrichRequest(BaseModel):
         graph: dict
@@ -2402,7 +2404,7 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
             except _ValidationError as exc:
                 print(f"[enrich] input failed validation: {exc}", flush=True)
                 return JSONResponse(
-                    {"error": f"input graph failed schema validation: {exc}"},
+                    {"error": "input graph failed schema validation"},
                     status_code=400,
                 )
 
@@ -2448,19 +2450,21 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
             try:
                 from agents import AgentError, SemanticGraphEnrichmentAgent
             except ImportError as e:
-                return JSONResponse({"error": f"agents package unavailable: {e}"}, status_code=503)
+                print(f"[enrich] import error: {e}", flush=True)
+                return JSONResponse({"error": "enrichment service unavailable"}, status_code=503)
 
             if _graph_enricher is None:
                 try:
                     _graph_enricher = SemanticGraphEnrichmentAgent()
                 except AgentError as e:
-                    return JSONResponse({"error": str(e)}, status_code=503)
+                    print(f"[enrich] agent init error: {e}", flush=True)
+                    return JSONResponse({"error": "enrichment service unavailable"}, status_code=503)
 
             try:
                 enriched_model = await _graph_enricher.aenrich(graph_model, context_in)
             except AgentError as e:
                 print(f"[enrich] agent error: {e}", flush=True)
-                return JSONResponse({"error": str(e)}, status_code=502)
+                return JSONResponse({"error": "enrichment failed"}, status_code=502)
 
             # Serialize back to the wire format for the cache and JSON
             # response — keeps the cache hit path returning dicts so the
@@ -2477,7 +2481,7 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
         except Exception as e:
             import traceback
             print(f"   ❌ /api/graph/enrich: {e}\n{traceback.format_exc()}")
-            return JSONResponse({"error": str(e)}, status_code=500)
+            return JSONResponse({"error": "internal error during enrichment"}, status_code=500)
 
     @fastapp.post("/api/graph/mermaid")
     async def post_graph_mermaid(req: MermaidRenderRequest):
@@ -2500,12 +2504,12 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
                                  "direction": theme.get("direction"),
                                  "mode": theme.get("mode", "dark"),
                                  "edgeStyles": theme.get("edgeStyles", {})})
-        except FileNotFoundError as e:
-            return JSONResponse({"error": str(e)}, status_code=404)
+        except FileNotFoundError:
+            return JSONResponse({"error": "theme not found"}, status_code=404)
         except Exception as e:
             import traceback
             print(f"   ❌ /api/graph/mermaid: {e}\n{traceback.format_exc()}")
-            return JSONResponse({"error": str(e)}, status_code=500)
+            return JSONResponse({"error": "internal error generating mermaid"}, status_code=500)
 
     @fastapp.get("/graph-panel/{filename:path}")
     async def get_graph_panel_file(filename: str):
@@ -2602,7 +2606,8 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
         except json.JSONDecodeError:
             return JSONResponse({"error": "Invalid JSON in scene file"}, status_code=400)
         except Exception as e:
-            return JSONResponse({"error": str(e)}, status_code=500)
+            print(f"   ❌ /api/scene_file: {e}", flush=True)
+            return JSONResponse({"error": "internal error reading scene file"}, status_code=500)
 
     @fastapp.get("/api/domains")
     async def get_domains():
@@ -2688,7 +2693,7 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
         except Exception as e:
             import traceback
             print(f"   ❌ /api/chat error: {e}\n{traceback.format_exc()}")
-            return JSONResponse({"error": str(e)}, status_code=500)
+            return JSONResponse({"error": "internal error processing chat request"}, status_code=500)
 
     @fastapp.post("/api/tts/stream")
     async def api_tts_stream(req: TtsRequest, request: Request):

--- a/server.py
+++ b/server.py
@@ -1304,7 +1304,7 @@ def _autofill_semantic_graphs(scene: dict) -> dict:
                     print(f"   ⚠️  auto-graph crashed for {math_src!r}: {e}")
                     graph = None
                     error_reason = 'parse_crashed'
-                    error_message = str(e) or e.__class__.__name__
+                    error_message = 'Parser crashed while processing this expression'
                 if graph:
                     _apply_highlights_to_graph(
                         graph, hl_pairs, step.get('highlights') or {},
@@ -1728,7 +1728,8 @@ def call_gemini_chat(message, history, context):
                 config=config,
             )
         except Exception as e:
-            return f"Gemini API error: {str(e)}", [], debug_info
+            print(f"   ❌ Gemini API error: {e}", flush=True)
+            return "Sorry, I encountered an error processing your request. Please try again.", [], debug_info
 
         # Log finish reason for debugging
         finish = None
@@ -2336,10 +2337,13 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
         try:
             graph = _derive_semantic_graph(req.latex, domain=req.domain)
             return JSONResponse({"graph": graph})
+        except (ValueError, SyntaxError, KeyError) as e:
+            print(f"   ⚠️ /api/graph/from-latex parse error: {e}", flush=True)
+            return JSONResponse({"error": "failed to derive semantic graph from LaTeX"}, status_code=400)
         except Exception as e:
             import traceback
             print(f"   ❌ /api/graph/from-latex: {e}\n{traceback.format_exc()}")
-            return JSONResponse({"error": "failed to derive semantic graph from LaTeX"}, status_code=400)
+            return JSONResponse({"error": "internal error processing LaTeX"}, status_code=500)
 
     class GraphEnrichRequest(BaseModel):
         graph: dict
@@ -2688,8 +2692,10 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
             )
             if DEBUG_MODE:
                 print(f"   💬 Response ({len(response_text)} chars): {response_text}")
-            return JSONResponse({"response": response_text, "toolCalls": tool_calls,
-                                 "debug": debug_info})
+            result = {"response": response_text, "toolCalls": tool_calls}
+            if DEBUG_MODE:
+                result["debug"] = debug_info
+            return JSONResponse(result)
         except Exception as e:
             import traceback
             print(f"   ❌ /api/chat error: {e}\n{traceback.format_exc()}")


### PR DESCRIPTION
## Summary
- Replace all 12 instances of `str(e)` / `f"...{e}"` in `JSONResponse` error payloads with generic, safe error messages
- Exception details are now logged server-side only (via `print`), preventing internal implementation details from leaking to HTTP clients
- Covers all API endpoints in `server.py`: `/api/graph/themes`, `/api/graph/theme/{name}`, `/api/graph/from-latex`, `/api/graph/enrich`, `/api/graph/mermaid`, `/api/scene_file`, `/api/chat`

Addresses [Code scanning alerts #1–#12](https://github.com/ibenian/algebench/security/code-scanning) (py/stack-trace-exposure).

## Test plan
- [ ] Verify API endpoints still return appropriate HTTP status codes
- [ ] Confirm error responses no longer contain exception text (trigger errors via invalid input)
- [ ] Check server logs still capture full error details for debugging

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>