### PR TITLE
fix: proof tree click navigates to wrong proof when id is missing

### DIFF
--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 |---|---|
-| **Branch** | `fix/65-codeql-path-injection-suppression` |
-| **Commit** | `3912716` |
-| **Date** | 2026-05-17 20:28:24 -0400 |
+| **Branch** | `fix/278-wrong-proof-step-navigation` |
+| **Commit** | `08867a7` |
+| **Date** | 2026-05-17 22:34:09 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [49613, 15585, 11866, 4219, 395, 137, 33]
+  bar [49613, 15580, 11866, 4219, 395, 137, 33]
 ```
 
 ## Summary by Language
@@ -27,7 +27,7 @@ xychart-beta horizontal
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  JSON                     41        49614        49613            0            1
- JavaScript               46        18021        15585          971         1465
+ JavaScript               46        18019        15580          974         1465
  Python                   31        15366        11866         1733         1767
  CSS                       3         4581         4219          169          193
  Shell                     2          172          137           14           21
@@ -47,7 +47,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            12036         1501         7938         2597
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   183       100956        83981        10861         6114
+ Total                   183       100954        83976        10864         6114
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -57,9 +57,9 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- JavaScript               46        18021        15585          971         1465
+ JavaScript               46        18019        15580          974         1465
 ─────────────────────────────────────────────────────────────────────────────────
- |bench/static/graph-view.js         2140         1664          319          157
+ |bench/static/graph-view.js         2138         1659          322          157
  |nch/static/json-browser.js         1403         1361            5           37
  |h/algebench/static/chat.js         1440         1174          113          153
  |panel/d3-semantic-graph.js         1452         1173          117          162
@@ -122,7 +122,7 @@ xychart-beta horizontal
  |islunar-dynamics/docs.json          122          122            0            0
  |tmospheric-entry/docs.json           41           41            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    53        23277        20468         1147         1662
+ Total                    53        23275        20463         1150         1662
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -174,6 +174,6 @@ xychart-beta horizontal
 
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
-| JavaScript (frontend) | 15585 | 56% |
+| JavaScript (frontend) | 15580 | 56% |
 | Python (backend) | 11866 | 44% |
-| **Total** | **27451** | **100%** |
+| **Total** | **27446** | **100%** |

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -553,6 +553,8 @@ function rebuildProofTree() {
         group.entries.forEach((entry) => {
             const proof = entry.proof;
             if (!proof || !proof.steps) return;
+            const specIdx = state.proofSpec ? state.proofSpec.indexOf(entry) : -1;
+            entry._entryId = _proofEntryId(entry, specIdx);
             const proofEl = document.createElement('div');
             proofEl.className = 'gp-tree-proof';
 
@@ -579,7 +581,7 @@ function rebuildProofTree() {
                 const stepEl = document.createElement('div');
                 stepEl.className = cls;
                 stepEl.dataset.sceneIdx = entry.sceneIndex != null ? entry.sceneIndex : '';
-                stepEl.dataset.proofId = proof.id || '';
+                stepEl.dataset.proofId = entry._entryId;
                 stepEl.dataset.stepIdx = sIdx;
 
                 const idxEl = document.createElement('span');
@@ -614,7 +616,7 @@ function rebuildProofTree() {
             header.addEventListener('click', () => proofEl.classList.toggle('expanded'));
             proofEl.appendChild(stepsEl);
 
-            if (isActiveProofEntry(entry)) proofEl.classList.add('expanded');
+            if (specIdx === state.proofActiveIndex) proofEl.classList.add('expanded');
             groupEl.appendChild(proofEl);
         });
         root.appendChild(groupEl);
@@ -622,12 +624,11 @@ function rebuildProofTree() {
     updateTreeHighlight();
 }
 
-function isActiveProofEntry(entry) {
-    const active = state.proofSpec && state.proofSpec[state.proofActiveIndex];
-    if (!active || !active.proof) return false;
-    return entry.proof && entry.proof.id &&
-        entry.proof.id === active.proof.id &&
-        entry.sceneIndex === active.sceneIndex;
+/** Stable identifier for a proof spec entry — uses the real proof id when
+ *  present, otherwise synthesises one from the spec-array position so that
+ *  every entry is matchable even when the lesson JSON omits the id field. */
+function _proofEntryId(entry, specIdx) {
+    return (entry.proof && entry.proof.id) || `__proof_${specIdx}`;
 }
 
 function handleTreeStepClick(entry, stepIdx) {
@@ -667,8 +668,8 @@ function handleTreeStepClick(entry, stepIdx) {
 function _forceActivateProofStep(entry, stepIdx) {
     // Ensure the tree-clicked proof becomes the active proof, then navigate the step.
     if (!state.proofSpec) return;
-    const targetIdx = state.proofSpec.findIndex(e =>
-        e.proof && e.proof.id && entry.proof && entry.proof.id === e.proof.id &&
+    const targetIdx = state.proofSpec.findIndex((e, idx) =>
+        _proofEntryId(e, idx) === entry._entryId &&
         e.sceneIndex === entry.sceneIndex);
     if (targetIdx < 0) return;
     if (targetIdx !== state.proofActiveIndex) {
@@ -684,13 +685,10 @@ function _forceActivateProofStep(entry, stepIdx) {
 
 function updateTreeHighlight() {
     const activeEntry = state.proofSpec && state.proofSpec[state.proofActiveIndex];
-    const activeId = activeEntry && activeEntry.proof && activeEntry.proof.id;
-    const activeSceneIdx = activeEntry && activeEntry.sceneIndex;
+    const activeId = activeEntry ? _proofEntryId(activeEntry, state.proofActiveIndex) : null;
     const activeStep = state.proofStepIndex;
     document.querySelectorAll('#graph-proof-tree .gp-tree-step').forEach(el => {
-        const elScene = el.dataset.sceneIdx === '' ? null : Number(el.dataset.sceneIdx);
-        const match = el.dataset.proofId === (activeId || '') &&
-            elScene === activeSceneIdx &&
+        const match = el.dataset.proofId === activeId &&
             Number(el.dataset.stepIdx) === activeStep;
         el.classList.toggle('active', match);
         if (match) {


### PR DESCRIPTION
## Summary

Fixes #278 — clicking a step in the second proof of the Math panel tree jumped to the wrong step in the first proof.

- **Root cause**: `_forceActivateProofStep` and `isActiveProofEntry` matched proofs by `proof.id`, but short-circuited when `id` was falsy. Proofs without an explicit `id` in the lesson JSON (e.g., the second proof in *Angles Encode Amplitudes*) could never be matched.
- **Fix**: Introduce `_proofEntryId(entry, specIdx)` — returns the real `proof.id` when present, otherwise synthesises a stable `__proof_<idx>` identifier from the spec-array position. This is stamped on each entry at tree-build time (`entry._entryId`) and used uniformly in activation, highlighting, and expand logic.
- **Removed** the now-dead `isActiveProofEntry` function (replaced by direct index comparison).
- Net change: **−2 lines** (13 added, 15 removed).

## Test plan

- [ ] Open the **Quantum States** lesson → Scene 6 (*Angles Encode Amplitudes*)
- [ ] Open the Math panel (semantic graph dock)
- [ ] Click a step in the **second** proof → should navigate to the correct proof and step
- [ ] Click a step in the **first** proof → should still work as before
- [ ] Verify the active step highlight tracks correctly when switching between proofs
- [ ] Verify the correct proof auto-expands in the tree on load

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>