### PR TITLE
fix(ci): handle fork PRs in loc-report workflow

### DIFF
--- a/.github/workflows/loc-report.yml
+++ b/.github/workflows/loc-report.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || github.ref }}
 
       - uses: taiki-e/install-action@v2
         with:
@@ -31,6 +31,7 @@ jobs:
         run: cat LOC-REPORT.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Commit report if changed
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/loc-report.yml
+++ b/.github/workflows/loc-report.yml
@@ -31,7 +31,7 @@ jobs:
         run: cat LOC-REPORT.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Commit report if changed
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -5,8 +5,8 @@
 | Field | Value |
 |---|---|
 | **Branch** | `fix/loc-report-fork-prs` |
-| **Commit** | `1401958` |
-| **Date** | 2026-05-17 14:46:21 -0400 |
+| **Commit** | `4abb87c` |
+| **Date** | 2026-05-17 14:53:36 -0400 |
 
 ## Language Breakdown
 

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 |---|---|
-| **Branch** | `fix/code-scanning-stack-trace-exposure` |
-| **Commit** | `f58ec65` |
-| **Date** | 2026-05-16 23:27:20 -0400 |
+| **Branch** | `fix/loc-report-fork-prs` |
+| **Commit** | `c81be6d` |
+| **Date** | 2026-05-17 13:49:45 -0400 |
 
 ## Language Breakdown
 

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -5,8 +5,8 @@
 | Field | Value |
 |---|---|
 | **Branch** | `fix/loc-report-fork-prs` |
-| **Commit** | `c81be6d` |
-| **Date** | 2026-05-17 13:49:45 -0400 |
+| **Commit** | `1401958` |
+| **Date** | 2026-05-17 14:46:21 -0400 |
 
 ## Language Breakdown
 

--- a/scripts/loc-report.sh
+++ b/scripts/loc-report.sh
@@ -22,7 +22,7 @@ fi
 
 COMMIT_SHA="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
 COMMIT_DATE="$(git -C "$REPO_ROOT" log -1 --format=%ci)"
-BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)"
+BRANCH="${GITHUB_HEAD_REF:-$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)}"
 
 {
   echo "# Lines of Code Report"


### PR DESCRIPTION
## Summary
- For fork PRs, checkout the merge ref instead of the head branch (which doesn't exist in the base repo)
- Skip the commit-and-push step for fork PRs since we can't write to the fork's branch
- Fork PRs still get the LOC report in the GitHub Actions step summary

Fixes the checkout failure seen in PR #293.

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>