### PR TITLE
chore: add frontmatter to skill definitions

### DIFF
--- a/.agents/skills/debug-chrome/SKILL.md
+++ b/.agents/skills/debug-chrome/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: debug-chrome
+description: Launch or restart AlgeBench, open it in Chrome browser tools, and debug UI behavior with console, DOM, screenshots, and interactions.
+args: "[action=<stop|restart>]"
+---
+
 # Debug AlgeBench in Chrome
 
 Launch AlgeBench (if not already running), open it in Chrome via browser tools, and interactively debug the UI.

--- a/.agents/skills/update-glt/SKILL.md
+++ b/.agents/skills/update-glt/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: update-glt
+description: Update the pinned gemini-live-tools dependency to a PR branch, named branch, version tag, or latest release and verify the installed package.
+args: "[target=<PR_NUMBER|BRANCH_NAME|TAG|latest>]"
+---
+
 # Update gemini-live-tools
 
 Update the gemini-live-tools dependency — either to a PR branch for testing, a specific version tag, or the latest release.

--- a/.agents/skills/version-bump/SKILL.md
+++ b/.agents/skills/version-bump/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: version-bump
+description: Bump the AlgeBench version by reviewing changes since the last tag, choosing the next semantic version, tagging it, and optionally creating a GitHub release.
+args: "[bump_level=<revision|minor|major>] [release=<yes|no>]"
+---
+
 # Version Bump
 
 Check what has changed since the last tag, bump the version, tag it, and optionally publish a GitHub release.


### PR DESCRIPTION
## Summary
- Add YAML frontmatter (name, description, args) to three skill files: `debug-chrome`, `update-glt`, and `version-bump`
- Enables Claude Code skill discovery and argument parsing from structured metadata

## Test plan
- [ ] Verify skills still load correctly via `/debug-chrome`, `/update-glt`, `/version-bump`

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>