### PR TITLE
Add CodeQL suppression for path-injection false positive (#65)

### DIFF
--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 |---|---|
-| **Branch** | `fix/297-scene-file-caching` |
-| **Commit** | `77cdce5` |
-| **Date** | 2026-05-17 20:13:17 -0400 |
+| **Branch** | `fix/65-codeql-path-injection-suppression` |
+| **Commit** | `3912716` |
+| **Date** | 2026-05-17 20:28:24 -0400 |
 
 ## Language Breakdown
 

--- a/server.py
+++ b/server.py
@@ -1495,7 +1495,7 @@ def load_builtin_scene(name):
     if not str(path).startswith(str(resolved_root) + os.sep):
         return None
     if path.exists():
-        return _load_scene(path)
+        return _load_scene(path)  # lgtm[py/path-injection]
     return None
 
 


### PR DESCRIPTION
## Summary
- Adds `lgtm[py/path-injection]` inline suppression for code scanning alert #65 in `load_builtin_scene()`
- The path is already validated by regex allowlist, `normpath`, `..` rejection, and directory containment check — confirmed false positive

Addresses [Code scanning #65](https://github.com/ibenian/algebench/security/code-scanning/65).

## Test plan
- [ ] CodeQL scan passes without flagging this line

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>