### PR TITLE
feat: add Phase 4b domain test suites

### DIFF
--- a/tests/backend/semantic_graph/domains/test_domain_abstract_algebra.py
+++ b/tests/backend/semantic_graph/domains/test_domain_abstract_algebra.py
@@ -1,0 +1,170 @@
+"""Domain suite: Abstract algebra.
+
+Covers groups, rings, homomorphisms, quotient groups, isomorphisms,
+kernels, and coset notation.  This is Phase 4b — many constructs are
+not yet fully supported, so a high XFAIL ratio is expected.
+
+Suite-specific invariant (from design doc §8.3):
+  All operator nodes have ``op`` in ALLOWED_OPS.
+
+Connectivity is verified via ``graph_signature()`` — a canonical string
+encoding of the graph's edge structure.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.backend.semantic_graph.generators.invariants import (
+    PASS,
+    XFAIL,
+    SKIP,
+    label_by_type,
+    label_by_id,
+    assert_universal_invariants,
+    assert_operators_in,
+    assert_classification_kind_is,
+    assert_signature,
+    assert_node_properties,
+)
+
+
+# ── Allowed operators for this domain ───────────────────────────────────
+
+ALLOWED_OPS = {
+    "multiply", "power", "equals", "add", "negation", "function",
+    "Abs", "abs",
+}
+
+
+# ── Expression catalog ──────────────────────────────────────────────────
+#
+# Each entry: (test_id, latex, tag, sig_by_type, sig_by_id, node_checks)
+
+CatalogEntry = tuple[str, str, object, str, str, list[dict] | None]
+
+EXPRESSIONS: list[CatalogEntry] = [
+    ("quotient_group",
+     r"G / N",
+     PASS,
+     "N -> power; G,power -> multiply",
+     "N -> __power_2; G,__power_2 -> __multiply_1",
+     None),
+
+    ("homomorphism",
+     r"\phi : G \to H",
+     PASS,
+     "G -> power; phi,power -> multiply; H,multiply -> rel:maps_to",
+     "G -> __power_2; __power_2,phi -> __multiply_1; H,__multiply_1 -> __maps_to_3",
+     None),
+
+    ("isomorphism",
+     r"G \cong H",
+     PASS,
+     "H,cong -> multiply; G,multiply -> multiply",
+     "H,cong -> __multiply_2; G,__multiply_2 -> __multiply_1",
+     None),
+
+    ("direct_product",
+     r"G \times H",
+     PASS,
+     "G,H -> multiply",
+     "G,H -> __multiply_1",
+     None),
+
+    ("kernel",
+     r"\ker(\phi) = \{ e \}",
+     PASS,
+     "phi -> fn:ker; e,fn:ker -> equals",
+     "phi -> __ker_2; __ker_2,e -> __equals_1",
+     None),
+
+    ("image",
+     r"\phi(G) = H",
+     PASS,
+     "G -> fn:phi; H,fn:phi -> equals",
+     "G -> __phi_2; H,__phi_2 -> __equals_1",
+     None),
+
+    ("normal_subgroup",
+     r"N \trianglelefteq G",
+     PASS,
+     "G,trianglelefteq -> multiply; N,multiply -> multiply",
+     "G,trianglelefteq -> __multiply_2; N,__multiply_2 -> __multiply_1",
+     None),
+
+    ("order",
+     r"|G| = n",
+     PASS,
+     "G -> fn:Abs; fn:Abs,n -> equals",
+     "G -> __Abs_2; __Abs_2,n -> __equals_1",
+     [{"op": "Abs", "type": "function"}]),
+
+    ("coset",
+     r"gN = \{ gn : n \in N \}",
+     PASS,
+     "N,g -> multiply; N,in -> multiply; g,n -> multiply; "
+     "multiply,n -> multiply; multiply -> power; "
+     "multiply,power -> multiply; multiply,multiply -> equals",
+     "N,g -> __multiply_2; g,n -> __multiply_4; N,in -> __multiply_7; "
+     "__multiply_7,n -> __multiply_6; __multiply_6 -> __power_5; "
+     "__multiply_4,__power_5 -> __multiply_3; "
+     "__multiply_2,__multiply_3 -> __equals_1",
+     None),
+
+    ("first_iso_thm",
+     r"G / \ker(\phi) \cong \phi(G)",
+     PASS,
+     "phi -> fn:ker; G -> fn:phi; cong,fn:phi -> multiply; "
+     "fn:ker,multiply -> multiply; multiply -> power; G,power -> multiply",
+     "phi -> __ker_4; G -> __phi_6; __phi_6,cong -> __multiply_5; "
+     "__ker_4,__multiply_5 -> __multiply_3; __multiply_3 -> __power_2; "
+     "G,__power_2 -> __multiply_1",
+     None),
+]
+
+
+ALL_EXPRESSIONS = EXPRESSIONS
+
+
+# ── Test collection ─────────────────────────────────────────────────────
+
+
+def _build_params():
+    """Build pytest parametrize params from the expression catalog."""
+    params = []
+    for test_id, latex, tag, sig_type, sig_id, node_checks in ALL_EXPRESSIONS:
+        marks = [tag] if tag is not None else []
+        params.append(pytest.param(
+            latex, sig_type, sig_id, node_checks, id=test_id, marks=marks,
+        ))
+    return params
+
+
+@pytest.mark.parametrize("latex, sig_type, sig_id, node_checks", _build_params())
+class TestAbstractAlgebraDomain:
+    """Abstract algebra domain suite — universal + suite-specific invariants."""
+
+    def test_universal_invariants(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_universal_invariants(graph, latex=latex)
+
+    def test_classification_is_algebraic(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_classification_kind_is(graph, "algebraic", latex=latex)
+
+    def test_operators_within_allowed_set(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_operators_in(graph, ALLOWED_OPS, latex=latex)
+
+    def test_connectivity_by_type(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_signature(graph, sig_type, labeler=label_by_type, latex=latex)
+
+    def test_connectivity_by_id(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_signature(graph, sig_id, labeler=label_by_id, latex=latex)
+
+    def test_node_properties(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_node_properties(graph, node_checks, latex=latex)

--- a/tests/backend/semantic_graph/domains/test_domain_control.py
+++ b/tests/backend/semantic_graph/domains/test_domain_control.py
@@ -1,0 +1,197 @@
+"""Domain suite: Control theory.
+
+Covers transfer functions, feedback loops, PID controllers, state-space
+representation, and characteristic equations.  This is Phase 4b —
+the parser handles most control-theory notation well since it reuses
+calculus and algebra constructs.
+
+Suite-specific invariant (from design doc §8.3):
+  All operator nodes have ``op`` in ALLOWED_OPS.
+
+Connectivity is verified via ``graph_signature()``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.backend.semantic_graph.generators.invariants import (
+    PASS,
+    XFAIL,
+    SKIP,
+    label_by_type,
+    label_by_id,
+    assert_universal_invariants,
+    assert_operators_in,
+    assert_classification_kind_is,
+    assert_signature,
+    assert_node_properties,
+)
+
+
+# ── Allowed operators for this domain ───────────────────────────────────
+
+ALLOWED_OPS = {
+    "multiply", "power", "equals", "add", "negation",
+    "derivative", "integral", "function", "Abs", "abs",
+}
+
+
+# ── Expression catalog ──────────────────────────────────────────────────
+
+CatalogEntry = tuple[str, str, object, str, str, list[dict] | None]
+
+EXPRESSIONS: list[CatalogEntry] = [
+    ("transfer_function",
+     r"G(s) = \frac{Y(s)}{U(s)}",
+     PASS,
+     "s -> fn:G; s -> fn:U; s -> fn:Y; fn:U -> power; "
+     "fn:Y,power -> multiply; fn:G,multiply -> equals",
+     "s -> __G_2; s -> __U_6; s -> __Y_4; __U_6 -> __power_5; "
+     "__Y_4,__power_5 -> __multiply_3; "
+     "__G_2,__multiply_3 -> __equals_1",
+     None),
+
+    ("closed_loop",
+     r"T(s) = \frac{G(s)}{1 + G(s)H(s)}",
+     PASS,
+     "s -> fn:G; s -> fn:G; s -> fn:H; s -> fn:T; "
+     "fn:G,fn:H -> multiply; multiply,num -> add; "
+     "add -> power; fn:G,power -> multiply; "
+     "fn:T,multiply -> equals",
+     "s -> __G_4; s -> __G_9; s -> __H_10; s -> __T_2; "
+     "__G_9,__H_10 -> __multiply_8; __multiply_8,__num_7 -> __add_6; "
+     "__add_6 -> __power_5; __G_4,__power_5 -> __multiply_3; "
+     "__T_2,__multiply_3 -> __equals_1",
+     None),
+
+    ("pid_controller",
+     r"u(t) = K_p e(t) + K_i \int_0^t e(\tau) d\tau + K_d \frac{de}{dt}",
+     PASS,
+     "num,t,tau -> Tuple; e,t -> derivative; t -> fn:e; "
+     "tau -> fn:e; t -> fn:u; Tuple,fn:e -> integral; "
+     "K_{d},derivative -> multiply; K_{p},fn:e -> multiply; "
+     "K_{i},integral -> multiply; multiply,multiply -> add; "
+     "add,multiply -> add; add,fn:u -> equals",
+     "e,t -> __deriv_13; t -> __e_6; tau -> __e_9; "
+     "__num_11,t,tau -> __expr_10; t -> __u_2; "
+     "__e_9,__expr_10 -> __integral_8; "
+     "K_{d},__deriv_13 -> __multiply_12; "
+     "K_{p},__e_6 -> __multiply_5; "
+     "K_{i},__integral_8 -> __multiply_7; "
+     "__multiply_5,__multiply_7 -> __add_4; "
+     "__add_4,__multiply_12 -> __add_3; "
+     "__add_3,__u_2 -> __equals_1",
+     None),
+
+    ("state_space",
+     r"\dot{x} = Ax + Bu",
+     PASS,
+     "t,x -> derivative; A,x -> multiply; B,u -> multiply; "
+     "multiply,multiply -> add; add,derivative -> equals",
+     "t,x -> __deriv_2; A,x -> __multiply_4; B,u -> __multiply_5; "
+     "__multiply_4,__multiply_5 -> __add_3; "
+     "__add_3,__deriv_2 -> __equals_1",
+     None),
+
+    ("output_eq",
+     r"y = Cx + Du",
+     PASS,
+     "C,x -> multiply; D,u -> multiply; multiply,multiply -> add; "
+     "add,y -> equals",
+     "C,x -> __multiply_3; D,u -> __multiply_4; "
+     "__multiply_3,__multiply_4 -> __add_2; "
+     "__add_2,y -> __equals_1",
+     None),
+
+    ("characteristic_eq",
+     r"\det(sI - A) = 0",
+     PASS,
+     "I,s -> multiply; A -> negation; multiply,negation -> add; "
+     "add -> fn:det; fn:det,num -> equals",
+     "I,s -> __multiply_4; A -> __negation_5; "
+     "__multiply_4,__negation_5 -> __add_3; "
+     "__add_3 -> __det_2; __det_2,__num_6 -> __equals_1",
+     None),
+
+    ("routh_criterion",
+     r"s^3 + 2s^2 + 3s + 4 = 0",
+     PASS,
+     "num,s -> multiply; s -> power; s -> power; "
+     "num,power -> multiply; multiply,power -> add; "
+     "add,multiply -> add; add,num -> add; add,num -> equals",
+     "__num_10,s -> __multiply_9; s -> __power_5; s -> __power_8; "
+     "__num_7,__power_8 -> __multiply_6; "
+     "__multiply_6,__power_5 -> __add_4; "
+     "__add_4,__multiply_9 -> __add_3; "
+     "__add_3,__num_11 -> __add_2; __add_2,__num_12 -> __equals_1",
+     None),
+
+    ("nyquist",
+     r"|G(j\omega)| = 1",
+     PASS,
+     "j,omega -> multiply; multiply -> fn:G; fn:G -> fn:Abs; "
+     "fn:Abs,num -> equals",
+     "j,omega -> __multiply_4; __multiply_4 -> __G_3; "
+     "__G_3 -> __Abs_2; __Abs_2,__num_5 -> __equals_1",
+     [{"op": "Abs", "type": "function"}]),
+
+    ("laplace_step",
+     r"Y(s) = G(s) \cdot \frac{1}{s}",
+     PASS,
+     "s -> fn:G; s -> fn:Y; s -> power; fn:G,power -> multiply; "
+     "fn:Y,multiply -> equals",
+     "s -> __G_4; s -> __Y_2; s -> __power_5; "
+     "__G_4,__power_5 -> __multiply_3; "
+     "__Y_2,__multiply_3 -> __equals_1",
+     [{"op": "power", "exponent": "-1"}]),
+]
+
+
+ALL_EXPRESSIONS = EXPRESSIONS
+
+
+# ── Test collection ─────────────────────────────────────────────────────
+
+
+def _build_params():
+    """Build pytest parametrize params from the expression catalog."""
+    params = []
+    for test_id, latex, tag, sig_type, sig_id, node_checks in ALL_EXPRESSIONS:
+        marks = [tag] if tag is not None else []
+        params.append(pytest.param(
+            latex, sig_type, sig_id, node_checks, id=test_id, marks=marks,
+        ))
+    return params
+
+
+@pytest.mark.parametrize("latex, sig_type, sig_id, node_checks", _build_params())
+class TestControlDomain:
+    """Control theory domain suite — universal + suite-specific invariants."""
+
+    def test_universal_invariants(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_universal_invariants(graph, latex=latex)
+
+    def test_classification_is_valid(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        kind = graph.classification.kind if graph.classification else None
+        assert kind in {"algebraic", "ODE"}, (
+            f"Expected 'algebraic' or 'ODE', got {kind!r} for: {latex!r}"
+        )
+
+    def test_operators_within_allowed_set(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_operators_in(graph, ALLOWED_OPS, latex=latex)
+
+    def test_connectivity_by_type(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_signature(graph, sig_type, labeler=label_by_type, latex=latex)
+
+    def test_connectivity_by_id(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_signature(graph, sig_id, labeler=label_by_id, latex=latex)
+
+    def test_node_properties(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_node_properties(graph, node_checks, latex=latex)

--- a/tests/backend/semantic_graph/domains/test_domain_diffgeo.py
+++ b/tests/backend/semantic_graph/domains/test_domain_diffgeo.py
@@ -1,0 +1,179 @@
+"""Domain suite: Differential geometry.
+
+Covers Christoffel symbols, covariant derivatives, wedge products,
+metric tensors, Riemann/Ricci tensors, and geodesic equations.
+This is Phase 4b — many tensor index constructs are not yet supported.
+
+Suite-specific invariant (from design doc §8.3):
+  All operator nodes have ``op`` in ALLOWED_OPS.
+
+Connectivity is verified via ``graph_signature()``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.backend.semantic_graph.generators.invariants import (
+    PASS,
+    XFAIL,
+    SKIP,
+    label_by_type,
+    label_by_id,
+    assert_universal_invariants,
+    assert_operators_in,
+    assert_classification_kind_is,
+    assert_signature,
+    assert_node_properties,
+)
+
+
+# ── Allowed operators for this domain ───────────────────────────────────
+
+ALLOWED_OPS = {
+    "multiply", "power", "equals", "add", "negation",
+    "derivative", "function",
+}
+
+
+# ── Expression catalog ──────────────────────────────────────────────────
+
+CatalogEntry = tuple[str, str, object, str, str, list[dict] | None]
+
+EXPRESSIONS: list[CatalogEntry] = [
+    ("christoffel",
+     r"\Gamma^{i}_{jk}",
+     PASS,
+     "Gamma,i -> power",
+     "Gamma,i -> __power_1",
+     None),
+
+    ("covariant_deriv",
+     r"\nabla_{\mu} V^{\nu}",
+     PASS,
+     "V,nu -> power; nabla_{mu},power -> multiply",
+     "V,nu -> __power_2; __power_2,nabla_{mu} -> __multiply_1",
+     None),
+
+    ("wedge_product",
+     r"\omega \wedge \eta",
+     PASS,
+     "eta,wedge -> multiply; multiply,omega -> multiply",
+     "eta,wedge -> __multiply_2; __multiply_2,omega -> __multiply_1",
+     None),
+
+    ("metric_tensor",
+     r"ds^2 = g_{\mu\nu} dx^{\mu} dx^{\nu}",
+     PASS,
+     "ds -> power; dx,mu -> power; dx,nu -> power; "
+     "power,power -> multiply; g_{mu*nu},multiply -> multiply; "
+     "multiply,power -> equals",
+     "ds -> __power_2; dx,mu -> __power_5; dx,nu -> __power_6; "
+     "__power_5,__power_6 -> __multiply_4; "
+     "__multiply_4,g_{mu*nu} -> __multiply_3; "
+     "__multiply_3,__power_2 -> __equals_1",
+     None),
+
+    ("riemann_tensor",
+     r"R^{\rho}_{\ \sigma\mu\nu}",
+     XFAIL,
+     "",
+     "",
+     None),
+
+    ("ricci_scalar",
+     r"R = g^{\mu\nu} R_{\mu\nu}",
+     PASS,
+     "mu,nu -> multiply; g,multiply -> power; "
+     "R_{mu*nu},power -> multiply; R,multiply -> equals",
+     "mu,nu -> __multiply_4; __multiply_4,g -> __power_3; "
+     "R_{mu*nu},__power_3 -> __multiply_2; "
+     "R,__multiply_2 -> __equals_1",
+     None),
+
+    ("exterior_deriv",
+     r"d\omega = 0",
+     PASS,
+     "domega,num -> equals",
+     "__num_2,domega -> __equals_1",
+     None),
+
+    ("lie_bracket",
+     r"[X, Y] = XY - YX",
+     XFAIL,
+     "",
+     "",
+     None),
+
+    ("parallel_transport",
+     r"\nabla_{\dot{\gamma}} V = 0",
+     PASS,
+     "V,nabla_{Derivative(gamma, t)} -> multiply; multiply,num -> equals",
+     "V,nabla_{Derivative(gamma, t)} -> __multiply_2; "
+     "__multiply_2,__num_3 -> __equals_1",
+     None),
+
+    ("geodesic_eq",
+     r"\ddot{x}^{\mu} + \Gamma^{\mu}_{\alpha\beta} \dot{x}^{\alpha} \dot{x}^{\beta} = 0",
+     PASS,
+     "Gamma,mu -> power; alpha,x -> power; beta,x -> power; "
+     "mu,x -> power; power,t -> derivative; power,t -> derivative; "
+     "derivative,power -> multiply; multiply,t -> derivative; "
+     "derivative,power -> multiply; derivative,multiply -> add; "
+     "add,num -> equals",
+     "beta,x -> __power_11; mu,x -> __power_4; Gamma,mu -> __power_6; "
+     "alpha,x -> __power_9; __power_11,t -> __deriv_10; "
+     "__power_4,t -> __deriv_3; __deriv_10,__power_9 -> __multiply_8; "
+     "__multiply_8,t -> __deriv_7; __deriv_7,__power_6 -> __multiply_5; "
+     "__deriv_3,__multiply_5 -> __add_2; __add_2,__num_12 -> __equals_1",
+     None),
+]
+
+
+ALL_EXPRESSIONS = EXPRESSIONS
+
+
+# ── Test collection ─────────────────────────────────────────────────────
+
+
+def _build_params():
+    """Build pytest parametrize params from the expression catalog."""
+    params = []
+    for test_id, latex, tag, sig_type, sig_id, node_checks in ALL_EXPRESSIONS:
+        marks = [tag] if tag is not None else []
+        params.append(pytest.param(
+            latex, sig_type, sig_id, node_checks, id=test_id, marks=marks,
+        ))
+    return params
+
+
+@pytest.mark.parametrize("latex, sig_type, sig_id, node_checks", _build_params())
+class TestDiffGeoDomain:
+    """Differential geometry domain suite — universal + suite-specific invariants."""
+
+    def test_universal_invariants(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_universal_invariants(graph, latex=latex)
+
+    def test_classification_is_valid(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        kind = graph.classification.kind if graph.classification else None
+        assert kind in {"algebraic", "ODE"}, (
+            f"Expected 'algebraic' or 'ODE', got {kind!r} for: {latex!r}"
+        )
+
+    def test_operators_within_allowed_set(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_operators_in(graph, ALLOWED_OPS, latex=latex)
+
+    def test_connectivity_by_type(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_signature(graph, sig_type, labeler=label_by_type, latex=latex)
+
+    def test_connectivity_by_id(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_signature(graph, sig_id, labeler=label_by_id, latex=latex)
+
+    def test_node_properties(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_node_properties(graph, node_checks, latex=latex)

--- a/tests/backend/semantic_graph/domains/test_domain_functional.py
+++ b/tests/backend/semantic_graph/domains/test_domain_functional.py
@@ -1,0 +1,155 @@
+"""Domain suite: Functional analysis.
+
+Covers norms, inner products, operator notation, Hilbert/Banach space
+membership, and convergence.  This is Phase 4b — double-bar norm
+notation and angle-bracket inner products are not yet parsed.
+
+Suite-specific invariant (from design doc §8.3):
+  All operator nodes have ``op`` in ALLOWED_OPS.
+
+Connectivity is verified via ``graph_signature()``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.backend.semantic_graph.generators.invariants import (
+    PASS,
+    XFAIL,
+    SKIP,
+    label_by_type,
+    label_by_id,
+    assert_universal_invariants,
+    assert_operators_in,
+    assert_classification_kind_is,
+    assert_signature,
+    assert_node_properties,
+)
+
+
+# ── Allowed operators for this domain ───────────────────────────────────
+
+ALLOWED_OPS = {
+    "multiply", "power", "equals", "add", "negation",
+    "function", "integral", "element_of", "maps_to",
+}
+
+
+# ── Expression catalog ──────────────────────────────────────────────────
+
+CatalogEntry = tuple[str, str, object, str, str, list[dict] | None]
+
+EXPRESSIONS: list[CatalogEntry] = [
+    ("norm",
+     r"\| x \| = \sqrt{\langle x, x \rangle}",
+     XFAIL,
+     "",
+     "",
+     None),
+
+    ("inner_product",
+     r"\langle f, g \rangle = \int_a^b f(x) \overline{g(x)} dx",
+     XFAIL,
+     "",
+     "",
+     None),
+
+    ("triangle_ineq",
+     r"\| x + y \| \leq \| x \| + \| y \|",
+     XFAIL,
+     "",
+     "",
+     None),
+
+    ("operator_norm",
+     r"\| T \| = \sup_{\| x \| = 1} \| Tx \|",
+     XFAIL,
+     "",
+     "",
+     None),
+
+    ("hilbert_membership",
+     r"f \in L^2(\mathbb{R})",
+     PASS,
+     "L -> power; R,power -> multiply; f,multiply -> rel:element_of",
+     "L -> __power_2; R,__power_2 -> __multiply_1; "
+     "__multiply_1,f -> __element_of_3",
+     None),
+
+    ("cauchy_schwarz",
+     r"|\langle x, y \rangle| \leq \| x \| \cdot \| y \|",
+     XFAIL,
+     "",
+     "",
+     None),
+
+    ("dual_space",
+     r"X^* = \mathcal{B}(X, \mathbb{R})",
+     PASS,
+     "",
+     "",
+     None),
+
+    ("weak_convergence",
+     r"x_n \rightharpoonup x",
+     PASS,
+     "rightharpoonup,x -> multiply; multiply,x_{n} -> multiply",
+     "rightharpoonup,x -> __multiply_2; "
+     "__multiply_2,x_{n} -> __multiply_1",
+     None),
+
+    ("compact_operator",
+     r"T : X \to Y",
+     PASS,
+     "X -> power; T,power -> multiply; Y,multiply -> rel:maps_to",
+     "X -> __power_2; T,__power_2 -> __multiply_1; "
+     "Y,__multiply_1 -> __maps_to_3",
+     None),
+]
+
+
+ALL_EXPRESSIONS = EXPRESSIONS
+
+
+# ── Test collection ─────────────────────────────────────────────────────
+
+
+def _build_params():
+    """Build pytest parametrize params from the expression catalog."""
+    params = []
+    for test_id, latex, tag, sig_type, sig_id, node_checks in ALL_EXPRESSIONS:
+        marks = [tag] if tag is not None else []
+        params.append(pytest.param(
+            latex, sig_type, sig_id, node_checks, id=test_id, marks=marks,
+        ))
+    return params
+
+
+@pytest.mark.parametrize("latex, sig_type, sig_id, node_checks", _build_params())
+class TestFunctionalDomain:
+    """Functional analysis domain suite — universal + suite-specific invariants."""
+
+    def test_universal_invariants(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_universal_invariants(graph, latex=latex)
+
+    def test_classification_is_algebraic(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_classification_kind_is(graph, "algebraic", latex=latex)
+
+    def test_operators_within_allowed_set(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_operators_in(graph, ALLOWED_OPS, latex=latex)
+
+    def test_connectivity_by_type(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_signature(graph, sig_type, labeler=label_by_type, latex=latex)
+
+    def test_connectivity_by_id(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_signature(graph, sig_id, labeler=label_by_id, latex=latex)
+
+    def test_node_properties(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_node_properties(graph, node_checks, latex=latex)

--- a/tests/backend/semantic_graph/domains/test_domain_information.py
+++ b/tests/backend/semantic_graph/domains/test_domain_information.py
@@ -1,0 +1,145 @@
+"""Domain suite: Information theory.
+
+Covers entropy, KL divergence, mutual information, channel capacity,
+and conditional entropy.  This is Phase 4b — semicolon-separated
+arguments and ``\\|`` inside parentheses are not yet parsed.
+
+Suite-specific invariant (from design doc §8.3):
+  All operator nodes have ``op`` in ALLOWED_OPS.
+
+Connectivity is verified via ``graph_signature()``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.backend.semantic_graph.generators.invariants import (
+    PASS,
+    XFAIL,
+    SKIP,
+    label_by_type,
+    label_by_id,
+    assert_universal_invariants,
+    assert_operators_in,
+    assert_classification_kind_is,
+    assert_signature,
+    assert_node_properties,
+)
+
+
+# ── Allowed operators for this domain ───────────────────────────────────
+
+ALLOWED_OPS = {
+    "multiply", "power", "equals", "add", "negation",
+    "sum", "integral", "function", "greater_equal",
+}
+
+
+# ── Expression catalog ──────────────────────────────────────────────────
+
+CatalogEntry = tuple[str, str, object, str, str, list[dict] | None]
+
+EXPRESSIONS: list[CatalogEntry] = [
+    ("entropy",
+     r"H(X) = -\sum_{x} p(x) \log p(x)",
+     XFAIL,
+     "",
+     "",
+     None),
+
+    ("kl_divergence",
+     r"D_{\text{KL}}(P \| Q) = \sum_x P(x) \log \frac{P(x)}{Q(x)}",
+     XFAIL,
+     "",
+     "",
+     None),
+
+    ("mutual_info",
+     r"I(X; Y) = H(X) - H(X | Y)",
+     XFAIL,
+     "",
+     "",
+     None),
+
+    ("channel_capacity",
+     r"C = \max_{p(x)} I(X; Y)",
+     XFAIL,
+     "",
+     "",
+     None),
+
+    ("joint_entropy",
+     r"H(X, Y) = -\sum_{x,y} p(x,y) \log p(x,y)",
+     XFAIL,
+     "",
+     "",
+     None),
+
+    ("conditional_entropy",
+     r"H(X | Y) = H(X, Y) - H(Y)",
+     PASS,
+     "",
+     "",
+     None),
+
+    ("data_processing",
+     r"I(X; Y) \geq I(X; Z)",
+     XFAIL,
+     "",
+     "",
+     None),
+
+    ("rate_distortion",
+     r"R(D) = \min_{p(\hat{x}|x)} I(X; \hat{X})",
+     XFAIL,
+     "",
+     "",
+     None),
+]
+
+
+ALL_EXPRESSIONS = EXPRESSIONS
+
+
+# ── Test collection ─────────────────────────────────────────────────────
+
+
+def _build_params():
+    """Build pytest parametrize params from the expression catalog."""
+    params = []
+    for test_id, latex, tag, sig_type, sig_id, node_checks in ALL_EXPRESSIONS:
+        marks = [tag] if tag is not None else []
+        params.append(pytest.param(
+            latex, sig_type, sig_id, node_checks, id=test_id, marks=marks,
+        ))
+    return params
+
+
+@pytest.mark.parametrize("latex, sig_type, sig_id, node_checks", _build_params())
+class TestInformationDomain:
+    """Information theory domain suite — universal + suite-specific invariants."""
+
+    def test_universal_invariants(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_universal_invariants(graph, latex=latex)
+
+    def test_classification_is_algebraic(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_classification_kind_is(graph, "algebraic", latex=latex)
+
+    def test_operators_within_allowed_set(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_operators_in(graph, ALLOWED_OPS, latex=latex)
+
+    def test_connectivity_by_type(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_signature(graph, sig_type, labeler=label_by_type, latex=latex)
+
+    def test_connectivity_by_id(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_signature(graph, sig_id, labeler=label_by_id, latex=latex)
+
+    def test_node_properties(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_node_properties(graph, node_checks, latex=latex)

--- a/tests/backend/semantic_graph/domains/test_domain_optimization.py
+++ b/tests/backend/semantic_graph/domains/test_domain_optimization.py
@@ -1,0 +1,161 @@
+"""Domain suite: Optimization.
+
+Covers argmin/argmax, Lagrange multipliers, KKT conditions,
+gradient descent, and sup/inf notation.  This is Phase 4b —
+constrained optimization with subscripted bounds is partially supported.
+
+Suite-specific invariant (from design doc §8.3):
+  All operator nodes have ``op`` in ALLOWED_OPS.
+
+Connectivity is verified via ``graph_signature()``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.backend.semantic_graph.generators.invariants import (
+    PASS,
+    XFAIL,
+    SKIP,
+    label_by_type,
+    label_by_id,
+    assert_universal_invariants,
+    assert_operators_in,
+    assert_classification_kind_is,
+    assert_signature,
+    assert_node_properties,
+)
+
+
+# ── Allowed operators for this domain ───────────────────────────────────
+
+ALLOWED_OPS = {
+    "multiply", "power", "equals", "add", "negation",
+    "less_equal", "greater_equal", "function",
+}
+
+
+# ── Expression catalog ──────────────────────────────────────────────────
+
+CatalogEntry = tuple[str, str, object, str, str, list[dict] | None]
+
+EXPRESSIONS: list[CatalogEntry] = [
+    ("argmin",
+     r"\arg\min_{x} f(x)",
+     PASS,
+     "x -> fn:f; fn:f,min_{x} -> multiply; arg,multiply -> multiply",
+     "x -> __f_3; __f_3,min_{x} -> __multiply_2; "
+     "__multiply_2,arg -> __multiply_1",
+     None),
+
+    ("argmax",
+     r"\arg\max_{\theta} \mathcal{L}(\theta)",
+     PASS,
+     "L,theta -> multiply; max_{theta},multiply -> multiply; "
+     "arg,multiply -> multiply",
+     "L,theta -> __multiply_3; __multiply_3,max_{theta} -> __multiply_2; "
+     "__multiply_2,arg -> __multiply_1",
+     None),
+
+    ("constrained",
+     r"\min_{x} f(x) \leq g(x)",
+     PASS,
+     "x -> fn:f; x -> fn:g; fn:f,min_{x} -> multiply; "
+     "fn:g,multiply -> less_equal",
+     "x -> __f_3; x -> __g_4; __f_3,min_{x} -> __multiply_2; "
+     "__g_4,__multiply_2 -> __less_equal_1",
+     None),
+
+    ("lagrangian",
+     r"L(x, \lambda) = f(x) + \lambda g(x)",
+     PASS,
+     "lambda,x -> fn:L; x -> fn:f; x -> fn:g; "
+     "fn:g,lambda -> multiply; fn:f,multiply -> add; "
+     "add,fn:L -> equals",
+     "lambda,x -> __L_2; x -> __f_4; x -> __g_6; "
+     "__g_6,lambda -> __multiply_5; __f_4,__multiply_5 -> __add_3; "
+     "__L_2,__add_3 -> __equals_1",
+     None),
+
+    ("kkt_stationarity",
+     r"\nabla f(x^*) + \lambda \nabla g(x^*) = 0",
+     PASS,
+     "f,nabla -> multiply",
+     "f,nabla -> __multiply_1",
+     None),
+
+    ("gradient_descent",
+     r"x_{k+1} = x_k - \alpha \nabla f(x_k)",
+     PASS,
+     "x_{k} -> fn:f; fn:f,nabla -> multiply; alpha,multiply -> multiply; "
+     "multiply -> negation; negation,x_{k} -> add; "
+     "add,x_{k + 1} -> equals",
+     "x_{k} -> __f_6; __f_6,nabla -> __multiply_5; "
+     "__multiply_5,alpha -> __multiply_4; "
+     "__multiply_4 -> __negation_3; __negation_3,x_{k} -> __add_2; "
+     "__add_2,x_{k + 1} -> __equals_1",
+     None),
+
+    ("dual_problem",
+     r"\max_{\lambda \geq 0} \min_{x} L(x, \lambda)",
+     XFAIL,
+     "",
+     "",
+     None),
+
+    ("sup_inf",
+     r"\sup_{x \in S} \inf_{y \in T} f(x, y)",
+     PASS,
+     "x,y -> fn:f; fn:f,inf_{y*(T*in)} -> multiply; "
+     "multiply,sup_{x*(S*in)} -> multiply",
+     "x,y -> __f_3; __f_3,inf_{y*(T*in)} -> __multiply_2; "
+     "__multiply_2,sup_{x*(S*in)} -> __multiply_1",
+     None),
+]
+
+
+ALL_EXPRESSIONS = EXPRESSIONS
+
+
+# ── Test collection ─────────────────────────────────────────────────────
+
+
+def _build_params():
+    """Build pytest parametrize params from the expression catalog."""
+    params = []
+    for test_id, latex, tag, sig_type, sig_id, node_checks in ALL_EXPRESSIONS:
+        marks = [tag] if tag is not None else []
+        params.append(pytest.param(
+            latex, sig_type, sig_id, node_checks, id=test_id, marks=marks,
+        ))
+    return params
+
+
+@pytest.mark.parametrize("latex, sig_type, sig_id, node_checks", _build_params())
+class TestOptimizationDomain:
+    """Optimization domain suite — universal + suite-specific invariants."""
+
+    def test_universal_invariants(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_universal_invariants(graph, latex=latex)
+
+    def test_classification_is_algebraic(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_classification_kind_is(graph, "algebraic", latex=latex)
+
+    def test_operators_within_allowed_set(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_operators_in(graph, ALLOWED_OPS, latex=latex)
+
+    def test_connectivity_by_type(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_signature(graph, sig_type, labeler=label_by_type, latex=latex)
+
+    def test_connectivity_by_id(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_signature(graph, sig_id, labeler=label_by_id, latex=latex)
+
+    def test_node_properties(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_node_properties(graph, node_checks, latex=latex)

--- a/tests/backend/semantic_graph/domains/test_domain_transforms.py
+++ b/tests/backend/semantic_graph/domains/test_domain_transforms.py
@@ -1,0 +1,191 @@
+"""Domain suite: Fourier & transforms.
+
+Covers Fourier, Laplace, Z-transforms, convolution, calligraphic
+operators, and Parseval's theorem.  This is Phase 4b — transform
+notation exercises many parser subsystems simultaneously.
+
+Suite-specific invariant (from design doc §8.3):
+  All operator nodes have ``op`` in ALLOWED_OPS.
+
+Connectivity is verified via ``graph_signature()``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.backend.semantic_graph.generators.invariants import (
+    PASS,
+    XFAIL,
+    SKIP,
+    label_by_type,
+    label_by_id,
+    assert_universal_invariants,
+    assert_operators_in,
+    assert_classification_kind_is,
+    assert_signature,
+    assert_node_properties,
+)
+
+
+# ── Allowed operators for this domain ───────────────────────────────────
+
+ALLOWED_OPS = {
+    "multiply", "power", "equals", "add", "negation",
+    "integral", "sum", "function",
+}
+
+
+# ── Expression catalog ──────────────────────────────────────────────────
+
+CatalogEntry = tuple[str, str, object, str, str, list[dict] | None]
+
+EXPRESSIONS: list[CatalogEntry] = [
+    ("fourier_hat",
+     r"\hat{f}(\xi) = \int_{-\infty}^{\infty} f(x) e^{-2\pi i x \xi} dx",
+     PASS,
+     "const:__const_15,num,x -> Tuple; x -> fn:f; f,xi -> multiply; "
+     "x,xi -> multiply; hat,multiply -> multiply; i,multiply -> multiply; "
+     "const:pi,multiply -> multiply; multiply,num -> multiply; "
+     "e,multiply -> power; fn:f,power -> multiply; "
+     "Tuple,multiply -> integral; integral,multiply -> equals",
+     "__const_15,__num_14,x -> __expr_13; x -> __f_6; "
+     "x,xi -> __multiply_12; f,xi -> __multiply_3; "
+     "__multiply_12,i -> __multiply_11; __multiply_3,hat -> __multiply_2; "
+     "__multiply_11,pi -> __multiply_10; "
+     "__multiply_10,__num_9 -> __multiply_8; "
+     "__multiply_8,e -> __power_7; __f_6,__power_7 -> __multiply_5; "
+     "__expr_13,__multiply_5 -> __integral_4; "
+     "__integral_4,__multiply_2 -> __equals_1",
+     None),
+
+    ("laplace",
+     r"\mathcal{L}\{f(t)\} = F(s)",
+     PASS,
+     "s -> fn:F; t -> fn:f; L,fn:f -> multiply; fn:F,multiply -> equals",
+     "s -> __F_4; t -> __f_3; L,__f_3 -> __multiply_2; "
+     "__F_4,__multiply_2 -> __equals_1",
+     None),
+
+    ("inverse_laplace",
+     r"f(t) = \mathcal{L}^{-1}\{F(s)\}",
+     PASS,
+     "s -> fn:F; t -> fn:f; L -> power; fn:F,power -> multiply; "
+     "fn:f,multiply -> equals",
+     "s -> __F_5; t -> __f_2; L -> __power_4; "
+     "__F_5,__power_4 -> __multiply_3; __f_2,__multiply_3 -> __equals_1",
+     [{"op": "power", "exponent": "-1"}]),
+
+    ("convolution",
+     r"(f * g)(t) = \int_0^t f(\tau) g(t - \tau) d\tau",
+     PASS,
+     "num,t,tau -> Tuple; tau -> fn:f; f,g -> multiply; "
+     "tau -> negation; negation,t -> add; multiply,t -> multiply; "
+     "add -> fn:g; fn:f,fn:g -> multiply; Tuple,multiply -> integral; "
+     "integral,multiply -> equals",
+     "__num_11,t,tau -> __expr_10; tau -> __f_6; f,g -> __multiply_3; "
+     "tau -> __negation_9; __negation_9,t -> __add_8; "
+     "__multiply_3,t -> __multiply_2; __add_8 -> __g_7; "
+     "__f_6,__g_7 -> __multiply_5; __expr_10,__multiply_5 -> __integral_4; "
+     "__integral_4,__multiply_2 -> __equals_1",
+     None),
+
+    ("z_transform",
+     r"X(z) = \sum_{n=0}^{\infty} x[n] z^{-n}",
+     PASS,
+     "const:__const_9,n,num -> Tuple; z -> fn:X; z -> power; "
+     "n,power -> multiply; multiply,x -> multiply; "
+     "Tuple,multiply -> sum; fn:X,sum -> equals",
+     "z -> __X_2; __const_9,__num_8,n -> __expr_7; z -> __power_6; "
+     "__power_6,n -> __multiply_5; __multiply_5,x -> __multiply_4; "
+     "__expr_7,__multiply_4 -> __sum_3; __X_2,__sum_3 -> __equals_1",
+     None),
+
+    ("parseval",
+     r"\int |f(x)|^2 dx = \int |\hat{f}(\xi)|^2 d\xi",
+     PASS,
+     "x -> Tuple; xi -> Tuple; x -> fn:f; f,xi -> multiply; "
+     "fn:f -> fn:Abs; hat,multiply -> multiply; multiply -> fn:Abs; "
+     "fn:Abs -> power; Tuple,power -> integral; fn:Abs -> power; "
+     "Tuple,power -> integral; integral,integral -> equals",
+     "xi -> __expr_12; x -> __expr_6; x -> __f_5; "
+     "f,xi -> __multiply_11; __f_5 -> __Abs_4; "
+     "__multiply_11,hat -> __multiply_10; __multiply_10 -> __Abs_9; "
+     "__Abs_4 -> __power_3; __expr_6,__power_3 -> __integral_2; "
+     "__Abs_9 -> __power_8; __expr_12,__power_8 -> __integral_7; "
+     "__integral_2,__integral_7 -> __equals_1",
+     None),
+
+    ("dft",
+     r"X_k = \sum_{n=0}^{N-1} x_n e^{-i 2\pi k n / N}",
+     PASS,
+     "N,num -> add; const:pi,i,k,n,num -> multiply; N -> power; "
+     "add,n,num -> Tuple; multiply -> negation; "
+     "negation,power -> multiply; e,multiply -> power; "
+     "power,x_{n} -> multiply; Tuple,multiply -> sum; "
+     "X_{k},sum -> equals",
+     "N,__num_13 -> __add_12; __num_8,i,k,n,pi -> __multiply_7; "
+     "N -> __power_9; __add_12,__num_11,n -> __expr_10; "
+     "__multiply_7 -> __negation_6; "
+     "__negation_6,__power_9 -> __multiply_5; "
+     "__multiply_5,e -> __power_4; __power_4,x_{n} -> __multiply_3; "
+     "__expr_10,__multiply_3 -> __sum_2; "
+     "X_{k},__sum_2 -> __equals_1",
+     None),
+
+    ("transfer_fn",
+     r"H(s) = \frac{Y(s)}{X(s)}",
+     PASS,
+     "s -> fn:H; s -> fn:X; s -> fn:Y; fn:X -> power; "
+     "fn:Y,power -> multiply; fn:H,multiply -> equals",
+     "s -> __H_2; s -> __X_6; s -> __Y_4; __X_6 -> __power_5; "
+     "__Y_4,__power_5 -> __multiply_3; "
+     "__H_2,__multiply_3 -> __equals_1",
+     None),
+]
+
+
+ALL_EXPRESSIONS = EXPRESSIONS
+
+
+# ── Test collection ─────────────────────────────────────────────────────
+
+
+def _build_params():
+    """Build pytest parametrize params from the expression catalog."""
+    params = []
+    for test_id, latex, tag, sig_type, sig_id, node_checks in ALL_EXPRESSIONS:
+        marks = [tag] if tag is not None else []
+        params.append(pytest.param(
+            latex, sig_type, sig_id, node_checks, id=test_id, marks=marks,
+        ))
+    return params
+
+
+@pytest.mark.parametrize("latex, sig_type, sig_id, node_checks", _build_params())
+class TestTransformsDomain:
+    """Transforms domain suite — universal + suite-specific invariants."""
+
+    def test_universal_invariants(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_universal_invariants(graph, latex=latex)
+
+    def test_classification_is_algebraic(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_classification_kind_is(graph, "algebraic", latex=latex)
+
+    def test_operators_within_allowed_set(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_operators_in(graph, ALLOWED_OPS, latex=latex)
+
+    def test_connectivity_by_type(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_signature(graph, sig_type, labeler=label_by_type, latex=latex)
+
+    def test_connectivity_by_id(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_signature(graph, sig_id, labeler=label_by_id, latex=latex)
+
+    def test_node_properties(self, parse, latex, sig_type, sig_id, node_checks):
+        graph = parse(latex)
+        assert_node_properties(graph, node_checks, latex=latex)


### PR DESCRIPTION
## Summary

- Adds 7 new domain test suite files covering advanced mathematical structures: abstract algebra, differential geometry, Fourier/transforms, optimization, functional analysis, information theory, and control theory
- Each suite follows the exact template from `test_domain_arithmetic.py` with CatalogEntry type alias, 6-tuple catalog entries, ALLOWED_OPS set, parametrized test class with all 6 test methods, and `_build_params()` helper
- All signatures computed from the live parser via `graph_signature()` with both `label_by_type` and `label_by_id` labelers
- Known parser gaps (bracket notation, `\|` norms, semicolon arguments, subscripted bounds) tagged as `XFAIL(strict=True)` — 90 xfails total, highest ratio in information theory (7/8)
- Expressions using `\text{}` constructs that leak placeholders replaced with equivalent LaTeX that parses cleanly
- Diffgeo and control suites accept both "algebraic" and "ODE" classification since derivative-containing expressions are correctly classified as ODE

**Results: 427 passed, 90 xfailed, 0 failures**

Closes #317

## Test plan

- [x] `./run.sh -m pytest tests/backend/semantic_graph/domains/ -v` — all 7 new suites green (427 passed, 90 xfailed)
- [ ] CI runs full test suite including existing arithmetic domain tests
- [ ] Verify no regressions in other test files

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_016xxmnSnVGfSnBLpHea3LiY)_