### PR TITLE
fix: escape markdown bold in workflow YAML to fix GitHub parsing

### DIFF
--- a/.github/workflows/loc.yml
+++ b/.github/workflows/loc.yml
@@ -68,7 +68,6 @@ jobs:
           echo "Preview: ${PREVIEW_URL}" >> "$GITHUB_STEP_SUMMARY"
           EXISTING=$(gh pr view ${{ github.event.pull_request.number }} --json comments --jq '[.comments[] | select(.body | contains("LOC Report"))] | length')
           if [ "$EXISTING" = "0" ]; then
-            gh pr comment ${{ github.event.pull_request.number }} \
-              --body "## 📊 LOC Report
-**Preview:** ${PREVIEW_URL}"
+            BODY="$(printf '## 📊 LOC Report\n**Preview:** %s' "$PREVIEW_URL")"
+            gh pr comment ${{ github.event.pull_request.number }} --body "$BODY"
           fi

--- a/.github/workflows/semantic-graph.yml
+++ b/.github/workflows/semantic-graph.yml
@@ -71,7 +71,6 @@ jobs:
           echo "Preview: ${PREVIEW_URL}" >> "$GITHUB_STEP_SUMMARY"
           EXISTING=$(gh pr view ${{ github.event.pull_request.number }} --json comments --jq '[.comments[] | select(.body | contains("Semantic Graph Visual Report"))] | length')
           if [ "$EXISTING" = "0" ]; then
-            gh pr comment ${{ github.event.pull_request.number }} \
-              --body "## 📊 Semantic Graph Visual Report
-**Preview:** ${PREVIEW_URL}"
+            BODY="$(printf '## 📊 Semantic Graph Visual Report\n**Preview:** %s' "$PREVIEW_URL")"
+            gh pr comment ${{ github.event.pull_request.number }} --body "$BODY"
           fi


### PR DESCRIPTION
## Summary
- The `**Preview:**` markdown bold in PR comment bodies was on an unindented line, breaking out of the YAML `run: |` block scalar
- The `*` character was parsed as a YAML alias, causing GitHub to fail reading the entire workflow file (triggers, name, everything)
- Fixed by using `printf` to build the comment body, keeping all lines properly indented within the block scalar
- Both `loc.yml` and `semantic-graph.yml` now parse correctly with all triggers (`pull_request`, `push`, `workflow_dispatch`)

## Root cause
```yaml
# BEFORE — line 76 has zero indentation, exits the block scalar
        run: |
          gh pr comment ... \
            --body "## 📊 Report
**Preview:** ${URL}"        # ← YAML alias parse error here
```

## Test plan
- [ ] After merge, verify `gh workflow list` shows proper names instead of file paths
- [ ] Verify `workflow_dispatch` works: `gh workflow run semantic-graph.yml`
- [ ] Verify PR triggers fire on next PR

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>