### PR TITLE
refactor: return SemanticGraph model and move server into backend

### DIFF
--- a/LOC-REPORT.md
+++ b/LOC-REPORT.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 |---|---|
-| **Branch** | `feat/303-semantic-graph-module` |
-| **Commit** | `9f41bb4` |
-| **Date** | 2026-05-19 19:39:00 -0400 |
+| **Branch** | `feat/semantic-graph-model-return` |
+| **Commit** | `07ba759` |
+| **Date** | 2026-05-19 22:00:26 -0400 |
 
 ## Language Breakdown
 
@@ -17,7 +17,7 @@
 xychart-beta horizontal
   title "Lines of Code by Language"
   x-axis ["JSON", "JavaScript", "Python", "CSS", "HTML", "Shell", "BASH"]
-  bar [49589, 15584, 12851, 4219, 395, 138, 33]
+  bar [49589, 15584, 12884, 4219, 395, 138, 34]
 ```
 
 ## Summary by Language
@@ -28,10 +28,10 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  JSON                     41        49590        49589            0            1
  JavaScript               46        18023        15584          974         1465
- Python                   53        16292        12851         1306         2135
+ Python                   53        16323        12884         1288         2151
  CSS                       3         4581         4219          169          193
  Shell                     2          176          138           16           22
- BASH                      1           41           33            4            4
+ BASH                      1           42           34            4            4
  Plain Text                1            9            0            9            0
 ─────────────────────────────────────────────────────────────────────────────────
  HTML                      3          412          395            7           10
@@ -47,7 +47,7 @@ xychart-beta horizontal
  |- Python                 3          441          407            4           30
  (Total)                            13209         1878         8548         2783
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                   206       103037        85319        11049         6669
+ Total                   206       103069        85353        11031         6685
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -132,31 +132,31 @@ xychart-beta horizontal
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Language              Files        Lines         Code     Comments       Blanks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Python                   53        16292        12851         1306         2135
+ Python                   53        16323        12884         1288         2151
 ─────────────────────────────────────────────────────────────────────────────────
- |ebench/algebench/server.py         2055         1735          133          187
- |aph/test_latex_to_graph.py         1983         1569          161          253
- |_graph/sympy_translator.py         1405         1212           49          144
+ |lgebench/backend/server.py         2037         1726          124          187
+ |aph/test_latex_to_graph.py         1984         1570          161          253
+ |_graph/sympy_translator.py         1417         1221           49          147
  |semantic_graph_enricher.py         1144          798          214          132
  |semantic_graph_enricher.py          853          676          106           71
  |cripts/graph_to_mermaid.py          871          613          174           84
- |h/algebench/agent_tools.py          610          522           35           53
+ |nch/backend/agent_tools.py          610          522           35           53
  |ripts/audit_expressions.py          697          515           90           92
- |nch/scripts/render_math.py          509          468            4           37
+ |nch/scripts/render_math.py          510          469            4           37
  |cripts/validate_content.py          602          453           42          107
  |s/test_graph_to_mermaid.py          612          440           89           83
  |ntic_graph/preprocessor.py          309          281            6           22
+ |raph/test_postprocessor.py          318          233           24           61
  |h/test_sympy_translator.py          333          231           22           80
  |t_autofill_proof_shapes.py          262          224            6           32
  |ripts/extract_structure.py          259          218            5           36
- |ic_graph/equation_chain.py          247          215            1           31
- |raph/test_postprocessor.py          290          211           24           55
+ |ic_graph/equation_chain.py          250          217            1           32
  |ench/scripts/lint_scene.py          236          185           14           37
- |tic_graph/postprocessor.py          204          173            9           22
+ |tic_graph/postprocessor.py          200          168            9           23
  |emantic_graph/constants.py          196          156           12           28
  |scripts/validate_schema.py          180          154            1           25
  |/scripts/assemble_scene.py          187          144            1           42
- |graph_highlight_overlay.py          183          134           11           38
+ |graph_highlight_overlay.py          178          137            2           39
  |/tests/test_render_math.py          177          124           18           35
  |graph/test_preprocessor.py          185          120           18           47
  |aph/test_equation_chain.py          177          114           15           48
@@ -168,15 +168,15 @@ xychart-beta horizontal
  |ests/test_path_security.py          109           83            0           26
  |ntic_graph/test_service.py           90           68            0           22
  |resolve_scene_path_safe.py           81           61            0           20
+ |mantic_graph/test_cache.py           70           57            0           13
  |ents/test_schema_parity.py           73           55            0           18
  |t_semantic_graph_themes.py           69           51            0           18
- |mantic_graph/test_cache.py           61           50            0           11
  |ests/test_scene_schemas.py           66           50            0           16
  |/agents/test_base_agent.py           71           47            0           24
- |/semantic_graph/service.py           51           40            0           11
+ |/semantic_graph/service.py           53           41            0           12
  |/test_preprocess_result.py           44           37            0            7
+ |nd/semantic_graph/cache.py           41           29            0           12
  |/backend/model/__init__.py           31           29            0            2
- |nd/semantic_graph/cache.py           39           28            0           11
  |semantic_graph/__init__.py           25           22            0            3
  |backend/agents/__init__.py           20           18            0            2
  |graph/preprocess_result.py           16           11            0            5
@@ -188,7 +188,7 @@ xychart-beta horizontal
  |/backend/model/__init__.py            0            0            0            0
  |lgebench/tests/__init__.py            0            0            0            0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                    53        16292        12851         1306         2135
+ Total                    53        16323        12884         1288         2151
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -197,5 +197,5 @@ xychart-beta horizontal
 | Category | Code Lines | % of JS+Python |
 |---|---|---|
 | JavaScript (frontend) | 15584 | 54% |
-| Python (backend) | 12851 | 46% |
-| **Total** | **28435** | **100%** |
+| Python (backend) | 12884 | 46% |
+| **Total** | **28468** | **100%** |

--- a/algebench
+++ b/algebench
@@ -38,4 +38,5 @@ if [ -f "$DIR/.env.local" ]; then
     set +a
 fi
 
-exec "$VENV/bin/python3" "$DIR/server.py" "$@"
+export PYTHONPATH="${DIR}${PYTHONPATH:+:$PYTHONPATH}"
+exec "$VENV/bin/python3" "$DIR/backend/server.py" "$@"

--- a/backend/agent_tools.py
+++ b/backend/agent_tools.py
@@ -307,7 +307,7 @@ def _make_tools(*exclude_names):
 
 def _load_agent_tools_reference():
     """Load the agent tools reference from the external markdown file."""
-    ref_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'agent-tools-reference.md')
+    ref_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'agent-tools-reference.md')
     try:
         with open(ref_path, 'r') as f:
             return f.read()
@@ -603,7 +603,7 @@ def build_system_prompt(context, agent_memory=None):
     for s in sections:
         if f"## {s}" in prompt_text:
             included.append(s)
-    import server as _srv
+    import backend.server as _srv
     if getattr(_srv, 'DEBUG_MODE', False):
         print(f"   📋 System prompt sections: {', '.join(included)} ({len(prompt_text)} chars)")
 

--- a/backend/model/semantic_graph.py
+++ b/backend/model/semantic_graph.py
@@ -95,7 +95,7 @@ class SemanticGraphNode(BaseModel):
 class SemanticGraphEdge(BaseModel):
     """An edge in the semantic graph."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     from_: str = Field(alias="from", min_length=1, max_length=80, pattern=_NO_HTML)
     to: str = Field(min_length=1, max_length=80, pattern=_NO_HTML)

--- a/backend/semantic_graph/cache.py
+++ b/backend/semantic_graph/cache.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from backend.model.semantic_graph import SemanticGraph
+
 _MISS = object()
 
 
@@ -11,9 +13,9 @@ class GraphCache:
     """Memoize parsed semantic graphs by (latex, domain) key."""
 
     def __init__(self) -> None:
-        self._store: dict[str | tuple[str, str | None], dict | None] = {}
+        self._store: dict[str | tuple[str, str | None], SemanticGraph | None] = {}
 
-    def get(self, latex: str, domain: str | None = None) -> dict | None | Any:
+    def get(self, latex: str, domain: str | None = None) -> SemanticGraph | None | Any:
         """Return the cached graph, or the *_MISS* sentinel if absent."""
         key = (latex, domain) if domain else latex
         return self._store.get(key, _MISS)
@@ -22,7 +24,7 @@ class GraphCache:
         self,
         latex: str,
         domain: str | None,
-        graph: dict | None,
+        graph: SemanticGraph | None,
     ) -> None:
         """Store *graph* under the (latex, domain) key."""
         key = (latex, domain) if domain else latex

--- a/backend/semantic_graph/equation_chain.py
+++ b/backend/semantic_graph/equation_chain.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+from backend.model.semantic_graph import (
+    SemanticGraph,
+    SemanticGraphNode,
+    SemanticGraphEdge,
+    Classification,
+)
+
 from .preprocessor import LaTeXPreprocessor
 from .postprocessor import GraphPostprocessor
 from .sympy_translator import latex_to_semantic_graph as _translate
@@ -109,7 +116,7 @@ def _split_equation_chain_sides(latex: str) -> list[str]:
     return [p for p in parts if p]
 
 
-def _derive_single_expression(latex: str) -> dict | None:
+def _derive_single_expression(latex: str) -> SemanticGraph | None:
     """Full pipeline for a single expression: preprocess -> translate -> postprocess."""
     if not isinstance(latex, str) or not latex:
         return None
@@ -121,7 +128,7 @@ def _derive_single_expression(latex: str) -> dict | None:
     return _postprocessor.postprocess(graph, result)
 
 
-def derive_equation_chain_graph(latex: str) -> dict | None:
+def derive_equation_chain_graph(latex: str) -> SemanticGraph | None:
     """Derive a semantic graph for a possibly-chained equation.
 
     For ``a = b = c = d`` each side is parsed as its own sub-graph, then
@@ -164,8 +171,8 @@ def derive_equation_chain_graph(latex: str) -> dict | None:
         return graph
 
     # --- Chain with 3+ sides: per-side preprocess, translate, merge ---
-    merged_nodes: dict[str, dict] = {}
-    merged_edges: list[dict] = []
+    merged_nodes: dict[str, SemanticGraphNode] = {}
+    merged_edges: list[SemanticGraphEdge] = []
     roots: list[str] = []
     dotted_vars: dict[str, int] = {}
     all_annotations: list[dict] = list(early_annotations)
@@ -183,7 +190,7 @@ def derive_equation_chain_graph(latex: str) -> dict | None:
             sub = _translate(rewritten)
         except Exception:
             return None
-        if not isinstance(sub, dict) or not sub.get("nodes"):
+        if not sub.nodes:
             return None
 
         _postprocessor.restore_subscripts(sub, mapping)
@@ -195,53 +202,49 @@ def derive_equation_chain_graph(latex: str) -> dict | None:
         def _rename(nid: str, p: str = prefix) -> str:
             return p + nid if nid.startswith("__") else nid
 
-        for n in sub.get("nodes") or []:
-            if not isinstance(n, dict):
-                continue
-            nid = n.get("id")
-            if not isinstance(nid, str):
-                continue
+        for n in sub.nodes:
+            nid = n.id
             new_id = _rename(nid)
-            cloned = dict(n)
-            cloned["id"] = new_id
+            cloned = n.model_copy(update={"id": new_id})
             if new_id not in merged_nodes:
                 merged_nodes[new_id] = cloned
             else:
                 existing = merged_nodes[new_id]
-                for k, v in cloned.items():
-                    existing.setdefault(k, v)
+                for field_name in type(n).model_fields:
+                    if field_name == "id":
+                        continue
+                    new_val = getattr(cloned, field_name)
+                    if new_val is not None and getattr(existing, field_name) is None:
+                        setattr(existing, field_name, new_val)
 
-        for e in sub.get("edges") or []:
-            merged_edges.append({
-                "from": _rename(e.get("from", "")),
-                "to": _rename(e.get("to", "")),
-            })
+        for e in sub.edges:
+            merged_edges.append(SemanticGraphEdge(
+                from_=_rename(e.from_),
+                to=_rename(e.to),
+            ))
 
-        out_set = {e.get("from") for e in sub.get("edges") or []}
-        root_candidates = [
-            n.get("id") for n in sub.get("nodes") or []
-            if isinstance(n, dict) and n.get("id") not in out_set
-        ]
+        out_set = {e.from_ for e in sub.edges}
+        root_candidates = [n.id for n in sub.nodes if n.id not in out_set]
         if root_candidates:
             roots.append(_rename(root_candidates[0]))
         else:
-            roots.append(_rename(sub["nodes"][0].get("id", "")))
+            roots.append(_rename(sub.nodes[0].id))
 
     equals_id = "__equals_1"
-    merged_nodes[equals_id] = {
-        "id": equals_id,
-        "type": "operator",
-        "op": "equals",
-        "subexpr": " = ".join(sides),
-    }
+    merged_nodes[equals_id] = SemanticGraphNode(
+        id=equals_id,
+        type="operator",
+        op="equals",
+        subexpr=" = ".join(sides),
+    )
     for r in roots:
         if r:
-            merged_edges.append({"from": r, "to": equals_id})
+            merged_edges.append(SemanticGraphEdge(from_=r, to=equals_id))
 
-    graph = {
-        "nodes": list(merged_nodes.values()),
-        "edges": merged_edges,
-        "classification": {"kind": "algebraic"},
-    }
+    graph = SemanticGraph(
+        nodes=list(merged_nodes.values()),
+        edges=merged_edges,
+        classification=Classification(kind="algebraic"),
+    )
     _postprocessor.inject_annotations(graph, all_annotations)
     return graph

--- a/backend/semantic_graph/postprocessor.py
+++ b/backend/semantic_graph/postprocessor.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from typing import Any
 
+from backend.model.semantic_graph import SemanticGraph, SemanticGraphNode, SemanticGraphEdge
+
 from .constants import _ORDER_TO_ACCENT
 
 
@@ -14,7 +16,7 @@ def _re_sub_literal(pattern: str, replacement: str, text: str) -> str:
 
 
 class GraphPostprocessor:
-    """Stateless postprocessor: each method mutates a graph dict in-place."""
+    """Stateless postprocessor: each method mutates a ``SemanticGraph`` in-place."""
 
     # ------------------------------------------------------------------
     # Public orchestrator
@@ -22,9 +24,9 @@ class GraphPostprocessor:
 
     def postprocess(
         self,
-        graph: dict | None,
+        graph: SemanticGraph | None,
         result: Any,
-    ) -> dict | None:
+    ) -> SemanticGraph | None:
         """Run all postprocessing passes on *graph* using *result* metadata.
 
         *result* is a ``PreprocessResult`` (or any object with the same attrs).
@@ -46,65 +48,58 @@ class GraphPostprocessor:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def reject_degenerate(graph: dict) -> bool:
+    def reject_degenerate(graph: SemanticGraph) -> bool:
         """Return ``True`` if the graph is a single ``__expr_*`` placeholder."""
-        nodes = graph.get("nodes") or []
-        if (len(nodes) == 1 and isinstance(nodes[0], dict)
-                and isinstance(nodes[0].get("id"), str)
-                and nodes[0]["id"].startswith("__expr_")):
+        nodes = graph.nodes
+        if len(nodes) == 1 and nodes[0].id.startswith("__expr_"):
             return True
         return False
 
     @staticmethod
     def restore_dot_notation(
-        graph: dict,
+        graph: SemanticGraph,
         dotted_vars: dict[str, int],
     ) -> None:
         """Walk every node's ``subexpr`` and restore ``\\dot`` notation."""
-        if not isinstance(graph, dict) or not dotted_vars:
+        if not dotted_vars:
             return
-        for node in graph.get("nodes") or []:
-            if not isinstance(node, dict):
-                continue
-            sub = node.get("subexpr")
+        for node in graph.nodes:
+            sub = node.subexpr
             if isinstance(sub, str) and "\\frac" in sub:
-                node["subexpr"] = _restore_dot_notation_str(sub, dotted_vars)
+                node.subexpr = _restore_dot_notation_str(sub, dotted_vars)
 
     @staticmethod
     def restore_accents(
-        graph: dict | None,
+        graph: SemanticGraph | None,
         accent_map: dict[str, str],
     ) -> None:
         """Re-wrap stripped accents in each node's display ``latex`` field."""
         if not graph or not accent_map:
             return
-        nodes = graph.get("nodes") or []
-        for node in nodes:
-            if not isinstance(node, dict):
+        for node in graph.nodes:
+            if node.type in ("operator", "relation"):
                 continue
-            if node.get("type") in ("operator", "relation"):
-                continue
-            latex = node.get("latex")
+            latex = node.latex
             if not isinstance(latex, str) or not latex:
                 continue
             for body, accent in accent_map.items():
                 if f"\\{accent}{{{body}}}" in latex:
                     continue
                 if latex == body:
-                    node["latex"] = f"\\{accent}{{{body}}}"
+                    node.latex = f"\\{accent}{{{body}}}"
                     if accent == "vec":
-                        node["type"] = "vector"
+                        node.type = "vector"
                     break
                 if latex.startswith(body) and len(latex) > len(body):
                     tail = latex[len(body):]
                     if tail[0] in "_^":
-                        node["latex"] = f"\\{accent}{{{body}}}{tail}"
+                        node.latex = f"\\{accent}{{{body}}}{tail}"
                         if accent == "vec":
-                            node["type"] = "vector"
+                            node.type = "vector"
                         break
 
     @staticmethod
-    def restore_subscripts(graph: dict, mapping: dict[str, str]) -> None:
+    def restore_subscripts(graph: SemanticGraph, mapping: dict[str, str]) -> None:
         """Swap each Greek placeholder back to the original subscript body."""
         if not mapping:
             return
@@ -126,50 +121,51 @@ class GraphPostprocessor:
 
         _TEXT_POLLUTION_KEYS = ("emoji", "quantity", "dimension", "unit", "value", "role")
 
-        for node in graph.get("nodes") or []:
-            if not isinstance(node, dict):
-                continue
-            node_id = node.get("id")
-            if isinstance(node_id, str) and node_id in mapping:
+        for node in graph.nodes:
+            node_id = node.id
+            if node_id in mapping:
                 original = mapping[node_id]
                 display, is_text = _display_of(original)
-                node["id"] = display
-                node["label"] = display
-                node["latex"] = original
+                node.id = display
+                node.label = display
+                node.latex = original
                 if is_text:
-                    node["type"] = "text"
+                    node.type = "text"
                     for k in _TEXT_POLLUTION_KEYS:
-                        node.pop(k, None)
-                    node.pop("role", None)
-                if "subexpr" in node and isinstance(node["subexpr"], str):
-                    node["subexpr"] = rewrite(node["subexpr"])
+                        setattr(node, k, None)
+                    node.role = None
+                if node.subexpr is not None:
+                    node.subexpr = rewrite(node.subexpr)
                 continue
             for field in ("id", "label", "latex", "subexpr"):
-                if field in node and isinstance(node[field], str):
-                    node[field] = rewrite(node[field])
-        for edge in graph.get("edges") or []:
-            if not isinstance(edge, dict):
-                continue
-            for field in ("from", "to"):
-                if field in edge and isinstance(edge[field], str):
-                    val = edge[field]
+                val = getattr(node, field, None)
+                if isinstance(val, str):
+                    setattr(node, field, rewrite(val))
+        for edge in graph.edges:
+            for attr in ("from_", "to"):
+                val = getattr(edge, attr)
+                if isinstance(val, str):
                     if val in mapping:
                         display, _ = _display_of(mapping[val])
-                        edge[field] = display
+                        setattr(edge, attr, display)
                     else:
-                        edge[field] = rewrite(val)
+                        setattr(edge, attr, rewrite(val))
 
     @staticmethod
     def inject_annotations(
-        graph: dict,
+        graph: SemanticGraph,
         annotations: list[dict[str, str]],
     ) -> None:
         """Append parenthetical annotation nodes to the graph."""
         for i, ann in enumerate(annotations):
             node_id = f"__annotation_{i}"
-            node: dict[str, Any] = {"id": node_id}
-            node.update(ann)
-            graph.setdefault("nodes", []).append(node)
+            node = SemanticGraphNode(
+                id=node_id,
+                type=ann.get("type", "annotation"),
+                label=ann.get("label"),
+                latex=ann.get("latex"),
+            )
+            graph.nodes.append(node)
 
 
 # ------------------------------------------------------------------

--- a/backend/semantic_graph/service.py
+++ b/backend/semantic_graph/service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from backend.model.semantic_graph import SemanticGraph
+
 from .cache import GraphCache, _MISS
 from .equation_chain import derive_equation_chain_graph
 from .postprocessor import GraphPostprocessor
@@ -17,8 +19,8 @@ class SemanticGraphService:
         self._preprocessor = LaTeXPreprocessor()
         self._postprocessor = GraphPostprocessor()
 
-    def derive(self, latex: str, domain: str | None = None) -> dict | None:
-        """Parse *latex* and return a semantic graph dict, or None on failure.
+    def derive(self, latex: str, domain: str | None = None) -> SemanticGraph | None:
+        """Parse *latex* and return a ``SemanticGraph``, or None on failure.
 
         Results are memoized by (latex, domain).
         """
@@ -32,7 +34,7 @@ class SemanticGraphService:
         graph = derive_equation_chain_graph(latex)
         if graph is not None:
             if domain:
-                graph["domain"] = domain
+                graph.domain = domain
             self._cache.put(latex, domain, graph)
             return graph
 

--- a/backend/semantic_graph/sympy_translator.py
+++ b/backend/semantic_graph/sympy_translator.py
@@ -23,6 +23,8 @@ from sympy.parsing.latex import parse_latex
 from sympy.physics.quantum.state import KetBase, BraBase
 from sympy.physics.quantum import InnerProduct
 
+from backend.model.semantic_graph import SemanticGraph
+
 from .preprocessor import LaTeXPreprocessor
 from .constants import (
     KNOWN_VARIABLES,
@@ -1224,7 +1226,7 @@ def _build_comma_separated_graph(
 
     for ci, clause in enumerate(cleaned_clauses):
         try:
-            sub = latex_to_semantic_graph(clause, overrides=overrides, domain=domain)
+            sub = _latex_to_semantic_graph_dict(clause, overrides=overrides, domain=domain)
         except Exception as exc:
             raise ValueError(
                 f"Failed to parse clause {ci + 1} ({clause!r}) of "
@@ -1288,12 +1290,12 @@ def _build_comma_separated_graph(
 # Main entry point
 # ---------------------------------------------------------------------------
 
-def latex_to_semantic_graph(
+def _latex_to_semantic_graph_dict(
     latex: str,
     overrides: dict[str, dict[str, str]] | None = None,
     domain: str | None = None,
 ) -> dict:
-    """Parse a LaTeX string and return a semantic graph dict."""
+    """Parse a LaTeX string and return a semantic graph dict (internal)."""
     user_overrides = overrides
     latex = _normalize_latex(latex)
     latex, parenthetical_annotations = _extract_parenthetical_annotations(latex)
@@ -1403,3 +1405,13 @@ def latex_to_semantic_graph(
         graph["domain"] = domain
     _inject_annotations(graph, parenthetical_annotations)
     return graph
+
+
+def latex_to_semantic_graph(
+    latex: str,
+    overrides: dict[str, dict[str, str]] | None = None,
+    domain: str | None = None,
+) -> SemanticGraph:
+    """Parse a LaTeX string and return a ``SemanticGraph`` model instance."""
+    raw = _latex_to_semantic_graph_dict(latex, overrides=overrides, domain=domain)
+    return SemanticGraph.model_validate(raw)

--- a/backend/server.py
+++ b/backend/server.py
@@ -32,7 +32,7 @@ import uvicorn
 from google import genai
 from google.genai import types
 
-script_dir = Path(__file__).parent.resolve()
+script_dir = Path(__file__).parent.parent.resolve()
 scenes_dir = script_dir / "scenes"
 
 # ---------------------------------------------------------------------------
@@ -551,7 +551,7 @@ def generate_html(debug=False):
     with open(index_html_path, 'r') as f:
         return f.read().replace('__DEBUG_MODE__', debug_mode_js)
 
-from agent_tools import (
+from backend.agent_tools import (
     ALL_TOOL_DECLS, _make_tools, build_system_prompt,
     NAVIGATE_TOOL_DECL, SET_CAMERA_TOOL_DECL, ADD_SCENE_TOOL_DECL,
     SET_SLIDERS_TOOL_DECL, EVAL_MATH_TOOL_DECL,

--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,7 @@
 # Usage:
 #   ./run.sh schemas/validate.py scenes/*.json
 #   ./run.sh schemas/validate.py --check-schema
-#   ./run.sh server.py
+#   ./run.sh backend/server.py
 #   ./run.sh -m pytest tests/
 #
 # Handles venv creation and dependency install on first use.

--- a/scripts/latex_to_graph.py
+++ b/scripts/latex_to_graph.py
@@ -94,7 +94,7 @@ def main() -> None:
         sys.exit(1)
 
     indent = 2 if args.pretty else None
-    result = json.dumps(graph, indent=indent, ensure_ascii=False)
+    result = json.dumps(graph.model_dump(by_alias=True, exclude_none=True), indent=indent, ensure_ascii=False)
 
     if args.output:
         with open(args.output, "w", encoding="utf-8") as f:

--- a/scripts/render_math.py
+++ b/scripts/render_math.py
@@ -283,7 +283,7 @@ class MathRenderer:
 
     def _build_mermaid_card(self) -> tuple[str, dict]:
         graph = self._graph if self._graph else latex_to_semantic_graph(self.latex)
-        graph_dict = graph.model_dump(by_alias=True) if hasattr(graph, "model_dump") else graph
+        graph_dict = graph.model_dump(by_alias=True, exclude_none=True) if hasattr(graph, "model_dump") else graph
         if self.validate:
             errors = validate_graph(graph_dict)
             if errors:

--- a/scripts/render_math.py
+++ b/scripts/render_math.py
@@ -283,15 +283,16 @@ class MathRenderer:
 
     def _build_mermaid_card(self) -> tuple[str, dict]:
         graph = self._graph if self._graph else latex_to_semantic_graph(self.latex)
+        graph_dict = graph.model_dump(by_alias=True) if hasattr(graph, "model_dump") else graph
         if self.validate:
-            errors = validate_graph(graph)
+            errors = validate_graph(graph_dict)
             if errors:
                 raise ValueError(
                     "Graph failed schema validation:\n"
                     + "\n".join(f"  {e}" for e in errors)
                 )
         mermaid_src = semantic_graph_to_mermaid(
-            graph, theme=self.graph_theme, label_mode=self.label_mode,
+            graph_dict, theme=self.graph_theme, label_mode=self.label_mode,
             show=self.show, color_by=self.color_by,
         )
         card = (
@@ -300,11 +301,11 @@ class MathRenderer:
             f'  <pre class="mermaid">\n{mermaid_src}  </pre>\n'
             "</div>"
         )
-        return card, graph
+        return card, graph_dict
 
     @staticmethod
     def _build_hover_script(graph: dict) -> str:
-        if not graph.get("nodes"):
+        if not graph or not graph.get("nodes"):
             return ""
         graph_panel_js = _GRAPH_PANEL_JS
         graph_json = json.dumps(graph).replace("</", "<\\/")

--- a/server.py
+++ b/server.py
@@ -38,6 +38,7 @@ scenes_dir = script_dir / "scenes"
 # ---------------------------------------------------------------------------
 # Semantic-graph auto-derivation for proof steps missing explicit graphs.
 # ---------------------------------------------------------------------------
+from backend.model.semantic_graph import SemanticGraph, SemanticGraphNode
 from backend.semantic_graph import SemanticGraphService
 from backend.semantic_graph.preprocessor import LaTeXPreprocessor
 from backend.semantic_graph.constants import _DOT_ACCENT_ORDERS
@@ -103,7 +104,7 @@ def _extract_htmlclass_pairs(latex: str) -> list[tuple[str, str]]:
 
 
 def _apply_highlights_to_graph(
-    graph: dict,
+    graph: SemanticGraph,
     hl_pairs: list[tuple[str, str]],
     highlights_meta: dict,
 ) -> None:
@@ -119,7 +120,7 @@ def _apply_highlights_to_graph(
     """
     if not graph or not hl_pairs or not isinstance(highlights_meta, dict):
         return
-    nodes = graph.get("nodes") or []
+    nodes = graph.nodes
 
     def _normalize(s: str) -> str:
         """Normalize LaTeX for comparison — peel visual accents (``\\vec``,
@@ -133,8 +134,6 @@ def _apply_highlights_to_graph(
         if not isinstance(s, str):
             return ""
         s = _strip_accent_commands(s)
-        # Repeatedly peel ``\dot{X}``/``\ddot{X}``/... → ``X`` (loop handles
-        # nested cases like ``\ddot{\vec{p}}`` after the accent strip above).
         prev = None
         while prev != s:
             prev = s
@@ -144,59 +143,42 @@ def _apply_highlights_to_graph(
         s = re.sub(r"\^([A-Za-z0-9])(?![A-Za-z0-9_{])", r"^{\1}", s)
         return s.replace(" ", "")
 
-    def _keys_for_node(n: dict) -> list[str]:
-        """Candidate normalized strings a highlight body might match against.
-
-        For leaf symbols, ``latex``/``id`` resolve to the symbol itself. For
-        intermediate operator/expression nodes, ``subexpr`` carries the
-        sympy-reconstructed LaTeX of the whole sub-tree — so a highlight
-        wrapping a sub-expression (e.g. ``\\htmlClass{hl-kinetic}{\\frac{1}{2}
-        m v^2}``) binds to the root operator of that sub-tree.
-        """
+    def _keys_for_node(n: SemanticGraphNode) -> list[str]:
+        """Candidate normalized strings a highlight body might match against."""
         keys: list[str] = []
         for f in ("latex", "id", "subexpr"):
-            v = n.get(f)
+            v = getattr(n, f, None)
             if isinstance(v, str):
                 keys.append(_normalize(v))
         return keys
 
-    # Also normalize body latex (strip surrounding whitespace; keep \text{}
-    # wrappers — restored subscripts should match).
     for class_key, body in hl_pairs:
         body = _normalize(body)
         meta = highlights_meta.get(class_key)
         if not isinstance(meta, dict):
             continue
-        # Prefer leaf symbols when the body is a bare symbol; fall back to
-        # operator/relation nodes (matched via ``subexpr``) when the body
-        # wraps an entire sub-expression.
-        matched: dict | None = None
+        matched = None
         for node in nodes:
-            if not isinstance(node, dict):
-                continue
-            if node.get("type") in ("operator", "relation"):
+            if node.type in ("operator", "relation"):
                 continue
             if body in _keys_for_node(node):
                 matched = node
                 break
         if matched is None:
             for node in nodes:
-                if not isinstance(node, dict):
-                    continue
-                if node.get("type") not in ("operator", "relation", "expression", "function"):
+                if node.type not in ("operator", "relation", "expression", "function"):
                     continue
                 if body in _keys_for_node(node):
                     matched = node
                     break
         if matched is None:
             continue
-        # Attach highlight metadata. Respect existing fields so hand-authored
-        # richness wins over auto-derived overlays.
-        if "color" in meta and not matched.get("color"):
-            matched["color"] = meta["color"]
-        if meta.get("label") and not matched.get("description"):
-            matched["description"] = meta["label"]
-        matched.setdefault("highlight", class_key)
+        if "color" in meta and not matched.color:
+            matched.color = meta["color"]
+        if meta.get("label") and not matched.description:
+            matched.description = meta["label"]
+        if not matched.highlight:
+            matched.highlight = class_key
 
 
 def _strip_html_class(latex: str) -> str:
@@ -329,7 +311,7 @@ def _autofill_semantic_graphs(scene: dict) -> dict:
                     _apply_highlights_to_graph(
                         graph, hl_pairs, step.get('highlights') or {},
                     )
-                    step['semanticGraph'] = {'graph': graph}
+                    step['semanticGraph'] = {'graph': graph.model_dump(by_alias=True, exclude_none=True)}
                     filled += 1
                 else:
                     if error_reason is None:
@@ -1388,7 +1370,7 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
         """
         try:
             graph = _graph_service.derive(req.latex, domain=req.domain)
-            return JSONResponse({"graph": graph})
+            return JSONResponse({"graph": graph.model_dump(by_alias=True, exclude_none=True) if graph else None})
         except (ValueError, SyntaxError, KeyError) as e:
             print(f"   ⚠️ /api/graph/from-latex parse error: {e}", flush=True)
             return JSONResponse({"error": "failed to derive semantic graph from LaTeX"}, status_code=400)

--- a/tests/backend/semantic_graph/test_cache.py
+++ b/tests/backend/semantic_graph/test_cache.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
+from backend.model.semantic_graph import SemanticGraph, SemanticGraphNode
 from backend.semantic_graph.cache import GraphCache, _MISS
+
+
+def _graph(*nodes: dict) -> SemanticGraph:
+    """Build a minimal SemanticGraph from node kwargs dicts."""
+    return SemanticGraph(
+        nodes=[SemanticGraphNode(type="scalar", **n) for n in nodes],
+        edges=[],
+    )
 
 
 class TestGraphCache:
@@ -12,21 +21,21 @@ class TestGraphCache:
 
     def test_put_and_get_no_domain(self):
         cache = GraphCache()
-        graph = {"nodes": [], "edges": []}
+        graph = SemanticGraph(nodes=[], edges=[])
         cache.put("x = 1", None, graph)
         assert cache.get("x = 1") is graph
 
     def test_put_and_get_with_domain(self):
         cache = GraphCache()
-        graph = {"nodes": [{"id": "x"}]}
+        graph = _graph({"id": "x"})
         cache.put("F = ma", "physics", graph)
         assert cache.get("F = ma", "physics") is graph
         assert cache.get("F = ma") is _MISS
 
     def test_domain_isolation(self):
         cache = GraphCache()
-        g1 = {"nodes": [{"id": "1"}]}
-        g2 = {"nodes": [{"id": "2"}]}
+        g1 = _graph({"id": "n1"})
+        g2 = _graph({"id": "n2"})
         cache.put("x", "physics", g1)
         cache.put("x", "math", g2)
         assert cache.get("x", "physics") is g1
@@ -40,21 +49,21 @@ class TestGraphCache:
 
     def test_clear(self):
         cache = GraphCache()
-        cache.put("x", None, {"nodes": []})
+        cache.put("x", None, SemanticGraph(nodes=[], edges=[]))
         cache.clear()
         assert cache.get("x") is _MISS
 
     def test_len(self):
         cache = GraphCache()
         assert len(cache) == 0
-        cache.put("a", None, {"nodes": []})
-        cache.put("b", "phys", {"nodes": []})
+        cache.put("a", None, SemanticGraph(nodes=[], edges=[]))
+        cache.put("b", "phys", SemanticGraph(nodes=[], edges=[]))
         assert len(cache) == 2
 
     def test_overwrite(self):
         cache = GraphCache()
-        g1 = {"nodes": [{"id": "old"}]}
-        g2 = {"nodes": [{"id": "new"}]}
+        g1 = _graph({"id": "old"})
+        g2 = _graph({"id": "new"})
         cache.put("x", None, g1)
         cache.put("x", None, g2)
         assert cache.get("x") is g2

--- a/tests/backend/semantic_graph/test_dot_notation_restore.py
+++ b/tests/backend/semantic_graph/test_dot_notation_restore.py
@@ -121,16 +121,16 @@ class TestIssue185Repro:
 
     def test_no_subexpr_carries_a_tab(self):
         g = _derive_semantic_graph(self.LATEX)
-        for node in g["nodes"]:
-            sub = node.get("subexpr", "")
+        for node in g.nodes:
+            sub = node.subexpr or ""
             assert "\t" not in sub, (
-                f"Node {node.get('id')!r} subexpr still has TAB: {sub!r}"
+                f"Node {node.id!r} subexpr still has TAB: {sub!r}"
             )
 
     def test_q_label_nodes_render_text_command_literally(self):
         g = _derive_semantic_graph(self.LATEX)
         # Both label nodes must keep ``\text{...}`` intact.
-        ids = {node["id"] for node in g["nodes"]}
+        ids = {node.id for node in g.nodes}
         assert r"q_{\text{lunar}}" in ids
         assert r"q_{\text{LEO}}" in ids
 
@@ -149,9 +149,9 @@ class TestIssue185Repro:
         # The deriv-operator nodes' subexprs should contain ``\dot{...}``
         # with the original ``\text{...}`` subscript fully preserved.
         deriv_subs = [
-            node.get("subexpr", "")
-            for node in g["nodes"]
-            if node.get("id", "").startswith("__deriv_")
+            node.subexpr or ""
+            for node in g.nodes
+            if node.id.startswith("__deriv_")
         ]
         assert deriv_subs, "expected at least one __deriv_* node"
         for sub in deriv_subs:

--- a/tests/backend/semantic_graph/test_equation_chain.py
+++ b/tests/backend/semantic_graph/test_equation_chain.py
@@ -111,8 +111,8 @@ class TestDeriveSingleExpression:
     def test_simple(self):
         graph = _derive_single_expression("F = m a")
         assert graph is not None
-        assert "nodes" in graph
-        assert "edges" in graph
+        assert graph.nodes is not None
+        assert graph.edges is not None
 
     def test_invalid(self):
         graph = _derive_single_expression("")
@@ -137,12 +137,12 @@ class TestDeriveEquationChainGraph:
     def test_simple_equation(self):
         graph = derive_equation_chain_graph("a = b")
         assert graph is not None
-        assert "nodes" in graph
+        assert graph.nodes is not None
 
     def test_chained_three_sides(self):
         graph = derive_equation_chain_graph("a = b = c")
         assert graph is not None
-        eq_nodes = [n for n in graph["nodes"] if n.get("op") == "equals"]
+        eq_nodes = [n for n in graph.nodes if n.op == "equals"]
         assert len(eq_nodes) >= 1
 
     def test_single_expression_no_equals(self):
@@ -166,12 +166,12 @@ class TestDeriveEquationChainGraph:
             r"F = ma \quad (v_e \text{ constant})"
         )
         assert graph is not None
-        ann_nodes = [n for n in graph["nodes"]
-                     if n.get("id", "").startswith("__annotation_")]
+        ann_nodes = [n for n in graph.nodes
+                     if n.id.startswith("__annotation_")]
         assert len(ann_nodes) >= 1
 
     def test_chain_merges_shared_variables(self):
         graph = derive_equation_chain_graph("x = y = x + 1")
         assert graph is not None
-        x_nodes = [n for n in graph["nodes"] if n.get("id") == "x"]
+        x_nodes = [n for n in graph.nodes if n.id == "x"]
         assert len(x_nodes) == 1

--- a/tests/backend/semantic_graph/test_latex_to_graph.py
+++ b/tests/backend/semantic_graph/test_latex_to_graph.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from backend.model.semantic_graph import SemanticGraph, SemanticGraphNode
 from backend.semantic_graph.sympy_translator import (
     latex_to_semantic_graph,
     parse_var_overrides,
@@ -20,23 +21,23 @@ from backend.semantic_graph.sympy_translator import (
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _find_node(graph, **attrs):
+def _find_node(graph: SemanticGraph, **attrs) -> SemanticGraphNode | None:
     """Find a node in the graph matching all given attrs."""
-    for node in graph["nodes"]:
-        if all(node.get(k) == v for k, v in attrs.items()):
+    for node in graph.nodes:
+        if all(getattr(node, k, None) == v for k, v in attrs.items()):
             return node
     return None
 
 
-def _find_nodes(graph, **attrs):
+def _find_nodes(graph: SemanticGraph, **attrs) -> list[SemanticGraphNode]:
     """Find all nodes matching given attrs."""
-    return [n for n in graph["nodes"]
-            if all(n.get(k) == v for k, v in attrs.items())]
+    return [n for n in graph.nodes
+            if all(getattr(n, k, None) == v for k, v in attrs.items())]
 
 
-def _has_edge(graph, src, dst):
+def _has_edge(graph: SemanticGraph, src: str, dst: str) -> bool:
     """Check if an edge exists from src to dst."""
-    return {"from": src, "to": dst} in graph["edges"]
+    return any(e.from_ == src and e.to == dst for e in graph.edges)
 
 
 # ---------------------------------------------------------------------------
@@ -46,9 +47,9 @@ def _has_edge(graph, src, dst):
 class TestGraphStructure:
     def test_returns_nodes_and_edges(self):
         g = latex_to_semantic_graph("x + y")
-        assert "nodes" in g
-        assert "edges" in g
-        assert "classification" in g
+        assert g.nodes is not None
+        assert g.edges is not None
+        assert g.classification is not None
 
     def test_simple_addition(self):
         g = latex_to_semantic_graph("x + y")
@@ -78,8 +79,8 @@ class TestGraphStructure:
         g = latex_to_semantic_graph("x + y")
         add_node = _find_node(g, type="operator", op="add")
         assert add_node is not None
-        assert _has_edge(g, "x", add_node["id"])
-        assert _has_edge(g, "y", add_node["id"])
+        assert _has_edge(g, "x", add_node.id)
+        assert _has_edge(g, "y", add_node.id)
 
 
 # ---------------------------------------------------------------------------
@@ -95,19 +96,19 @@ class TestKnownVariables:
         # ``latex`` (so KaTeX renders the symbol nicely).
         g = latex_to_semantic_graph("F")
         node = _find_node(g, id="F")
-        assert node["type"] == "vector"
-        assert node["latex"] == "F"
+        assert node.type == "vector"
+        assert node.latex == "F"
         # No semantic claims pre-filled — those wait for the enricher.
         for forbidden in ("label", "emoji", "quantity", "dimension", "unit", "role", "value"):
-            assert forbidden not in node, f"{forbidden!r} should not be parser-set"
+            assert getattr(node, forbidden, None) is None, f"{forbidden!r} should not be parser-set"
 
     def test_unknown_variable_gets_defaults(self):
         g = latex_to_semantic_graph("Q")
         node = _find_node(g, id="Q")
         # Unknown symbols intentionally have no ``label`` — the SymPy
         # identifier would just duplicate the rendered ``latex`` field.
-        assert "label" not in node
-        assert node["type"] == "scalar"
+        assert node.label is None
+        assert node.type == "scalar"
 
     def test_symbol_deduplication(self):
         g = latex_to_semantic_graph("x + x")
@@ -121,8 +122,8 @@ class TestKnownVariables:
         # The subexpr must carry the same LaTeX command as `latex`.
         g = latex_to_semantic_graph(r"\rho_0 + 1")
         node = _find_node(g, id="rho_{0}")
-        assert node["latex"] == r"\rho_{0}"
-        assert node["subexpr"] == r"\rho_{0}"
+        assert node.latex == r"\rho_{0}"
+        assert node.subexpr == r"\rho_{0}"
 
     def test_compound_mul_subexpr_recovers_greek_command(self):
         # Regression for gh-197: a non-root Mul containing a Greek-named
@@ -134,7 +135,7 @@ class TestKnownVariables:
         g = latex_to_semantic_graph(r"\rho_0 V + 1")
         muls = _find_nodes(g, type="operator", op="multiply")
         assert muls
-        sub = muls[0].get("subexpr", "")
+        sub = muls[0].subexpr or ""
         assert r"\rho_{0}" in sub, sub
         assert "rho_{0}" not in sub.replace(r"\rho_{0}", ""), sub
 
@@ -143,21 +144,21 @@ class TestKnownVariables:
         # macro. `_symbol_latex` must NOT invent a `\x` command for it.
         g = latex_to_semantic_graph(r"x_0 + 1")
         node = _find_node(g, id="x_{0}")
-        assert node["latex"] == "x_{0}"
-        assert node["subexpr"] == "x_{0}"
+        assert node.latex == "x_{0}"
+        assert node.subexpr == "x_{0}"
 
     def test_mathbb_symbol_unwrapped_without_leaking_command_node(self):
         g = latex_to_semantic_graph(r"\alpha \in \mathbb{C}")
         c = _find_node(g, id="C")
         assert c is not None
-        assert c["latex"] == r"\mathbb{C}"
+        assert c.latex == r"\mathbb{C}"
         assert _find_node(g, id="mathbb") is None
 
     def test_bold_symbol_unwrapped_without_leaking_command_node(self):
         g = latex_to_semantic_graph(r"\mathbf{x} + 1")
         x = _find_node(g, id="x")
         assert x is not None
-        assert x["latex"] == r"\mathbf{x}"
+        assert x.latex == r"\mathbf{x}"
         assert _find_node(g, id="mathbf") is None
 
 
@@ -173,14 +174,14 @@ class TestNumbersAndConstants:
     def test_fraction(self):
         g = latex_to_semantic_graph("\\frac{1}{2}")
         # Should produce a number node or a division
-        assert len(g["nodes"]) > 0
+        assert len(g.nodes) > 0
 
     def test_float_label_no_precision_noise(self):
         """Regression: Float(7.2) label was '7.20000000000000' (gh-145)."""
         g = latex_to_semantic_graph("7.2 x")
         num = _find_node(g, type="number")
         assert num is not None
-        assert num["label"] == "7.2"
+        assert num.label == "7.2"
 
     def test_negative_integer_label_preserved(self):
         """Regression: -122 label should stay '-122', not be split (gh-145)."""
@@ -198,14 +199,14 @@ class TestNumbersAndConstants:
         g = latex_to_semantic_graph(r"e^{-122/7.2}")
         mul = _find_node(g, type="operator", op="multiply")
         assert mul is not None
-        assert "-1 122" not in mul.get("subexpr", "")
+        assert "-1 122" not in (mul.subexpr or "")
 
     def test_float_exponent_no_precision_noise(self):
         """Regression: x^{7.2} exponent was '7.20000000000000' (gh-145)."""
         g = latex_to_semantic_graph("x^{7.2}")
         pw = _find_node(g, type="operator", op="power")
         assert pw is not None
-        assert pw["exponent"] == "7.2"
+        assert pw.exponent == "7.2"
 
 
 # ---------------------------------------------------------------------------
@@ -254,7 +255,7 @@ class TestDerivatives:
         g = latex_to_semantic_graph("\\frac{d v}{d t}")
         deriv = _find_node(g, type="operator", op="derivative")
         assert deriv is not None
-        assert "t" in deriv.get("with_respect_to", "")
+        assert "t" in (deriv.with_respect_to or "")
 
     def test_dot_notation_preprocessed(self):
         result = _preprocess_latex(r"\dot{x}")
@@ -265,7 +266,7 @@ class TestDerivatives:
         g = latex_to_semantic_graph(r"\dot{x}")
         deriv = _find_node(g, type="operator", op="derivative")
         assert deriv is not None
-        assert "t" in deriv.get("with_respect_to", "")
+        assert "t" in (deriv.with_respect_to or "")
 
     def test_ddot_notation_preprocessed(self):
         result = _preprocess_latex(r"\ddot{x}")
@@ -276,7 +277,7 @@ class TestDerivatives:
         deriv = _find_node(g, type="operator", op="derivative")
         assert deriv is not None
         # SymPy collapses nested derivatives; ddot produces Derivative(x, t, t)
-        assert "t" in deriv.get("with_respect_to", "")
+        assert "t" in (deriv.with_respect_to or "")
 
     def test_higher_order_derivative(self):
         result = _preprocess_latex(r"\frac{d^2 y}{dy^2}")
@@ -286,7 +287,7 @@ class TestDerivatives:
         g = latex_to_semantic_graph(r"\frac{d^2 y}{d y^2}")
         deriv = _find_node(g, type="operator", op="derivative")
         assert deriv is not None
-        assert "y" in deriv.get("with_respect_to", "")
+        assert "y" in (deriv.with_respect_to or "")
 
     def test_higher_order_derivative_braced(self):
         result = _preprocess_latex(r"\frac{d^{2} y}{dy^{2}}")
@@ -314,8 +315,8 @@ class TestRelations:
         g = latex_to_semantic_graph(r"F \propto m a")
         rel = _find_node(g, type="relation", op="proportional")
         assert rel is not None
-        assert rel["label"] == "proportional to"
-        assert rel["emoji"] == "∝"
+        assert rel.label == "proportional to"
+        assert rel.emoji == "∝"
         assert _find_node(g, id="F")
         assert _find_node(g, type="operator", op="multiply")
 
@@ -323,27 +324,27 @@ class TestRelations:
         g = latex_to_semantic_graph(r"x > 0 \implies x^2 > 0")
         rel = _find_node(g, type="relation", op="implies")
         assert rel is not None
-        assert rel["label"] == "implies"
-        assert rel["emoji"] == "⇒"
+        assert rel.label == "implies"
+        assert rel.emoji == "⇒"
 
     def test_rightarrow_implies(self):
         g = latex_to_semantic_graph(r"x > 0 \Rightarrow x^2 > 0")
         rel = _find_node(g, type="relation", op="implies")
         assert rel is not None
-        assert rel["emoji"] == "⇒"
+        assert rel.emoji == "⇒"
 
     def test_iff(self):
         g = latex_to_semantic_graph(r"x = 0 \iff x^2 = 0")
         rel = _find_node(g, type="relation", op="iff")
         assert rel is not None
-        assert rel["label"] == "if and only if"
-        assert rel["emoji"] == "⇔"
+        assert rel.label == "if and only if"
+        assert rel.emoji == "⇔"
 
     def test_leftrightarrow_iff(self):
         g = latex_to_semantic_graph(r"A \Leftrightarrow B")
         rel = _find_node(g, type="relation", op="iff")
         assert rel is not None
-        assert rel["emoji"] == "⇔"
+        assert rel.emoji == "⇔"
         assert _find_node(g, id="A")
         assert _find_node(g, id="B")
 
@@ -351,8 +352,8 @@ class TestRelations:
         g = latex_to_semantic_graph(r"\pi \approx 3.14")
         rel = _find_node(g, type="relation", op="approximately")
         assert rel is not None
-        assert rel["label"] == "approximately equal"
-        assert rel["emoji"] == "≈"
+        assert rel.label == "approximately equal"
+        assert rel.emoji == "≈"
         # parse_latex emits ``\pi`` as a Symbol named ``pi`` (not the
         # sympy.pi NumberSymbol), so the parser routes it through the
         # symbol path — KNOWN_VARIABLES["pi"] still pins type=constant.
@@ -362,8 +363,8 @@ class TestRelations:
         g = latex_to_semantic_graph(r"x \to y")
         rel = _find_node(g, type="relation", op="maps_to")
         assert rel is not None
-        assert rel["label"] == "maps to"
-        assert rel["emoji"] == "→"
+        assert rel.label == "maps to"
+        assert rel.emoji == "→"
         assert _find_node(g, id="x")
         assert _find_node(g, id="y")
 
@@ -376,7 +377,7 @@ class TestRelations:
         """Every relation node should connect LHS and RHS."""
         g = latex_to_semantic_graph(r"F \propto m a")
         rel = _find_node(g, type="relation", op="proportional")
-        incoming = [e for e in g["edges"] if e["to"] == rel["id"]]
+        incoming = [e for e in g.edges if e.to == rel.id]
         assert len(incoming) == 2
 
     def test_leftmost_relation_wins(self):
@@ -437,31 +438,31 @@ class TestComparisonOperators:
     def test_comparison_has_two_children(self):
         g = latex_to_semantic_graph(r"x > 0")
         op = _find_node(g, type="operator", op="greater_than")
-        incoming = [e for e in g["edges"] if e["to"] == op["id"]]
+        incoming = [e for e in g.edges if e.to == op.id]
         assert len(incoming) == 2
 
     def test_comparison_edges_have_lhs_rhs_roles(self):
         g = latex_to_semantic_graph(r"x > 0")
         op = _find_node(g, type="operator", op="greater_than")
-        edges = [e for e in g["edges"] if e["to"] == op["id"]]
-        roles = {e["role"] for e in edges}
+        edges = [e for e in g.edges if e.to == op.id]
+        roles = {e.role for e in edges}
         assert roles == {"lhs", "rhs"}
-        lhs_edge = next(e for e in edges if e["role"] == "lhs")
-        assert lhs_edge["from"] == "x"
+        lhs_edge = next(e for e in edges if e.role == "lhs")
+        assert lhs_edge.from_ == "x"
 
     def test_equals_edges_have_no_roles(self):
         """Symmetric operators should not have role tags."""
         g = latex_to_semantic_graph(r"x = 0")
         op = _find_node(g, type="operator", op="equals")
-        edges = [e for e in g["edges"] if e["to"] == op["id"]]
-        assert all("role" not in e for e in edges)
+        edges = [e for e in g.edges if e.to == op.id]
+        assert all(e.role is None for e in edges)
 
     def test_relation_map_comparison_edges_have_roles(self):
         """\\gt routed through RELATION_MAP should also get lhs/rhs roles."""
         g = latex_to_semantic_graph(r"x \gt 0")
         rel = _find_node(g, type="relation", op="greater_than")
-        edges = [e for e in g["edges"] if e["to"] == rel["id"]]
-        roles = {e["role"] for e in edges}
+        edges = [e for e in g.edges if e.to == rel.id]
+        roles = {e.role for e in edges}
         assert roles == {"lhs", "rhs"}
 
 
@@ -475,11 +476,11 @@ class TestRelationOperandComma:
     from the implies node entirely.
     """
 
-    def _reaches(self, graph, src, dst):
+    def _reaches(self, graph: SemanticGraph, src: str, dst: str):
         """Return True iff a directed edge path exists from *src* to *dst*."""
         adj: dict[str, list[str]] = {}
-        for e in graph["edges"]:
-            adj.setdefault(e["from"], []).append(e["to"])
+        for e in graph.edges:
+            adj.setdefault(e.from_, []).append(e.to)
         seen = {src}
         stack = [src]
         while stack:
@@ -500,22 +501,22 @@ class TestRelationOperandComma:
         equals_nodes = _find_nodes(g, type="operator", op="equals")
         assert len(equals_nodes) == 2
         for eq in equals_nodes:
-            assert self._reaches(g, eq["id"], impl["id"]), (
-                f"clause {eq.get('subexpr')!r} does not reach implies"
+            assert self._reaches(g, eq.id, impl.id), (
+                f"clause {eq.subexpr!r} does not reach implies"
             )
         # And they reach it through a synthetic ``and`` conjunction node.
         conj = _find_node(g, type="relation", op="and")
         assert conj is not None
-        assert self._reaches(g, conj["id"], impl["id"])
+        assert self._reaches(g, conj.id, impl.id)
 
     def test_iff_with_comma_rhs_groups_as_conjunction(self):
         g = latex_to_semantic_graph(r"P \iff A, B")
         iff = _find_node(g, type="relation", op="iff")
         conj = _find_node(g, type="relation", op="and")
         assert iff is not None and conj is not None
-        assert self._reaches(g, conj["id"], iff["id"])
-        assert self._reaches(g, "A", iff["id"])
-        assert self._reaches(g, "B", iff["id"])
+        assert self._reaches(g, conj.id, iff.id)
+        assert self._reaches(g, "A", iff.id)
+        assert self._reaches(g, "B", iff.id)
 
     def test_implies_with_comma_lhs_groups_as_conjunction(self):
         """Comma on the LHS of an implication groups the antecedents."""
@@ -523,10 +524,10 @@ class TestRelationOperandComma:
         impl = _find_node(g, type="relation", op="implies")
         conj = _find_node(g, type="relation", op="and")
         assert impl is not None and conj is not None
-        assert self._reaches(g, "A", conj["id"])
-        assert self._reaches(g, "B", conj["id"])
-        assert self._reaches(g, conj["id"], impl["id"])
-        assert self._reaches(g, "C", impl["id"])
+        assert self._reaches(g, "A", conj.id)
+        assert self._reaches(g, "B", conj.id)
+        assert self._reaches(g, conj.id, impl.id)
+        assert self._reaches(g, "C", impl.id)
 
     def test_function_arg_comma_inside_implies_unaffected(self):
         """Comma inside a function-argument group ``f(x, y)`` stays a
@@ -552,10 +553,10 @@ class TestSubjectGroupComma:
     α and β belong to ℂ.  The comma between α and β groups them as a
     composite LHS for the ``\in`` relation, not as a statement separator."""
 
-    def _reaches(self, graph, src, dst):
+    def _reaches(self, graph: SemanticGraph, src: str, dst: str):
         adj: dict[str, list[str]] = {}
-        for e in graph["edges"]:
-            adj.setdefault(e["from"], []).append(e["to"])
+        for e in graph.edges:
+            adj.setdefault(e.from_, []).append(e.to)
         seen = {src}
         stack = [src]
         while stack:
@@ -576,10 +577,10 @@ class TestSubjectGroupComma:
         assert elem is not None
         conj = _find_node(g, type="relation", op="and")
         assert conj is not None, "expected an 'and' conjunction for the composite LHS"
-        assert self._reaches(g, "alpha", conj["id"])
-        assert self._reaches(g, "beta", conj["id"])
-        assert self._reaches(g, conj["id"], elem["id"])
-        assert self._reaches(g, "C", elem["id"])
+        assert self._reaches(g, "alpha", conj.id)
+        assert self._reaches(g, "beta", conj.id)
+        assert self._reaches(g, conj.id, elem.id)
+        assert self._reaches(g, "C", elem.id)
 
     def test_three_variables_in_R(self):
         r"""``x, y, z \in \mathbb{R}`` — chained subject grouping."""
@@ -589,7 +590,7 @@ class TestSubjectGroupComma:
         conj = _find_node(g, type="relation", op="and")
         assert conj is not None
         for var in ("x", "y", "z"):
-            assert self._reaches(g, var, elem["id"]), f"{var} should reach element_of"
+            assert self._reaches(g, var, elem.id), f"{var} should reach element_of"
 
     def test_multi_statement_with_subject_group(self):
         r"""``a = 1, \quad \alpha, \beta \in \mathbb{C}`` should produce
@@ -625,19 +626,19 @@ class TestSubjectGroupComma:
         assert elem is not None, "expected element_of for α,β ∈ ℂ"
         conj = _find_node(g, type="relation", op="and")
         assert conj is not None, "expected 'and' conjunction grouping α and β"
-        assert self._reaches(g, "alpha", conj["id"])
-        assert self._reaches(g, "beta", conj["id"])
-        assert self._reaches(g, conj["id"], elem["id"])
+        assert self._reaches(g, "alpha", conj.id)
+        assert self._reaches(g, "beta", conj.id)
+        assert self._reaches(g, conj.id, elem.id)
 
 
 class TestStatementSeparators:
     r"""Scene-level regression tests for the unified statement separator
     that handles both ``\\`` and ``, \quad`` in a single pass."""
 
-    def _reaches(self, graph, src, dst):
+    def _reaches(self, graph: SemanticGraph, src: str, dst: str):
         adj: dict[str, list[str]] = {}
-        for e in graph["edges"]:
-            adj.setdefault(e["from"], []).append(e["to"])
+        for e in graph.edges:
+            adj.setdefault(e.from_, []).append(e.to)
         seen = {src}
         stack = [src]
         while stack:
@@ -667,9 +668,9 @@ class TestStatementSeparators:
         assert elem is not None, "expected element_of for α,β ∈ ℂ"
         conj = _find_node(g, type="relation", op="and")
         assert conj is not None, "expected 'and' conjunction grouping α and β"
-        assert self._reaches(g, "alpha", conj["id"])
-        assert self._reaches(g, "beta", conj["id"])
-        assert self._reaches(g, conj["id"], elem["id"])
+        assert self._reaches(g, "alpha", conj.id)
+        assert self._reaches(g, "beta", conj.id)
+        assert self._reaches(g, conj.id, elem.id)
 
     def test_borns_rule_step(self):
         r"""'Apply Born's rule' scene step uses ``\\`` to separate two
@@ -696,7 +697,7 @@ class TestTextCommand:
         g = latex_to_semantic_graph(r"T = \text{const}")
         node = _find_node(g, type="text", label="const")
         assert node is not None
-        assert node["latex"] == r"\text{const}"
+        assert node.latex == r"\text{const}"
         # No stray per-character symbols (c, o, n, s) should appear.
         for letter in ("c", "o", "n", "s"):
             assert _find_node(g, id=letter) is None, f"stray {letter!r} symbol leaked"
@@ -710,15 +711,15 @@ class TestTextCommand:
         assert _find_node(g, type="text", label="const") is not None
         assert _find_node(g, type="relation", op="implies") is not None
         # Two equals nodes: one per side of the implication.
-        equals_nodes = [n for n in g["nodes"]
-                        if n.get("type") == "operator" and n.get("op") == "equals"]
+        equals_nodes = [n for n in g.nodes
+                        if n.type == "operator" and n.op == "equals"]
         assert len(equals_nodes) == 2
 
     def test_repeated_text_dedups(self):
         """Same \\text{...} content should map to one node, not duplicate."""
         g = latex_to_semantic_graph(r"\text{foo} + \text{foo} = \text{bar}")
-        foo_nodes = [n for n in g["nodes"]
-                     if n.get("type") == "text" and n.get("label") == "foo"]
+        foo_nodes = [n for n in g.nodes
+                     if n.type == "text" and n.label == "foo"]
         assert len(foo_nodes) == 1
         assert _find_node(g, type="text", label="bar") is not None
 
@@ -742,7 +743,7 @@ class TestComplexFormulas:
         assert _find_node(g, id="pi", type="constant")  # label/emoji are enricher's job
         assert _find_node(g, type="operator", op="power")
         assert _find_node(g, type="operator", op="add")
-        assert g["classification"]["kind"] == "algebraic"
+        assert g.classification.kind == "algebraic"
 
     def test_kinetic_energy(self):
         """K = 1/2 m v^2 — equation with fraction, multiplication, power."""
@@ -764,7 +765,7 @@ class TestComplexFormulas:
         assert _find_node(g, type="operator", op="integral")
         assert _find_node(g, type="operator", op="power")
         assert _find_node(g, id="x")
-        assert g["classification"]["kind"] == "algebraic"
+        assert g.classification.kind == "algebraic"
 
     def test_wave_equation_pde(self):
         """u_tt = c^2 u_xx — second-order PDE, partial derivatives."""
@@ -773,13 +774,13 @@ class TestComplexFormulas:
         )
         derivs = _find_nodes(g, type="operator", op="partial_derivative")
         assert len(derivs) == 2
-        wrt_vars = {d["with_respect_to"] for d in derivs}
+        wrt_vars = {d.with_respect_to for d in derivs}
         assert "t" in wrt_vars
         assert "x" in wrt_vars
-        c = g["classification"]
-        assert c["kind"] == "PDE"
-        assert c["order"] == 2
-        assert set(c["independent_variables"]) == {"t", "x"}
+        c = g.classification
+        assert c.kind == "PDE"
+        assert c.order == 2
+        assert set(c.independent_variables) == {"t", "x"}
 
     def test_harmonic_oscillator_ode(self):
         """x'' + omega^2 x = 0 — second-order linear ODE."""
@@ -788,10 +789,10 @@ class TestComplexFormulas:
         )
         assert _find_node(g, type="operator", op="derivative")
         assert _find_node(g, id="omega")  # label/quantity left for the enricher
-        c = g["classification"]
-        assert c["kind"] == "ODE"
-        assert c["order"] == 2
-        assert c.get("linear") is True
+        c = g.classification
+        assert c.kind == "ODE"
+        assert c.order == 2
+        assert c.linear is True
 
     def test_schrodinger_time_independent(self):
         """E psi = -(h^2/2m) psi'' + V psi — ODE with many operators."""
@@ -802,9 +803,9 @@ class TestComplexFormulas:
         assert _find_node(g, id="h")
         assert _find_node(g, type="operator", op="derivative")
         assert _find_node(g, type="operator", op="equals")
-        c = g["classification"]
-        assert c["kind"] == "ODE"
-        assert c["order"] == 2
+        c = g.classification
+        assert c.kind == "ODE"
+        assert c.order == 2
 
     def test_coulomb_law(self):
         """F = k q1 q2 / r^2 — subscripted variables, fractions."""
@@ -814,8 +815,8 @@ class TestComplexFormulas:
         assert _find_node(g, id="r")
         assert _find_node(g, type="operator", op="power")
         # q_1 and q_2 are distinct symbols
-        nodes = g["nodes"]
-        q_nodes = [n for n in nodes if n["id"].startswith("q_")]
+        nodes = g.nodes
+        q_nodes = [n for n in nodes if n.id.startswith("q_")]
         assert len(q_nodes) == 2
 
     def test_taylor_series_sin(self):
@@ -828,7 +829,7 @@ class TestComplexFormulas:
         assert _find_node(g, type="operator", op="equals")
         # Should have factorial node
         assert _find_node(g, op="factorial")
-        assert g["classification"]["kind"] == "algebraic"
+        assert g.classification.kind == "algebraic"
 
     def test_lorentz_factor(self):
         """gamma = 1/sqrt(1 - v^2/c^2) — nested fractions, sqrt via power."""
@@ -839,7 +840,7 @@ class TestComplexFormulas:
         assert _find_node(g, id="v")  # parser emits structural fields only
         assert _find_node(g, id="c")
         assert _find_node(g, type="operator", op="equals")
-        assert g["classification"]["kind"] == "algebraic"
+        assert g.classification.kind == "algebraic"
 
     def test_quadratic_formula(self):
         """x = (-b +/- sqrt(b^2 - 4ac)) / 2a — covers many node types."""
@@ -856,8 +857,8 @@ class TestComplexFormulas:
         assert _find_node(g, type="operator", op="multiply")
         assert _find_node(g, type="operator", op="power")
         # Graph should be non-trivial
-        assert len(g["nodes"]) >= 10
-        assert len(g["edges"]) >= 10
+        assert len(g.nodes) >= 10
+        assert len(g.edges) >= 10
 
 
 # ---------------------------------------------------------------------------
@@ -867,26 +868,26 @@ class TestComplexFormulas:
 class TestClassification:
     def test_algebraic_expression(self):
         g = latex_to_semantic_graph("x^2 + y^2")
-        assert g["classification"]["kind"] == "algebraic"
+        assert g.classification.kind == "algebraic"
 
     def test_ode_detected(self):
         g = latex_to_semantic_graph("\\frac{d v}{d t} = a")
-        c = g["classification"]
-        assert c["kind"] == "ODE"
-        assert c["order"] == 1
+        c = g.classification
+        assert c.kind == "ODE"
+        assert c.order == 1
 
     def test_algebraic_equation(self):
         g = latex_to_semantic_graph("E = m c^2")
-        assert g["classification"]["kind"] == "algebraic"
+        assert g.classification.kind == "algebraic"
 
     def test_mixed_partial_derivative_order(self):
         """Mixed partial d²u/(dx dt) should report order 2, not 1."""
         g = latex_to_semantic_graph(
             r"\frac{\partial}{\partial x}\frac{\partial u}{\partial t} = 0"
         )
-        c = g["classification"]
-        assert c["kind"] == "PDE"
-        assert c["order"] == 2
+        c = g.classification
+        assert c.kind == "PDE"
+        assert c.order == 2
 
 
 # ---------------------------------------------------------------------------
@@ -920,24 +921,24 @@ class TestOverrides:
     def test_overrides_applied_to_graph(self):
         # Overrides still win — authors can pin any field explicitly.
         # The parser no longer pre-fills ``label`` for ``m``, so the
-        # override is the only source of label / unit / tooltip metadata.
+        # override is the only source of label / unit metadata.
         g = latex_to_semantic_graph("F = m \\cdot a", overrides={
-            "m": {"label": "mass", "unit": "kg", "tooltip": "Inertial mass"},
+            "m": {"label": "mass", "unit": "kg", "description": "Inertial mass"},
         })
         m_node = _find_node(g, id="m")
-        assert m_node["unit"] == "kg"
-        assert m_node["tooltip"] == "Inertial mass"
-        assert m_node["label"] == "mass"
+        assert m_node.unit == "kg"
+        assert m_node.description == "Inertial mass"
+        assert m_node.label == "mass"
 
 
 # ---------------------------------------------------------------------------
 # Edge semantics (direct / inverse)
 # ---------------------------------------------------------------------------
 
-def _edge(graph, src, dst):
+def _edge(graph: SemanticGraph, src: str, dst: str):
     """Return the edge matching (src -> dst), or None."""
-    for e in graph["edges"]:
-        if e.get("from") == src and e.get("to") == dst:
+    for e in graph.edges:
+        if e.from_ == src and e.to == dst:
             return e
     return None
 
@@ -971,40 +972,40 @@ class TestEdgeSemantics:
             pow_nodes = _find_nodes(g, type="operator", op="power")
             assert pow_nodes, f"expected a power node for {latex_src!r}"
             for pn in pow_nodes:
-                incoming = [e for e in g["edges"] if e["to"] == pn["id"]]
+                incoming = [e for e in g.edges if e.to == pn.id]
                 assert incoming, "power node should have an incoming edge"
                 for edge in incoming:
-                    assert "semantic" not in edge, (
+                    assert edge.semantic is None, (
                         f"{latex_src!r}: pow incoming edge should not be tagged "
                         f"at parse time (got {edge})"
                     )
-                    assert "weight" not in edge, (
+                    assert edge.weight is None, (
                         f"{latex_src!r}: pow incoming edge should not have a "
                         f"weight at parse time (got {edge})"
                     )
 
     def test_addition_has_no_semantic_tags(self):
         g = latex_to_semantic_graph("y = a + b")
-        add_edges = [e for e in g["edges"] if e["to"].startswith("__add")]
+        add_edges = [e for e in g.edges if e.to.startswith("__add")]
         assert add_edges, "expected at least one add-edge"
         for edge in add_edges:
-            assert "semantic" not in edge
-            assert "weight" not in edge
+            assert edge.semantic is None
+            assert edge.weight is None
 
     def test_multiplication_tags_factors_as_direct(self):
         # ``a · t`` — both operands are linearly proportional to the
         # product, so every factor edge gets ``direct`` + weight 1.
         g = latex_to_semantic_graph(r"y = a \cdot t")
-        mul_edges = [e for e in g["edges"] if e["to"].startswith("__multiply")]
+        mul_edges = [e for e in g.edges if e.to.startswith("__multiply")]
         assert len(mul_edges) == 2
         for edge in mul_edges:
-            assert edge.get("semantic") == "direct"
-            assert edge.get("weight") == 1.0
+            assert edge.semantic == "direct"
+            assert edge.weight == 1.0
 
     def test_edge_weight_survives_schema_validation(self):
         from scripts.graph_to_mermaid import validate_graph
         g = latex_to_semantic_graph(r"v = \frac{x}{t^2}")
-        errs = validate_graph(g)
+        errs = validate_graph(g.model_dump(by_alias=True, exclude_none=True))
         assert errs == [], f"unexpected schema errors: {errs}"
 
     def test_multiply_skips_tagging_for_inverse_pow_children(self):
@@ -1015,16 +1016,16 @@ class TestEdgeSemantics:
         g = latex_to_semantic_graph(r"y = a / b")
         mul_node = _find_node(g, type="operator", op="multiply")
         assert mul_node is not None
-        a_edge = next(e for e in g["edges"]
-                      if e["to"] == mul_node["id"] and e["from"] == "a")
-        assert a_edge.get("semantic") == "direct"
-        assert a_edge.get("weight") == 1.0
-        pow_edge = next(e for e in g["edges"]
-                        if e["to"] == mul_node["id"] and e["from"].startswith("__power"))
-        assert "semantic" not in pow_edge, (
+        a_edge = next(e for e in g.edges
+                      if e.to == mul_node.id and e.from_ == "a")
+        assert a_edge.semantic == "direct"
+        assert a_edge.weight == 1.0
+        pow_edge = next(e for e in g.edges
+                        if e.to == mul_node.id and e.from_.startswith("__power"))
+        assert pow_edge.semantic is None, (
             f"inverse-pow → multiply edge must stay plain (got {pow_edge})"
         )
-        assert "weight" not in pow_edge
+        assert pow_edge.weight is None
 
     def test_symbolic_negative_pow_absorbs_exponent(self):
         # ``x^{-n}`` should produce a single power node with
@@ -1035,10 +1036,10 @@ class TestEdgeSemantics:
         pow_nodes = _find_nodes(g, type="operator", op="power")
         assert len(pow_nodes) == 1
         pn = pow_nodes[0]
-        assert pn.get("exponent") == "-n"
-        incoming = [e for e in g["edges"] if e["to"] == pn["id"]]
+        assert pn.exponent == "-n"
+        incoming = [e for e in g.edges if e.to == pn.id]
         assert len(incoming) == 1
-        assert incoming[0]["from"] == "x"
+        assert incoming[0].from_ == "x"
         # And no negate/exponent helper nodes leaked through.
         assert not _find_nodes(g, type="operator", op="negation")
 
@@ -1163,8 +1164,8 @@ class TestCommaSeparatedClauses:
             "second clause (γ = const) must survive — this is the bug"
         )
         # Graph carries two independent statements — no parent/relation node.
-        assert g["classification"]["kind"] == "statements"
-        assert g["classification"]["count"] == 2
+        assert g.classification.kind == "statements"
+        assert g.classification.count == 2
 
     def test_no_parent_relation_node_is_emitted(self):
         """Per author intent (issue #144 follow-up): the comma is a pure
@@ -1187,10 +1188,10 @@ class TestCommaSeparatedClauses:
         assert len(equals_nodes) == 2
         # The graph has exactly two roots (nodes with no outgoing edges
         # among the operator/relation nodes) — the two equals nodes.
-        out_set = {e["from"] for e in g["edges"]}
-        op_roots = [n for n in g["nodes"]
-                    if n.get("type") in ("operator", "relation")
-                    and n["id"] not in out_set]
+        out_set = {e.from_ for e in g.edges}
+        op_roots = [n for n in g.nodes
+                    if n.type in ("operator", "relation")
+                    and n.id not in out_set]
         assert len(op_roots) == 2, (
             f"expected two statement roots, got {len(op_roots)}: {op_roots}"
         )
@@ -1202,10 +1203,10 @@ class TestCommaSeparatedClauses:
         # Build undirected adjacency and check connected components.
         from collections import defaultdict
         adj = defaultdict(set)
-        for e in g["edges"]:
-            adj[e["from"]].add(e["to"])
-            adj[e["to"]].add(e["from"])
-        node_ids = {n["id"] for n in g["nodes"]}
+        for e in g.edges:
+            adj[e.from_].add(e.to)
+            adj[e.to].add(e.from_)
+        node_ids = {n.id for n in g.nodes}
         visited = set()
 
         def walk(start):
@@ -1243,7 +1244,7 @@ class TestCommaSeparatedClauses:
         g = latex_to_semantic_graph("a = 1, b = 2, c = 3")
         equals_nodes = _find_nodes(g, type="operator", op="equals")
         assert len(equals_nodes) == 3
-        assert g["classification"]["count"] == 3
+        assert g.classification.count == 3
 
     def test_classification_lists_per_clause_kinds(self):
         """Per-clause classifications are preserved under
@@ -1251,14 +1252,14 @@ class TestCommaSeparatedClauses:
         that clause 0 is algebraic and clause 1 is too, without walking
         the subtrees."""
         g = latex_to_semantic_graph("a = 1, b = 2")
-        cls = g["classification"]
-        assert cls["kind"] == "statements"
-        assert cls["count"] == 2
-        assert "clauses" in cls
-        assert len(cls["clauses"]) == 2
+        cls = g.classification
+        assert cls.kind == "statements"
+        assert cls.count == 2
+        assert cls.clauses is not None
+        assert len(cls.clauses) == 2
         # Every clause must have its own ``kind`` field populated.
-        for sub in cls["clauses"]:
-            assert "kind" in sub
+        for sub in cls.clauses:
+            assert sub.kind is not None
 
     def test_four_clauses_all_present(self):
         """Any number of commas — the splitter iterates, the builder
@@ -1267,9 +1268,9 @@ class TestCommaSeparatedClauses:
         g = latex_to_semantic_graph("a = 1, b = 2, c = 3, d = 4")
         equals_nodes = _find_nodes(g, type="operator", op="equals")
         assert len(equals_nodes) == 4
-        assert g["classification"]["count"] == 4
+        assert g.classification.count == 4
         # All four clause equals-node ids must be uniquely prefixed.
-        equals_ids = {n["id"] for n in equals_nodes}
+        equals_ids = {n.id for n in equals_nodes}
         assert equals_ids == {
             "c0___equals_1", "c1___equals_1", "c2___equals_1", "c3___equals_1",
         }
@@ -1280,14 +1281,14 @@ class TestCommaSeparatedClauses:
         connected components (clauses 0+1 glued through shared ``a``;
         clause 2 standalone)."""
         g = latex_to_semantic_graph("a = 1, a + b = 5, c = 3")
-        assert g["classification"]["count"] == 3
+        assert g.classification.count == 3
         # Count connected components via undirected traversal.
         from collections import defaultdict
         adj = defaultdict(set)
-        for e in g["edges"]:
-            adj[e["from"]].add(e["to"])
-            adj[e["to"]].add(e["from"])
-        node_ids = {n["id"] for n in g["nodes"]}
+        for e in g.edges:
+            adj[e.from_].add(e.to)
+            adj[e.to].add(e.from_)
+        node_ids = {n.id for n in g.nodes}
         visited = set()
 
         def walk(start):
@@ -1318,7 +1319,7 @@ class TestCommaSeparatedClauses:
         otherwise \text{a, b} would be broken into two bogus clauses."""
         g = latex_to_semantic_graph(r"x = \text{foo, bar}")
         # Single equation — not multi-statement.
-        assert g["classification"].get("kind") != "statements"
+        assert g.classification.kind != "statements"
         equals_nodes = _find_nodes(g, type="operator", op="equals")
         assert len(equals_nodes) == 1
 
@@ -1327,7 +1328,7 @@ class TestCommaSeparatedClauses:
         g = latex_to_semantic_graph("f(x, y)")
         # Single statement — the comma is a function-arg separator, not a
         # statement separator.
-        assert g["classification"].get("kind") != "statements"
+        assert g.classification.kind != "statements"
 
     def test_failed_clause_raises_not_silently_dropped(self):
         """Per issue #137: parse failures must surface, not silently drop.
@@ -1354,7 +1355,7 @@ class TestCommaSeparatedClauses:
             r"\frac{dh}{dt} = -V \sin \gamma, \quad \gamma = \text{const}"
         )
         equals_nodes = _find_nodes(g, type="operator", op="equals")
-        subexprs = {n.get("subexpr", "") for n in equals_nodes}
+        subexprs = {(n.subexpr or "") for n in equals_nodes}
         # Neither equals subexpr should start with a leading \quad/\qquad/etc.
         for s in subexprs:
             assert not s.lstrip().startswith("\\quad"), (
@@ -1375,7 +1376,7 @@ class TestCommaSeparatedClauses:
         a single text node — clause 1's ``bar`` would disappear."""
         g = latex_to_semantic_graph(r"x = \text{foo}, y = \text{bar}")
         text_nodes = _find_nodes(g, type="text")
-        labels = sorted(n.get("label") for n in text_nodes)
+        labels = sorted(n.label for n in text_nodes)
         assert labels == ["bar", "foo"], (
             f"expected two distinct text nodes (foo, bar), got {labels!r} "
             f"— Xi_{{N}} placeholder collision across clauses"
@@ -1403,7 +1404,7 @@ class TestCommaSeparatedClauses:
             r"\frac{dh}{dt} = -V \sin \gamma, \quad \gamma = \text{const}"
         )
         equals_nodes = _find_nodes(g, type="operator", op="equals")
-        subexprs = [n.get("subexpr", "") for n in equals_nodes]
+        subexprs = [(n.subexpr or "") for n in equals_nodes]
         # Neither subexpr should contain a comma (that would mean the
         # whole original expression leaked in).
         for s in subexprs:
@@ -1437,14 +1438,14 @@ class TestCompoundSymbols:
         # The compound symbol's latex field should be the original LaTeX.
         compound = _find_node(g, latex=r"\Delta t")
         assert compound is not None, "expected a node with latex = '\\Delta t'"
-        assert compound.get("subexpr") == r"\Delta t"
+        assert compound.subexpr == r"\Delta t"
 
     def test_delta_x_over_delta_t(self):
         """``\\Delta x / \\Delta t`` produces two compound nodes, no split."""
         g = latex_to_semantic_graph(r"v = \frac{\Delta x}{\Delta t}")
         compounds = sorted(
-            n.get("latex") for n in g["nodes"]
-            if n.get("latex") in (r"\Delta x", r"\Delta t")
+            n.latex for n in g.nodes
+            if n.latex in (r"\Delta x", r"\Delta t")
         )
         assert compounds == [r"\Delta t", r"\Delta x"], (
             f"both \\Delta x and \\Delta t should be present as compounds, "
@@ -1459,8 +1460,8 @@ class TestCompoundSymbols:
         delta = _find_node(g, latex=r"\Delta")
         assert delta is not None, "bare \\Delta should still produce a Δ node"
         # And no compound-collapsing should have triggered.
-        thetas = [n for n in g["nodes"]
-                  if isinstance(n.get("id"), str) and n["id"].startswith("Theta_{")]
+        thetas = [n for n in g.nodes
+                  if isinstance(n.id, str) and n.id.startswith("Theta_{")]
         assert not thetas, "no compound placeholder should be created for lone \\Delta"
 
     def test_partial_derivative_still_parses(self):
@@ -1531,8 +1532,8 @@ class TestCompoundSymbols:
         """
         g = latex_to_semantic_graph(r"\nabla f(x,y)")
         # No compound placeholder should be created — ``\nabla`` stands alone.
-        thetas = [n for n in g["nodes"]
-                  if isinstance(n.get("id"), str) and n["id"].startswith("Theta_{")]
+        thetas = [n for n in g.nodes
+                  if isinstance(n.id, str) and n.id.startswith("Theta_{")]
         assert not thetas, (
             "\\nabla must not be collapsed onto its operand; got "
             f"placeholder nodes {thetas!r}"
@@ -1551,8 +1552,8 @@ class TestCompoundSymbols:
         """
         g = latex_to_semantic_graph(r"y = (\Delta t)^2")
         power_subexprs = [
-            n.get("subexpr", "") for n in g["nodes"]
-            if n.get("op") == "power"
+            (n.subexpr or "") for n in g.nodes
+            if n.op == "power"
         ]
         assert power_subexprs, "expected a power node in the graph"
         for s in power_subexprs:
@@ -1612,9 +1613,9 @@ class TestCompoundSymbols:
         assert const is not None, (
             "user override on 't' must not corrupt \\text{const}"
         )
-        for node in g["nodes"]:
+        for node in g.nodes:
             for field in ("latex", "subexpr"):
-                value = node.get(field)
+                value = getattr(node, field, None)
                 if isinstance(value, str):
                     assert r"\ex" not in value or r"\text" in value, (
                         f"\\text macro corrupted in {field}={value!r}"
@@ -1645,9 +1646,9 @@ class TestCompoundSymbols:
         g = latex_to_semantic_graph(r"\Delta t \propto x")
         rel = _find_node(g, type="relation")
         assert rel is not None, "should produce a relation node"
-        for node in g["nodes"]:
+        for node in g.nodes:
             for field in ("latex", "subexpr"):
-                value = node.get(field)
+                value = getattr(node, field, None)
                 if isinstance(value, str):
                     assert "Theta" not in value, (
                         f"placeholder leaked into {field}={value!r}"
@@ -1716,8 +1717,8 @@ class TestParentheticalAnnotations:
         g = latex_to_semantic_graph(r"F = m a \quad (m \text{ constant})")
         anno = _find_node(g, type="annotation")
         assert anno is not None, "annotation node should be in graph"
-        assert anno["id"] == "__annotation_0"
-        assert "constant" in anno["label"]
+        assert anno.id == "__annotation_0"
+        assert "constant" in anno.label
 
     def test_annotation_does_not_break_equation_parsing(self):
         g = latex_to_semantic_graph(r"v = v_0 + a t \quad (a \text{ constant})")
@@ -1800,7 +1801,7 @@ class TestDiracNotation:
             r"|\psi\rangle = e^{i\gamma_\alpha}\left(r_\alpha|0\rangle "
             r"+ r_\beta e^{i(\gamma_\beta - \gamma_\alpha)}|1\rangle\right)"
         )
-        kets = [n for n in g["nodes"] if n["type"] == "ket"]
+        kets = [n for n in g.nodes if n.type == "ket"]
         assert len(kets) == 3, f"expected 3 kets, got {len(kets)}"
         eq = _find_node(g, op="equals")
         assert eq is not None, "equation root should exist"
@@ -1809,34 +1810,34 @@ class TestDiracNotation:
 
     def test_simple_ket(self):
         g = latex_to_semantic_graph(r"|\psi\rangle")
-        kets = [n for n in g["nodes"] if n["type"] == "ket"]
+        kets = [n for n in g.nodes if n.type == "ket"]
         assert len(kets) == 1
-        assert r"\rangle" in kets[0]["latex"]
+        assert r"\rangle" in kets[0].latex
 
     def test_ket_addition(self):
         g = latex_to_semantic_graph(r"|0\rangle + |1\rangle")
-        kets = [n for n in g["nodes"] if n["type"] == "ket"]
+        kets = [n for n in g.nodes if n.type == "ket"]
         assert len(kets) == 2
         add = _find_node(g, op="add")
         assert add is not None
 
     def test_bra_standalone(self):
         g = latex_to_semantic_graph(r"\langle\phi|")
-        bras = [n for n in g["nodes"] if n["type"] == "bra"]
+        bras = [n for n in g.nodes if n.type == "bra"]
         assert len(bras) == 1
-        assert r"\langle" in bras[0]["latex"]
+        assert r"\langle" in bras[0].latex
 
     def test_braket_inner_product_equation(self):
         g = latex_to_semantic_graph(r"\langle\phi|\psi\rangle = 0")
         # Inner product is an operator with ``op="inner_product"`` —
         # filter by op so we don't pick up ``=`` or ``+`` operators.
-        brakets = [n for n in g["nodes"] if n.get("op") == "inner_product"]
+        brakets = [n for n in g.nodes if n.op == "inner_product"]
         assert len(brakets) == 1, "one inner product → one operator node"
         # Symbolic operands are wired in via edges, not baked into the label.
         bk = brakets[0]
-        assert bk["type"] == "operator"
-        bk_id = bk["id"]
-        operand_ids = {e["from"] for e in g["edges"] if e["to"] == bk_id}
+        assert bk.type == "operator"
+        bk_id = bk.id
+        operand_ids = {e.from_ for e in g.edges if e.to == bk_id}
         assert "phi" in operand_ids and "psi" in operand_ids
         eq = _find_node(g, op="equals")
         assert eq is not None
@@ -1844,11 +1845,11 @@ class TestDiracNotation:
     def test_braket_constant_bra_is_baked_in(self):
         """``⟨0|ψ⟩`` — the ``0`` stays in the operator label, not as an edge."""
         g = latex_to_semantic_graph(r"\langle 0|\psi\rangle = c")
-        brakets = [n for n in g["nodes"] if n.get("op") == "inner_product"]
+        brakets = [n for n in g.nodes if n.op == "inner_product"]
         assert len(brakets) == 1
-        assert brakets[0]["type"] == "operator"
-        bk_id = brakets[0]["id"]
-        operand_ids = {e["from"] for e in g["edges"] if e["to"] == bk_id}
+        assert brakets[0].type == "operator"
+        bk_id = brakets[0].id
+        operand_ids = {e.from_ for e in g.edges if e.to == bk_id}
         # Only ψ flows in. The constant ``0`` lives in the operator label.
         assert operand_ids == {"psi"}, f"expected only psi, got {operand_ids}"
 
@@ -1857,9 +1858,9 @@ class TestDiracNotation:
         g = latex_to_semantic_graph(
             r"a = \langle 0|\psi\rangle \\ b = \langle 1|\psi\rangle"
         )
-        psi_nodes = [n for n in g["nodes"] if n["id"] == "psi"]
+        psi_nodes = [n for n in g.nodes if n.id == "psi"]
         assert len(psi_nodes) == 1, "ψ should be a single shared node"
-        psi_edges = [e for e in g["edges"] if e["from"] == "psi"]
+        psi_edges = [e for e in g.edges if e.from_ == "psi"]
         assert len(psi_edges) == 2, "ψ should connect to both brakets"
 
     def test_braket_node_latex_is_compact_skeleton(self):
@@ -1873,11 +1874,11 @@ class TestDiracNotation:
         the other operators (``cos``, ``|·|``, ``(·)²``).
         """
         g = latex_to_semantic_graph(r"\langle 0|\psi\rangle = c")
-        bk = next(n for n in g["nodes"] if n.get("op") == "inner_product")
+        bk = next(n for n in g.nodes if n.op == "inner_product")
         # Compact skeleton on the node label.
-        assert bk["latex"] == r"\langle 0\,|\,\cdot\rangle"
+        assert bk.latex == r"\langle 0\,|\,\cdot\rangle"
         # Full applied form in subexpr — what the details panel shows.
-        assert bk["subexpr"] == r"\langle 0|\psi\rangle"
+        assert bk.subexpr == r"\langle 0|\psi\rangle"
 
 
 class TestOperatorKind:
@@ -1934,50 +1935,50 @@ class TestOperatorKind:
         # Every operator/function whose subexpr involves the braket
         # must contain the full ``\psi``, never a ``\cdot`` placeholder.
         wrappers = [
-            n for n in g["nodes"]
-            if "langle" in (n.get("subexpr") or "")
+            n for n in g.nodes
+            if "langle" in (n.subexpr or "")
         ]
         assert wrappers, "expected at least one wrapper node referencing the braket"
         for n in wrappers:
-            sx = n["subexpr"]
-            assert r"\psi" in sx, f"node {n['id']} subexpr lost ψ: {sx!r}"
+            sx = n.subexpr
+            assert r"\psi" in sx, f"node {n.id} subexpr lost ψ: {sx!r}"
             assert r"\cdot" not in sx, (
-                f"node {n['id']} subexpr leaks operator skeleton: {sx!r}"
+                f"node {n.id} subexpr leaks operator skeleton: {sx!r}"
             )
 
     def test_braket_edge_roles(self):
         """Bra-side operands get ``role='lhs'``, ket-side ``role='rhs'``."""
         g = latex_to_semantic_graph(r"\langle\phi|\psi\rangle = 0")
-        bk_id = next(n["id"] for n in g["nodes"] if n.get("op") == "inner_product")
-        edges = {e["from"]: e.get("role") for e in g["edges"] if e["to"] == bk_id}
+        bk_id = next(n.id for n in g.nodes if n.op == "inner_product")
+        edges = {e.from_: e.role for e in g.edges if e.to == bk_id}
         assert edges.get("phi") == "lhs", f"phi should be bra (lhs): {edges}"
         assert edges.get("psi") == "rhs", f"psi should be ket (rhs): {edges}"
 
     def test_braket_pure_constants_have_no_operand_edges(self):
         """``⟨0|1⟩`` — both sides constant → no operand edges into the braket."""
         g = latex_to_semantic_graph(r"\langle 0|1\rangle = c")
-        bk_id = next(n["id"] for n in g["nodes"] if n.get("op") == "inner_product")
+        bk_id = next(n.id for n in g.nodes if n.op == "inner_product")
         # Only the upstream ``=`` edge points away from the braket; nothing
         # symbolic flows in.  Edges *to* the braket must be empty.
-        in_edges = [e for e in g["edges"] if e["to"] == bk_id]
+        in_edges = [e for e in g.edges if e.to == bk_id]
         assert in_edges == [], f"expected no operand edges, got {in_edges}"
 
     def test_ket_equation_has_equals(self):
         g = latex_to_semantic_graph(r"|\psi\rangle = |0\rangle")
         eq = _find_node(g, op="equals")
         assert eq is not None
-        kets = [n for n in g["nodes"] if n["type"] == "ket"]
+        kets = [n for n in g.nodes if n.type == "ket"]
         assert len(kets) == 2
 
     def test_ket_with_subscript(self):
         g = latex_to_semantic_graph(r"|\psi_n\rangle")
-        kets = [n for n in g["nodes"] if n["type"] == "ket"]
+        kets = [n for n in g.nodes if n.type == "ket"]
         assert len(kets) == 1
 
     def test_ket_coefficient_multiply(self):
         """Coefficient × ket should produce multiply node."""
         g = latex_to_semantic_graph(r"\alpha|0\rangle + \beta|1\rangle")
-        kets = [n for n in g["nodes"] if n["type"] == "ket"]
+        kets = [n for n in g.nodes if n.type == "ket"]
         assert len(kets) == 2
-        muls = [n for n in g["nodes"] if n.get("op") == "multiply"]
+        muls = [n for n in g.nodes if n.op == "multiply"]
         assert len(muls) >= 2, "each coefficient×ket should be a multiply"

--- a/tests/backend/semantic_graph/test_postprocessor.py
+++ b/tests/backend/semantic_graph/test_postprocessor.py
@@ -6,6 +6,11 @@ import copy
 
 import pytest
 
+from backend.model.semantic_graph import (
+    SemanticGraph,
+    SemanticGraphEdge,
+    SemanticGraphNode,
+)
 from backend.semantic_graph.postprocessor import (
     GraphPostprocessor,
     _re_sub_literal,
@@ -17,6 +22,22 @@ from backend.semantic_graph.preprocess_result import PreprocessResult
 @pytest.fixture
 def pp():
     return GraphPostprocessor()
+
+
+def _graph(nodes=(), edges=()):
+    """Shorthand to build a ``SemanticGraph`` from node/edge lists."""
+    return SemanticGraph(nodes=list(nodes), edges=list(edges))
+
+
+def _node(**kwargs):
+    """Shorthand to build a ``SemanticGraphNode`` with sensible defaults."""
+    kwargs.setdefault("type", "scalar")
+    return SemanticGraphNode(**kwargs)
+
+
+def _edge(from_, to, **kwargs):
+    """Shorthand to build a ``SemanticGraphEdge``."""
+    return SemanticGraphEdge(from_=from_, to=to, **kwargs)
 
 
 # ------------------------------------------------------------------
@@ -57,21 +78,21 @@ class TestRestoreDotNotationStr:
 
 class TestRejectDegenerate:
     def test_single_expr_node(self, pp):
-        graph = {"nodes": [{"id": "__expr_0", "type": "expression"}]}
+        graph = _graph(nodes=[_node(id="__expr_0", type="expression")])
         assert pp.reject_degenerate(graph) is True
 
     def test_normal_graph(self, pp):
-        graph = {"nodes": [{"id": "F", "type": "variable"}]}
+        graph = _graph(nodes=[_node(id="F", type="scalar")])
         assert pp.reject_degenerate(graph) is False
 
     def test_empty_nodes(self, pp):
-        assert pp.reject_degenerate({"nodes": []}) is False
+        assert pp.reject_degenerate(_graph()) is False
 
     def test_multiple_nodes(self, pp):
-        graph = {"nodes": [
-            {"id": "__expr_0", "type": "expression"},
-            {"id": "x", "type": "variable"},
-        ]}
+        graph = _graph(nodes=[
+            _node(id="__expr_0", type="expression"),
+            _node(id="x", type="scalar"),
+        ])
         assert pp.reject_degenerate(graph) is False
 
 
@@ -81,26 +102,28 @@ class TestRejectDegenerate:
 
 class TestRestoreDotNotationGraph:
     def test_restores_subexpr(self, pp):
-        graph = {"nodes": [
-            {"id": "eq", "subexpr": r"\frac{d}{d t} x = 0"},
-        ]}
+        graph = _graph(nodes=[
+            _node(id="eq", subexpr=r"\frac{d}{d t} x = 0"),
+        ])
         pp.restore_dot_notation(graph, {"x": 1})
-        assert graph["nodes"][0]["subexpr"] == r"\dot{x} = 0"
+        assert graph.nodes[0].subexpr == r"\dot{x} = 0"
 
     def test_no_frac_untouched(self, pp):
-        graph = {"nodes": [{"id": "a", "subexpr": "a + b"}]}
+        graph = _graph(nodes=[_node(id="a", subexpr="a + b")])
         pp.restore_dot_notation(graph, {"a": 1})
-        assert graph["nodes"][0]["subexpr"] == "a + b"
+        assert graph.nodes[0].subexpr == "a + b"
 
     def test_empty_dotted_vars(self, pp):
-        graph = {"nodes": [{"id": "a", "subexpr": r"\frac{d}{d t} a"}]}
+        graph = _graph(nodes=[_node(id="a", subexpr=r"\frac{d}{d t} a")])
         pp.restore_dot_notation(graph, {})
-        assert graph["nodes"][0]["subexpr"] == r"\frac{d}{d t} a"
+        assert graph.nodes[0].subexpr == r"\frac{d}{d t} a"
 
     def test_no_subexpr_field(self, pp):
-        graph = {"nodes": [{"id": "x", "latex": "x"}]}
+        graph = _graph(nodes=[_node(id="x", latex="x")])
         pp.restore_dot_notation(graph, {"x": 1})
-        assert graph["nodes"][0] == {"id": "x", "latex": "x"}
+        assert graph.nodes[0].id == "x"
+        assert graph.nodes[0].latex == "x"
+        assert graph.nodes[0].subexpr is None
 
 
 # ------------------------------------------------------------------
@@ -109,36 +132,36 @@ class TestRestoreDotNotationGraph:
 
 class TestRestoreAccents:
     def test_bare_body_restored(self, pp):
-        graph = {"nodes": [{"id": "F", "type": "variable", "latex": "F"}]}
+        graph = _graph(nodes=[_node(id="F", type="scalar", latex="F")])
         pp.restore_accents(graph, {"F": "vec"})
-        assert graph["nodes"][0]["latex"] == r"\vec{F}"
-        assert graph["nodes"][0]["type"] == "vector"
+        assert graph.nodes[0].latex == r"\vec{F}"
+        assert graph.nodes[0].type == "vector"
 
     def test_subscripted_body(self, pp):
-        graph = {"nodes": [{"id": "n_0", "type": "variable", "latex": "n_0"}]}
+        graph = _graph(nodes=[_node(id="n_0", type="scalar", latex="n_0")])
         pp.restore_accents(graph, {"n": "hat"})
-        assert graph["nodes"][0]["latex"] == r"\hat{n}_0"
+        assert graph.nodes[0].latex == r"\hat{n}_0"
 
     def test_already_accented_skip(self, pp):
-        graph = {"nodes": [{"id": "F", "type": "variable", "latex": r"\vec{F}"}]}
+        graph = _graph(nodes=[_node(id="F", type="scalar", latex=r"\vec{F}")])
         pp.restore_accents(graph, {"F": "vec"})
-        assert graph["nodes"][0]["latex"] == r"\vec{F}"
+        assert graph.nodes[0].latex == r"\vec{F}"
 
     def test_operator_skipped(self, pp):
-        graph = {"nodes": [{"id": "+", "type": "operator", "latex": "+"}]}
+        graph = _graph(nodes=[_node(id="+", type="operator", latex="+")])
         pp.restore_accents(graph, {"+": "hat"})
-        assert graph["nodes"][0]["latex"] == "+"
+        assert graph.nodes[0].latex == "+"
 
     def test_empty_accent_map(self, pp):
-        graph = {"nodes": [{"id": "F", "type": "variable", "latex": "F"}]}
+        graph = _graph(nodes=[_node(id="F", type="scalar", latex="F")])
         pp.restore_accents(graph, {})
-        assert graph["nodes"][0]["latex"] == "F"
+        assert graph.nodes[0].latex == "F"
 
     def test_non_vec_accent(self, pp):
-        graph = {"nodes": [{"id": "x", "type": "variable", "latex": "x"}]}
+        graph = _graph(nodes=[_node(id="x", type="scalar", latex="x")])
         pp.restore_accents(graph, {"x": "hat"})
-        assert graph["nodes"][0]["latex"] == r"\hat{x}"
-        assert graph["nodes"][0]["type"] == "variable"
+        assert graph.nodes[0].latex == r"\hat{x}"
+        assert graph.nodes[0].type == "scalar"
 
 
 # ------------------------------------------------------------------
@@ -147,65 +170,68 @@ class TestRestoreAccents:
 
 class TestRestoreSubscripts:
     def test_text_placeholder(self, pp):
-        graph = {
-            "nodes": [{"id": "alpha", "label": "alpha", "latex": r"\alpha", "subexpr": ""}],
-            "edges": [],
-        }
+        graph = _graph(
+            nodes=[_node(id="alpha", label="alpha", latex=r"\alpha", subexpr="")],
+            edges=[],
+        )
         pp.restore_subscripts(graph, {"alpha": r"\text{sp}"})
-        assert graph["nodes"][0]["id"] == "sp"
-        assert graph["nodes"][0]["label"] == "sp"
-        assert graph["nodes"][0]["latex"] == r"\text{sp}"
-        assert graph["nodes"][0]["type"] == "text"
+        assert graph.nodes[0].id == "sp"
+        assert graph.nodes[0].label == "sp"
+        assert graph.nodes[0].latex == r"\text{sp}"
+        assert graph.nodes[0].type == "text"
 
     def test_plain_subscript(self, pp):
-        graph = {
-            "nodes": [{"id": "alpha", "label": "alpha", "latex": r"\alpha", "subexpr": ""}],
-            "edges": [],
-        }
+        graph = _graph(
+            nodes=[_node(id="alpha", label="alpha", latex=r"\alpha", subexpr="")],
+            edges=[],
+        )
         pp.restore_subscripts(graph, {"alpha": "exhaust"})
-        assert graph["nodes"][0]["id"] == "exhaust"
-        assert graph["nodes"][0]["label"] == "exhaust"
-        assert graph["nodes"][0]["latex"] == "exhaust"
+        assert graph.nodes[0].id == "exhaust"
+        assert graph.nodes[0].label == "exhaust"
+        assert graph.nodes[0].latex == "exhaust"
 
     def test_edge_refs_remapped(self, pp):
-        graph = {
-            "nodes": [
-                {"id": "F", "label": "F", "latex": "F"},
-                {"id": "alpha", "label": "alpha", "latex": r"\alpha", "subexpr": ""},
+        graph = _graph(
+            nodes=[
+                _node(id="F", label="F", latex="F"),
+                _node(id="alpha", label="alpha", latex=r"\alpha", subexpr=""),
             ],
-            "edges": [{"from": "F", "to": "alpha"}],
-        }
+            edges=[_edge("F", "alpha")],
+        )
         pp.restore_subscripts(graph, {"alpha": r"\text{prop}"})
-        assert graph["edges"][0]["to"] == "prop"
+        assert graph.edges[0].to == "prop"
 
     def test_inline_replacement(self, pp):
-        graph = {
-            "nodes": [{"id": "v_alpha", "label": "v_alpha", "latex": r"v_{\alpha}", "subexpr": r"v_{\alpha}"}],
-            "edges": [],
-        }
+        graph = _graph(
+            nodes=[_node(id="v_alpha", label="v_alpha", latex=r"v_{\alpha}", subexpr=r"v_{\alpha}")],
+            edges=[],
+        )
         pp.restore_subscripts(graph, {"alpha": "exhaust"})
-        assert "exhaust" in graph["nodes"][0]["id"]
-        assert r"\alpha" not in graph["nodes"][0]["latex"]
+        assert "exhaust" in graph.nodes[0].id
+        assert r"\alpha" not in graph.nodes[0].latex
 
     def test_empty_mapping(self, pp):
-        graph = {"nodes": [{"id": "x", "label": "x", "latex": "x"}], "edges": []}
+        graph = _graph(
+            nodes=[_node(id="x", label="x", latex="x")],
+            edges=[],
+        )
         original = copy.deepcopy(graph)
         pp.restore_subscripts(graph, {})
         assert graph == original
 
     def test_text_pollution_keys_removed(self, pp):
-        graph = {
-            "nodes": [{
-                "id": "alpha", "label": "alpha", "latex": r"\alpha",
-                "subexpr": "", "emoji": "α", "quantity": "angle",
-                "dimension": "rad", "unit": "rad", "value": None, "role": "variable",
-            }],
-            "edges": [],
-        }
+        graph = _graph(
+            nodes=[_node(
+                id="alpha", label="alpha", latex=r"\alpha",
+                subexpr="", emoji="α", quantity="angle",
+                dimension="rad", unit="rad", value=None, role="parameter",
+            )],
+            edges=[],
+        )
         pp.restore_subscripts(graph, {"alpha": r"\text{const}"})
-        node = graph["nodes"][0]
+        node = graph.nodes[0]
         for k in ("emoji", "quantity", "dimension", "unit", "value", "role"):
-            assert k not in node
+            assert getattr(node, k) is None
 
 
 # ------------------------------------------------------------------
@@ -214,28 +240,27 @@ class TestRestoreSubscripts:
 
 class TestInjectAnnotations:
     def test_appends_nodes(self, pp):
-        graph = {"nodes": [{"id": "x"}]}
+        graph = _graph(nodes=[_node(id="x")])
         pp.inject_annotations(graph, [{"type": "annotation", "label": "constant"}])
-        assert len(graph["nodes"]) == 2
-        assert graph["nodes"][1]["id"] == "__annotation_0"
-        assert graph["nodes"][1]["type"] == "annotation"
+        assert len(graph.nodes) == 2
+        assert graph.nodes[1].id == "__annotation_0"
+        assert graph.nodes[1].type == "annotation"
 
     def test_multiple_annotations(self, pp):
-        graph = {"nodes": []}
+        graph = _graph()
         anns = [
             {"type": "annotation", "label": "a"},
             {"type": "annotation", "label": "b"},
         ]
         pp.inject_annotations(graph, anns)
-        assert len(graph["nodes"]) == 2
-        assert graph["nodes"][0]["id"] == "__annotation_0"
-        assert graph["nodes"][1]["id"] == "__annotation_1"
+        assert len(graph.nodes) == 2
+        assert graph.nodes[0].id == "__annotation_0"
+        assert graph.nodes[1].id == "__annotation_1"
 
-    def test_creates_nodes_key(self, pp):
-        graph: dict = {}
+    def test_creates_nodes_on_empty_graph(self, pp):
+        graph = _graph()
         pp.inject_annotations(graph, [{"type": "annotation", "label": "note"}])
-        assert "nodes" in graph
-        assert len(graph["nodes"]) == 1
+        assert len(graph.nodes) == 1
 
 
 # ------------------------------------------------------------------
@@ -259,32 +284,35 @@ class TestPostprocess:
         assert pp.postprocess(None, result) is None
 
     def test_degenerate_graph(self, pp):
-        graph = {"nodes": [{"id": "__expr_0"}]}
+        graph = _graph(nodes=[_node(id="__expr_0", type="expression")])
         result = self._make_result()
         assert pp.postprocess(graph, result) is None
 
     def test_full_pipeline(self, pp):
-        graph = {
-            "nodes": [
-                {"id": "F", "type": "variable", "latex": "F"},
-                {"id": "eq", "type": "relation", "latex": "=", "subexpr": r"\frac{d}{d t} x = F"},
+        graph = _graph(
+            nodes=[
+                _node(id="F", type="scalar", latex="F"),
+                _node(id="eq", type="relation", latex="=", subexpr=r"\frac{d}{d t} x = F"),
             ],
-            "edges": [],
-        }
+            edges=[],
+        )
         result = self._make_result(
             dotted_vars={"x": 1},
             accent_map={"F": "vec"},
         )
         out = pp.postprocess(graph, result)
         assert out is not None
-        assert out["nodes"][0]["latex"] == r"\vec{F}"
-        assert r"\dot{x}" in out["nodes"][1]["subexpr"]
+        assert out.nodes[0].latex == r"\vec{F}"
+        assert r"\dot{x}" in out.nodes[1].subexpr
 
     def test_annotations_injected(self, pp):
-        graph = {"nodes": [{"id": "x", "type": "variable", "latex": "x"}], "edges": []}
+        graph = _graph(
+            nodes=[_node(id="x", type="scalar", latex="x")],
+            edges=[],
+        )
         result = self._make_result(
             annotations=[{"type": "annotation", "label": "constant"}],
         )
         out = pp.postprocess(graph, result)
         assert out is not None
-        assert any(n["id"] == "__annotation_0" for n in out["nodes"])
+        assert any(n.id == "__annotation_0" for n in out.nodes)

--- a/tests/backend/semantic_graph/test_service.py
+++ b/tests/backend/semantic_graph/test_service.py
@@ -16,8 +16,8 @@ class TestDerive:
     def test_simple_equation(self, svc):
         graph = svc.derive("F = m a")
         assert graph is not None
-        assert "nodes" in graph
-        assert "edges" in graph
+        assert graph.nodes is not None
+        assert graph.edges is not None
 
     def test_returns_none_for_empty(self, svc):
         assert svc.derive("") is None
@@ -28,12 +28,12 @@ class TestDerive:
     def test_domain_carried(self, svc):
         graph = svc.derive("F = ma", domain="physics")
         assert graph is not None
-        assert graph.get("domain") == "physics"
+        assert graph.domain == "physics"
 
     def test_chained_equals(self, svc):
         graph = svc.derive("a = b = c")
         assert graph is not None
-        eq_nodes = [n for n in graph["nodes"] if n.get("op") == "equals"]
+        eq_nodes = [n for n in graph.nodes if n.op == "equals"]
         assert len(eq_nodes) >= 1
 
     def test_statement_separator(self, svc):
@@ -47,14 +47,14 @@ class TestDerive:
     def test_element_of(self, svc):
         graph = svc.derive(r"x \in \mathbb{R}")
         assert graph is not None
-        rel_nodes = [n for n in graph["nodes"] if n.get("op") == "element_of"]
+        rel_nodes = [n for n in graph.nodes if n.op == "element_of"]
         assert len(rel_nodes) == 1
 
     def test_annotation_preserved(self, svc):
         graph = svc.derive(r"F = ma \quad (v_e \text{ constant})")
         assert graph is not None
-        ann_nodes = [n for n in graph["nodes"]
-                     if n.get("id", "").startswith("__annotation_")]
+        ann_nodes = [n for n in graph.nodes
+                     if n.id.startswith("__annotation_")]
         assert len(ann_nodes) >= 1
 
     def test_compound_symbol(self, svc):

--- a/tests/backend/semantic_graph/test_sympy_translator.py
+++ b/tests/backend/semantic_graph/test_sympy_translator.py
@@ -269,45 +269,45 @@ class TestClassifyExpression:
 class TestLatexToSemanticGraph:
     def test_simple_equation(self):
         graph = latex_to_semantic_graph("F = m a")
-        assert "nodes" in graph
-        assert "edges" in graph
-        assert "classification" in graph
+        assert graph.nodes is not None
+        assert graph.edges is not None
+        assert graph.classification is not None
 
     def test_returns_equals_node(self):
         graph = latex_to_semantic_graph("F = m a")
-        eq_nodes = [n for n in graph["nodes"] if n.get("op") == "equals"]
+        eq_nodes = [n for n in graph.nodes if n.op == "equals"]
         assert len(eq_nodes) >= 1
 
     def test_quadratic(self):
         graph = latex_to_semantic_graph("E = mc^2")
-        ids = {n["id"] for n in graph["nodes"]}
+        ids = {n.id for n in graph.nodes}
         assert "E" in ids
 
     def test_domain_carried(self):
         graph = latex_to_semantic_graph("F = ma", domain="physics")
-        assert graph.get("domain") == "physics"
+        assert graph.domain == "physics"
 
     def test_chained_equals(self):
         graph = latex_to_semantic_graph("a = b = c")
-        eq_nodes = [n for n in graph["nodes"]
-                     if n.get("type") == "relation" and n.get("op") == "equals"]
+        eq_nodes = [n for n in graph.nodes
+                     if n.type == "relation" and n.op == "equals"]
         assert len(eq_nodes) >= 1
 
     def test_statement_separator(self):
         graph = latex_to_semantic_graph(r"a = 1 \\ b = 2")
-        assert graph["classification"]["kind"] == "statements"
-        assert graph["classification"]["count"] == 2
+        assert graph.classification.kind == "statements"
+        assert graph.classification.count == 2
 
     def test_relation_approx(self):
         graph = latex_to_semantic_graph(r"a \approx b")
-        rel_nodes = [n for n in graph["nodes"]
-                     if n.get("op") == "approximately"]
+        rel_nodes = [n for n in graph.nodes
+                     if n.op == "approximately"]
         assert len(rel_nodes) == 1
 
     def test_element_of_relation(self):
         graph = latex_to_semantic_graph(r"x \in \mathbb{R}")
-        rel_nodes = [n for n in graph["nodes"]
-                     if n.get("op") == "element_of"]
+        rel_nodes = [n for n in graph.nodes
+                     if n.op == "element_of"]
         assert len(rel_nodes) == 1
 
     def test_invalid_latex_raises(self):
@@ -316,18 +316,18 @@ class TestLatexToSemanticGraph:
 
     def test_parenthetical_annotation(self):
         graph = latex_to_semantic_graph(r"F = ma \quad (v_e \text{ constant})")
-        ann_nodes = [n for n in graph["nodes"]
-                     if n.get("id", "").startswith("__annotation_")]
+        ann_nodes = [n for n in graph.nodes
+                     if n.id.startswith("__annotation_")]
         assert len(ann_nodes) >= 1
 
     def test_compound_symbol(self):
         graph = latex_to_semantic_graph(r"\Delta t = 1")
-        node_latexes = [n.get("latex", "") for n in graph["nodes"]]
+        node_latexes = [(n.latex or "") for n in graph.nodes]
         assert any(r"\Delta t" in lt for lt in node_latexes)
 
     def test_text_command(self):
         graph = latex_to_semantic_graph(r"I_{\text{sp}} = 300")
         all_text = " ".join(
-            str(v) for n in graph["nodes"] for v in n.values()
+            str(v) for n in graph.nodes for v in n.model_dump().values()
         )
         assert "sp" in all_text

--- a/tests/test_autofill_proof_shapes.py
+++ b/tests/test_autofill_proof_shapes.py
@@ -15,8 +15,8 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-import server  # noqa: E402
-from server import _autofill_semantic_graphs, _normalize_proofs  # noqa: E402
+import backend.server as server  # noqa: E402
+from backend.server import _autofill_semantic_graphs, _normalize_proofs  # noqa: E402
 
 
 REPO_ROOT = Path(__file__).parent.parent

--- a/tests/test_graph_highlight_overlay.py
+++ b/tests/test_graph_highlight_overlay.py
@@ -22,7 +22,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from backend.model.semantic_graph import SemanticGraph
 
-from server import (  # noqa: E402  (path manipulation above)
+from backend.server import (  # noqa: E402  (path manipulation above)
     _apply_highlights_to_graph,
     _autofill_semantic_graphs,
     _extract_htmlclass_pairs,

--- a/tests/test_graph_highlight_overlay.py
+++ b/tests/test_graph_highlight_overlay.py
@@ -20,6 +20,8 @@ from jsonschema import Draft202012Validator
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+from backend.model.semantic_graph import SemanticGraph
+
 from server import (  # noqa: E402  (path manipulation above)
     _apply_highlights_to_graph,
     _autofill_semantic_graphs,
@@ -50,7 +52,8 @@ def _build_scene(math: str, highlights: dict) -> dict:
     }
 
 
-def _graph(scene: dict) -> dict:
+def _graph_dict(scene: dict) -> dict:
+    """Extract the serialized graph dict from the scene."""
     return scene["scenes"][0]["proof"]["steps"][0]["semanticGraph"]["graph"]
 
 
@@ -64,7 +67,7 @@ def test_highlight_overlay_annotates_matched_nodes(graph_validator):
         },
     )
     _autofill_semantic_graphs(scene)
-    graph = _graph(scene)
+    graph = _graph_dict(scene)
 
     by_id = {n["id"]: n for n in graph["nodes"]}
     assert by_id["m"]["color"] == "#e91e63"
@@ -72,11 +75,8 @@ def test_highlight_overlay_annotates_matched_nodes(graph_validator):
     assert by_id["m"]["highlight"] == "m"
 
     assert by_id["c"]["color"] == "#3f51b5"
-    # Node already had a label-derived description; the overlay still wins
-    # via description-fallback only when the node had no description.
     assert by_id["c"]["highlight"] == "c"
 
-    # Bare highlight key — no "hl-" prefix leaks through.
     for node in graph["nodes"]:
         hl = node.get("highlight")
         if hl is not None:
@@ -95,7 +95,7 @@ def test_highlight_overlay_preserves_schema_validity(graph_validator):
         },
     )
     _autofill_semantic_graphs(scene)
-    graph = _graph(scene)
+    graph = _graph_dict(scene)
 
     errors = sorted(graph_validator.iter_errors(graph), key=lambda e: e.path)
     assert not errors, "\n".join(e.message for e in errors)
@@ -106,21 +106,22 @@ def test_highlight_overlay_idempotent_and_respects_existing_fields():
     math = r"y = \htmlClass{hl-x}{x}"
     highlights = {"x": {"color": "#ff0000", "label": "input"}}
 
-    # Pre-build the graph with an author-authored color, then run overlay.
     scene = _build_scene(math, highlights)
     _autofill_semantic_graphs(scene)
-    graph = _graph(scene)
-    by_id = {n["id"]: n for n in graph["nodes"]}
-    by_id["x"]["color"] = "#0000ff"  # author override
+    # Re-parse the serialized graph back into a SemanticGraph model,
+    # modify a field, then re-run the overlay.
+    graph_dict = _graph_dict(scene)
+    graph = SemanticGraph.model_validate(graph_dict)
+    by_id = {n.id: n for n in graph.nodes}
+    by_id["x"].color = "#0000ff"  # author override
 
     hl_pairs = _extract_htmlclass_pairs(math)
     _apply_highlights_to_graph(graph, hl_pairs, highlights)
 
-    assert by_id["x"]["color"] == "#0000ff", (
+    assert by_id["x"].color == "#0000ff", (
         "overlay must not clobber author-provided color"
     )
-    # The highlight name is still attached — it's informational metadata.
-    assert by_id["x"]["highlight"] == "x"
+    assert by_id["x"].highlight == "x"
 
 
 def test_highlight_overlay_binds_subexpression_to_root_operator(graph_validator):
@@ -130,25 +131,21 @@ def test_highlight_overlay_binds_subexpression_to_root_operator(graph_validator)
         highlights={"kinetic": {"color": "#ff9800", "label": "kinetic energy"}},
     )
     _autofill_semantic_graphs(scene)
-    graph = _graph(scene)
+    graph = _graph_dict(scene)
 
     annotated = [n for n in graph["nodes"] if n.get("highlight") == "kinetic"]
     assert len(annotated) == 1, "exactly one node should carry the highlight"
     root = annotated[0]
     assert root["type"] == "operator"
     assert root["op"] == "multiply"
-    # subexpr covers the entire highlighted body
     assert "v^{2}" in root["subexpr"]
     assert root["color"] == "#ff9800"
     assert root["description"] == "kinetic energy"
 
-    # Leaf children of the sub-expression are NOT tagged — the overlay
-    # marks only the sub-tree root.
     for leaf_id in ("m", "v"):
         leaf = next(n for n in graph["nodes"] if n["id"] == leaf_id)
-        assert "highlight" not in leaf
+        assert leaf.get("highlight") is None
 
-    # Still schema-valid with operator-level annotation.
     errors = sorted(graph_validator.iter_errors(graph), key=lambda e: e.path)
     assert not errors, "\n".join(e.message for e in errors)
 
@@ -157,11 +154,9 @@ def test_highlight_overlay_noop_when_no_highlights():
     """Math with no htmlClass spans and no highlights — graph stays clean."""
     scene = _build_scene(math=r"y = x^2", highlights={})
     _autofill_semantic_graphs(scene)
-    graph = _graph(scene)
+    graph = _graph_dict(scene)
     for node in graph["nodes"]:
-        assert "highlight" not in node
-        # "color" may legitimately appear if role-based palettes ever attach
-        # one, but the overlay itself should contribute nothing here.
+        assert node.get("highlight") is None
 
 
 def test_strip_html_class_removes_wrappers_from_middle_of_math():

--- a/tests/test_graph_to_mermaid.py
+++ b/tests/test_graph_to_mermaid.py
@@ -587,7 +587,7 @@ class TestEndToEnd:
     def test_latex_to_mermaid_pipeline(self):
         from backend.semantic_graph.sympy_translator import latex_to_semantic_graph
 
-        graph = latex_to_semantic_graph(r"F = m \cdot a")
+        graph = latex_to_semantic_graph(r"F = m \cdot a").model_dump(by_alias=True)
         result = semantic_graph_to_mermaid(graph)
         assert result.startswith("flowchart")
         assert "classDef" in result
@@ -597,7 +597,7 @@ class TestEndToEnd:
     def test_emc2_pipeline(self):
         from backend.semantic_graph.sympy_translator import latex_to_semantic_graph
 
-        graph = latex_to_semantic_graph("E = mc^2")
+        graph = latex_to_semantic_graph("E = mc^2").model_dump(by_alias=True)
         for theme_name in list_themes():
             theme = load_theme(theme_name)
             result = semantic_graph_to_mermaid(graph, theme=theme)
@@ -606,7 +606,7 @@ class TestEndToEnd:
     def test_all_label_modes(self):
         from backend.semantic_graph.sympy_translator import latex_to_semantic_graph
 
-        graph = latex_to_semantic_graph(r"F = m \cdot a")
+        graph = latex_to_semantic_graph(r"F = m \cdot a").model_dump(by_alias=True)
         for mode in ("emoji", "latex", "plain"):
             result = semantic_graph_to_mermaid(graph, label_mode=mode)
             assert result.startswith("flowchart")

--- a/tests/test_path_security.py
+++ b/tests/test_path_security.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-import server
+import backend.server as server
 
 
 class TestLoadScene:

--- a/tests/test_resolve_scene_path_safe.py
+++ b/tests/test_resolve_scene_path_safe.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from server import resolve_scene_path_safe, script_dir, scenes_dir
+from backend.server import resolve_scene_path_safe, script_dir, scenes_dir
 
 
 def test_rejects_absolute_path_outside_project():


### PR DESCRIPTION
## Summary
- `latex_to_semantic_graph()` now returns a `SemanticGraph` Pydantic model instead of a plain dict, enabling type-safe attribute access throughout the codebase (closes #307)
- Moves `server.py` and `agent_tools.py` into `backend/`, consolidating all Python source under one package

## Test plan
- [x] All 616 tests pass
- [x] `./algebench --help` works from new server location
- [x] `./run.sh backend/server.py --help` works
- [x] CLI script `scripts/latex_to_graph.py` produces valid JSON output

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>