### PR TITLE
feat: element-of relation, quad-comma splitting, and unified statement separators

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,10 +2,6 @@ name: Tests
 
 on:
   pull_request:
-    paths:
-      - 'scripts/**/*.py'
-      - 'tests/**/*.py'
-      - 'requirements.txt'
   push:
     branches: [main]
     paths:
@@ -26,16 +22,29 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Check for relevant changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            python:
+              - 'scripts/**/*.py'
+              - 'tests/**/*.py'
+              - 'requirements.txt'
+
       - name: Set up Python
+        if: steps.filter.outputs.python == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
       - name: Install test runner
+        if: steps.filter.outputs.python == 'true'
         run: |
           ./run.sh -m pip install pytest -q
 
       - name: Run tests
+        if: steps.filter.outputs.python == 'true'
         id: tests
         run: |
           ./run.sh -m pytest tests/ -v --tb=short --junitxml=test-results.xml 2>&1 | tee test-output.txt
@@ -75,9 +84,7 @@ jobs:
             --body "$BODY"
 
       - name: Fail if tests failed
-        if: always()
+        if: always() && steps.tests.outputs.exit_code != '' && steps.tests.outputs.exit_code != '0'
         run: |
-          if [ "${{ steps.tests.outputs.exit_code }}" != "0" ]; then
-            echo "❌ Tests failed"
-            exit 1
-          fi
+          echo "❌ Tests failed"
+          exit 1

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -5,8 +5,8 @@
 | Field | Value |
 |---|---|
 | **Branch** | `fix/281-element-of-relation` |
-| **Commit** | `44fd260` |
-| **Date** | 2026-05-17 23:30:02 -0400 |
+| **Commit** | `4982b11` |
+| **Date** | 2026-05-17 23:59:50 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [49589, 15584, 11872, 4219, 395, 137, 33]
+  bar [49589, 15584, 12097, 4219, 395, 137, 33]
 ```
 
 ## Summary by Language
@@ -28,7 +28,7 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  JSON                     41        49590        49589            0            1
  JavaScript               46        18023        15584          974         1465
- Python                   31        15372        11872         1733         1767
+ Python                   31        15613        12097         1724         1792
  CSS                       3         4581         4219          169          193
  Shell                     2          172          137           14           21
  BASH                      1           41           33            4            4
@@ -47,7 +47,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            12036         1501         7938         2597
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   183       100940        83962        10864         6114
+ Total                   183       101181        84187        10855         6139
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -132,11 +132,11 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Python                   31        15372        11872         1733         1767
+ Python                   31        15613        12097         1724         1792
 ─────────────────────────────────────────────────────────────────────────────────
  |ebench/algebench/server.py         3048         2450          348          250
- |/scripts/latex_to_graph.py         2131         1591          375          165
- |sts/test_latex_to_graph.py         1847         1444          162          241
+ |/scripts/latex_to_graph.py         2289         1741          366          182
+ |sts/test_latex_to_graph.py         1930         1519          162          249
  |semantic_graph_enricher.py         1144          798          214          132
  |semantic_graph_enricher.py          853          676          106           71
  |cripts/graph_to_mermaid.py          871          613          174           84
@@ -166,7 +166,7 @@ xychart-beta horizontal
  |lgebench/tests/__init__.py            0            0            0            0
  |h/tests/agents/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    31        15372        11872         1733         1767
+ Total                    31        15613        12097         1724         1792
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -175,5 +175,5 @@ xychart-beta horizontal
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
 | JavaScript (frontend) | 15584 | 56% |
-| Python (backend) | 11872 | 44% |
-| **Total** | **27456** | **100%** |
+| Python (backend) | 12097 | 44% |
+| **Total** | **27681** | **100%** |

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 |---|---|
-| **Branch** | `fix/278-wrong-proof-step-navigation` |
-| **Commit** | `08867a7` |
-| **Date** | 2026-05-17 22:34:09 -0400 |
+| **Branch** | `fix/281-element-of-relation` |
+| **Commit** | `44fd260` |
+| **Date** | 2026-05-17 23:30:02 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [49613, 15580, 11866, 4219, 395, 137, 33]
+  bar [49589, 15584, 11872, 4219, 395, 137, 33]
 ```
 
 ## Summary by Language
@@ -26,9 +26,9 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- JSON                     41        49614        49613            0            1
- JavaScript               46        18019        15580          974         1465
- Python                   31        15366        11866         1733         1767
+ JSON                     41        49590        49589            0            1
+ JavaScript               46        18023        15584          974         1465
+ Python                   31        15372        11872         1733         1767
  CSS                       3         4581         4219          169          193
  Shell                     2          172          137           14           21
  BASH                      1           41           33            4            4
@@ -47,7 +47,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            12036         1501         7938         2597
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   183       100954        83976        10864         6114
+ Total                   183       100940        83962        10864         6114
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -57,12 +57,12 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- JavaScript               46        18019        15580          974         1465
+ JavaScript               46        18023        15584          974         1465
 ─────────────────────────────────────────────────────────────────────────────────
- |bench/static/graph-view.js         2138         1659          322          157
+ |bench/static/graph-view.js         2140         1661          322          157
  |nch/static/json-browser.js         1403         1361            5           37
+ |panel/d3-semantic-graph.js         1454         1175          117          162
  |h/algebench/static/chat.js         1440         1174          113          153
- |panel/d3-semantic-graph.js         1452         1173          117          162
  |lgebench/static/overlay.js         1175         1104           29           42
  |/algebench/static/proof.js         1109         1040           33           36
  |nch/static/scene-loader.js          942          801           46           95
@@ -122,7 +122,7 @@ xychart-beta horizontal
  |islunar-dynamics/docs.json          122          122            0            0
  |tmospheric-entry/docs.json           41           41            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    53        23275        20463         1150         1662
+ Total                    53        23279        20467         1150         1662
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -132,14 +132,14 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Python                   31        15366        11866         1733         1767
+ Python                   31        15372        11872         1733         1767
 ─────────────────────────────────────────────────────────────────────────────────
  |ebench/algebench/server.py         3048         2450          348          250
- |/scripts/latex_to_graph.py         2127         1587          375          165
+ |/scripts/latex_to_graph.py         2131         1591          375          165
  |sts/test_latex_to_graph.py         1847         1444          162          241
  |semantic_graph_enricher.py         1144          798          214          132
  |semantic_graph_enricher.py          853          676          106           71
- |cripts/graph_to_mermaid.py          869          611          174           84
+ |cripts/graph_to_mermaid.py          871          613          174           84
  |h/algebench/agent_tools.py          610          522           35           53
  |ripts/audit_expressions.py          697          515           90           92
  |nch/scripts/render_math.py          509          469            4           36
@@ -166,7 +166,7 @@ xychart-beta horizontal
  |lgebench/tests/__init__.py            0            0            0            0
  |h/tests/agents/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    31        15366        11866         1733         1767
+ Total                    31        15372        11872         1733         1767
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -174,6 +174,6 @@ xychart-beta horizontal
 
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
-| JavaScript (frontend) | 15580 | 56% |
-| Python (backend) | 11866 | 44% |
-| **Total** | **27446** | **100%** |
+| JavaScript (frontend) | 15584 | 56% |
+| Python (backend) | 11872 | 44% |
+| **Total** | **27456** | **100%** |

--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -5,8 +5,8 @@
 | Field | Value |
 |---|---|
 | **Branch** | `fix/281-element-of-relation` |
-| **Commit** | `4982b11` |
-| **Date** | 2026-05-17 23:59:50 -0400 |
+| **Commit** | `4bf5c37` |
+| **Date** | 2026-05-18 00:20:26 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [49589, 15584, 12097, 4219, 395, 137, 33]
+  bar [49589, 15584, 12124, 4219, 395, 137, 33]
 ```
 
 ## Summary by Language
@@ -28,7 +28,7 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  JSON                     41        49590        49589            0            1
  JavaScript               46        18023        15584          974         1465
- Python                   31        15613        12097         1724         1792
+ Python                   31        15644        12124         1725         1795
  CSS                       3         4581         4219          169          193
  Shell                     2          172          137           14           21
  BASH                      1           41           33            4            4
@@ -47,7 +47,7 @@ xychart-beta horizontal
  |- Python                 2           38           30            2            6
  (Total)                            12036         1501         7938         2597
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   183       101181        84187        10855         6139
+ Total                   183       101212        84214        10856         6142
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -132,11 +132,11 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Python                   31        15613        12097         1724         1792
+ Python                   31        15644        12124         1725         1795
 ─────────────────────────────────────────────────────────────────────────────────
  |ebench/algebench/server.py         3048         2450          348          250
- |/scripts/latex_to_graph.py         2289         1741          366          182
- |sts/test_latex_to_graph.py         1930         1519          162          249
+ |/scripts/latex_to_graph.py         2262         1715          367          180
+ |sts/test_latex_to_graph.py         1988         1572          162          254
  |semantic_graph_enricher.py         1144          798          214          132
  |semantic_graph_enricher.py          853          676          106           71
  |cripts/graph_to_mermaid.py          871          613          174           84
@@ -166,7 +166,7 @@ xychart-beta horizontal
  |lgebench/tests/__init__.py            0            0            0            0
  |h/tests/agents/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    31        15613        12097         1724         1792
+ Total                    31        15644        12124         1725         1795
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -175,5 +175,5 @@ xychart-beta horizontal
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
 | JavaScript (frontend) | 15584 | 56% |
-| Python (backend) | 12097 | 44% |
-| **Total** | **27681** | **100%** |
+| Python (backend) | 12124 | 44% |
+| **Total** | **27708** | **100%** |

--- a/scenes/draft/graph-panel-demo.json
+++ b/scenes/draft/graph-panel-demo.json
@@ -1920,60 +1920,36 @@
               "graph": {
                 "nodes": [
                   {
-                    "id": "__multiply_1",
-                    "type": "operator",
-                    "op": "multiply",
-                    "subexpr": "\\alpha \\in \\mathbb{C}"
-                  },
-                  {
                     "id": "alpha",
                     "type": "scalar",
                     "latex": "\\alpha",
                     "subexpr": "\\alpha"
                   },
                   {
-                    "id": "__multiply_2",
-                    "type": "operator",
-                    "op": "multiply",
-                    "subexpr": "\\in \\mathbb{C}"
-                  },
-                  {
-                    "id": "in",
-                    "type": "scalar",
-                    "latex": "\\in",
-                    "subexpr": "\\in"
-                  },
-                  {
                     "id": "C",
                     "type": "scalar",
                     "latex": "\\mathbb{C}",
-                    "subexpr": "\\mathbb{C}"
+                    "subexpr": "{C}"
+                  },
+                  {
+                    "id": "__element_of_1",
+                    "type": "relation",
+                    "subexpr": "\\alpha \\in \\mathbb{C}",
+                    "op": "element_of",
+                    "label": "element of",
+                    "emoji": "∈"
                   }
                 ],
                 "edges": [
                   {
                     "from": "alpha",
-                    "to": "__multiply_1",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "in",
-                    "to": "__multiply_2",
-                    "semantic": "direct",
-                    "weight": 1.0
+                    "to": "__element_of_1",
+                    "role": "lhs"
                   },
                   {
                     "from": "C",
-                    "to": "__multiply_2",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "__multiply_2",
-                    "to": "__multiply_1",
-                    "semantic": "direct",
-                    "weight": 1.0
+                    "to": "__element_of_1",
+                    "role": "rhs"
                   }
                 ],
                 "classification": {

--- a/scripts/graph_to_mermaid.py
+++ b/scripts/graph_to_mermaid.py
@@ -175,6 +175,8 @@ RELATION_SYMBOLS: dict[str, str] = {
     "proportional": "∝",
     "approximately": "≈",
     "maps_to": "→",
+    "element_of": "∈",
+    "not_element_of": "∉",
 }
 
 

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -1562,19 +1562,26 @@ def _classify_expression(expr: sympy.Basic) -> dict[str, Any]:
     return meta
 
 
-def _split_on_top_level_newline(latex: str) -> list[str]:
-    r"""Split *latex* on top-level ``\\`` (LaTeX line-break) tokens that act
-    as **statement separators**.
+_QUAD_COMMA_RE = re.compile(r",\s*\\(?:quad|qquad)\b")
 
-    A ``\\`` is treated as a separator only when it sits at brace / paren /
-    bracket depth 0 — i.e. outside every ``{...}``, ``(...)``, ``[...]``
-    group.  Inside environments like ``\begin{cases}`` or matrices the
-    double-backslash is a row separator, not a statement separator, but
-    those environments are already wrapped in braces so the depth check
-    handles them automatically.
 
-    Returns a list of trimmed, non-empty sub-expressions.  A single-element
-    list means no top-level ``\\`` was found.
+def _split_on_statement_separators(latex: str) -> list[str]:
+    r"""Split *latex* on **statement separators** at brace depth 0.
+
+    Two separator conventions are recognized in a single pass:
+
+    1. ``\\`` — LaTeX line-break.  The strongest separator.  An optional
+       spacing argument (``\\[6pt]``) is consumed and discarded.
+    2. ``, \quad`` / ``, \qquad`` — a comma immediately followed by a
+       ``\quad`` or ``\qquad`` spacing command.  The typographic
+       convention for separating independent assertions on one line.
+
+    Both are only matched at brace/paren/bracket depth 0, so they are
+    inert inside ``{...}``, ``(...)``, ``[...]`` groups (e.g. inside
+    ``\begin{cases}`` environments or matrices).
+
+    Returns a list of trimmed, non-empty sub-expressions.  A
+    single-element list means no separator was found.
     """
     parts: list[str] = []
     depth = 0
@@ -1591,6 +1598,7 @@ def _split_on_top_level_newline(latex: str) -> list[str]:
                 depth -= 1
             i += 1
         elif ch == "\\" and depth == 0:
+            # --- ``\\`` newline separator ---
             if i + 1 < n and latex[i + 1] == "\\":
                 end_of_bs = i + 2
                 after = end_of_bs
@@ -1609,6 +1617,23 @@ def _split_on_top_level_newline(latex: str) -> list[str]:
                 i = after
             else:
                 i += 1
+        elif ch == "," and depth == 0:
+            # --- ``, \quad`` / ``, \qquad`` separator ---
+            bs = 0
+            j = i - 1
+            while j >= 0 and latex[j] == "\\":
+                bs += 1
+                j -= 1
+            if bs % 2 == 1:
+                i += 1
+                continue
+            m = _QUAD_COMMA_RE.match(latex, i)
+            if m:
+                parts.append(latex[start:i])
+                start = m.end()
+                i = start
+                continue
+            i += 1
         else:
             i += 1
     parts.append(latex[start:])
@@ -1664,55 +1689,6 @@ def _split_on_top_level_comma(latex: str) -> list[str]:
                 continue
             parts.append(latex[start:i])
             start = i + 1
-    parts.append(latex[start:])
-    nonempty = [p.strip() for p in parts if p.strip()]
-    return nonempty if nonempty else [latex]
-
-
-_QUAD_COMMA_RE = re.compile(r",\s*\\(?:quad|qquad)\b")
-
-
-def _split_on_quad_comma(latex: str) -> list[str]:
-    r"""Split on ``, \quad`` or ``, \qquad`` at brace depth 0.
-
-    In mathematical typesetting, ``\quad`` (1 em space) after a comma is
-    the conventional signal for a **statement boundary** — it separates
-    independent assertions on the same line.  A bare comma without
-    ``\quad`` typically groups items within the same assertion (function
-    arguments, subject lists like ``\alpha, \beta \in \mathbb{C}``).
-
-    Returns a list of trimmed, non-empty clauses.  A single-element list
-    means no ``\quad``-comma was found (caller should fall back to bare
-    comma splitting).
-    """
-    parts: list[str] = []
-    depth = 0
-    start = 0
-    i = 0
-    n = len(latex)
-    while i < n:
-        ch = latex[i]
-        if ch in "{([":
-            depth += 1
-        elif ch in "})]":
-            if depth > 0:
-                depth -= 1
-        elif ch == "," and depth == 0:
-            bs = 0
-            j = i - 1
-            while j >= 0 and latex[j] == "\\":
-                bs += 1
-                j -= 1
-            if bs % 2 == 1:
-                i += 1
-                continue
-            m = _QUAD_COMMA_RE.match(latex, i)
-            if m:
-                parts.append(latex[start:i])
-                start = m.end()
-                i = start
-                continue
-        i += 1
     parts.append(latex[start:])
     nonempty = [p.strip() for p in parts if p.strip()]
     return nonempty if nonempty else [latex]
@@ -2107,13 +2083,13 @@ def latex_to_semantic_graph(latex: str, overrides: dict[str, dict[str, str]] | N
     latex = _normalize_latex(latex)
     latex, parenthetical_annotations = _extract_parenthetical_annotations(latex)
 
-    # ``\\`` (LaTeX newline) is the strongest separator — check before
-    # any other splitting or SymPy parsing.  Each clause is parsed
-    # independently via recursive ``latex_to_semantic_graph`` calls.
-    newline_clauses = _split_on_top_level_newline(latex)
-    if len(newline_clauses) > 1:
+    # --- Strong statement separators (``\\`` and ``, \quad``) ---
+    # Both are checked in a single pass before any preprocessing.
+    # Each resulting clause is parsed independently via recursive calls.
+    strong_clauses = _split_on_statement_separators(latex)
+    if len(strong_clauses) > 1:
         graph = _build_comma_separated_graph(
-            newline_clauses, overrides=user_overrides, domain=domain,
+            strong_clauses, overrides=user_overrides, domain=domain,
         )
         _inject_annotations(graph, parenthetical_annotations)
         return graph
@@ -2150,17 +2126,14 @@ def latex_to_semantic_graph(latex: str, overrides: dict[str, dict[str, str]] | N
         )
         return graph
 
-    # --- Comma split ---
-    # Prefer ``, \quad`` as the statement separator — it's the
-    # typographic convention for independent assertions on one line.
-    # Bare commas without ``\quad`` stay within their clause, naturally
-    # preserving subject-grouping commas like ``\alpha, \beta \in C``.
-    # Fall back to bare comma split + re-joining when no ``\quad`` is present.
-    clauses = _split_on_quad_comma(latex)
-    if len(clauses) <= 1:
-        clauses = _split_on_top_level_comma(latex)
-        if len(clauses) > 1:
-            clauses = _rejoin_subject_group_commas(clauses)
+    # --- Bare-comma split (fallback) ---
+    # Strong separators (``\\``, ``, \quad``) were already handled above.
+    # Bare commas without ``\quad`` may still separate statements
+    # (e.g. ``a = 1, b = 2``).  Re-join subject-group commas so that
+    # ``\alpha, \beta \in \mathbb{C}`` stays as one clause.
+    clauses = _split_on_top_level_comma(latex)
+    if len(clauses) > 1:
+        clauses = _rejoin_subject_group_commas(clauses)
     if len(clauses) > 1:
         graph = _build_comma_separated_graph(
             clauses, overrides=user_overrides, domain=domain,

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -132,6 +132,12 @@ _ASYMMETRIC_OPS: set[str] = {
     "element_of", "not_element_of",
 }
 
+# Relations that scope over commas: commas on either side are operand
+# conjunctions, not statement separators.  Other (object-level) relations
+# like ``\in`` or ``\leq`` do NOT scope over commas — the comma split
+# runs first and the relation is found per-clause.
+_META_RELATION_OPS: set[str] = {"implies", "iff"}
+
 # Synthetic placeholder names emitted by ``_collapse_compound_symbols``,
 # ``_collapse_text_commands``, and ``_collapse_braket_notation``. Used to
 # gate placeholder restoration so user overrides keyed on real symbol names
@@ -1663,6 +1669,125 @@ def _split_on_top_level_comma(latex: str) -> list[str]:
     return nonempty if nonempty else [latex]
 
 
+_QUAD_COMMA_RE = re.compile(r",\s*\\(?:quad|qquad)\b")
+
+
+def _split_on_quad_comma(latex: str) -> list[str]:
+    r"""Split on ``, \quad`` or ``, \qquad`` at brace depth 0.
+
+    In mathematical typesetting, ``\quad`` (1 em space) after a comma is
+    the conventional signal for a **statement boundary** — it separates
+    independent assertions on the same line.  A bare comma without
+    ``\quad`` typically groups items within the same assertion (function
+    arguments, subject lists like ``\alpha, \beta \in \mathbb{C}``).
+
+    Returns a list of trimmed, non-empty clauses.  A single-element list
+    means no ``\quad``-comma was found (caller should fall back to bare
+    comma splitting).
+    """
+    parts: list[str] = []
+    depth = 0
+    start = 0
+    i = 0
+    n = len(latex)
+    while i < n:
+        ch = latex[i]
+        if ch in "{([":
+            depth += 1
+        elif ch in "})]":
+            if depth > 0:
+                depth -= 1
+        elif ch == "," and depth == 0:
+            bs = 0
+            j = i - 1
+            while j >= 0 and latex[j] == "\\":
+                bs += 1
+                j -= 1
+            if bs % 2 == 1:
+                i += 1
+                continue
+            m = _QUAD_COMMA_RE.match(latex, i)
+            if m:
+                parts.append(latex[start:i])
+                start = m.end()
+                i = start
+                continue
+        i += 1
+    parts.append(latex[start:])
+    nonempty = [p.strip() for p in parts if p.strip()]
+    return nonempty if nonempty else [latex]
+
+
+_LEADING_SPACE_CMD_RE = re.compile(r"^\s*(?:\\(?:quad|qquad|,|;|!|:)\s*)+")
+
+
+def _is_bare_variable(clause: str) -> bool:
+    r"""Return ``True`` when *clause* looks like a bare variable/symbol.
+
+    A "bare variable" is a single symbol token — e.g. ``\alpha``,
+    ``x``, ``\hat{y}``, ``\mathbb{C}`` — with no operators.  Used by
+    :func:`_rejoin_subject_group_commas` to detect the subject-grouping
+    comma pattern ``\alpha, \beta \in \mathbb{C}``.
+    """
+    stripped = _LEADING_SPACE_CMD_RE.sub("", clause).strip()
+    if not stripped:
+        return False
+    if _split_on_relation(stripped) is not None:
+        return False
+    d = 0
+    for ch in stripped:
+        if ch in "{([":
+            d += 1
+        elif ch in "})]":
+            if d > 0:
+                d -= 1
+        elif d == 0 and ch in "=+":
+            return False
+    return True
+
+
+def _rejoin_subject_group_commas(clauses: list[str]) -> list[str]:
+    r"""Re-join comma-separated subject lists that precede a relation.
+
+    In mathematical notation ``\alpha, \beta \in \mathbb{C}`` means *both*
+    α and β belong to ℂ.  After :func:`_split_on_top_level_comma` this
+    becomes ``['\alpha', '\beta \in \mathbb{C}']`` — the bare ``\alpha``
+    clause should be re-joined with ``\beta \in \mathbb{C}`` to form the
+    composite expression ``\alpha, \beta \in \mathbb{C}``.
+
+    A bare-variable clause is re-joined with its successor when:
+
+    1. It contains no relation operator and no arithmetic operators
+       (``=``, ``+``) at depth 0 — see :func:`_is_bare_variable`.
+    2. The successor contains a relation operator from ``RELATION_MAP``.
+
+    The loop runs until no more re-joins are possible, handling chains
+    like ``x, y, z \in \mathbb{R}`` (three variables, one relation).
+    """
+    if len(clauses) <= 1:
+        return clauses
+    result = list(clauses)
+    changed = True
+    while changed:
+        changed = False
+        merged: list[str] = []
+        i = 0
+        while i < len(result):
+            if (
+                i + 1 < len(result)
+                and _is_bare_variable(result[i])
+                and _split_on_relation(result[i + 1]) is not None
+            ):
+                merged.append(result[i] + ", " + result[i + 1])
+                i += 2
+                changed = True
+            else:
+                merged.append(result[i])
+                i += 1
+        result = merged
+    return result
+
+
 def _split_on_relation(latex: str) -> tuple[str, dict[str, str], str] | None:
     """If *latex* contains a top-level relation operator from RELATION_MAP,
     return ``(lhs_latex, relation_meta, rhs_latex)``.  Returns ``None``
@@ -1685,11 +1810,16 @@ def _split_on_relation(latex: str) -> tuple[str, dict[str, str], str] | None:
             depth[i] = d
     for cmd, meta in RELATION_MAP:
         clen = len(cmd)
+        cmd_is_alpha = cmd[-1].isalpha()
         idx = 0
         while idx <= n - clen:
             pos = latex.find(cmd, idx)
             if pos == -1:
                 break
+            end = pos + clen
+            if cmd_is_alpha and end < n and latex[end].isalpha():
+                idx = end
+                continue
             if depth[pos] == 0:
                 if best is None or pos < best[0]:
                     best = (pos, cmd, meta)
@@ -1732,6 +1862,94 @@ def _split_chained_equals(latex: str) -> tuple[str, dict[str, str], str] | None:
         meta = {"op": "equals", "label": "equals", "emoji": "="}
         return lhs, meta, rhs
     return None
+
+
+def _build_relation_graph(
+    lhs_latex: str,
+    rel_meta: dict[str, str],
+    rhs_latex: str,
+    original_latex: str,
+    *,
+    overrides: dict[str, dict[str, str]] | None,
+    latex_commands: dict[str, str] | None = None,
+    parenthetical_annotations: list | None = None,
+    domain: str | None = None,
+) -> dict:
+    r"""Build a graph for a binary relation ``lhs <op> rhs``.
+
+    Handles comma-joined operand conjunctions on either side (e.g. the
+    LHS of ``\alpha, \beta \in \mathbb{C}`` becomes an ``and`` node
+    grouping α and β).  Classification falls back to ``algebraic`` when
+    either side is a conjunction.
+    """
+    builder = SemanticGraphBuilder(
+        overrides=overrides,
+        latex_commands=latex_commands or {},
+        original_latex=original_latex,
+    )
+
+    def _walk_relation_side(side_latex: str) -> tuple[str, sympy.Basic | None]:
+        side_clauses = _split_on_top_level_comma(side_latex)
+        if len(side_clauses) <= 1:
+            expr = parse_latex(side_latex)
+            return builder._walk(expr), expr
+
+        clause_roots: list[str] = []
+        for clause in side_clauses:
+            cleaned = _LEADING_SPACE_CMD_RE.sub("", clause).strip()
+            sub_expr = parse_latex(cleaned)
+            cid = builder._walk(sub_expr)
+            for node in builder.nodes:
+                if node["id"] == cid:
+                    node["subexpr"] = builder._restore_placeholders(cleaned)
+                    break
+            clause_roots.append(cid)
+        conj_id = builder._next_id("and")
+        builder._add_node(
+            conj_id,
+            type="relation",
+            op="and",
+            label="and",
+            emoji=",",
+            subexpr=builder._restore_placeholders(side_latex.strip()),
+        )
+        for cid in clause_roots:
+            builder._add_edge(cid, conj_id)
+        return conj_id, None
+
+    try:
+        lhs_id, lhs_expr = _walk_relation_side(lhs_latex)
+        rhs_id, rhs_expr = _walk_relation_side(rhs_latex)
+    except Exception as exc:
+        raise ValueError(f"Failed to parse LaTeX: {exc}") from exc
+
+    for node in builder.nodes:
+        if node["id"] == lhs_id and lhs_expr is not None:
+            node["subexpr"] = builder._restore_placeholders(lhs_latex.strip())
+        elif node["id"] == rhs_id and rhs_expr is not None:
+            node["subexpr"] = builder._restore_placeholders(rhs_latex.strip())
+
+    rel_id = builder._next_id(rel_meta["op"])
+    builder._add_node(
+        rel_id, type="relation", subexpr=original_latex.strip(), **rel_meta,
+    )
+    rel_asymmetric = rel_meta["op"] in _ASYMMETRIC_OPS
+    builder._add_edge(lhs_id, rel_id, role="lhs" if rel_asymmetric else None)
+    builder._add_edge(rhs_id, rel_id, role="rhs" if rel_asymmetric else None)
+
+    graph: dict = {"nodes": builder.nodes, "edges": builder.edges}
+    if lhs_expr is not None and rhs_expr is not None:
+        try:
+            combined = lhs_expr - rhs_expr
+        except TypeError:
+            combined = lhs_expr
+        graph["classification"] = _classify_expression(combined)
+    else:
+        graph["classification"] = {"kind": "algebraic"}
+    if domain:
+        graph["domain"] = domain
+    _inject_annotations(graph, parenthetical_annotations or [])
+    return graph
 
 
 def _build_comma_separated_graph(
@@ -1916,110 +2134,50 @@ def latex_to_semantic_graph(latex: str, overrides: dict[str, dict[str, str]] | N
     }
     overrides = merged_overrides
 
-    # Check for a top-level relation operator (before the comma split).
-    # When a relation is present, comma-joined clauses on either side are
-    # operand-level conjunctions — the comma scopes inside the
-    # connective's operand, not above it. See #208: previously the comma
-    # split ran first and orphaned the second RHS clause from the
-    # ``\implies`` node.
+    # Detect the top-level relation once; reused by both the meta-first
+    # path and the deferred object-relation path below.
     rel = _split_on_relation(preprocessed)
-    if rel is not None:
+
+    # --- Meta relations (implies, iff) take priority over commas (#208) ---
+    # Commas on either side of a meta connective are operand-level
+    # conjunctions, not statement separators.
+    if rel is not None and rel[1]["op"] in _META_RELATION_OPS:
         lhs_latex, rel_meta, rhs_latex = rel
-        builder = SemanticGraphBuilder(overrides=overrides, latex_commands=latex_commands, original_latex=latex)
-
-        def _walk_relation_side(side_latex: str) -> tuple[str, sympy.Basic | None]:
-            """Walk a relation operand. Returns ``(root_id, expr)`` where
-            ``expr`` is the parsed SymPy expression for the side, or
-            ``None`` when the side is a comma-joined conjunction (no
-            single SymPy expression — each clause is parsed
-            independently and joined under a synthetic ``and`` relation
-            node)."""
-            side_clauses = _split_on_top_level_comma(side_latex)
-            if len(side_clauses) <= 1:
-                expr = parse_latex(side_latex)
-                return builder._walk(expr), expr
-
-            _leading_space = re.compile(r"^\s*(?:\\(?:quad|qquad|,|;|!|:)\s*)+")
-            clause_roots: list[str] = []
-            for clause in side_clauses:
-                cleaned = _leading_space.sub("", clause).strip()
-                sub_expr = parse_latex(cleaned)
-                cid = builder._walk(sub_expr)
-                for node in builder.nodes:
-                    if node["id"] == cid:
-                        node["subexpr"] = builder._restore_placeholders(cleaned)
-                        break
-                clause_roots.append(cid)
-            conj_id = builder._next_id("and")
-            builder._add_node(
-                conj_id,
-                type="relation",
-                op="and",
-                label="and",
-                emoji=",",
-                subexpr=builder._restore_placeholders(side_latex.strip()),
-            )
-            for cid in clause_roots:
-                builder._add_edge(cid, conj_id)
-            return conj_id, None
-
-        try:
-            lhs_id, lhs_expr = _walk_relation_side(lhs_latex)
-            rhs_id, rhs_expr = _walk_relation_side(rhs_latex)
-        except Exception as exc:
-            raise ValueError(f"Failed to parse LaTeX: {exc}") from exc
-
-        # Restore subexpr on the side root nodes when they are *not*
-        # synthetic conjunction nodes (those already carry the full side
-        # latex from creation; per-clause subexprs were set per-clause
-        # above). For single-expression sides, the SymPy walk leaves an
-        # internal subexpr — overwrite with the side slice so the
-        # tooltip reflects the side string we actually parsed.
-        # ``lhs_latex``/``rhs_latex`` come from
-        # ``_split_on_relation(preprocessed)``, so they are the
-        # preprocessed/cleaned side LaTeX (e.g. ``x_i`` brace-canonicalized
-        # to ``x_{i}``, spacing macros stripped). This matches the
-        # pre-existing convention for relation-side ``subexpr`` values.
-        for node in builder.nodes:
-            if node["id"] == lhs_id and not (lhs_expr is None):
-                node["subexpr"] = builder._restore_placeholders(lhs_latex.strip())
-            elif node["id"] == rhs_id and not (rhs_expr is None):
-                node["subexpr"] = builder._restore_placeholders(rhs_latex.strip())
-        rel_id = builder._next_id(rel_meta["op"])
-        builder._add_node(rel_id, type="relation", subexpr=latex.strip(), **rel_meta)
-        rel_asymmetric = rel_meta["op"] in _ASYMMETRIC_OPS
-        builder._add_edge(lhs_id, rel_id, role="lhs" if rel_asymmetric else None)
-        builder._add_edge(rhs_id, rel_id, role="rhs" if rel_asymmetric else None)
-        graph = {"nodes": builder.nodes, "edges": builder.edges}
-        # Classify based on both sides combined when both are single
-        # SymPy expressions. Relational expressions (inequalities, Eq)
-        # don't support arithmetic, so fall back gracefully. When either
-        # side is a comma-joined conjunction we have no single
-        # expression to classify, so default to algebraic.
-        if lhs_expr is not None and rhs_expr is not None:
-            try:
-                combined = lhs_expr - rhs_expr
-            except TypeError:
-                combined = lhs_expr
-            graph["classification"] = _classify_expression(combined)
-        else:
-            graph["classification"] = {"kind": "algebraic"}
-        if domain:
-            graph["domain"] = domain
-        _inject_annotations(graph, parenthetical_annotations)
+        graph = _build_relation_graph(
+            lhs_latex, rel_meta, rhs_latex, latex,
+            overrides=overrides, latex_commands=latex_commands,
+            parenthetical_annotations=parenthetical_annotations, domain=domain,
+        )
         return graph
 
-    # A top-level comma now acts as a statement separator (preserves
-    # existing ``a = 1, b = 2`` behavior — multiple independent rooted
-    # statements, no synthetic ``and`` node). Pass only the user-supplied
-    # overrides; the recursive call re-derives text/compound placeholders
-    # per clause so they don't collide with parent-scoped ``Xi_{N}`` ids.
-    clauses = _split_on_top_level_comma(latex)
+    # --- Comma split ---
+    # Prefer ``, \quad`` as the statement separator — it's the
+    # typographic convention for independent assertions on one line.
+    # Bare commas without ``\quad`` stay within their clause, naturally
+    # preserving subject-grouping commas like ``\alpha, \beta \in C``.
+    # Fall back to bare comma split + re-joining when no ``\quad`` is present.
+    clauses = _split_on_quad_comma(latex)
+    if len(clauses) <= 1:
+        clauses = _split_on_top_level_comma(latex)
+        if len(clauses) > 1:
+            clauses = _rejoin_subject_group_commas(clauses)
     if len(clauses) > 1:
         graph = _build_comma_separated_graph(
             clauses, overrides=user_overrides, domain=domain,
         )
         _inject_annotations(graph, parenthetical_annotations)
+        return graph
+
+    # --- Object-level relations (\in, \leq, etc.) ---
+    # Reached when the expression is a single clause (possibly after
+    # re-joining collapsed all commas back, e.g. ``α, β ∈ ℂ``).
+    if rel is not None:
+        lhs_latex, rel_meta, rhs_latex = rel
+        graph = _build_relation_graph(
+            lhs_latex, rel_meta, rhs_latex, latex,
+            overrides=overrides, latex_commands=latex_commands,
+            parenthetical_annotations=parenthetical_annotations, domain=domain,
+        )
         return graph
 
     # Chained equals (``a = b = c``): SymPy produces

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -129,6 +129,7 @@ OPERATOR_MAP: dict[type, str] = {
 
 _ASYMMETRIC_OPS: set[str] = {
     "greater_than", "less_than", "greater_equal", "less_equal",
+    "element_of", "not_element_of",
 }
 
 # Synthetic placeholder names emitted by ``_collapse_compound_symbols``,
@@ -170,6 +171,8 @@ RELATION_MAP: list[tuple[str, dict[str, str]]] = [
     (r"\to", {"op": "maps_to", "label": "maps to", "emoji": "→"}),
     (r"\rightarrow", {"op": "maps_to", "label": "maps to", "emoji": "→"}),
     (r"\neq", {"op": "not_equal", "label": "not equal to", "emoji": "≠"}),
+    (r"\notin", {"op": "not_element_of", "label": "not element of", "emoji": "∉"}),
+    (r"\in", {"op": "element_of", "label": "element of", "emoji": "∈"}),
     (r"\gt", {"op": "greater_than", "label": "greater than", "emoji": ">"}),
     (r"\lt", {"op": "less_than", "label": "less than", "emoji": "<"}),
 ]
@@ -354,6 +357,7 @@ _OPERATOR_KINDS: dict[str, str] = {
     "equals": "comparison", "not_equal": "comparison",
     "greater_than": "comparison", "less_than": "comparison",
     "greater_equal": "comparison", "less_equal": "comparison",
+    "element_of": "comparison", "not_element_of": "comparison",
     # logical
     "implies": "logical", "iff": "logical",
     "not": "logical", "logical_not": "logical",

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -171,6 +171,7 @@ const OPERATOR_GLYPHS = {
 const OPERATOR_LATEX = {
     equals: '=', greater_than: '>', less_than: '<',
     greater_equal: '\\geq', less_equal: '\\leq', not_equal: '\\neq',
+    element_of: '\\in', not_element_of: '\\notin',
     multiply: '\\times', add: '+', subtract: '-',
     divide: '\\div', integral: '\\int',
     implies: '\\Rightarrow', iff: '\\Leftrightarrow',
@@ -207,6 +208,7 @@ const OPERATOR_KINDS = {
     equals: 'comparison', not_equal: 'comparison',
     greater_than: 'comparison', less_than: 'comparison',
     greater_equal: 'comparison', less_equal: 'comparison',
+    element_of: 'comparison', not_element_of: 'comparison',
     implies: 'logical', iff: 'logical',
     not: 'logical', logical_not: 'logical',
     conjunction: 'logical', disjunction: 'logical',

--- a/static/graph-panel/graph-panel.js
+++ b/static/graph-panel/graph-panel.js
@@ -235,13 +235,13 @@ export class SemanticGraphPanel {
     const fieldsEl = this.panel.querySelector(".gp-fields");
     const emoji = data.emoji || "";
     const expr = this._subexprs[nodeId];
-    const hasOwnLatex = !!data.latex;
+    const isOp = data.type === 'operator' || data.type === 'relation' || data.type === 'function';
     // Details panel shows the *long label* — the full applied form
     // (``\cos(θ/2)``, ``⟨0|ψ⟩``, ``|⟨0|ψ⟩|²``).  ``nodeLongLabel``
     // encapsulates the precedence (``subexpr → latex → short``).
     const titleLatex = nodeLongLabel(data) || null;
     const titleText = data.id || "";
-    const showEmoji = emoji && hasOwnLatex;
+    const showEmoji = emoji && !isOp;
 
     if (titleLatex && this.katex) {
       try {

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -976,18 +976,20 @@ function _showD3InfoPanel(nodeId, nodeData, graph) {
     // (``\cos(θ/2)``, ``⟨0|ψ⟩``, ``|⟨0|ψ⟩|²``).  ``nodeLongLabel``
     // encapsulates the precedence (``subexpr → latex → short``).
     const latex = nodeLongLabel(fullNode);
+    const isOp = fullNode.type === 'operator' || fullNode.type === 'relation' || fullNode.type === 'function';
+    const showEmoji = fullNode.emoji && !isOp;
     if (latex && window.katex) {
         try {
             const span = document.createElement('span');
             window.katex.render(latex, span, { displayMode: false, throwOnError: false });
             symbolEl.innerHTML = '';
-            if (fullNode.emoji) symbolEl.appendChild(document.createTextNode(fullNode.emoji + ' '));
+            if (showEmoji) symbolEl.appendChild(document.createTextNode(fullNode.emoji + ' '));
             symbolEl.appendChild(span);
         } catch (_) {
-            symbolEl.textContent = (fullNode.emoji || '') + ' ' + (fullNode.label || fullNode.id);
+            symbolEl.textContent = (showEmoji ? fullNode.emoji + ' ' : '') + (fullNode.label || fullNode.id);
         }
     } else {
-        symbolEl.textContent = (fullNode.emoji || '') + ' ' + (fullNode.label || fullNode.id);
+        symbolEl.textContent = (showEmoji ? fullNode.emoji + ' ' : '') + (fullNode.label || fullNode.id);
     }
     symbolEl.style.opacity = '1';
     symbolEl.style.fontSize = '';

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -552,6 +552,89 @@ class TestRelationOperandComma:
         assert len(equals_nodes) == 2
 
 
+class TestSubjectGroupComma:
+    r"""Subject-grouping commas: ``\alpha, \beta \in \mathbb{C}`` means both
+    α and β belong to ℂ.  The comma between α and β groups them as a
+    composite LHS for the ``\in`` relation, not as a statement separator."""
+
+    def _reaches(self, graph, src, dst):
+        adj: dict[str, list[str]] = {}
+        for e in graph["edges"]:
+            adj.setdefault(e["from"], []).append(e["to"])
+        seen = {src}
+        stack = [src]
+        while stack:
+            cur = stack.pop()
+            if cur == dst:
+                return True
+            for nxt in adj.get(cur, []):
+                if nxt not in seen:
+                    seen.add(nxt)
+                    stack.append(nxt)
+        return False
+
+    def test_alpha_beta_in_C(self):
+        r"""``\alpha, \beta \in \mathbb{C}`` produces an element_of relation
+        with a conjunction (and) LHS grouping α and β."""
+        g = latex_to_semantic_graph(r"\alpha, \beta \in \mathbb{C}")
+        elem = _find_node(g, type="relation", op="element_of")
+        assert elem is not None
+        conj = _find_node(g, type="relation", op="and")
+        assert conj is not None, "expected an 'and' conjunction for the composite LHS"
+        assert self._reaches(g, "alpha", conj["id"])
+        assert self._reaches(g, "beta", conj["id"])
+        assert self._reaches(g, conj["id"], elem["id"])
+        assert self._reaches(g, "C", elem["id"])
+
+    def test_three_variables_in_R(self):
+        r"""``x, y, z \in \mathbb{R}`` — chained subject grouping."""
+        g = latex_to_semantic_graph(r"x, y, z \in \mathbb{R}")
+        elem = _find_node(g, type="relation", op="element_of")
+        assert elem is not None
+        conj = _find_node(g, type="relation", op="and")
+        assert conj is not None
+        for var in ("x", "y", "z"):
+            assert self._reaches(g, var, elem["id"]), f"{var} should reach element_of"
+
+    def test_multi_statement_with_subject_group(self):
+        r"""``a = 1, \quad \alpha, \beta \in \mathbb{C}`` should produce
+        two independent statements: the equality and the element_of."""
+        g = latex_to_semantic_graph(
+            r"a = 1, \quad \alpha, \beta \in \mathbb{C}"
+        )
+        eq = _find_node(g, type="operator", op="equals")
+        elem = _find_node(g, type="relation", op="element_of")
+        assert eq is not None, "expected an equals node for a = 1"
+        assert elem is not None, "expected an element_of node for α, β ∈ ℂ"
+
+    def test_subject_group_does_not_merge_expressions(self):
+        r"""``x + 1, y \in S`` — the ``x + 1`` clause has operators,
+        so it should NOT be merged with ``y \in S``."""
+        g = latex_to_semantic_graph(r"x + 1, y \in S")
+        elem = _find_node(g, type="relation", op="element_of")
+        assert elem is not None
+        add = _find_node(g, type="operator", op="add")
+        assert add is not None, "x + 1 should parse as a separate clause with add"
+
+    def test_quad_comma_separates_statements(self):
+        r"""``\quad`` after a comma is the strongest statement boundary.
+        ``\alpha,\beta\in\mathbb{C}`` stays intact because the comma
+        between α and β has no ``\quad``."""
+        g = latex_to_semantic_graph(
+            r"a = 1, \quad \alpha,\beta\in\mathbb{C}, "
+            r"\quad |\alpha|^2 + |\beta|^2 = 1"
+        )
+        equals = _find_nodes(g, type="operator", op="equals")
+        elem = _find_node(g, type="relation", op="element_of")
+        assert len(equals) == 2, f"expected 2 equals nodes, got {len(equals)}"
+        assert elem is not None, "expected element_of for α,β ∈ ℂ"
+        conj = _find_node(g, type="relation", op="and")
+        assert conj is not None, "expected 'and' conjunction grouping α and β"
+        assert self._reaches(g, "alpha", conj["id"])
+        assert self._reaches(g, "beta", conj["id"])
+        assert self._reaches(g, conj["id"], elem["id"])
+
+
 class TestTextCommand:
     """\\text{NAME} should become a single text node, not decomposed into
     per-character multiplications (SymPy's parse_latex default behavior)."""

--- a/tests/test_latex_to_graph.py
+++ b/tests/test_latex_to_graph.py
@@ -635,6 +635,64 @@ class TestSubjectGroupComma:
         assert self._reaches(g, conj["id"], elem["id"])
 
 
+class TestStatementSeparators:
+    r"""Scene-level regression tests for the unified statement separator
+    that handles both ``\\`` and ``, \quad`` in a single pass."""
+
+    def _reaches(self, graph, src, dst):
+        adj: dict[str, list[str]] = {}
+        for e in graph["edges"]:
+            adj.setdefault(e["from"], []).append(e["to"])
+        seen = {src}
+        stack = [src]
+        while stack:
+            cur = stack.pop()
+            if cur == dst:
+                return True
+            for nxt in adj.get(cur, []):
+                if nxt not in seen:
+                    seen.add(nxt)
+                    stack.append(nxt)
+        return False
+
+    def test_general_qubit_step(self):
+        r"""'Start with a general qubit' scene step uses ``, \quad`` to
+        separate three statements:
+        ``|\psi\rangle = \alpha|0\rangle + \beta|1\rangle``,
+        ``\alpha,\beta\in\mathbb{C}``, and
+        ``|\alpha|^2 + |\beta|^2 = 1``."""
+        g = latex_to_semantic_graph(
+            r"\htmlClass{hl-gen}{\lvert\psi\rangle = \alpha\lvert 0\rangle"
+            r" + \beta\lvert 1\rangle}, \quad \alpha,\beta\in\mathbb{C},"
+            r" \quad \lvert\alpha\rvert^2 + \lvert\beta\rvert^2 = 1"
+        )
+        equals = _find_nodes(g, type="operator", op="equals")
+        elem = _find_node(g, type="relation", op="element_of")
+        assert len(equals) == 2, f"expected 2 equals nodes, got {len(equals)}"
+        assert elem is not None, "expected element_of for α,β ∈ ℂ"
+        conj = _find_node(g, type="relation", op="and")
+        assert conj is not None, "expected 'and' conjunction grouping α and β"
+        assert self._reaches(g, "alpha", conj["id"])
+        assert self._reaches(g, "beta", conj["id"])
+        assert self._reaches(g, conj["id"], elem["id"])
+
+    def test_borns_rule_step(self):
+        r"""'Apply Born's rule' scene step uses ``\\`` to separate two
+        equations: ``p(0) = \cos^2(\theta/2)`` and
+        ``p(1) = \sin^2(\theta/2)``."""
+        g = latex_to_semantic_graph(
+            r"p(0)=\lvert\langle 0\vert\psi\rangle\rvert^2="
+            r"\htmlClass{hl-p0}{\cos^2\!\left(\frac{\theta}{2}\right)}"
+            r" \\ "
+            r"p(1)=\lvert\langle 1\vert\psi\rangle\rvert^2="
+            r"\htmlClass{hl-p1}{\sin^2\!\left(\frac{\theta}{2}\right)}"
+        )
+        equals = _find_nodes(g, type="operator", op="equals")
+        assert len(equals) >= 2, (
+            f"expected at least 2 equals nodes (one per line), got {len(equals)}"
+        )
+
+
 class TestTextCommand:
     """\\text{NAME} should become a single text node, not decomposed into
     per-character multiplications (SymPy's parse_latex default behavior)."""


### PR DESCRIPTION
## Summary

- Parse `\in` (element-of) and `\notin` (not-element-of) as first-class relation operators across the full stack: Python parser, Mermaid renderer, D3 JS renderer, and demo scene
- Fix duplicate emoji display in node detail panels (e.g. `∈ α ∈ ℂ` → `α ∈ ℂ`)
- Use `, \quad` / `, \qquad` as statement separators instead of bare commas, preserving subject-grouping patterns like `α, β ∈ ℂ`
- Unify `\\` (newline) and `, \quad` splitting into a single `_split_on_statement_separators` pass
- Fix `\in` incorrectly matching inside `\infty` via word-boundary check in `_split_on_relation`
- Fall back to bare-comma split with heuristic re-joining for expressions without `\quad`

## Changes

**Element-of relation (initial feature)**
- `scripts/latex_to_graph.py` — Add `\in`/`\notin` to `RELATION_MAP`, `_ASYMMETRIC_OPS`, `_OPERATOR_KINDS`
- `scripts/graph_to_mermaid.py` — Add `element_of`/`not_element_of` to `RELATION_SYMBOLS`
- `static/graph-panel/d3-semantic-graph.js` — Add to `OPERATOR_LATEX` and `OPERATOR_KINDS`
- `static/graph-view.js` / `static/graph-panel/graph-panel.js` — Fix duplicate emoji with `isOp` check
- `scenes/draft/graph-panel-demo.json` — Update step 22 graph

**Statement separator consolidation**
- `scripts/latex_to_graph.py`:
  - Add `_split_on_statement_separators` — handles both `\\` and `, \quad` in one depth-tracking pass
  - Add `_META_RELATION_OPS` — meta relations (`\implies`, `\iff`) scope over commas (#208)
  - Add `_is_bare_variable`, `_rejoin_subject_group_commas` — heuristic re-joining for bare-comma fallback
  - Extract `_build_relation_graph` helper — reusable for meta and object-level relation paths
  - Word-boundary fix in `_split_on_relation` — prevents `\in` matching inside `\infty`
  - Remove `_split_on_top_level_newline` and `_split_on_quad_comma` (consolidated)

**Tests** (7 new + 1 pre-existing fix)
- `TestSubjectGroupComma` — 5 tests for subject-grouping commas
- `TestStatementSeparators` — 2 scene-level regression tests from quantum-states.json
- `test_sum_with_limits` — pre-existing test now passes (was failing on main)

## Test plan

### Automated
- [ ] **CI: Tests** — `./run.sh -m pytest tests/` passes (419 passed, 1 skipped)
- [ ] **CI: CodeQL** — no new security findings
- [ ] **CI: Validate Data Files** — scene JSON schema validation passes
- [ ] **CI: Audit Expression Sandbox Coverage** — expression audit passes

### Manual verification
- [ ] **Run the test suite locally**
  ```bash
  ./run.sh -m pytest tests/test_latex_to_graph.py -v -k "SubjectGroup or StatementSep"
  ```
- [ ] **Verify subject grouping** — `α, β ∈ ℂ` produces `and(α,β) → element_of → ℂ`, not two separate clauses
  ```bash
  ./run.sh scripts/latex_to_graph.py '\alpha, \beta \in \mathbb{C}'
  ```
- [ ] **Verify statement splitting** — three independent clauses from `, \quad` separators
  ```bash
  ./run.sh scripts/latex_to_graph.py 'a = 1, \quad \alpha,\beta\in\mathbb{C}, \quad |\alpha|^2 + |\beta|^2 = 1'
  ```
- [ ] **Verify `\\` splitting** — Born's rule expression splits into two equations
  ```bash
  ./run.sh scripts/latex_to_graph.py 'p(0)=\cos^2(\theta/2) \\ p(1)=\sin^2(\theta/2)'
  ```
- [ ] **Verify `\infty` regression** — `\in` does not match inside `\infty`
  ```bash
  ./run.sh scripts/latex_to_graph.py '\sum_{n=1}^\infty n'
  ```
- [ ] **Start dev server** and open quantum-states scene → check "Start with a general qubit" step renders the semantic graph with element_of relation and and-conjunction for α,β

Closes #281

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>