### PR TITLE
fix(ci): remove [skip ci] from LOC report to unblock PR checks

### DIFF
--- a/.github/workflows/loc-report.yml
+++ b/.github/workflows/loc-report.yml
@@ -23,7 +23,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           SHA="${{ github.event.pull_request.head.sha }}"
-          LOGIN=$(gh api "repos/${{ github.repository }}/commits/${SHA}" --jq '.author.login // empty')
+          LOGIN=$(gh api "repos/${{ github.repository }}/commits/${SHA}" --jq '.author.login // empty' 2>/dev/null || true)
           if [ "$LOGIN" = "github-actions[bot]" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "Skipping — HEAD commit is from github-actions[bot]"

--- a/.github/workflows/loc-report.yml
+++ b/.github/workflows/loc-report.yml
@@ -18,16 +18,15 @@ jobs:
     steps:
       - name: Skip if triggered by bot commit
         id: guard
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          SHA="${{ github.event.pull_request.head.sha || github.sha }}"
-          AUTHOR=$(gh api "repos/${{ github.repository }}/commits/${SHA}" --jq '.commit.author.name')
-          if [ "$AUTHOR" = "github-actions[bot]" ]; then
+          SHA="${{ github.event.pull_request.head.sha }}"
+          LOGIN=$(gh api "repos/${{ github.repository }}/commits/${SHA}" --jq '.author.login // empty')
+          if [ "$LOGIN" = "github-actions[bot]" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "Skipping — HEAD commit is from github-actions[bot]"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/checkout@v4

--- a/.github/workflows/loc-report.yml
+++ b/.github/workflows/loc-report.yml
@@ -16,22 +16,40 @@ jobs:
   loc-report:
     runs-on: ubuntu-latest
     steps:
+      - name: Skip if triggered by bot commit
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          AUTHOR=$(gh api "repos/${{ github.repository }}/commits/${SHA}" --jq '.commit.author.name')
+          if [ "$AUTHOR" = "github-actions[bot]" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping — HEAD commit is from github-actions[bot]"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.guard.outputs.skip != 'true'
         with:
           ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || github.ref }}
 
       - uses: taiki-e/install-action@v2
+        if: steps.guard.outputs.skip != 'true'
         with:
           tool: tokei@14.0.0
 
       - name: Generate report
+        if: steps.guard.outputs.skip != 'true'
         run: ./scripts/loc-report.sh LOC-REPORT.md
 
       - name: Post summary
+        if: steps.guard.outputs.skip != 'true'
         run: cat LOC-REPORT.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Commit report if code lines changed
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.guard.outputs.skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         run: |
           # Strip volatile metadata (Branch/Commit/Date) before comparing
           # so only actual code-line changes trigger a commit.
@@ -43,6 +61,6 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add LOC-REPORT.md
-            git diff --cached --quiet || git commit -m "docs: update lines-of-code report [skip ci]"
+            git diff --cached --quiet || git commit -m "docs: update lines-of-code report"
             git push
           fi


### PR DESCRIPTION
## Summary
- The LOC report workflow committed with `[skip ci]`, which suppressed **all** workflow triggers on the new HEAD commit — including the Tests workflow
- PRs showed "Waiting for status to be reported" for the pytest check because it never ran on the LOC commit
- Replaced `[skip ci]` with a guard step that checks if the HEAD commit author is `github-actions[bot]` and skips only the LOC workflow itself
- Other workflows (Tests, etc.) now trigger normally on the LOC commit

## Test plan
- [ ] Open a PR with Python changes, verify the LOC report commits without `[skip ci]`
- [ ] Verify the Tests workflow runs on the LOC report's commit
- [ ] Verify the LOC workflow does not loop (skips when HEAD is from bot)

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>