### PR TITLE
feat: semantic graph visual examination report with GitHub Pages deploy

### DIFF
--- a/.github/workflows/semantic-graph-cleanup.yml
+++ b/.github/workflows/semantic-graph-cleanup.yml
@@ -1,0 +1,31 @@
+name: Semantic Graph Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    name: Remove PR preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Remove PR directory
+        run: |
+          PR_DIR="semantic-graph/pr-${{ github.event.pull_request.number }}"
+          if [ -d "$PR_DIR" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git rm -rf "$PR_DIR"
+            git commit -m "chore: clean up preview for PR #${{ github.event.pull_request.number }}"
+            git push
+          else
+            echo "No preview directory found for PR #${{ github.event.pull_request.number }}"
+          fi

--- a/.github/workflows/semantic-graph-cleanup.yml
+++ b/.github/workflows/semantic-graph-cleanup.yml
@@ -12,12 +12,23 @@ jobs:
     name: Remove PR preview
     runs-on: ubuntu-latest
     steps:
+      - name: Check gh-pages branch exists
+        id: check
+        run: |
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout gh-pages
+        if: steps.check.outputs.exists == 'true'
         uses: actions/checkout@v4
         with:
           ref: gh-pages
 
       - name: Remove PR directory
+        if: steps.check.outputs.exists == 'true'
         run: |
           PR_DIR="semantic-graph/pr-${{ github.event.pull_request.number }}"
           if [ -d "$PR_DIR" ]; then

--- a/.github/workflows/semantic-graph-cleanup.yml
+++ b/.github/workflows/semantic-graph-cleanup.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check gh-pages branch exists
         id: check
         run: |
-          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+          if git ls-remote --exit-code --heads "https://github.com/${{ github.repository }}.git" gh-pages >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/semantic-graph-report.yml
+++ b/.github/workflows/semantic-graph-report.yml
@@ -1,0 +1,50 @@
+name: Semantic Graph Report
+
+on:
+  pull_request:
+    paths:
+      - 'backend/semantic_graph/**'
+      - 'backend/model/semantic_graph.py'
+      - 'scripts/graph_to_mermaid.py'
+      - 'scripts/semantic_graph_report.py'
+      - 'themes/semantic-graph/**'
+  push:
+    branches: [main]
+    paths:
+      - 'backend/semantic_graph/**'
+      - 'backend/model/semantic_graph.py'
+      - 'scripts/graph_to_mermaid.py'
+      - 'scripts/semantic_graph_report.py'
+      - 'themes/semantic-graph/**'
+  workflow_dispatch:
+
+jobs:
+  report:
+    name: Visual examination
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: ./run.sh -m pip install pytest -q
+
+      - name: Generate site
+        run: ./run.sh scripts/semantic_graph_report.py --outdir _site
+
+      - name: Deploy to GitHub Pages
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+          destination_dir: semantic-graph
+          keep_files: true

--- a/.github/workflows/semantic-graph-report.yml
+++ b/.github/workflows/semantic-graph-report.yml
@@ -18,13 +18,19 @@ on:
       - 'themes/semantic-graph/**'
   workflow_dispatch:
 
-jobs:
-  report:
-    name: Visual examination
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Generate reports
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -38,13 +44,24 @@ jobs:
         run: ./run.sh -m pip install pytest -q
 
       - name: Generate site
-        run: ./run.sh scripts/semantic_graph_report.py --outdir _site
+        run: |
+          mkdir -p _site/semantic-graph
+          ./run.sh scripts/semantic_graph_report.py --outdir _site/semantic-graph
 
-      - name: Deploy to GitHub Pages
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./_site
-          destination_dir: semantic-graph
-          keep_files: true
+          path: _site
+
+  deploy:
+    name: Deploy to Pages
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}semantic-graph/
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/semantic-graph-report.yml
+++ b/.github/workflows/semantic-graph-report.yml
@@ -59,7 +59,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
           destination_dir: ${{ steps.dest.outputs.dir }}
-          keep_files: true
+          keep_files: ${{ github.event_name == 'pull_request' }}
 
       - name: Post preview URL
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/semantic-graph-report.yml
+++ b/.github/workflows/semantic-graph-report.yml
@@ -55,7 +55,6 @@ jobs:
 
   deploy:
     name: Deploy to Pages
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/semantic-graph-report.yml
+++ b/.github/workflows/semantic-graph-report.yml
@@ -68,15 +68,9 @@ jobs:
           PREVIEW_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ steps.dest.outputs.dir }}/"
           echo "## 📊 Semantic Graph Report" >> "$GITHUB_STEP_SUMMARY"
           echo "Preview: ${PREVIEW_URL}" >> "$GITHUB_STEP_SUMMARY"
-          COMMENT_BODY="## 📊 Semantic Graph Report
+          EXISTING=$(gh pr view ${{ github.event.pull_request.number }} --json comments --jq '[.comments[] | select(.body | contains("Semantic Graph Report"))] | length')
+          if [ "$EXISTING" = "0" ]; then
+            gh pr comment ${{ github.event.pull_request.number }} --body "## 📊 Semantic Graph Report
 
-          **Preview:** ${PREVIEW_URL}
-
-          *Updated: $(date -u '+%Y-%m-%d %H:%M UTC')*"
-          EXISTING=$(gh pr view ${{ github.event.pull_request.number }} --json comments --jq '.comments[] | select(.body | contains("Semantic Graph Report")) | .url' | head -1)
-          if [ -n "$EXISTING" ]; then
-            COMMENT_ID=$(echo "$EXISTING" | grep -oE '[0-9]+$')
-            gh api repos/${{ github.repository }}/issues/comments/${COMMENT_ID} -X PATCH -f body="${COMMENT_BODY}"
-          else
-            gh pr comment ${{ github.event.pull_request.number }} --body "${COMMENT_BODY}"
+          **Preview:** ${PREVIEW_URL}"
           fi

--- a/.github/workflows/semantic-graph-report.yml
+++ b/.github/workflows/semantic-graph-report.yml
@@ -20,6 +20,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   build-and-deploy:
@@ -61,8 +62,21 @@ jobs:
 
       - name: Post preview URL
         if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          PREVIEW_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ steps.dest.outputs.dir }}/"
           echo "## 📊 Semantic Graph Report" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          OWNER="${{ github.repository_owner }}"
-          echo "Preview: https://${OWNER}.github.io/${{ github.event.repository.name }}/${{ steps.dest.outputs.dir }}/" >> "$GITHUB_STEP_SUMMARY"
+          echo "Preview: ${PREVIEW_URL}" >> "$GITHUB_STEP_SUMMARY"
+          COMMENT_BODY="## 📊 Semantic Graph Report
+
+          **Preview:** ${PREVIEW_URL}
+
+          *Updated: $(date -u '+%Y-%m-%d %H:%M UTC')*"
+          EXISTING=$(gh pr view ${{ github.event.pull_request.number }} --json comments --jq '.comments[] | select(.body | contains("Semantic Graph Report")) | .url' | head -1)
+          if [ -n "$EXISTING" ]; then
+            COMMENT_ID=$(echo "$EXISTING" | grep -oE '[0-9]+$')
+            gh api repos/${{ github.repository }}/issues/comments/${COMMENT_ID} -X PATCH -f body="${COMMENT_BODY}"
+          else
+            gh pr comment ${{ github.event.pull_request.number }} --body "${COMMENT_BODY}"
+          fi

--- a/.github/workflows/semantic-graph-report.yml
+++ b/.github/workflows/semantic-graph-report.yml
@@ -19,17 +19,11 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: pages
-  cancel-in-progress: false
+  contents: write
 
 jobs:
-  build:
-    name: Generate reports
+  build-and-deploy:
+    name: Generate & deploy reports
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -43,24 +37,32 @@ jobs:
       - name: Install dependencies
         run: ./run.sh -m pip install pytest -q
 
+      - name: Determine destination directory
+        id: dest
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "dir=semantic-graph/pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "dir=semantic-graph" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Generate site
         run: |
-          mkdir -p _site/semantic-graph
-          ./run.sh scripts/semantic_graph_report.py --outdir _site/semantic-graph
+          mkdir -p _site
+          ./run.sh scripts/semantic_graph_report.py --outdir _site
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: _site
-
-  deploy:
-    name: Deploy to Pages
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}semantic-graph/
-    steps:
       - name: Deploy to GitHub Pages
-        id: deploy
-        uses: actions/deploy-pages@v4
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+          destination_dir: ${{ steps.dest.outputs.dir }}
+          keep_files: true
+
+      - name: Post preview URL
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "## 📊 Semantic Graph Report" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          OWNER="${{ github.repository_owner }}"
+          echo "Preview: https://${OWNER}.github.io/${{ github.event.repository.name }}/${{ steps.dest.outputs.dir }}/" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/semantic-graph-report.yml
+++ b/.github/workflows/semantic-graph-report.yml
@@ -1,4 +1,4 @@
-name: Semantic Graph Report
+name: Semantic Graph Visual Report
 
 on:
   pull_request:
@@ -53,6 +53,7 @@ jobs:
           ./run.sh scripts/semantic_graph_report.py --outdir _site
 
       - name: Deploy to GitHub Pages
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -61,16 +62,16 @@ jobs:
           keep_files: true
 
       - name: Post preview URL
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PREVIEW_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ steps.dest.outputs.dir }}/"
-          echo "## 📊 Semantic Graph Report" >> "$GITHUB_STEP_SUMMARY"
+          echo "## 📊 Semantic Graph Visual Report" >> "$GITHUB_STEP_SUMMARY"
           echo "Preview: ${PREVIEW_URL}" >> "$GITHUB_STEP_SUMMARY"
-          EXISTING=$(gh pr view ${{ github.event.pull_request.number }} --json comments --jq '[.comments[] | select(.body | contains("Semantic Graph Report"))] | length')
+          EXISTING=$(gh pr view ${{ github.event.pull_request.number }} --json comments --jq '[.comments[] | select(.body | contains("Semantic Graph Visual Report"))] | length')
           if [ "$EXISTING" = "0" ]; then
-            gh pr comment ${{ github.event.pull_request.number }} --body "## 📊 Semantic Graph Report
-
-          **Preview:** ${PREVIEW_URL}"
+            gh pr comment ${{ github.event.pull_request.number }} \
+              --body "## 📊 Semantic Graph Visual Report
+**Preview:** ${PREVIEW_URL}"
           fi

--- a/scripts/render_math.py
+++ b/scripts/render_math.py
@@ -129,7 +129,59 @@ PAGE_TEMPLATE = """\
   onload="renderMathInElement(document.body, {{delimiters:[{{left:'$$',right:'$$',display:true}},{{left:'$',right:'$',display:false}}]}});"></script>
 <script type="module">
   import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.4.0/dist/mermaid.esm.min.mjs';
-  mermaid.initialize({{ startOnLoad: true, theme: '{mermaid_theme}' }});
+  mermaid.initialize({{ startOnLoad: false, theme: '{mermaid_theme}',
+    flowchart: {{ htmlLabels: true, curve: 'basis' }} }});
+  await mermaid.run();
+  // Post-render: replace $...$ inside Mermaid foreignObject labels with KaTeX
+  if (window.katex) {{
+    const INLINE_MATH = /\\$([^$\\n]+)\\$/g;
+    document.querySelectorAll(
+      'foreignObject span, foreignObject div, foreignObject p, .nodeLabel'
+    ).forEach((host) => {{
+      if (!host.textContent || host.textContent.indexOf('$') === -1) return;
+      const walker = document.createTreeWalker(host, NodeFilter.SHOW_TEXT, null);
+      const textNodes = [];
+      while (walker.nextNode()) textNodes.push(walker.currentNode);
+      textNodes.forEach((tn) => {{
+        const src = tn.nodeValue;
+        if (!src || src.indexOf('$') === -1) return;
+        INLINE_MATH.lastIndex = 0;
+        if (!INLINE_MATH.test(src)) return;
+        INLINE_MATH.lastIndex = 0;
+        const frag = document.createDocumentFragment();
+        let last = 0, m;
+        while ((m = INLINE_MATH.exec(src)) !== null) {{
+          if (m.index > last)
+            frag.appendChild(document.createTextNode(src.slice(last, m.index)));
+          const span = document.createElement('span');
+          try {{ katex.render(m[1], span, {{ throwOnError: false, displayMode: false }}); }}
+          catch (_) {{ span.textContent = m[0]; }}
+          frag.appendChild(span);
+          last = m.index + m[0].length;
+        }}
+        if (last < src.length)
+          frag.appendChild(document.createTextNode(src.slice(last)));
+        tn.parentNode.replaceChild(frag, tn);
+      }});
+    }});
+    // Center labels inside foreignObject after KaTeX changes text width
+    const svg = document.querySelector('.render-math-container svg');
+    if (svg) {{
+      const NS = 'http://www.w3.org/1999/xhtml';
+      svg.querySelectorAll('g.node foreignObject').forEach((fo) => {{
+        const outer = fo.firstElementChild;
+        if (!outer || outer.dataset?.gvCentered === 'wrapper') return;
+        const wrapper = document.createElementNS(NS, 'div');
+        wrapper.dataset.gvCentered = 'wrapper';
+        Object.assign(wrapper.style, {{
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          width: '100%', height: '100%',
+        }});
+        fo.replaceChild(wrapper, outer);
+        wrapper.appendChild(outer);
+      }});
+    }}
+  }}
 </script>
 <style>
   * {{ margin: 0; padding: 0; box-sizing: border-box; }}

--- a/scripts/semantic_graph_report.py
+++ b/scripts/semantic_graph_report.py
@@ -7,7 +7,7 @@ Renders every expression from the domain test catalogs as a row containing:
   - expandable JSON panel
 
 Supports two output modes:
-  - Single file:  -o report.html
+  - Single file:  -o report.html  (requires internet for KaTeX/Mermaid CDN)
   - Site directory: --outdir _site  (one HTML per domain + index page)
 
 The site mode is used by CI to deploy to GitHub Pages.
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 import textwrap
 import traceback
 from pathlib import Path
@@ -286,7 +285,6 @@ def _render_row(
     test_id: str,
     latex: str,
     theme: dict[str, Any],
-    theme_colors: dict[str, str],
 ) -> tuple[str, bool]:
     """Render a single expression row. Returns (html, success)."""
     parts: list[str] = []
@@ -303,7 +301,7 @@ def _render_row(
         graph_json = json.dumps(graph_dict, indent=2, ensure_ascii=False)
 
         parts.append(f'  <div class="row-graph">')
-        parts.append(f'    <pre class="mermaid">{mermaid_src}</pre>')
+        parts.append(f'    <pre class="mermaid">{_escape_html(mermaid_src)}</pre>')
         parts.append(f'  </div>')
         parts.append(f'  <div class="row-actions">')
         parts.append(
@@ -360,7 +358,7 @@ def _build_report_html(
             f'({len(expressions)} expressions)</div>'
         )
         for test_id, latex in expressions:
-            row_html, success = _render_row(test_id, latex, theme, colors)
+            row_html, success = _render_row(test_id, latex, theme)
             body_parts.append(row_html)
             if success:
                 ok_count += 1

--- a/scripts/semantic_graph_report.py
+++ b/scripts/semantic_graph_report.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python3
+"""Generate visual examination reports for the semantic graph pipeline.
+
+Renders every expression from the domain test catalogs as a row containing:
+  - rendered LaTeX (KaTeX)
+  - Mermaid semantic graph
+  - expandable JSON panel
+
+Supports two output modes:
+  - Single file:  -o report.html
+  - Site directory: --outdir _site  (one HTML per domain + index page)
+
+The site mode is used by CI to deploy to GitHub Pages.
+
+Usage:
+    ./run.sh scripts/semantic_graph_report.py
+    ./run.sh scripts/semantic_graph_report.py -o report.html
+    ./run.sh scripts/semantic_graph_report.py --outdir _site
+    ./run.sh scripts/semantic_graph_report.py --theme default-dark
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import textwrap
+import traceback
+from pathlib import Path
+from typing import Any
+
+# Support both direct and module invocation
+try:
+    from graph_to_mermaid import semantic_graph_to_mermaid, load_theme
+except ImportError:
+    from scripts.graph_to_mermaid import semantic_graph_to_mermaid, load_theme
+
+from backend.semantic_graph.sympy_translator import latex_to_semantic_graph
+from tests.backend.semantic_graph.domains.test_domain_arithmetic import (
+    ALL_EXPRESSIONS as ARITHMETIC_EXPRESSIONS,
+)
+
+
+# ── Expression catalog ─────────────────────────────────────────────────
+# Each domain contributes (section_name, [(test_id, latex), ...]).
+# Expand this list as new domain test files are added.
+
+
+def _collect_expressions() -> list[tuple[str, list[tuple[str, str]]]]:
+    sections: list[tuple[str, list[tuple[str, str]]]] = []
+    arith = [(tid, latex) for tid, latex, *_ in ARITHMETIC_EXPRESSIONS]
+    sections.append(("Arithmetic", arith))
+    return sections
+
+
+# ── HTML templates ─────────────────────────────────────────────────────
+
+THEMES = {
+    "light": {
+        "bg": "#f8f9fa",
+        "fg": "#1a1a2e",
+        "card_bg": "#ffffff",
+        "border": "#e2e8f0",
+        "shadow": "rgba(0,0,0,0.06)",
+        "muted": "#718096",
+        "mermaid_theme": "default",
+        "error_bg": "#fff5f5",
+        "error_border": "#feb2b2",
+        "error_fg": "#c53030",
+    },
+    "dark": {
+        "bg": "#0d1117",
+        "fg": "#e6edf3",
+        "card_bg": "#161b22",
+        "border": "#30363d",
+        "shadow": "rgba(0,0,0,0.3)",
+        "muted": "#8b949e",
+        "mermaid_theme": "dark",
+        "error_bg": "#2d1b1b",
+        "error_border": "#6b2020",
+        "error_fg": "#f87171",
+    },
+}
+
+
+def _page_template() -> str:
+    return textwrap.dedent("""\
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Semantic Graph Visual Report</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"
+      onload="renderMathInElement(document.body, {{delimiters:[{{left:'$$',right:'$$',display:true}},{{left:'$',right:'$',display:false}}]}});"></script>
+    <script type="module">
+      import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.4.0/dist/mermaid.esm.min.mjs';
+      mermaid.initialize({{ startOnLoad: false, theme: '{mermaid_theme}',
+        flowchart: {{ htmlLabels: true, curve: 'basis' }} }});
+      await mermaid.run();
+      if (window.katex) {{
+        const INLINE_MATH = /\\$([^$\\n]+)\\$/g;
+        document.querySelectorAll(
+          'foreignObject span, foreignObject div, foreignObject p, .nodeLabel'
+        ).forEach((host) => {{
+          if (!host.textContent || host.textContent.indexOf('$') === -1) return;
+          const walker = document.createTreeWalker(host, NodeFilter.SHOW_TEXT, null);
+          const textNodes = [];
+          while (walker.nextNode()) textNodes.push(walker.currentNode);
+          textNodes.forEach((tn) => {{
+            const src = tn.nodeValue;
+            if (!src || src.indexOf('$') === -1) return;
+            INLINE_MATH.lastIndex = 0;
+            if (!INLINE_MATH.test(src)) return;
+            INLINE_MATH.lastIndex = 0;
+            const frag = document.createDocumentFragment();
+            let last = 0, m;
+            while ((m = INLINE_MATH.exec(src)) !== null) {{
+              if (m.index > last)
+                frag.appendChild(document.createTextNode(src.slice(last, m.index)));
+              const span = document.createElement('span');
+              try {{ katex.render(m[1], span, {{ throwOnError: false, displayMode: false }}); }}
+              catch (_) {{ span.textContent = m[0]; }}
+              frag.appendChild(span);
+              last = m.index + m[0].length;
+            }}
+            if (last < src.length)
+              frag.appendChild(document.createTextNode(src.slice(last)));
+            tn.parentNode.replaceChild(frag, tn);
+          }});
+        }});
+        document.querySelectorAll('svg g.node foreignObject').forEach((fo) => {{
+          const outer = fo.firstElementChild;
+          if (!outer || outer.dataset?.gvCentered === 'wrapper') return;
+          const NS = 'http://www.w3.org/1999/xhtml';
+          const wrapper = document.createElementNS(NS, 'div');
+          wrapper.dataset.gvCentered = 'wrapper';
+          Object.assign(wrapper.style, {{
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            width: '100%', height: '100%',
+          }});
+          fo.replaceChild(wrapper, outer);
+          wrapper.appendChild(outer);
+        }});
+      }}
+    </script>
+    <style>
+      * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+      body {{
+        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: {bg};
+        color: {fg};
+        padding: 2rem;
+      }}
+      h1 {{
+        font-size: 1.4rem;
+        margin-bottom: 0.5rem;
+      }}
+      .report-meta {{
+        font-size: 0.8rem;
+        color: {muted};
+        margin-bottom: 2rem;
+      }}
+      .section-title {{
+        font-size: 1.1rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: {muted};
+        margin: 2rem 0 1rem 0;
+        border-bottom: 1px solid {border};
+        padding-bottom: 0.5rem;
+      }}
+      .row {{
+        display: grid;
+        grid-template-columns: 1fr 2fr auto;
+        gap: 1rem;
+        align-items: start;
+        background: {card_bg};
+        border: 1px solid {border};
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        margin-bottom: 0.75rem;
+        box-shadow: 0 1px 4px {shadow};
+      }}
+      .row-id {{
+        font-family: monospace;
+        font-size: 0.7rem;
+        color: {muted};
+        margin-bottom: 0.3rem;
+      }}
+      .row-latex {{
+        font-size: 1.2rem;
+        padding: 0.5rem 0;
+      }}
+      .row-graph {{
+        min-width: 0;
+        overflow-x: auto;
+      }}
+      .row-graph .mermaid {{
+        font-size: 0.85rem;
+      }}
+      .row-actions {{
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+        align-self: center;
+      }}
+      .row-toggle {{
+        background: none;
+        border: 1px solid {border};
+        border-radius: 4px;
+        color: {muted};
+        font-family: monospace;
+        font-size: 0.75rem;
+        padding: 0.2rem 0.5rem;
+        cursor: pointer;
+        white-space: nowrap;
+      }}
+      .row-toggle:hover {{
+        color: {fg};
+        border-color: {fg};
+      }}
+      .row-panel {{
+        display: none;
+        grid-column: 1 / -1;
+        background: {bg};
+        border: 1px solid {border};
+        border-radius: 6px;
+        padding: 0.8rem;
+        font-family: monospace;
+        font-size: 0.7rem;
+        line-height: 1.4;
+        white-space: pre-wrap;
+        word-break: break-word;
+        max-height: 400px;
+        overflow: auto;
+      }}
+      .row-panel.open {{
+        display: block;
+      }}
+      .row-error {{
+        grid-column: 2 / -1;
+        background: {error_bg};
+        border: 1px solid {error_border};
+        border-radius: 6px;
+        padding: 0.5rem 0.8rem;
+        font-family: monospace;
+        font-size: 0.75rem;
+        color: {error_fg};
+        white-space: pre-wrap;
+      }}
+      .summary {{
+        margin-top: 2rem;
+        padding: 1rem;
+        background: {card_bg};
+        border: 1px solid {border};
+        border-radius: 8px;
+        font-size: 0.85rem;
+      }}
+      .summary .count {{
+        font-weight: 600;
+      }}
+    </style>
+    </head>
+    <body>
+    <h1>Semantic Graph &mdash; Visual Examination Report</h1>
+    <div class="report-meta">{meta}</div>
+    {body}
+    <script>
+    document.querySelectorAll('.row-toggle').forEach(btn => {{
+      btn.addEventListener('click', () => {{
+        const target = btn.dataset.target;
+        const panel = btn.closest('.row').querySelector('.' + target);
+        if (panel) panel.classList.toggle('open');
+      }});
+    }});
+    </script>
+    </body>
+    </html>
+    """)
+
+
+def _render_row(
+    test_id: str,
+    latex: str,
+    theme: dict[str, Any],
+    theme_colors: dict[str, str],
+) -> tuple[str, bool]:
+    """Render a single expression row. Returns (html, success)."""
+    parts: list[str] = []
+    parts.append(f'<div class="row">')
+    parts.append(f'  <div>')
+    parts.append(f'    <div class="row-id">{test_id}</div>')
+    parts.append(f'    <div class="row-latex">$${_escape_html(latex)}$$</div>')
+    parts.append(f'  </div>')
+
+    try:
+        graph_obj = latex_to_semantic_graph(latex)
+        graph_dict = graph_obj.model_dump(by_alias=True, exclude_none=True)
+        mermaid_src = semantic_graph_to_mermaid(graph_dict, theme=theme)
+        graph_json = json.dumps(graph_dict, indent=2, ensure_ascii=False)
+
+        parts.append(f'  <div class="row-graph">')
+        parts.append(f'    <pre class="mermaid">{mermaid_src}</pre>')
+        parts.append(f'  </div>')
+        parts.append(f'  <div class="row-actions">')
+        parts.append(
+            f'    <button class="row-toggle" data-target="row-latex-src" '
+            f'title="Toggle LaTeX source">LaTeX</button>'
+        )
+        parts.append(
+            f'    <button class="row-toggle" data-target="row-json" '
+            f'title="Toggle JSON">{{}}</button>'
+        )
+        parts.append(f'  </div>')
+        parts.append(
+            f'  <div class="row-panel row-latex-src">'
+            f'{_escape_html(latex)}</div>'
+        )
+        parts.append(
+            f'  <div class="row-panel row-json">'
+            f'{_escape_html(graph_json)}</div>'
+        )
+        success = True
+    except Exception:
+        tb = traceback.format_exc()
+        parts.append(
+            f'  <div class="row-error">{_escape_html(tb)}</div>'
+        )
+        success = False
+
+    parts.append('</div>')
+    return "\n".join(parts), success
+
+
+def _escape_html(s: str) -> str:
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _build_report_html(
+    sections: list[tuple[str, list[tuple[str, str]]]],
+    *,
+    graph_theme: str,
+    theme: dict[str, Any],
+    colors: dict[str, str],
+) -> tuple[str, int, int]:
+    """Build report HTML body and return (html, ok_count, err_count)."""
+    import datetime
+
+    total = sum(len(exprs) for _, exprs in sections)
+    body_parts: list[str] = []
+    ok_count = 0
+    err_count = 0
+
+    for section_name, expressions in sections:
+        body_parts.append(
+            f'<div class="section-title">{section_name} '
+            f'({len(expressions)} expressions)</div>'
+        )
+        for test_id, latex in expressions:
+            row_html, success = _render_row(test_id, latex, theme, colors)
+            body_parts.append(row_html)
+            if success:
+                ok_count += 1
+            else:
+                err_count += 1
+
+    summary = (
+        f'<div class="summary">'
+        f'<span class="count">{ok_count}</span> rendered, '
+        f'<span class="count">{err_count}</span> errors '
+        f'out of <span class="count">{total}</span> expressions'
+        f'</div>'
+    )
+    body_parts.append(summary)
+
+    now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    meta = f"Generated {now} &middot; theme: {graph_theme} &middot; {total} expressions"
+
+    html = _page_template().format(
+        body="\n".join(body_parts),
+        meta=meta,
+        **colors,
+    )
+    return html, ok_count, err_count
+
+
+def generate_report(
+    *,
+    graph_theme: str = "default-dark",
+    output: Path | None = None,
+) -> Path:
+    theme = load_theme(graph_theme)
+    color_mode = theme.get("mode", "dark")
+    colors = THEMES[color_mode]
+    sections = _collect_expressions()
+
+    html, _, _ = _build_report_html(
+        sections, graph_theme=graph_theme, theme=theme, colors=colors,
+    )
+
+    if output is None:
+        import tempfile
+        fd, path = tempfile.mkstemp(prefix="sg_report_", suffix=".html")
+        import os
+        os.close(fd)
+        output = Path(path)
+
+    output.write_text(html, encoding="utf-8")
+    return output
+
+
+def _index_template() -> str:
+    return textwrap.dedent("""\
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Semantic Graph Reports</title>
+    <style>
+      * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+      body {{
+        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: {bg}; color: {fg}; padding: 2rem;
+      }}
+      h1 {{ font-size: 1.4rem; margin-bottom: 0.5rem; }}
+      .meta {{ font-size: 0.8rem; color: {muted}; margin-bottom: 2rem; }}
+      .domain-list {{ list-style: none; }}
+      .domain-list li {{
+        background: {card_bg}; border: 1px solid {border}; border-radius: 8px;
+        padding: 1rem 1.2rem; margin-bottom: 0.75rem;
+        box-shadow: 0 1px 4px {shadow};
+      }}
+      .domain-list a {{
+        color: {fg}; text-decoration: none; font-weight: 600; font-size: 1.05rem;
+      }}
+      .domain-list a:hover {{ text-decoration: underline; }}
+      .domain-list .stats {{
+        font-size: 0.8rem; color: {muted}; margin-top: 0.3rem;
+      }}
+    </style>
+    </head>
+    <body>
+    <h1>Semantic Graph &mdash; Visual Examination Reports</h1>
+    <div class="meta">{meta}</div>
+    <ul class="domain-list">
+    {entries}
+    </ul>
+    </body>
+    </html>
+    """)
+
+
+def generate_site(
+    *,
+    graph_theme: str = "default-dark",
+    outdir: Path,
+) -> Path:
+    import datetime
+
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    theme = load_theme(graph_theme)
+    color_mode = theme.get("mode", "dark")
+    colors = THEMES[color_mode]
+    sections = _collect_expressions()
+
+    index_entries: list[str] = []
+    total_ok = 0
+    total_err = 0
+
+    for section_name, expressions in sections:
+        slug = section_name.lower().replace(" ", "-")
+        filename = f"{slug}.html"
+
+        html, ok, err = _build_report_html(
+            [(section_name, expressions)],
+            graph_theme=graph_theme, theme=theme, colors=colors,
+        )
+        (outdir / filename).write_text(html, encoding="utf-8")
+        total_ok += ok
+        total_err += err
+
+        index_entries.append(
+            f'<li><a href="{filename}">{section_name}</a>'
+            f'<div class="stats">{ok} rendered, {err} errors '
+            f'out of {len(expressions)} expressions</div></li>'
+        )
+
+    now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    total = total_ok + total_err
+    meta = (
+        f"Generated {now} &middot; theme: {graph_theme} "
+        f"&middot; {total} expressions across {len(sections)} domains"
+    )
+
+    index_html = _index_template().format(
+        entries="\n".join(index_entries),
+        meta=meta,
+        **colors,
+    )
+    index_path = outdir / "index.html"
+    index_path.write_text(index_html, encoding="utf-8")
+    return outdir
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate semantic graph visual examination report.",
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "-o", "--output",
+        type=Path,
+        default=None,
+        help="Output single HTML file (default: temp file)",
+    )
+    group.add_argument(
+        "--outdir",
+        type=Path,
+        default=None,
+        help="Output directory for per-domain reports + index page",
+    )
+    parser.add_argument(
+        "--theme",
+        default="default-dark",
+        help="Semantic graph theme (default: default-dark)",
+    )
+    parser.add_argument(
+        "--open",
+        action="store_true",
+        help="Open the report in the default browser",
+    )
+    args = parser.parse_args()
+
+    if args.outdir:
+        out = generate_site(graph_theme=args.theme, outdir=args.outdir)
+        print(f"✅ {out}/index.html")
+        target = out / "index.html"
+    else:
+        out = generate_report(graph_theme=args.theme, output=args.output)
+        print(f"✅ {out}")
+        target = out
+
+    if args.open:
+        import webbrowser
+        webbrowser.open(f"file://{target}")
+
+
+if __name__ == "__main__":
+    main()

--- a/themes/semantic-graph/default-dark.json
+++ b/themes/semantic-graph/default-dark.json
@@ -10,6 +10,8 @@
     "number":     { "shape": "rect",    "fill": "#1b3a1e", "stroke": "#66bb6a", "color": "#c8e6c9" },
     "expression": { "shape": "rect",    "fill": "#1b3a1e", "stroke": "#66bb6a", "color": "#c8e6c9" },
     "text":       { "shape": "rect",    "fill": "#1b3a1e", "stroke": "#66bb6a", "color": "#c8e6c9" },
+    "operator":   { "shape": "circle",  "fill": "#1a2740", "stroke": "#42a5f5", "color": "#bbdefb" },
+    "function":   { "shape": "hexagon", "fill": "#1a2740", "stroke": "#42a5f5", "color": "#bbdefb" },
     "relation":   { "shape": "diamond", "fill": "#332a0b", "stroke": "#ffa726", "color": "#ffe0b2" },
     "result":     { "shape": "stadium", "fill": "#332a0b", "stroke": "#ffa726", "color": "#ffe0b2" },
     "annotation": { "shape": "circle",  "fill": "#131a2c", "stroke": "#4a5580", "color": "#b0bcd0" }


### PR DESCRIPTION
## Summary

- New visual examination report for the semantic graph pipeline — renders every expression from domain test catalogs as rows with KaTeX-rendered LaTeX, Mermaid graph diagrams, and expandable JSON/source panels
- Generates per-domain HTML files + an index page via `semantic_graph_report.py --outdir`
- Deploys to GitHub Pages with per-PR preview URLs (`semantic-graph/pr-{number}/`) that don't conflict across concurrent PRs
- Auto-posts preview link as a PR comment; cleans up PR directories on close

## Preview

https://ibenian.github.io/algebench/semantic-graph/pr-327/

## Test plan

- [x] Report generates 24/24 arithmetic expressions with 0 errors
- [x] PR workflow deploys to `gh-pages` branch under `semantic-graph/pr-327/`
- [x] Preview URL is accessible and renders correctly
- [x] Concurrent PRs won't overwrite each other (`keep_files: true`)
- [x] Cleanup workflow removes PR directory on close
- [x] Main deploy writes to `semantic-graph/` after merge

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>