### PR TITLE
feat: D3 tab, split source view, and UX polish for semantic graph report

### DIFF
--- a/backend/semantic_graph/sympy_translator.py
+++ b/backend/semantic_graph/sympy_translator.py
@@ -1273,10 +1273,13 @@ class SemanticGraphBuilder:
             tends_id = self._next_id("tends_to")
             self._add_edge(var_id, tends_id, role="lhs")
             self._add_edge(point_id, tends_id, role="rhs")
+            var_latex = self._subexpr_ordered(expr.args[1])
+            point_latex = self._subexpr_ordered(expr.args[2])
             tends_attrs: dict[str, str] = {
                 "type": "operator", "op": "tends_to",
                 "with_respect_to": var_id,
                 "limit_point": point_id,
+                "subexpr": f"{var_latex} \\to {point_latex}",
             }
             if len(expr.args) > 3:
                 direction = str(expr.args[3])

--- a/backend/semantic_graph/sympy_translator.py
+++ b/backend/semantic_graph/sympy_translator.py
@@ -1377,7 +1377,12 @@ class SemanticGraphBuilder:
                         # Index specification: ``n = 0`` as a symmetric
                         # equals node — no roles (same as any other ``=``).
                         idx_id = self._next_id("equals")
-                        self._add_node(idx_id, type="relation", op="equals")
+                        var_latex = self._subexpr_ordered(limit_tuple[0])
+                        lb_latex = self._subexpr_ordered(lb_expr)
+                        self._add_node(
+                            idx_id, type="relation", op="equals",
+                            subexpr=f"{var_latex} = {lb_latex}",
+                        )
                         self._add_edge(var_id, idx_id)
                         self._add_edge(lower_nid, idx_id)
                         self._add_edge(idx_id, node_id, role="lb")

--- a/scripts/graph_to_mermaid.py
+++ b/scripts/graph_to_mermaid.py
@@ -334,8 +334,10 @@ def _format_label(
             agg_cmd = OPERATOR_LATEX.get(op, r"\sum")
             return f"${agg_cmd}_{{{wrt}}}$"
         if node_type == "function" and op:
-            dots = r", ".join([r"\cdot"] * max(arity, 1))
             fn_name = OPERATOR_LATEX.get(op, op)
+            if r"\cdot" in fn_name:
+                return f"${fn_name}$"
+            dots = r", ".join([r"\cdot"] * max(arity, 1))
             return f"${fn_name}({dots})$"
         node_latex = node.get("latex")
         if node_latex:

--- a/scripts/semantic_graph_report.py
+++ b/scripts/semantic_graph_report.py
@@ -396,6 +396,40 @@ def _page_template() -> str:
       .summary .count {{
         font-weight: 600;
       }}
+      .row-panel.row-json {{
+        display: none;
+        padding: 0;
+      }}
+      .row-panel.row-json.open {{
+        display: flex;
+        gap: 1px;
+      }}
+      .row-json-pane {{
+        flex: 1;
+        min-width: 0;
+        max-height: 400px;
+        overflow: auto;
+        padding: 0.5rem 0.8rem;
+      }}
+      .row-json-pane pre {{
+        margin: 0;
+        white-space: pre-wrap;
+        word-break: break-word;
+        font-size: 0.7rem;
+        line-height: 1.4;
+      }}
+      .row-json-label {{
+        font-size: 0.65rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: {muted};
+        margin-bottom: 0.3rem;
+        position: sticky;
+        top: 0;
+        background: {card_bg};
+        padding: 0.2rem 0;
+        z-index: 1;
+      }}
       .row-toggle.active {{
         color: {fg};
         border-color: {fg};
@@ -537,7 +571,11 @@ def _render_row(
     if graph_json is not None:
         parts.append(
             f'  <div class="row-panel row-json">'
-            f'{_escape_html(graph_json)}</div>'
+            f'<div class="row-json-pane"><div class="row-json-label">Semantic Graph JSON</div>'
+            f'<pre>{_escape_html(graph_json)}</pre></div>'
+            f'<div class="row-json-pane"><div class="row-json-label">Mermaid Script</div>'
+            f'<pre>{_escape_html(mermaid_src)}</pre></div>'
+            f'</div>'
         )
         compact_json = json.dumps(
             json.loads(graph_json), separators=(",", ":"), ensure_ascii=False,

--- a/scripts/semantic_graph_report.py
+++ b/scripts/semantic_graph_report.py
@@ -515,16 +515,27 @@ def _page_template() -> str:
       }});
     }});
     function copyText(text, btn) {{
+      function onSuccess() {{
+        btn.textContent = 'copied';
+        btn.classList.add('copied');
+        setTimeout(function() {{ btn.textContent = 'copy'; btn.classList.remove('copied'); }}, 1500);
+      }}
+      if (navigator.clipboard && navigator.clipboard.writeText) {{
+        navigator.clipboard.writeText(text).then(onSuccess, function() {{ fallbackCopy(text, btn, onSuccess); }});
+      }} else {{
+        fallbackCopy(text, btn, onSuccess);
+      }}
+    }}
+    function fallbackCopy(text, btn, onSuccess) {{
       var ta = document.createElement('textarea');
       ta.value = text;
       ta.style.cssText = 'position:fixed;left:-9999px';
       document.body.appendChild(ta);
       ta.select();
-      document.execCommand('copy');
+      var ok = false;
+      try {{ ok = document.execCommand('copy'); }} catch(e) {{}}
       document.body.removeChild(ta);
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() {{ btn.textContent = 'copy'; btn.classList.remove('copied'); }}, 1500);
+      if (ok) onSuccess();
     }}
     document.querySelectorAll('.row-copy-btn').forEach(btn => {{
       btn.addEventListener('click', () => {{
@@ -651,7 +662,7 @@ def _render_row(
             f'</div>'
         )
         compact_json = json.dumps(
-            json.loads(graph_json), separators=(",", ":"), ensure_ascii=False,
+            graph_dict, separators=(",", ":"), ensure_ascii=False,
         )
         parts.append(
             f'  <div class="row-panel row-d3" data-graph="{_escape_attr(compact_json)}">'

--- a/scripts/semantic_graph_report.py
+++ b/scripts/semantic_graph_report.py
@@ -410,6 +410,7 @@ def _page_template() -> str:
         max-height: 400px;
         overflow: auto;
         padding: 0.5rem 0.8rem;
+        position: relative;
       }}
       .row-json-pane pre {{
         margin: 0;
@@ -418,17 +419,40 @@ def _page_template() -> str:
         font-size: 0.7rem;
         line-height: 1.4;
       }}
-      .row-json-label {{
-        font-size: 0.65rem;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        color: {muted};
-        margin-bottom: 0.3rem;
+      .row-json-header {{
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
         position: sticky;
         top: 0;
         background: {card_bg};
         padding: 0.2rem 0;
         z-index: 1;
+        margin-bottom: 0.3rem;
+      }}
+      .row-json-label {{
+        font-size: 0.65rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: {muted};
+      }}
+      .row-copy-btn {{
+        background: none;
+        border: 1px solid {border};
+        border-radius: 3px;
+        color: {muted};
+        font-size: 0.6rem;
+        padding: 1px 5px;
+        cursor: pointer;
+        line-height: 1.3;
+      }}
+      .row-copy-btn:hover {{
+        color: {fg};
+        border-color: {fg};
+      }}
+      .row-copy-btn.copied {{
+        color: #66bb6a;
+        border-color: #66bb6a;
       }}
       .row-toggle.active {{
         color: {fg};
@@ -468,6 +492,17 @@ def _page_template() -> str:
         const target = btn.dataset.target;
         const panel = btn.closest('.row').querySelector('.' + target);
         if (panel) panel.classList.toggle('open');
+      }});
+    }});
+    document.querySelectorAll('.row-copy-btn').forEach(btn => {{
+      btn.addEventListener('click', () => {{
+        const pre = btn.closest('.row-json-pane').querySelector('pre');
+        if (!pre) return;
+        navigator.clipboard.writeText(pre.textContent).then(() => {{
+          btn.textContent = 'copied';
+          btn.classList.add('copied');
+          setTimeout(() => {{ btn.textContent = 'copy'; btn.classList.remove('copied'); }}, 1500);
+        }});
       }});
     }});
     </script>
@@ -571,9 +606,13 @@ def _render_row(
     if graph_json is not None:
         parts.append(
             f'  <div class="row-panel row-json">'
-            f'<div class="row-json-pane"><div class="row-json-label">Semantic Graph JSON</div>'
+            f'<div class="row-json-pane">'
+            f'<div class="row-json-header"><span class="row-json-label">Semantic Graph JSON</span>'
+            f'<button class="row-copy-btn" title="Copy JSON">copy</button></div>'
             f'<pre>{_escape_html(graph_json)}</pre></div>'
-            f'<div class="row-json-pane"><div class="row-json-label">Mermaid Script</div>'
+            f'<div class="row-json-pane">'
+            f'<div class="row-json-header"><span class="row-json-label">Mermaid Script</span>'
+            f'<button class="row-copy-btn" title="Copy Mermaid">copy</button></div>'
             f'<pre>{_escape_html(mermaid_src)}</pre></div>'
             f'</div>'
         )

--- a/scripts/semantic_graph_report.py
+++ b/scripts/semantic_graph_report.py
@@ -396,6 +396,14 @@ def _page_template() -> str:
       .summary .count {{
         font-weight: 600;
       }}
+      .row-panel.row-latex-src {{
+        position: relative;
+      }}
+      .row-copy-latex {{
+        position: absolute;
+        top: 0.4rem;
+        right: 0.4rem;
+      }}
       .row-panel.row-json {{
         display: none;
         padding: 0;
@@ -496,9 +504,14 @@ def _page_template() -> str:
     }});
     document.querySelectorAll('.row-copy-btn').forEach(btn => {{
       btn.addEventListener('click', () => {{
-        const pre = btn.closest('.row-json-pane').querySelector('pre');
-        if (!pre) return;
-        navigator.clipboard.writeText(pre.textContent).then(() => {{
+        const pane = btn.closest('.row-json-pane');
+        var text;
+        if (pane) {{
+          text = pane.querySelector('pre').textContent;
+        }} else {{
+          text = btn.parentElement.dataset.latex || btn.parentElement.querySelector('pre')?.textContent || '';
+        }}
+        navigator.clipboard.writeText(text).then(() => {{
           btn.textContent = 'copied';
           btn.classList.add('copied');
           setTimeout(() => {{ btn.textContent = 'copy'; btn.classList.remove('copied'); }}, 1500);
@@ -600,7 +613,8 @@ def _render_row(
         )
     parts.append(f'  </div>')
     parts.append(
-        f'  <div class="row-panel row-latex-src">'
+        f'  <div class="row-panel row-latex-src" data-latex="{_escape_attr(latex)}">'
+        f'<button class="row-copy-btn row-copy-latex" title="Copy LaTeX">copy</button>'
         f'{_escape_html(latex)}</div>'
     )
     if graph_json is not None:

--- a/scripts/semantic_graph_report.py
+++ b/scripts/semantic_graph_report.py
@@ -121,6 +121,20 @@ THEMES = {
 }
 
 
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+_D3_MODULE_URL = (
+    "https://cdn.jsdelivr.net/gh/ibenian/algebench@main"
+    "/static/graph-panel/d3-semantic-graph.js"
+)
+
+
+def _load_d3_css() -> str:
+    """Read the D3 semantic graph CSS and return it for inline embedding."""
+    css_path = _PROJECT_ROOT / "static" / "graph-panel" / "d3-semantic-graph.css"
+    return css_path.read_text(encoding="utf-8")
+
+
 def _page_template() -> str:
     return textwrap.dedent("""\
     <!DOCTYPE html>
@@ -133,6 +147,14 @@ def _page_template() -> str:
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"
       onload="renderMathInElement(document.body, {{delimiters:[{{left:'$$',right:'$$',display:true}},{{left:'$',right:'$',display:false}}]}});"></script>
+    <script type="importmap">{{
+      "imports": {{
+        "/labels.js": "data:text/javascript,export function makeAiAskButton(){{return document.createElement('span')}}"
+      }}
+    }}</script>
+    <script>
+      window.__SG_REPORT_THEME__ = {theme_json};
+    </script>
     <script type="module">
       import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.4.0/dist/mermaid.esm.min.mjs';
       mermaid.initialize({{ startOnLoad: false, theme: '{mermaid_theme}',
@@ -317,7 +339,8 @@ def _page_template() -> str:
         gap: 0.4rem;
         align-self: center;
       }}
-      .row-toggle {{
+      .row-toggle,
+      .row-toggle-d3 {{
         background: none;
         border: 1px solid {border};
         border-radius: 4px;
@@ -328,7 +351,8 @@ def _page_template() -> str:
         cursor: pointer;
         white-space: nowrap;
       }}
-      .row-toggle:hover {{
+      .row-toggle:hover,
+      .row-toggle-d3:hover {{
         color: {fg};
         border-color: {fg};
       }}
@@ -372,6 +396,32 @@ def _page_template() -> str:
       .summary .count {{
         font-weight: 600;
       }}
+      .row-toggle.active {{
+        color: {fg};
+        border-color: {fg};
+        background: {bg};
+      }}
+      .row-panel.row-d3 {{
+        position: relative;
+        height: 400px;
+        padding: 0;
+        overflow: hidden;
+        font-family: inherit;
+        white-space: normal;
+        word-break: normal;
+      }}
+      .row-panel.row-d3.open {{
+        display: block;
+      }}
+      .row-d3-placeholder {{
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100%;
+        color: {muted};
+        font-size: 0.85rem;
+      }}
+      {d3_css}
     </style>
     </head>
     <body>
@@ -384,6 +434,47 @@ def _page_template() -> str:
         const target = btn.dataset.target;
         const panel = btn.closest('.row').querySelector('.' + target);
         if (panel) panel.classList.toggle('open');
+      }});
+    }});
+    </script>
+    <script>
+    // Patch fetchTheme to use inlined theme data
+    (function() {{
+      var _origFetch = window.fetch;
+      window.fetch = function(url, opts) {{
+        if (typeof url === 'string' && url.startsWith('/api/graph/theme/')) {{
+          var theme = window.__SG_REPORT_THEME__;
+          return Promise.resolve(new Response(JSON.stringify(theme), {{
+            status: 200, headers: {{ 'Content-Type': 'application/json' }}
+          }}));
+        }}
+        return _origFetch.call(this, url, opts);
+      }};
+    }})();
+
+    import('{d3_module_url}').then(function(mod) {{
+      var D3SemanticGraphRenderer = mod.D3SemanticGraphRenderer;
+      document.querySelectorAll('.row-toggle-d3').forEach(function(btn) {{
+        btn.addEventListener('click', function() {{
+          var row = btn.closest('.row');
+          var panel = row.querySelector('.row-d3');
+          if (!panel) return;
+          panel.classList.toggle('open');
+          if (!panel.classList.contains('open')) return;
+          if (panel.dataset.rendered) return;
+          panel.dataset.rendered = '1';
+          var graphJson = panel.dataset.graph;
+          if (!graphJson) return;
+          panel.innerHTML = '';
+          var graph = JSON.parse(graphJson);
+          var renderer = new D3SemanticGraphRenderer(panel, {{
+            direction: '{d3_direction}',
+            labels: 'description',
+            theme: '{d3_theme}',
+            katex: window.katex || null,
+          }});
+          renderer.render(graph);
+        }});
       }});
     }});
     </script>
@@ -434,6 +525,10 @@ def _render_row(
             f'    <button class="row-toggle" data-target="row-json" '
             f'title="Toggle JSON">{{}}</button>'
         )
+        parts.append(
+            f'    <button class="row-toggle-d3" '
+            f'title="Toggle D3 graph">D3</button>'
+        )
     parts.append(f'  </div>')
     parts.append(
         f'  <div class="row-panel row-latex-src">'
@@ -444,6 +539,13 @@ def _render_row(
             f'  <div class="row-panel row-json">'
             f'{_escape_html(graph_json)}</div>'
         )
+        compact_json = json.dumps(
+            json.loads(graph_json), separators=(",", ":"), ensure_ascii=False,
+        )
+        parts.append(
+            f'  <div class="row-panel row-d3" data-graph="{_escape_attr(compact_json)}">'
+            f'<div class="row-d3-placeholder">Click D3 to render</div></div>'
+        )
 
     parts.append('</div>')
     return "\n".join(parts), success
@@ -453,12 +555,17 @@ def _escape_html(s: str) -> str:
     return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
+def _escape_attr(s: str) -> str:
+    return _escape_html(s).replace('"', "&quot;")
+
+
 def _build_report_html(
     sections: list[tuple[str, list[tuple[str, str]]]],
     *,
     graph_theme: str,
     theme: dict[str, Any],
     colors: dict[str, str],
+    d3_module_url: str | None = None,
 ) -> tuple[str, int, int]:
     """Build report HTML body and return (html, ok_count, err_count)."""
     import datetime
@@ -493,9 +600,25 @@ def _build_report_html(
     now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     meta = f"Generated {now} &middot; theme: {graph_theme} &middot; {total} expressions"
 
+    d3_css = _load_d3_css()
+    theme_json_str = json.dumps(theme, ensure_ascii=False)
+    d3_direction = theme.get("direction", "LR")
+    # Mermaid reverses edge direction (child→parent), so its LR puts
+    # leaves on the left and the root relation on the right.  The D3
+    # renderer uses raw parent→child edges, so we flip the direction
+    # to produce the same visual flow.
+    dir_map = {"LR": "right-left", "RL": "left-right", "TB": "bottom-up", "BT": "top-down"}
+    d3_direction_full = dir_map.get(d3_direction, "right-left")
+    effective_d3_url = d3_module_url or _D3_MODULE_URL
+
     html = _page_template().format(
         body="\n".join(body_parts),
         meta=meta,
+        theme_json=theme_json_str,
+        d3_css=d3_css,
+        d3_module_url=effective_d3_url,
+        d3_direction=d3_direction_full,
+        d3_theme=graph_theme,
         **colors,
     )
     return html, ok_count, err_count
@@ -506,14 +629,12 @@ def generate_report(
     graph_theme: str = "default-dark",
     output: Path | None = None,
 ) -> Path:
+    import shutil
+
     theme = load_theme(graph_theme)
     color_mode = theme.get("mode", "dark")
     colors = THEMES[color_mode]
     sections = _collect_expressions()
-
-    html, _, _ = _build_report_html(
-        sections, graph_theme=graph_theme, theme=theme, colors=colors,
-    )
 
     if output is None:
         import tempfile
@@ -521,6 +642,15 @@ def generate_report(
         import os
         os.close(fd)
         output = Path(path)
+
+    d3_js_src = _PROJECT_ROOT / "static" / "graph-panel" / "d3-semantic-graph.js"
+    d3_js_dst = output.parent / "d3-semantic-graph.js"
+    shutil.copy2(d3_js_src, d3_js_dst)
+
+    html, _, _ = _build_report_html(
+        sections, graph_theme=graph_theme, theme=theme, colors=colors,
+        d3_module_url="./d3-semantic-graph.js",
+    )
 
     output.write_text(html, encoding="utf-8")
     return output
@@ -574,8 +704,13 @@ def generate_site(
     outdir: Path,
 ) -> Path:
     import datetime
+    import shutil
 
     outdir.mkdir(parents=True, exist_ok=True)
+
+    d3_js_src = _PROJECT_ROOT / "static" / "graph-panel" / "d3-semantic-graph.js"
+    d3_js_dst = outdir / "d3-semantic-graph.js"
+    shutil.copy2(d3_js_src, d3_js_dst)
 
     theme = load_theme(graph_theme)
     color_mode = theme.get("mode", "dark")
@@ -593,6 +728,7 @@ def generate_site(
         html, ok, err = _build_report_html(
             [(section_name, expressions)],
             graph_theme=graph_theme, theme=theme, colors=colors,
+            d3_module_url="./d3-semantic-graph.js",
         )
         (outdir / filename).write_text(html, encoding="utf-8")
         total_ok += ok

--- a/scripts/semantic_graph_report.py
+++ b/scripts/semantic_graph_report.py
@@ -271,6 +271,18 @@ def _page_template() -> str:
     </script>
     <style>
       * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+      ::-webkit-scrollbar {{ width: 6px; height: 6px; }}
+      ::-webkit-scrollbar-track {{ background: transparent; }}
+      ::-webkit-scrollbar-thumb {{
+        background: {border};
+        border-radius: 3px;
+      }}
+      ::-webkit-scrollbar-thumb:hover {{ background: {muted}; }}
+      ::-webkit-scrollbar-corner {{ background: transparent; }}
+      * {{
+        scrollbar-width: thin;
+        scrollbar-color: {border} transparent;
+      }}
       body {{
         font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
         background: {bg};
@@ -502,6 +514,18 @@ def _page_template() -> str:
         if (panel) panel.classList.toggle('open');
       }});
     }});
+    function copyText(text, btn) {{
+      var ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.cssText = 'position:fixed;left:-9999px';
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+      btn.textContent = 'copied';
+      btn.classList.add('copied');
+      setTimeout(function() {{ btn.textContent = 'copy'; btn.classList.remove('copied'); }}, 1500);
+    }}
     document.querySelectorAll('.row-copy-btn').forEach(btn => {{
       btn.addEventListener('click', () => {{
         const pane = btn.closest('.row-json-pane');
@@ -509,13 +533,9 @@ def _page_template() -> str:
         if (pane) {{
           text = pane.querySelector('pre').textContent;
         }} else {{
-          text = btn.parentElement.dataset.latex || btn.parentElement.querySelector('pre')?.textContent || '';
+          text = btn.parentElement.dataset.latex || '';
         }}
-        navigator.clipboard.writeText(text).then(() => {{
-          btn.textContent = 'copied';
-          btn.classList.add('copied');
-          setTimeout(() => {{ btn.textContent = 'copy'; btn.classList.remove('copied'); }}, 1500);
-        }});
+        copyText(text, btn);
       }});
     }});
     </script>

--- a/scripts/serve_sg_report.sh
+++ b/scripts/serve_sg_report.sh
@@ -23,7 +23,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 echo "▶ Generating semantic graph report → $OUTDIR"
-./run.sh scripts/semantic_graph_report.py --outdir "$OUTDIR" "${EXTRA_ARGS[@]}"
+./run.sh scripts/semantic_graph_report.py --outdir "$OUTDIR" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}
 
 echo "▶ Serving on http://localhost:$PORT"
 python3 -m http.server "$PORT" -d "$OUTDIR"

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -1387,7 +1387,7 @@ export class D3SemanticGraphRenderer {
             if (wrt) return `${cmd}_{${wrt}}`;
             return cmd;
         }
-        return `\\text{${op.replace(/_/g, '\\_')}}`;
+        return `\\text{${op.replace(/\\/g, '\\\\').replace(/_/g, '\\_')}}`;
     }
 
     /**

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -160,10 +160,10 @@ const OPERATOR_GLYPHS = {
     conjunction: '∧', disjunction: '∨',
     sum: '∑', product: '∏', limit: 'lim',
     factorial: '(·)!', sqrt: '√(·)',
-    log: 'log', logarithm: 'log', exp: 'exp',
-    sin: 'sin', cos: 'cos', tan: 'tan',
+    log: 'log(·)', logarithm: 'log(·)', exp: 'exp(·)',
+    sin: 'sin(·)', cos: 'cos(·)', tan: 'tan(·)',
     Abs: '|·|', abs: '|·|',
-    function: 'f',
+    function: 'f(·)',
 };
 
 // LaTeX equivalents for operator glyphs — used when rendering operator
@@ -174,15 +174,16 @@ const OPERATOR_LATEX = {
     element_of: '\\in', not_element_of: '\\notin',
     multiply: '\\times', add: '+', subtract: '-',
     divide: '\\div', integral: '\\int', closed_integral: '\\oint',
+    tends_to: '\\to',
     implies: '\\Rightarrow', iff: '\\Leftrightarrow',
     negation: '-', not: '\\lnot', logical_not: '\\lnot',
     conjunction: '\\land', disjunction: '\\lor',
     sum: '\\sum', product: '\\prod', limit: '\\lim',
     factorial: '(\\cdot)!', sqrt: '\\sqrt{\\cdot}',
-    log: '\\log', logarithm: '\\log', exp: '\\exp',
-    sin: '\\sin', cos: '\\cos', tan: '\\tan',
+    log: '\\log(\\cdot)', logarithm: '\\log(\\cdot)', exp: '\\exp(\\cdot)',
+    sin: '\\sin(\\cdot)', cos: '\\cos(\\cdot)', tan: '\\tan(\\cdot)',
     Abs: '\\lvert\\cdot\\rvert', abs: '\\lvert\\cdot\\rvert',
-    function: 'f',
+    function: 'f(\\cdot)',
 };
 
 const OP_KINDS = new Set(['operator', 'relation', 'function']);
@@ -256,10 +257,23 @@ function operatorGlyph(node) {
 export function nodeShortLabel(node) {
     if (!node) return '';
     if (OP_KINDS.has(node.type)) {
-        if (node.latex) return node.latex;
+        if (node.latex) {
+            if (node.type === 'function' && !node.latex.includes('\\cdot') && !node.latex.includes('·')) {
+                const arity = (node._childIds || []).length || 1;
+                const dots = Array(arity).fill('·').join(', ');
+                return `${node.latex}(${dots})`;
+            }
+            return node.latex;
+        }
         const g = operatorGlyph(node);
         if (g) return g;
-        return node.op || node.id || '';
+        const name = node.op || node.id || '';
+        if (node.type === 'function' && name && !name.includes('·')) {
+            const arity = (node._childIds || []).length || 1;
+            const dots = Array(arity).fill('·').join(', ');
+            return `${name}(${dots})`;
+        }
+        return name;
     }
     return node.latex || node.label || node.id || '';
 }
@@ -1373,7 +1387,7 @@ export class D3SemanticGraphRenderer {
             if (wrt) return `${cmd}_{${wrt}}`;
             return cmd;
         }
-        return `\\text{${op}}`;
+        return `\\text{${op.replace(/_/g, '\\_')}}`;
     }
 
     /**
@@ -1396,6 +1410,13 @@ export class D3SemanticGraphRenderer {
         // plain op name wrapped in \text{} only as a last resort.
         if (!latex && isOp && this.katex) {
             latex = this._operatorLatex(data);
+        }
+
+        if (latex && data.type === 'function' && !isCollapsed
+            && !latex.includes('\\cdot') && !latex.includes('·')) {
+            const arity = (data._childIds || []).length || 1;
+            const dots = Array(arity).fill('\\cdot').join(', ');
+            latex = `${latex}(${dots})`;
         }
 
         if (latex && this.katex) {

--- a/tests/backend/semantic_graph/test_latex_to_graph.py
+++ b/tests/backend/semantic_graph/test_latex_to_graph.py
@@ -350,6 +350,33 @@ class TestCalculus:
         assert _find_node(g, label="1") is not None
         assert _find_node(g, label="infinity") is not None
 
+class TestLimits:
+    def test_limit_basic_structure(self):
+        g = latex_to_semantic_graph(r"\lim_{x \to 0} \frac{\sin x}{x}")
+        limit_node = _find_node(g, type="operator", op="limit")
+        assert limit_node is not None
+        tends_to = _find_node(g, type="operator", op="tends_to")
+        assert tends_to is not None
+
+    def test_tends_to_subexpr(self):
+        g = latex_to_semantic_graph(r"\lim_{x \to 0} x^2")
+        tends_to = _find_node(g, type="operator", op="tends_to")
+        assert tends_to is not None
+        assert tends_to.subexpr is not None
+        assert r"\to" in tends_to.subexpr
+        assert "x" in tends_to.subexpr
+        assert "0" in tends_to.subexpr
+
+    def test_tends_to_subexpr_infinity(self):
+        g = latex_to_semantic_graph(r"\lim_{n \to \infty} \frac{1}{n}")
+        tends_to = _find_node(g, type="operator", op="tends_to")
+        assert tends_to is not None
+        assert tends_to.subexpr is not None
+        assert r"\to" in tends_to.subexpr
+        assert "n" in tends_to.subexpr
+        assert "infty" in tends_to.subexpr or "\\infty" in tends_to.subexpr
+
+
 class TestDerivatives:
     def test_first_order_derivative(self):
         g = latex_to_semantic_graph("\\frac{d v}{d t}")

--- a/tests/backend/semantic_graph/test_latex_to_graph.py
+++ b/tests/backend/semantic_graph/test_latex_to_graph.py
@@ -350,6 +350,15 @@ class TestCalculus:
         assert _find_node(g, label="1") is not None
         assert _find_node(g, label="infinity") is not None
 
+    def test_sum_lower_bound_equals_subexpr(self):
+        g = latex_to_semantic_graph("\\sum_{n=1}^\\infty n")
+        eq_node = _find_node(g, type="relation", op="equals")
+        assert eq_node is not None
+        assert eq_node.subexpr is not None
+        assert "n" in eq_node.subexpr
+        assert "=" in eq_node.subexpr
+        assert "1" in eq_node.subexpr
+
 class TestLimits:
     def test_limit_basic_structure(self):
         g = latex_to_semantic_graph(r"\lim_{x \to 0} \frac{\sin x}{x}")

--- a/themes/semantic-graph/default-dark.json
+++ b/themes/semantic-graph/default-dark.json
@@ -1,7 +1,7 @@
 {
   "name": "default-dark",
   "mode": "dark",
-  "direction": "LR",
+  "direction": "RL",
   "labelMode": "emoji",
   "nodeStyles": {
     "scalar":   { "shape": "rect",    "fill": "#1b3a1e", "stroke": "#66bb6a", "color": "#c8e6c9" },


### PR DESCRIPTION
## Summary

- **D3 tab** on every expression row — lazily renders the D3 semantic graph on first click, reusing the same theme and direction as Mermaid
- **Split `{}` panel** — clicking `{}` now shows semantic graph JSON (left) and Mermaid script (right) side-by-side with independent scrolling
- **Copy buttons** on all source panels (LaTeX, JSON, Mermaid) using `execCommand` fallback for broad compatibility
- **Direction fix** — default theme changed to RL; D3 direction flipped to match Mermaid's visual flow
- **Abs/sqrt/factorial label fix** — functions whose LaTeX symbol already wraps the argument (e.g. `|\cdot|`) no longer get redundant `(\cdot)` parentheses
- **Dark scrollbar styling** — thin rounded scrollbars via webkit + standard `scrollbar-color`
- **Shell fix** — `serve_sg_report.sh` handles empty `EXTRA_ARGS` under `set -u`

## Changed files

| File | What |
|------|------|
| `scripts/semantic_graph_report.py` | D3 tab, split panel, copy buttons, scrollbar CSS, theme injection |
| `scripts/graph_to_mermaid.py` | Skip `(dots)` suffix when LaTeX symbol already contains `\cdot` |
| `themes/semantic-graph/default-dark.json` | Direction LR → RL |
| `scripts/serve_sg_report.sh` | Fix unbound variable with empty array |

## Test plan

- [ ] Run `./scripts/serve_sg_report.sh` and open in browser
- [ ] Verify all D3 tabs are hidden on load
- [ ] Click D3 on a few rows — graph renders lazily on first click, toggles on subsequent
- [ ] Verify Mermaid and D3 flow in the same direction (RL)
- [ ] Check abs/sqrt/factorial labels show no redundant parentheses in Mermaid
- [ ] Click `{}` — verify JSON + Mermaid split view with sticky headers
- [ ] Click copy buttons on LaTeX, JSON, and Mermaid panels — verify clipboard content
- [ ] Verify dark thin scrollbars in panels

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>