### PR TITLE
fix: remove hardcoded vector types from KNOWN_VARIABLES

### DIFF
--- a/backend/semantic_graph/constants.py
+++ b/backend/semantic_graph/constants.py
@@ -69,11 +69,6 @@ DIMENSION_PATTERN: str = (
 )
 
 KNOWN_VARIABLES: dict[str, dict[str, str]] = {
-    "F": {"type": "vector", "latex": "F"},
-    "a": {"type": "vector", "latex": "a"},
-    "v": {"type": "vector", "latex": "v"},
-    "p": {"type": "vector", "latex": "p"},
-    "B": {"type": "vector", "latex": "B"},
     "alpha":   {"type": "scalar", "latex": "\\alpha"},
     "beta":    {"type": "scalar", "latex": "\\beta"},
     "gamma":   {"type": "scalar", "latex": "\\gamma"},

--- a/scenes/draft/graph-panel-demo.json
+++ b/scenes/draft/graph-panel-demo.json
@@ -120,6 +120,10 @@
         {
           "title": "Domain constraint: \u03b1 \u2208 \u2102",
           "description": "\u03b1 \u2208 \u2102 \u2014 styled symbol correctly parsed"
+        },
+        {
+          "title": "Bare symbols (formerly hardcoded vectors)",
+          "description": "$y = F + a \\cdot v - p + B$"
         }
       ],
       "proof": {
@@ -1957,6 +1961,14 @@
                 }
               }
             }
+          },
+          {
+            "id": "proof-step-23",
+            "type": "given",
+            "label": "Bare symbols (formerly hardcoded vectors)",
+            "math": "y = F + a \\cdot v - p + B",
+            "justification": "All five symbols (F, a, v, p, B) were previously hardcoded as vectors in KNOWN_VARIABLES. After PR #311 they should appear as scalars from the raw graph builder.",
+            "sceneStep": 22
           }
         ]
       }

--- a/tests/backend/semantic_graph/test_constants.py
+++ b/tests/backend/semantic_graph/test_constants.py
@@ -72,7 +72,8 @@ class TestTranslatorConstants:
         assert not pat.match("XYZ")
 
     def test_known_variables(self):
-        assert "F" in KNOWN_VARIABLES
+        assert "alpha" in KNOWN_VARIABLES
+        assert KNOWN_VARIABLES["alpha"]["latex"] == "\\alpha"
         assert KNOWN_VARIABLES["pi"]["type"] == "constant"
 
     def test_operator_map_keys_are_types(self):

--- a/tests/backend/semantic_graph/test_latex_to_graph.py
+++ b/tests/backend/semantic_graph/test_latex_to_graph.py
@@ -62,12 +62,12 @@ class TestGraphStructure:
         # by the enricher, not pre-baked from a hardcoded symbol table.
         g = latex_to_semantic_graph("m \\cdot a")
         assert _find_node(g, id="m", type="scalar")
-        assert _find_node(g, id="a", type="vector")  # 'a' is in vector hints
+        assert _find_node(g, id="a", type="scalar")
         assert _find_node(g, type="operator", op="multiply")
 
     def test_equation(self):
         g = latex_to_semantic_graph("F = m \\cdot a")
-        assert _find_node(g, id="F", type="vector")
+        assert _find_node(g, id="F", type="scalar")
         assert _find_node(g, type="operator", op="equals")
 
     def test_power(self):
@@ -88,19 +88,24 @@ class TestGraphStructure:
 # ---------------------------------------------------------------------------
 
 class TestKnownVariables:
-    def test_known_vector_gets_type_hint_only(self):
-        # The parser used to bake in a hardcoded label/emoji/quantity/unit
-        # for ``F`` (force, 🏹, M·L·T⁻², N). That guess was misleading in
-        # other domains and is now the enricher's job. The parser emits
-        # only ``type`` (so the renderer picks the right node shape) and
-        # ``latex`` (so KaTeX renders the symbol nicely).
+    def test_bare_symbol_defaults_to_scalar(self):
         g = latex_to_semantic_graph("F")
         node = _find_node(g, id="F")
-        assert node.type == "vector"
+        assert node.type == "scalar"
         assert node.latex == "F"
-        # No semantic claims pre-filled — those wait for the enricher.
         for forbidden in ("label", "emoji", "quantity", "dimension", "unit", "role", "value"):
             assert getattr(node, forbidden, None) is None, f"{forbidden!r} should not be parser-set"
+
+    def test_vec_accent_assigns_vector_type(self):
+        from backend.semantic_graph import SemanticGraphService
+        svc = SemanticGraphService()
+        g = svc.derive(r"\vec{F} = m \vec{a}")
+        f_node = _find_node(g, id="F")
+        assert f_node.type == "vector"
+        assert f_node.latex == r"\vec{F}"
+        a_node = _find_node(g, id="a")
+        assert a_node.type == "vector"
+        assert a_node.latex == r"\vec{a}"
 
     def test_unknown_variable_gets_defaults(self):
         g = latex_to_semantic_graph("Q")

--- a/tests/backend/semantic_graph/test_latex_to_graph.py
+++ b/tests/backend/semantic_graph/test_latex_to_graph.py
@@ -91,6 +91,7 @@ class TestKnownVariables:
     def test_bare_symbol_defaults_to_scalar(self):
         g = latex_to_semantic_graph("F")
         node = _find_node(g, id="F")
+        assert node is not None
         assert node.type == "scalar"
         assert node.latex == "F"
         for forbidden in ("label", "emoji", "quantity", "dimension", "unit", "role", "value"):
@@ -101,9 +102,11 @@ class TestKnownVariables:
         svc = SemanticGraphService()
         g = svc.derive(r"\vec{F} = m \vec{a}")
         f_node = _find_node(g, id="F")
+        assert f_node is not None
         assert f_node.type == "vector"
         assert f_node.latex == r"\vec{F}"
         a_node = _find_node(g, id="a")
+        assert a_node is not None
         assert a_node.type == "vector"
         assert a_node.latex == r"\vec{a}"
 


### PR DESCRIPTION
## Summary

- Removed the 5 hardcoded vector entries (`F`, `a`, `v`, `p`, `B`) from `KNOWN_VARIABLES` in `constants.py`. Bare single-letter symbols now default to `type="scalar"` like any other symbol, making graph signatures consistent and context-independent.
- The `\vec{}` accent detection in the postprocessor remains the sole path to `type="vector"`, respecting actual LaTeX input rather than guessing from variable names.
- Preserved Greek letter `latex` field mappings (e.g. `alpha` → `\alpha`) and the `pi` constant type — these serve a real purpose unrelated to vector typing.
- Updated tests to reflect the new behavior and added a new end-to-end test verifying `\vec{F}` correctly gets `type="vector"` through the full `SemanticGraphService` pipeline.

Closes #310

## Test plan

- [x] `test_bare_symbol_defaults_to_scalar` — bare `F` gets `type="scalar"`
- [x] `test_vec_accent_assigns_vector_type` — `\vec{F}` and `\vec{a}` get `type="vector"` via accent detection
- [x] `test_simple_multiplication` / `test_equation` — bare `a`, `F` now scalar
- [x] `test_known_variables` — constants test updated for Greek letter entries
- [x] Full suite: 1308 passed, 0 failed

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>

https://claude.ai/code/session_01NKG5KhJreBWthwk7zA9dN2

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKG5KhJreBWthwk7zA9dN2)_