### PR TITLE
feat: chained inequality assertions in probability functions

### DIFF
--- a/backend/semantic_graph/sympy_translator.py
+++ b/backend/semantic_graph/sympy_translator.py
@@ -360,7 +360,7 @@ _ASSERTION_OP_META: dict[str, dict[str, str]] = {
 }
 
 
-def _rewrite_assertion_ops(latex: str) -> tuple[str, dict[str, str]]:
+def _rewrite_assertion_ops(latex: str) -> tuple[str, dict[str, list[str]]]:
     r"""Rewrite assertion operators inside function-call parens to ``,``.
 
     Probability expressions like ``P(X = k)`` or ``P(|X-\mu| \geq k)``
@@ -369,25 +369,26 @@ def _rewrite_assertion_ops(latex: str) -> tuple[str, dict[str, str]]:
     function calls — it silently collapses the expression.  This
     preprocessor rewrites the operator to ``,`` so SymPy sees
     ``P(X, k)``, and records which function names had an assertion
-    and what operator was used so the subexpr restorer can show the
-    original operator again.
+    and what operator(s) were used so the subexpr restorer can show
+    the original operator(s) again.
 
-    Only a **single** assertion operator at argument depth 0 is
-    rewritten; nested operators or multiple operators are left alone.
+    Both single-operator assertions (``P(X = k)``) and chained
+    inequalities (``P(1 < X \leq 10)``) are supported.
 
     Returns
     -------
-    tuple[str, dict[str, str]]
+    tuple[str, dict[str, list[str]]]
         ``(rewritten_latex, assertion_funcs)`` where
-        *assertion_funcs* maps function names to the original
-        LaTeX operator string (e.g. ``{"P": "\\geq"}``).
+        *assertion_funcs* maps function names to a list of the
+        original LaTeX operator strings (e.g. ``{"P": ["\\geq"]}``
+        for single-op, ``{"P": ["<", "\\leq"]}`` for chained).
     """
     # Quick bail-out: nothing to do if no operator could be present.
     if not any(op in latex for op in _ASSERTION_OPS):
         return latex, {}
 
     out: list[str] = []
-    assertion_funcs: dict[str, str] = {}
+    assertion_funcs: dict[str, list[str]] = {}
     i = 0
     n = len(latex)
     while i < n:
@@ -451,17 +452,19 @@ def _rewrite_assertion_ops(latex: str) -> tuple[str, dict[str, str]]:
                     else:
                         bi += 1
 
-                if len(op_hits) == 1:
-                    start_op, end_op, orig_op = op_hits[0]
-                    # Consume optional whitespace around the operator.
-                    before = start_op
-                    while before > 0 and body[before - 1] == " ":
-                        before -= 1
-                    after = end_op
-                    while after < blen and body[after] == " ":
-                        after += 1
-                    body = body[:before] + ", " + body[after:]
-                    assertion_funcs[func_name] = orig_op
+                if len(op_hits) >= 1:
+                    # Replace operators with commas right-to-left so
+                    # earlier indices remain valid.
+                    for start_op, end_op, _orig_op in reversed(op_hits):
+                        # Consume optional whitespace around the operator.
+                        before = start_op
+                        while before > 0 and body[before - 1] == " ":
+                            before -= 1
+                        after = end_op
+                        while after < len(body) and body[after] == " ":
+                            after += 1
+                        body = body[:before] + ", " + body[after:]
+                    assertion_funcs[func_name] = [h[2] for h in op_hits]
 
                 out.append("(")
                 out.append(body)
@@ -933,19 +936,23 @@ def _restore_all_conditional_bars(
 
 
 def _restore_all_assertion_ops(
-    latex: str, func_names: dict[str, str] | set[str],
+    latex: str, func_names: dict[str, list[str]] | set[str],
 ) -> str:
     r"""Restore assertion operators in ALL occurrences of named functions.
 
     The preprocessor rewrites e.g. ``P(X = k)`` → ``P(X, k)`` or
     ``P(|X-\mu| \geq k)`` → ``P(|X-\mu|, k)`` before SymPy parsing.
     SymPy then renders ``P{\left(X,k \right)}`` in subexprs.  This
-    function restores the **last** comma at argument depth to the
-    original operator for functions in *func_names*.
+    function restores commas at argument depth to the original
+    operator(s) for functions in *func_names*.
 
-    *func_names* can be a ``dict[str, str]`` mapping function name →
-    original operator (e.g. ``{"P": "\\geq"}``) or a legacy
-    ``set[str]`` which defaults the operator to ``=``.
+    For single-operator assertions (``[\"=\"]``), only the **last**
+    comma is replaced.  For chained inequalities (``[\"<\", \"\\leq\"]``),
+    all commas are replaced in order with the corresponding operators.
+
+    *func_names* can be a ``dict[str, list[str]]`` mapping function name →
+    original operator list (e.g. ``{"P": ["\\geq"]}``) or a legacy
+    ``set[str]`` which defaults the operator to ``["="]``.
 
     Uses the same scanning logic as ``_restore_all_conditional_bars``.
     """
@@ -954,7 +961,7 @@ def _restore_all_assertion_ops(
 
     # Normalise to dict form.
     if isinstance(func_names, set):
-        func_map: dict[str, str] = {f: "=" for f in func_names}
+        func_map: dict[str, list[str]] = {f: ["="] for f in func_names}
     else:
         func_map = func_names
 
@@ -971,12 +978,12 @@ def _restore_all_assertion_ops(
     for m in pattern.finditer(latex):
         start = m.start()
         fname = m.group("fname")
-        orig_op = func_map.get(fname, "=")
+        orig_ops = func_map.get(fname, ["="])
         result.append(latex[pos:start])
 
         depth = 1
         k = m.end()
-        last_comma = -1
+        comma_positions: list[int] = []
         while k < len(latex) and depth > 0:
             c = latex[k]
             if c in "({":
@@ -984,18 +991,39 @@ def _restore_all_assertion_ops(
             elif c in ")}":
                 depth -= 1
             elif c == "," and depth == 1:
-                last_comma = k
+                comma_positions.append(k)
             k += 1
 
         func_region = latex[start:k]
-        if last_comma >= 0:
-            rel = last_comma - start
-            after = rel + 1
-            while after < len(func_region) and func_region[after] == " ":
-                after += 1
-            func_region = (
-                func_region[:rel] + f" {orig_op} " + func_region[after:]
-            )
+        if comma_positions:
+            if len(orig_ops) == 1:
+                # Single-op: replace LAST comma (backward-compatible).
+                last_comma = comma_positions[-1]
+                rel = last_comma - start
+                after = rel + 1
+                while after < len(func_region) and func_region[after] == " ":
+                    after += 1
+                func_region = (
+                    func_region[:rel]
+                    + f" {orig_ops[0]} "
+                    + func_region[after:]
+                )
+            else:
+                # Chained: replace ALL commas right-to-left with their
+                # corresponding operators.
+                n_replace = min(len(comma_positions), len(orig_ops))
+                for idx in range(n_replace - 1, -1, -1):
+                    comma_abs = comma_positions[idx]
+                    rel = comma_abs - start
+                    after = rel + 1
+                    while (after < len(func_region)
+                           and func_region[after] == " "):
+                        after += 1
+                    func_region = (
+                        func_region[:rel]
+                        + f" {orig_ops[idx]} "
+                        + func_region[after:]
+                    )
         result.append(func_region)
         pos = k
 
@@ -1824,7 +1852,7 @@ class SemanticGraphBuilder:
         original_latex: str | None = None,
         bare_sum_indices: set[str] | None = None,
         conditional_bar_funcs: set[str] | None = None,
-        assertion_funcs: dict[str, str] | None = None,
+        assertion_funcs: dict[str, list[str]] | None = None,
     ) -> None:
         self.nodes: list[dict[str, str]] = []
         self.edges: list[dict[str, str]] = []
@@ -1835,7 +1863,7 @@ class SemanticGraphBuilder:
         self._original_latex = original_latex or ""
         self._bare_sum_indices: set[str] = bare_sum_indices or set()
         self._conditional_bar_funcs: set[str] = conditional_bar_funcs or set()
-        self._assertion_funcs: dict[str, str] = assertion_funcs or {}
+        self._assertion_funcs: dict[str, list[str]] = assertion_funcs or {}
         self._symbol_order = self._build_symbol_order()
         # Per-integral closed-integral flags: scan the *original* LaTeX for
         # \oint vs \int in left-to-right order so each Integral node can be
@@ -1931,8 +1959,19 @@ class SemanticGraphBuilder:
         """
         if not self._overrides:
             return
-        # Build mapping: Xi index → infix node subexpr
+        # Build mapping: Xi index → infix node subexpr.
+        # Prefer the _xi_idx stored on the node (set in _walk when the
+        # Xi placeholder is resolved) so that duplicate ops (e.g. two
+        # ``union`` nodes) each map to their own subexpr.
         infix_subexprs: dict[int, str] = {}
+        # First pass: nodes with explicit _xi_idx (preferred).
+        seen_idxs: set[int] = set()
+        for nd in self.nodes:
+            xi_idx = nd.get("_xi_idx")
+            if xi_idx is not None and nd.get("subexpr"):
+                infix_subexprs[xi_idx] = nd["subexpr"]
+                seen_idxs.add(xi_idx)
+        # Fallback: match by op for nodes without _xi_idx (legacy).
         for name, ovr in self._overrides.items():
             if "op" not in ovr or "type" not in ovr:
                 continue
@@ -1940,6 +1979,8 @@ class SemanticGraphBuilder:
             if not m:
                 continue
             idx = int(name.split("{")[1].rstrip("}"))
+            if idx in seen_idxs:
+                continue  # already resolved via _xi_idx
             for nd in self.nodes:
                 if nd.get("op") == ovr["op"] and nd.get("subexpr"):
                     infix_subexprs[idx] = nd["subexpr"]
@@ -2009,6 +2050,10 @@ class SemanticGraphBuilder:
             if not sub or "Xi" not in sub:
                 continue
             nd["subexpr"] = _replace_xi_calls(sub)
+
+        # Strip internal _xi_idx field — it was only needed for mapping.
+        for nd in self.nodes:
+            nd.pop("_xi_idx", None)
 
     def _build_symbol_order(self) -> dict[str, int]:
         if not self._original_latex:
@@ -2361,9 +2406,13 @@ class SemanticGraphBuilder:
                                     nd.get("subexpr", cid))
                                 break
                     subexpr = f" {infix_latex} ".join(child_subexprs)
+                    # Extract Xi index so _cleanup_infix_subexprs can
+                    # match this node directly (not by op name).
+                    xi_idx = int(func_name.split("{")[1].rstrip("}"))
                     self._add_node(
                         node_id, type=ovr["type"], op=infix_op,
                         emoji=infix_emoji, subexpr=subexpr,
+                        _xi_idx=xi_idx,
                     )
                     return node_id
                 # --- Text-command placeholder (e.g. \text{Res} → Xi_{0}) ---
@@ -2380,13 +2429,16 @@ class SemanticGraphBuilder:
             is_log = isinstance(expr, log)
             has_cond_bar = (op_name in self._conditional_bar_funcs
                            and len(expr.args) >= 2)
-            orig_op = self._assertion_funcs.get(op_name)
-            has_assertion = orig_op is not None and len(expr.args) >= 2
+            orig_ops = self._assertion_funcs.get(op_name)
+            has_assertion = (orig_ops is not None
+                            and len(expr.args) >= 2
+                            and len(orig_ops) == len(expr.args) - 1)
 
-            if has_assertion:
-                # Build an inner relation node for the assertion.
-                # E.g. P(X = k) → P contains an equals(X, k) child.
-                meta = _ASSERTION_OP_META.get(orig_op, {"op": "equals", "emoji": "="})
+            if has_assertion and len(orig_ops) == 1:
+                # Single-op assertion: P(X = k) → one relation node.
+                orig_op = orig_ops[0]
+                meta = _ASSERTION_OP_META.get(
+                    orig_op, {"op": "equals", "emoji": "="})
                 rel_op = meta["op"]
                 rel_emoji = meta["emoji"]
                 rel_id = self._next_id(rel_op)
@@ -2405,7 +2457,7 @@ class SemanticGraphBuilder:
                         edge_role = None
                     self._add_edge(child_id, rel_id, role=edge_role)
                 # Build subexpr from children: "lhs_subexpr OP rhs_subexpr"
-                child_subexprs = []
+                child_subexprs: list[str] = []
                 for cid in child_ids:
                     for nd in self.nodes:
                         if nd["id"] == cid:
@@ -2413,11 +2465,48 @@ class SemanticGraphBuilder:
                             break
                 rel_subexpr = f" {orig_op} ".join(child_subexprs)
                 self._add_node(
-                    rel_id, type="relation", op=rel_op, emoji=rel_emoji,
-                    subexpr=rel_subexpr,
+                    rel_id, type="relation", op=rel_op,
+                    emoji=rel_emoji, subexpr=rel_subexpr,
                 )
                 # Connect the inner relation to the function.
                 self._add_edge(rel_id, node_id, role="assertion")
+            elif has_assertion:
+                # Chained assertion: P(1 < X ≤ 10) → right-associative
+                # chain of relation nodes.  Each consecutive pair of
+                # children is joined by its operator, and each new
+                # relation node becomes the lhs of the next one.
+                child_ids = []
+                for arg in expr.args:
+                    child_ids.append(self._walk(arg))
+                child_subexprs = []
+                for cid in child_ids:
+                    for nd in self.nodes:
+                        if nd["id"] == cid:
+                            child_subexprs.append(nd.get("subexpr", cid))
+                            break
+                prev_id: str = child_ids[0]
+                prev_subexpr: str = child_subexprs[0]
+                for j, op_latex in enumerate(orig_ops):
+                    meta = _ASSERTION_OP_META.get(
+                        op_latex, {"op": "equals", "emoji": "="})
+                    rel_op = meta["op"]
+                    rel_emoji = meta["emoji"]
+                    rel_id = self._next_id(rel_op)
+                    rhs_child = child_ids[j + 1]
+                    rel_subexpr = (
+                        f"{prev_subexpr} {op_latex} "
+                        f"{child_subexprs[j + 1]}"
+                    )
+                    self._add_edge(prev_id, rel_id, role="lhs")
+                    self._add_edge(rhs_child, rel_id, role="rhs")
+                    self._add_node(
+                        rel_id, type="relation", op=rel_op,
+                        emoji=rel_emoji, subexpr=rel_subexpr,
+                    )
+                    prev_id = rel_id
+                    prev_subexpr = rel_subexpr
+                # Connect outermost relation to the function.
+                self._add_edge(prev_id, node_id, role="assertion")
             else:
                 last_idx = len(expr.args) - 1
                 for i, arg in enumerate(expr.args):
@@ -2748,7 +2837,7 @@ def _build_relation_graph(
     domain: str | None = None,
     bare_sum_indices: set[str] | None = None,
     conditional_bar_funcs: set[str] | None = None,
-    assertion_funcs: dict[str, str] | None = None,
+    assertion_funcs: dict[str, list[str]] | None = None,
 
 ) -> dict:
     r"""Build a graph for a binary relation ``lhs <op> rhs``."""
@@ -2874,7 +2963,7 @@ def _build_chained_asymmetric_relation_graph(
     domain: str | None = None,
     bare_sum_indices: set[str] | None = None,
     conditional_bar_funcs: set[str] | None = None,
-    assertion_funcs: dict[str, str] | None = None,
+    assertion_funcs: dict[str, list[str]] | None = None,
 
 ) -> dict:
     r"""Build right-associative nested binary nodes for chained asymmetric relations.
@@ -2949,7 +3038,7 @@ def _build_nary_relation_graph(
     domain: str | None = None,
     bare_sum_indices: set[str] | None = None,
     conditional_bar_funcs: set[str] | None = None,
-    assertion_funcs: dict[str, str] | None = None,
+    assertion_funcs: dict[str, list[str]] | None = None,
 
 ) -> dict:
     r"""Build an n-ary relation graph: all parts feed into one relation node.

--- a/schemas/semantic-graph.schema.json
+++ b/schemas/semantic-graph.schema.json
@@ -181,8 +181,8 @@
         },
         "role": {
           "type": "string",
-          "enum": ["lhs", "rhs", "wrt", "exp", "base", "lb", "ub", "value", "condition", "modulus"],
-          "description": "Operand position or relationship. 'lhs'/'rhs' for asymmetric operators (comparisons, tends_to). 'wrt' for the differentiation/integration variable edge into derivative/integral nodes. 'exp' for the exponent edge into a power node with symbolic exponent. 'base' for the base argument edge into a log function node. 'lb'/'ub' for lower/upper bound edges into sum/product nodes. 'value'/'condition' for piecewise branch nodes — 'value' is the branch result, 'condition' is the guard predicate. 'modulus' for the modulus operand of a congruence relation. Omit for symmetric operators (add, multiply, equals)."
+          "enum": ["lhs", "rhs", "wrt", "exp", "base", "lb", "ub", "value", "condition", "modulus", "assertion"],
+          "description": "Operand position or relationship. 'lhs'/'rhs' for asymmetric operators (comparisons, tends_to). 'wrt' for the differentiation/integration variable edge into derivative/integral nodes. 'exp' for the exponent edge into a power node with symbolic exponent. 'base' for the base argument edge into a log function node. 'lb'/'ub' for lower/upper bound edges into sum/product nodes. 'value'/'condition' for piecewise branch nodes — 'value' is the branch result, 'condition' is the guard predicate. 'modulus' for the modulus operand of a congruence relation. 'assertion' for an assertion-form relation (e.g. X=k) feeding into a probability function P(X=k). Omit for symmetric operators (add, multiply, equals)."
         }
       }
     },

--- a/scripts/graph_to_mermaid.py
+++ b/scripts/graph_to_mermaid.py
@@ -372,11 +372,13 @@ def _format_label(
             if r"\cdot" in fn_name:
                 return f"${fn_name}$"
             # Conditional probability: P(·|·) instead of P(·, ·)
-            # Assertion equals: P(· = ·) instead of P(·, ·)
+            # Assertion: P(…) — the assertion is an arbitrary predicate
+            # (X=k, X≥a, |X−μ|≥kσ, …) so we show ellipsis rather than
+            # trying to decompose it.
             if has_condition and effective_arity >= 2:
                 regular_dots = r", ".join([r"\cdot"] * (effective_arity - 1))
                 dots = regular_dots + r"\mid " + r"\cdot"
-            elif has_assertion and effective_arity >= 2:
+            elif has_assertion:
                 dots = r"\ldots"
             else:
                 dots = r", ".join([r"\cdot"] * max(effective_arity, 1))

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -278,7 +278,10 @@ function _arityDots(arity, hasCondition, hasAssertion, dot) {
         const regular = Array(arity - 1).fill(dot).join(', ');
         return `${regular}${sep}${dot}`;
     }
-    if (hasAssertion && arity >= 2) {
+    // Assertion-form: the assertion is an arbitrary predicate (X=k, X≥a,
+    // |X−μ|≥kσ, …) fed in as a single edge.  Show ``…`` rather than
+    // trying to decompose it into ``·op·``.
+    if (hasAssertion) {
         return dot === '·' ? '…' : '\\ldots';
     }
     return Array(arity).fill(dot).join(', ');

--- a/tests/backend/semantic_graph/domains/test_domain_probability.py
+++ b/tests/backend/semantic_graph/domains/test_domain_probability.py
@@ -37,7 +37,7 @@ ALLOWED_OPS = {
     "function", "binomial", "factorial", "sum",
     "P", "E",
     "Abs", "abs",
-    "less_equal", "greater_equal",
+    "less_than", "less_equal", "greater_than", "greater_equal",
     "intersection",
 }
 
@@ -206,6 +206,16 @@ PROBABILITY_EXPRESSIONS: list[CatalogEntry] = [
          "__greater_equal_2 -> __P_1; "
          "__P_1,__power_7 -> __less_equal_9",
      None),
+
+    ("prob_chained_ineq",
+     r"P(1 < X \leq 10) = 0.5",
+     PASS,
+         "X,num -> rel:less_than; num,rel:less_than -> rel:less_equal; "
+         "rel:less_equal -> fn:P; fn:P,num -> rel:equals",
+         "X,__num_3 -> __less_than_5; "
+         "__less_than_5,__num_4 -> __less_equal_6; "
+         "__less_equal_6 -> __P_2; __P_2,__num_7 -> __equals_1",
+     [{"op": "P", "id": "__P_2", "_edge_roles": {"assertion": 1}}]),
 
     ("prob_uniform",
      r"f(x) = \frac{1}{b - a}",

--- a/tests/backend/semantic_graph/test_conditional_bar.py
+++ b/tests/backend/semantic_graph/test_conditional_bar.py
@@ -43,8 +43,10 @@ class TestRewriteConditionalBar:
     def test_nested_abs_not_rewritten(self):
         """Paired ``|…|`` inside function args (abs value) must survive."""
         result, funcs = _rewrite_conditional_bar(r"P(|X| > a)")
-        # The paired |X| should not be treated as a conditional bar
-        assert "|" not in funcs or result.count(",") == 0
+        # The paired |X| should not be treated as a conditional bar —
+        # the result must still contain the abs bars and no comma rewrite.
+        assert "|X|" in result, f"Abs bars lost: {result!r}"
+        assert "," not in result, f"Unexpected comma rewrite: {result!r}"
 
     def test_no_bar_passthrough(self):
         result, funcs = _rewrite_conditional_bar(r"P(A)")
@@ -251,12 +253,20 @@ class TestSubexprConditionalBar:
     def test_single_arg_subexpr_unchanged(self, parse):
         r"""Single-arg ``P(A)`` subexprs must NOT get ``\mid``."""
         graph = parse(r"P(A|B) = \frac{P(B|A) P(A)}{P(B)}")
-        for n in graph.nodes:
-            if n.subexpr and r"P{\left(A \right)}" in n.subexpr:
-                # This is fine — single arg, no \mid
-                assert r"\mid" not in r"P{\left(A \right)}"
-            if n.subexpr and r"P{\left(B \right)}" in n.subexpr:
-                assert r"\mid" not in r"P{\left(B \right)}"
+        # Find single-arg P function nodes (P(A) and P(B))
+        single_arg_p = [
+            n for n in graph.nodes
+            if n.type == "function" and n.op == "P"
+            and n.subexpr and n.subexpr.count(",") == 0
+            and r"\mid" not in n.subexpr
+        ]
+        # There must be at least the P(A) and P(B) nodes
+        # and none of them should contain \mid
+        for n in single_arg_p:
+            assert r"\mid" not in n.subexpr, (
+                f"Single-arg function {n.id} has \\mid in subexpr: "
+                f"{n.subexpr!r}"
+            )
 
     def test_conditional_prob_subexpr(self, parse):
         r"""``P(A ∩ B) = P(A) P(B|A)`` — only P(B|A) gets bar."""
@@ -301,3 +311,107 @@ class TestBracketNotationWithBar:
             assert e.to in p_func_ids, (
                 "condition edge should only target P nodes, not E"
             )
+
+
+# ── Integration: chained inequality assertions ──────────────────────
+
+
+class TestChainedInequalityAssertion:
+    """Chained inequalities like ``P(1 < X \\leq 10)`` must produce a
+    right-associative chain of relation nodes connected to the function
+    via an ``assertion`` edge."""
+
+    def test_rewrite_chained_ops(self):
+        """Preprocessor rewrites both operators to commas."""
+        from backend.semantic_graph.sympy_translator import (
+            _rewrite_assertion_ops,
+        )
+        result, funcs = _rewrite_assertion_ops(r"P(1 < X \leq 10)")
+        assert result == r"P(1, X, 10)"
+        assert funcs == {"P": ["<", r"\leq"]}
+
+    def test_rewrite_single_op_returns_list(self):
+        """Single-op assertions now return a one-element list."""
+        from backend.semantic_graph.sympy_translator import (
+            _rewrite_assertion_ops,
+        )
+        result, funcs = _rewrite_assertion_ops(r"P(X = k)")
+        assert result == r"P(X, k)"
+        assert funcs == {"P": ["="]}
+
+    def test_chained_produces_assertion_edge(self, parse):
+        """``P(1 < X ≤ 10)`` must have exactly one assertion edge
+        pointing to the P function node."""
+        graph = parse(r"P(1 < X \leq 10)")
+        assertion_edges = [e for e in graph.edges if e.role == "assertion"]
+        assert len(assertion_edges) == 1
+        p_ids = {n.id for n in graph.nodes
+                 if n.type == "function" and n.op == "P"}
+        assert assertion_edges[0].to in p_ids
+
+    def test_chained_relation_chain(self, parse):
+        r"""``P(1 < X \leq 10)`` must produce ``less_than`` and
+        ``less_equal`` relation nodes in a right-associative chain."""
+        graph = parse(r"P(1 < X \leq 10)")
+        rel_nodes = {n.id: n for n in graph.nodes if n.type == "relation"}
+        # Must have exactly two relation nodes.
+        assert len(rel_nodes) == 2, (
+            f"Expected 2 relation nodes, got {len(rel_nodes)}: "
+            f"{[n.op for n in rel_nodes.values()]}"
+        )
+        ops = {n.op for n in rel_nodes.values()}
+        assert ops == {"less_than", "less_equal"}
+
+        # The less_than node must be lhs of the less_equal node.
+        lt_id = next(n.id for n in rel_nodes.values()
+                     if n.op == "less_than")
+        le_id = next(n.id for n in rel_nodes.values()
+                     if n.op == "less_equal")
+        lhs_edges = [e for e in graph.edges
+                     if e.from_ == lt_id and e.to == le_id
+                     and e.role == "lhs"]
+        assert len(lhs_edges) == 1, (
+            "less_than should be lhs of less_equal"
+        )
+
+    def test_chained_subexpr_has_operators(self, parse):
+        r"""Subexprs must show original operators, not commas."""
+        graph = parse(r"P(1 < X \leq 10)")
+        p_nodes = [n for n in graph.nodes
+                   if n.type == "function" and n.op == "P"]
+        assert len(p_nodes) == 1
+        subexpr = p_nodes[0].subexpr
+        assert subexpr is not None
+        assert "," not in subexpr, (
+            f"P function subexpr has comma instead of operators: "
+            f"{subexpr!r}"
+        )
+
+    def test_chained_in_equation(self, parse):
+        r"""``P(1 < X \leq 10) = 0.5`` — equation subexpr must show
+        the chained inequality, not commas."""
+        graph = parse(r"P(1 < X \leq 10) = 0.5")
+        eq_nodes = [n for n in graph.nodes if n.op == "equals"]
+        assert len(eq_nodes) == 1
+        assert eq_nodes[0].subexpr is not None
+        assert "," not in eq_nodes[0].subexpr, (
+            f"Equation subexpr has comma: {eq_nodes[0].subexpr!r}"
+        )
+
+    def test_reversed_direction(self, parse):
+        r"""``P(a \geq X > b)`` — reversed direction chain."""
+        graph = parse(r"P(a \geq X > b)")
+        rel_nodes = {n.id: n for n in graph.nodes if n.type == "relation"}
+        ops = {n.op for n in rel_nodes.values()}
+        assert ops == {"greater_equal", "greater_than"}
+        assertion_edges = [e for e in graph.edges if e.role == "assertion"]
+        assert len(assertion_edges) == 1
+
+    def test_single_op_unaffected(self, parse):
+        r"""Single-op assertions (``P(X = k)``) still work as before."""
+        graph = parse(r"P(X = k)")
+        assertion_edges = [e for e in graph.edges if e.role == "assertion"]
+        assert len(assertion_edges) == 1
+        rel_nodes = [n for n in graph.nodes if n.type == "relation"]
+        assert len(rel_nodes) == 1
+        assert rel_nodes[0].op == "equals"


### PR DESCRIPTION
## Summary
- Support chained inequality assertions like `P(1 < X ≤ 10)` — preprocessor rewrites multiple operators to commas, graph builder creates a right-associative chain of relation nodes, and subexpr restorer puts original operators back
- Add `assertion` edge role to schema for relations feeding into probability functions
- Update Mermaid and D3 renderers to show `…` for assertion-form functions (arbitrary predicate, not decomposed)
- Comprehensive test coverage for chained and single-op assertions

## Test plan
- [x] Unit tests for preprocessor rewriting (`_rewrite_assertion_ops`)
- [x] Integration tests for graph structure (assertion edges, relation chains)
- [x] Subexpr restoration tests (operators instead of commas)
- [x] Backward compatibility for single-op assertions (`P(X = k)`)
- [x] Domain catalog entry for `prob_chained_ineq`

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>