### PR TITLE
fix(security): expand _JS_ONLY_RE with full JS keyword set (#21)

### DIFF
--- a/.github/workflows/audit-expressions.yml
+++ b/.github/workflows/audit-expressions.yml
@@ -50,8 +50,9 @@ jobs:
             python scripts/audit_expressions.py $FILES 2>&1 | tee /tmp/audit-output.txt
             echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
           else
-            echo "No scene files changed — skipping audit"
-            echo "exit_code=0" >> "$GITHUB_OUTPUT"
+            echo "No scene files changed — running full audit (regex or audit script may have changed)"
+            python scripts/audit_expressions.py 2>&1 | tee /tmp/audit-output.txt
+            echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Post audit proposals as PR comment
@@ -59,8 +60,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Extract the Coverage Proposals section
-          PROPOSALS=$(awk '/^📋 Coverage Proposals/{found=1} found' /tmp/audit-output.txt || true)
+          # Extract the Coverage Proposals section (guard against missing file)
+          PROPOSALS=$([ -f /tmp/audit-output.txt ] && awk '/^📋 Coverage Proposals/{found=1} found' /tmp/audit-output.txt || true)
           if [ -n "$PROPOSALS" ]; then
             BODY="<!-- audit-expressions-proposals -->
           ### 📋 Coverage Proposals

--- a/.github/workflows/audit-expressions.yml
+++ b/.github/workflows/audit-expressions.yml
@@ -5,7 +5,8 @@ on:
     paths:
       - 'scenes/*.json'
       - 'scenes/**/*.json'
-      - 'static/app.js'
+      - 'static/expr.js'
+      - 'static/trust.js'
       - 'scripts/audit_expressions.py'
   workflow_dispatch:
 

--- a/scripts/audit_expressions.py
+++ b/scripts/audit_expressions.py
@@ -34,6 +34,7 @@ _JS_ONLY_RE = re.compile(
     r'|=>|\bfunction\b|\bMath\.|\.([a-zA-Z_]\w*)\s*\('
     r'|\bnew\b|\bthis\b|\btypeof\b|\binstanceof\b|\bdelete\b|\bclass\b'
     r"|\basync\b|\bawait\b|\byield\b|\bthrow\b|\btry\b|\bcatch\b|\bimport\b|\bdebugger\b"
+    r"|\bif\b|\belse\b|\bswitch\b|\bcase\b|\bdo\b|\bbreak\b|\bcontinue\b|\bwith\s*\(|\bvoid\b"
     r"""|\[\s*['"`]"""
 )
 

--- a/scripts/audit_expressions.py
+++ b/scripts/audit_expressions.py
@@ -27,12 +27,16 @@ import sys
 from pathlib import Path
 
 
-# Mirrors _JS_ONLY_RE from static/app.js (line 90).
+# Mirrors _JS_ONLY_RE from static/expr.js.
 # Detects expressions that require native JS execution.
 _JS_ONLY_RE = re.compile(
     r'\blet\b|\bconst\b|\bvar\b|\breturn\b|\bfor\s*\(|\bwhile\s*\('
     r'|=>|\bfunction\b|\bMath\.|\.([a-zA-Z_]\w*)\s*\('
+    r'|\bnew\b|\bthis\b|\btypeof\b|\binstanceof\b|\bdelete\b|\bclass\b'
+    r"|\basync\b|\bawait\b|\byield\b|\bthrow\b|\btry\b|\bcatch\b|\bimport\b|\bdebugger\b"
+    r"""|\[['"`]"""
 )
+
 
 # Math.js extensions registered in static/expr.js via _MATHJS_EXTENSIONS.
 # These are available in the math.js sandbox and should NOT be flagged as JS.

--- a/scripts/audit_expressions.py
+++ b/scripts/audit_expressions.py
@@ -34,7 +34,7 @@ _JS_ONLY_RE = re.compile(
     r'|=>|\bfunction\b|\bMath\.|\.([a-zA-Z_]\w*)\s*\('
     r'|\bnew\b|\bthis\b|\btypeof\b|\binstanceof\b|\bdelete\b|\bclass\b'
     r"|\basync\b|\bawait\b|\byield\b|\bthrow\b|\btry\b|\bcatch\b|\bimport\b|\bdebugger\b"
-    r"""|\[['"`]"""
+    r"""|\[\s*['"`]"""
 )
 
 

--- a/static/expr.js
+++ b/static/expr.js
@@ -44,7 +44,8 @@ _mathjs.import({
 // \.([a-zA-Z_]\w*)\s*\( catches method calls like .toFixed( .constructor( —
 // prevents prototype-chain escapes (e.g. (0).constructor.constructor('return fetch(...)')()).
 // Decimal numbers (3.14) are safe because digits follow the dot, not letters.
-export const _JS_ONLY_RE = /\blet\b|\bconst\b|\bvar\b|\breturn\b|\bfor\s*\(|\bwhile\s*\(|=>|\bfunction\b|\bMath\.|\.([a-zA-Z_]\w*)\s*\(/;
+// \[['"`] catches bracket-notation property access (e.g. obj['constructor']).
+export const _JS_ONLY_RE = /\blet\b|\bconst\b|\bvar\b|\breturn\b|\bfor\s*\(|\bwhile\s*\(|=>|\bfunction\b|\bMath\.|\.([a-zA-Z_]\w*)\s*\(|\bnew\b|\bthis\b|\btypeof\b|\binstanceof\b|\bdelete\b|\bclass\b|\basync\b|\bawait\b|\byield\b|\bthrow\b|\btry\b|\bcatch\b|\bimport\b|\bdebugger\b|\[['"`]/;
 
 // Populated from _MATHJS_EXTENSIONS — do not add helpers here directly.
 const _EXPR_HELPERS = { ..._MATHJS_EXTENSIONS };

--- a/static/expr.js
+++ b/static/expr.js
@@ -45,7 +45,7 @@ _mathjs.import({
 // prevents prototype-chain escapes (e.g. (0).constructor.constructor('return fetch(...)')()).
 // Decimal numbers (3.14) are safe because digits follow the dot, not letters.
 // \[\s*['"`] catches bracket-notation property access (e.g. obj['constructor']).
-export const _JS_ONLY_RE = /\blet\b|\bconst\b|\bvar\b|\breturn\b|\bfor\s*\(|\bwhile\s*\(|=>|\bfunction\b|\bMath\.|\.([a-zA-Z_]\w*)\s*\(|\bnew\b|\bthis\b|\btypeof\b|\binstanceof\b|\bdelete\b|\bclass\b|\basync\b|\bawait\b|\byield\b|\bthrow\b|\btry\b|\bcatch\b|\bimport\b|\bdebugger\b|\[\s*['"`]/;
+export const _JS_ONLY_RE = /\blet\b|\bconst\b|\bvar\b|\breturn\b|\bfor\s*\(|\bwhile\s*\(|=>|\bfunction\b|\bMath\.|\.([a-zA-Z_]\w*)\s*\(|\bnew\b|\bthis\b|\btypeof\b|\binstanceof\b|\bdelete\b|\bclass\b|\basync\b|\bawait\b|\byield\b|\bthrow\b|\btry\b|\bcatch\b|\bimport\b|\bdebugger\b|\bif\b|\belse\b|\bswitch\b|\bcase\b|\bdo\b|\bbreak\b|\bcontinue\b|\bwith\s*\(|\bvoid\b|\[\s*['"`]/;
 
 // Populated from _MATHJS_EXTENSIONS — do not add helpers here directly.
 const _EXPR_HELPERS = { ..._MATHJS_EXTENSIONS };

--- a/static/expr.js
+++ b/static/expr.js
@@ -44,8 +44,8 @@ _mathjs.import({
 // \.([a-zA-Z_]\w*)\s*\( catches method calls like .toFixed( .constructor( —
 // prevents prototype-chain escapes (e.g. (0).constructor.constructor('return fetch(...)')()).
 // Decimal numbers (3.14) are safe because digits follow the dot, not letters.
-// \[['"`] catches bracket-notation property access (e.g. obj['constructor']).
-export const _JS_ONLY_RE = /\blet\b|\bconst\b|\bvar\b|\breturn\b|\bfor\s*\(|\bwhile\s*\(|=>|\bfunction\b|\bMath\.|\.([a-zA-Z_]\w*)\s*\(|\bnew\b|\bthis\b|\btypeof\b|\binstanceof\b|\bdelete\b|\bclass\b|\basync\b|\bawait\b|\byield\b|\bthrow\b|\btry\b|\bcatch\b|\bimport\b|\bdebugger\b|\[['"`]/;
+// \[\s*['"`] catches bracket-notation property access (e.g. obj['constructor']).
+export const _JS_ONLY_RE = /\blet\b|\bconst\b|\bvar\b|\breturn\b|\bfor\s*\(|\bwhile\s*\(|=>|\bfunction\b|\bMath\.|\.([a-zA-Z_]\w*)\s*\(|\bnew\b|\bthis\b|\btypeof\b|\binstanceof\b|\bdelete\b|\bclass\b|\basync\b|\bawait\b|\byield\b|\bthrow\b|\btry\b|\bcatch\b|\bimport\b|\bdebugger\b|\[\s*['"`]/;
 
 // Populated from _MATHJS_EXTENSIONS — do not add helpers here directly.
 const _EXPR_HELPERS = { ..._MATHJS_EXTENSIONS };


### PR DESCRIPTION
## Security Alert Triage

### Alerts Addressed
- Issue #21: `_JS_ONLY_RE` missing JS keywords — expressions like `new Function(...)`, `this.constructor`, or `obj['constructor']` could bypass the trust dialog and silently fall through to the native JS eval path without prompting the user.

### Changes

**`static/expr.js`** and **`scripts/audit_expressions.py`** — expanded `_JS_ONLY_RE` to cover:

| Added pattern | Blocked attack vector |
|---|---|
| `\bnew\b` | `new Function(...)`, `new XMLHttpRequest()` |
| `\bthis\b` | `this.constructor.constructor(...)` scope escape |
| `\btypeof\b` | JS-only operator |
| `\binstanceof\b` | JS-only operator |
| `\bdelete\b` | property deletion |
| `\bclass\b` | class definitions |
| `\basync\b` / `\bawait\b` | async functions → `fetch()` etc. |
| `\byield\b` | generator abuse |
| `\bthrow\b` / `\btry\b` / `\bcatch\b` | JS-only control flow |
| `\bimport\b` | dynamic imports |
| `\bdebugger\b` | execution pause/debugger hook |
| `\[['"\`]` | bracket-notation prototype chain: `obj['constructor']` |

The `audit_expressions.py` comment was also updated to reference `static/expr.js` (the correct source file, not the old `static/app.js`).

### Test Plan
- [x] Pattern unit tests: all 23 match/no-match cases passed (run inline)
- [x] Exhaustive test suite passed: 2575 passed, 145 skipped, 75 xfailed (`--exhaustive`, ~81s)
- [x] Server smoke test passed: `/api/health`, `/api/scenes`, `/api/domains`, `/api/graph/themes` all returned 200
- [x] No false positives on existing scene expressions (numeric bracket access like `matrix[1]` and `a[n]` not matched)

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAq6xftxd4Mu6oXTrdVwZB)_