### PR TITLE
Interactive chart plotting for semantic graph nodes

### DIFF
--- a/backend/semantic_graph/mathjs_converter.py
+++ b/backend/semantic_graph/mathjs_converter.py
@@ -73,6 +73,29 @@ def _sanitize_primed_symbols(expr: sympy.Basic) -> sympy.Basic:
     return expr.subs(subs) if subs else expr
 
 
+def _sanitize_subscript_braces(expr: sympy.Basic) -> sympy.Basic:
+    """Strip LaTeX subscript braces from symbol names.
+
+    ``parse_latex`` emits ``Symbol("x_{i}")`` for ``x_i`` — the braces
+    are not valid in JavaScript/mathjs identifiers.  This replaces them:
+
+    * ``x_{i}``   → ``x_i``
+    * ``p_{ij}``  → ``p_ij``
+    * ``a_{12}``  → ``a_12``
+
+    Nested braces (rare) are also stripped.
+    """
+    subs: dict[Symbol, Symbol] = {}
+    for sym in expr.free_symbols:
+        name = sym.name
+        if "{" not in name and "}" not in name:
+            continue
+        clean = name.replace("{", "").replace("}", "")
+        if clean != name:
+            subs[sym] = Symbol(clean)
+    return expr.subs(subs) if subs else expr
+
+
 # ── jscode → mathjs conversion ────────────────────────────────────────
 
 def jscode_to_mathjs(js_code: str) -> str:
@@ -105,6 +128,10 @@ def jscode_to_mathjs(js_code: str) -> str:
     # are not valid JS/mathjs identifiers.
     result = re.sub(r"(\w)('{2,})", lambda m: m.group(1) + "_" + _prime_suffix(len(m.group(2))), result)
     result = re.sub(r"(\w)'", r"\1_prime", result)
+
+    # Safety-net: strip LaTeX subscript braces that may slip through
+    # (e.g. from parse_latex symbols like ``x_{i}``).
+    result = result.replace("{", "").replace("}", "")
 
     return result.strip()
 
@@ -160,6 +187,10 @@ def latex_to_mathjs(latex: str) -> tuple[str, list[str]]:
     # Sanitize primed symbols (u' → u_prime) so jscode emits valid
     # JavaScript identifiers.
     expr = _sanitize_primed_symbols(expr)
+
+    # Strip LaTeX subscript braces (x_{i} → x_i) so jscode emits
+    # valid JavaScript/mathjs identifiers.
+    expr = _sanitize_subscript_braces(expr)
 
     # Extract free variables (after substitution).
     variables = sorted(str(s) for s in expr.free_symbols)

--- a/backend/semantic_graph/mathjs_converter.py
+++ b/backend/semantic_graph/mathjs_converter.py
@@ -1,0 +1,129 @@
+"""Convert LaTeX math expressions to mathjs-compatible script strings.
+
+Pipeline: LaTeX → ``parse_latex()`` → SymPy → ``jscode()`` → regex
+conversion → mathjs string.
+
+The public API is :func:`latex_to_mathjs` which accepts a raw LaTeX
+string (typically the ``subexpr`` field on a semantic graph node) and
+returns a ``(script, variables)`` tuple ready for client-side
+``math.compile()`` / ``compiled.evaluate(scope)``.
+
+Relations (``Eq``, ``Gt``, ``Lt``, …) are automatically converted to
+``LHS - RHS`` so charts can plot zero-crossings.
+"""
+
+from __future__ import annotations
+
+import re
+
+import sympy
+from sympy import E, Rel, Symbol
+from sympy import pi as sympy_pi
+from sympy.parsing.latex import parse_latex
+from sympy.printing.jscode import jscode
+
+# ── Constants ──────────────────────────────────────────────────────────
+
+# Symbols that ``parse_latex`` emits as plain ``Symbol`` instances but
+# which should be treated as SymPy constants for numeric evaluation.
+_SYMBOL_TO_CONSTANT: dict[Symbol, sympy.Basic] = {
+    Symbol("e"): E,
+    Symbol("pi"): sympy_pi,
+}
+
+# ``jscode`` emits ``Math.<name>`` — map the few constant names to their
+# mathjs equivalents.  Function names (``sin``, ``cos``, …) just drop
+# the ``Math.`` prefix since mathjs uses bare function names.
+_JS_CONST_MAP: dict[str, str] = {
+    "PI": "pi",
+    "E": "e",
+    "LN2": "ln2",
+    "LN10": "ln10",
+    "SQRT2": "sqrt(2)",
+    "SQRT1_2": "sqrt(1/2)",
+}
+
+
+# ── jscode → mathjs conversion ────────────────────────────────────────
+
+def jscode_to_mathjs(js_code: str) -> str:
+    """Convert SymPy ``jscode()`` output to a mathjs-compatible string.
+
+    Transformations performed:
+
+    * ``Math.sin(x)``  →  ``sin(x)``  (strip ``Math.`` prefix)
+    * ``Math.PI``      →  ``pi``      (map JS constants)
+    * ``Math.E``       →  ``e``
+    * Comment blocks emitted by ``jscode(strict=False)`` for unsupported
+      functions are stripped, leaving bare function names that mathjs
+      handles natively (e.g. ``factorial(x)``).
+    """
+    # Strip ``// Not supported …`` comment lines.
+    js_code = re.sub(r"//[^\n]*\n?", "", js_code)
+
+    # Replace ``Math.<name>`` with either a constant alias or the bare
+    # function name.
+    def _replace(m: re.Match) -> str:
+        name = m.group(1)
+        return _JS_CONST_MAP.get(name, name)
+
+    result = re.sub(r"Math\.(\w+)", _replace, js_code)
+    return result.strip()
+
+
+# ── LaTeX → mathjs full pipeline ──────────────────────────────────────
+
+def latex_to_mathjs(latex: str) -> tuple[str, list[str]]:
+    """Convert a LaTeX expression to a mathjs script string.
+
+    Parameters
+    ----------
+    latex:
+        Raw LaTeX (e.g. the ``subexpr`` field of a semantic graph node).
+
+    Returns
+    -------
+    (script, variables):
+        *script* is a mathjs-compatible expression string.
+        *variables* is a sorted list of free-symbol names (variables the
+        caller must supply numeric values for).
+
+    Raises
+    ------
+    ValueError:
+        If ``parse_latex`` cannot parse the input.
+
+    Notes
+    -----
+    * Relations (``=``, ``>``, ``<``, ``\\geq``, ``\\leq``, ``\\neq``)
+      are automatically converted to ``LHS - RHS`` so the chart can
+      plot the zero-crossing.
+    * ``Symbol('e')`` and ``Symbol('pi')`` are replaced with SymPy's
+      numeric constants ``E`` and ``pi`` before code generation so they
+      don't appear as free variables.
+    """
+    try:
+        expr = parse_latex(latex)
+    except Exception as exc:
+        raise ValueError(f"parse_latex failed: {exc}") from exc
+
+    # Auto-detect relations and build LHS − RHS.
+    if isinstance(expr, Rel):
+        expr = expr.lhs - expr.rhs
+
+    # Replace Symbol('e') → E, Symbol('pi') → π, etc.
+    expr = expr.subs(_SYMBOL_TO_CONSTANT)
+
+    # Normalize sub-expressions that ``parse_latex`` leaves in
+    # un-evaluated form (e.g. ``log(x, E)`` with two args instead of
+    # the canonical single-arg ``log(x)``).
+    expr = expr.doit()
+
+    # Extract free variables (after substitution).
+    variables = sorted(str(s) for s in expr.free_symbols)
+
+    # Generate JavaScript, then convert to mathjs.
+    js = jscode(expr, strict=False)
+    script = jscode_to_mathjs(js)
+
+    return script, variables

--- a/backend/semantic_graph/mathjs_converter.py
+++ b/backend/semantic_graph/mathjs_converter.py
@@ -44,6 +44,35 @@ _JS_CONST_MAP: dict[str, str] = {
 }
 
 
+# ── Prime-character helpers ───────────────────────────────────────────
+
+_PRIME_SUFFIXES = {1: "prime", 2: "dprime", 3: "tprime"}
+
+
+def _prime_suffix(count: int) -> str:
+    """Return a suffix for *count* prime marks: 1→prime, 2→dprime, etc."""
+    return _PRIME_SUFFIXES.get(count, f"{count}prime")
+
+
+def _sanitize_primed_symbols(expr: sympy.Basic) -> sympy.Basic:
+    """Replace primed free symbols with valid-identifier equivalents.
+
+    ``Symbol("u'")`` → ``Symbol("u_prime")``, ``Symbol("x''")`` →
+    ``Symbol("x_dprime")``, etc.  This ensures ``jscode()`` emits valid
+    JavaScript/mathjs identifiers.
+    """
+    subs: dict[Symbol, Symbol] = {}
+    for sym in expr.free_symbols:
+        name = sym.name
+        if "'" not in name:
+            continue
+        base = name.rstrip("'")
+        prime_count = len(name) - len(base)
+        clean = f"{base}_{_prime_suffix(prime_count)}" if base else f"_{_prime_suffix(prime_count)}"
+        subs[sym] = Symbol(clean)
+    return expr.subs(subs) if subs else expr
+
+
 # ── jscode → mathjs conversion ────────────────────────────────────────
 
 def jscode_to_mathjs(js_code: str) -> str:
@@ -57,6 +86,8 @@ def jscode_to_mathjs(js_code: str) -> str:
     * Comment blocks emitted by ``jscode(strict=False)`` for unsupported
       functions are stripped, leaving bare function names that mathjs
       handles natively (e.g. ``factorial(x)``).
+    * Prime characters in identifiers are sanitized:
+      ``u'`` → ``u_prime``, ``u''`` → ``u_dprime``.
     """
     # Strip ``// Not supported …`` comment lines.
     js_code = re.sub(r"//[^\n]*\n?", "", js_code)
@@ -68,6 +99,13 @@ def jscode_to_mathjs(js_code: str) -> str:
         return _JS_CONST_MAP.get(name, name)
 
     result = re.sub(r"Math\.(\w+)", _replace, js_code)
+
+    # Safety-net: sanitize any remaining prime characters in identifiers.
+    # ``jscode`` may emit ``u'`` or ``u''`` for primed symbols — these
+    # are not valid JS/mathjs identifiers.
+    result = re.sub(r"(\w)('{2,})", lambda m: m.group(1) + "_" + _prime_suffix(len(m.group(2))), result)
+    result = re.sub(r"(\w)'", r"\1_prime", result)
+
     return result.strip()
 
 
@@ -118,6 +156,10 @@ def latex_to_mathjs(latex: str) -> tuple[str, list[str]]:
     # un-evaluated form (e.g. ``log(x, E)`` with two args instead of
     # the canonical single-arg ``log(x)``).
     expr = expr.doit()
+
+    # Sanitize primed symbols (u' → u_prime) so jscode emits valid
+    # JavaScript identifiers.
+    expr = _sanitize_primed_symbols(expr)
 
     # Extract free variables (after substitution).
     variables = sorted(str(s) for s in expr.free_symbols)

--- a/backend/server.py
+++ b/backend/server.py
@@ -1386,15 +1386,16 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
             script, variables = latex_to_mathjs(req.subexpr)
             return JSONResponse({"script": script, "variables": variables})
         except (ValueError, SyntaxError) as e:
+            print(f"   ⚠️  /api/graph/generate-mathjs: conversion failed: {e}")
             return JSONResponse(
-                {"error": "failed to convert LaTeX to mathjs", "detail": str(e)},
+                {"error": "failed to convert LaTeX to mathjs"},
                 status_code=400,
             )
         except Exception as e:
             import traceback
             print(f"   ❌ /api/graph/generate-mathjs: {e}\n{traceback.format_exc()}")
             return JSONResponse(
-                {"error": "internal error generating mathjs", "detail": str(e)},
+                {"error": "internal error generating mathjs"},
                 status_code=500,
             )
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -1368,6 +1368,36 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
             print(f"   ❌ /api/graph/from-latex: {e}\n{traceback.format_exc()}")
             return JSONResponse({"error": "internal error processing LaTeX"}, status_code=500)
 
+    class GenerateMathjsRequest(BaseModel):
+        subexpr: str
+
+    @fastapp.post("/api/graph/generate-mathjs")
+    async def post_generate_mathjs(req: GenerateMathjsRequest):
+        """Convert a LaTeX sub-expression to a mathjs-compatible script.
+
+        Accepts the ``subexpr`` field from a semantic graph node and returns
+        a mathjs expression string suitable for ``math.compile()`` on the
+        client.  Relations (``=``, ``>``, …) are automatically converted to
+        ``LHS - RHS``.
+        """
+        from backend.semantic_graph.mathjs_converter import latex_to_mathjs
+
+        try:
+            script, variables = latex_to_mathjs(req.subexpr)
+            return JSONResponse({"script": script, "variables": variables})
+        except (ValueError, SyntaxError) as e:
+            return JSONResponse(
+                {"error": "failed to convert LaTeX to mathjs", "detail": str(e)},
+                status_code=400,
+            )
+        except Exception as e:
+            import traceback
+            print(f"   ❌ /api/graph/generate-mathjs: {e}\n{traceback.format_exc()}")
+            return JSONResponse(
+                {"error": "internal error generating mathjs", "detail": str(e)},
+                status_code=500,
+            )
+
     class GraphEnrichRequest(BaseModel):
         graph: dict
         context: dict | None = None

--- a/scripts/semantic_graph_report.py
+++ b/scripts/semantic_graph_report.py
@@ -640,25 +640,32 @@ def _page_template() -> str:
           var graphJson = panel.dataset.graph;
           if (!graphJson) return;
           panel.innerHTML = '';
-          var graph = JSON.parse(graphJson);
-          var chartMgr = new SgChartManager(panel, graph, {{
-            katex: window.katex || null,
-          }});
-          var renderer = new D3SemanticGraphRenderer(panel, {{
-            direction: '{d3_direction}',
-            labels: 'description',
-            theme: '{d3_theme}',
-            katex: window.katex || null,
-            onTransformChange: function(t) {{ chartMgr.setTransform(t); }},
-            onChartClick: function(nodeId, nodeData, btnEl) {{
-              if (chartMgr.charts.has(nodeId)) {{
-                chartMgr.closeChart(nodeId);
-              }} else {{
-                chartMgr.openChart(nodeId, btnEl);
-              }}
-            }},
-          }});
-          renderer.render(graph);
+          try {{
+            var graph = JSON.parse(graphJson);
+            var chartMgr = new SgChartManager(panel, graph, {{
+              katex: window.katex || null,
+            }});
+            var renderer = new D3SemanticGraphRenderer(panel, {{
+              direction: '{d3_direction}',
+              labels: 'description',
+              theme: '{d3_theme}',
+              katex: window.katex || null,
+              onTransformChange: function(t) {{ chartMgr.setTransform(t); }},
+              onChartClick: function(nodeId, nodeData, btnEl) {{
+                if (chartMgr.charts.has(nodeId)) {{
+                  chartMgr.closeChart(nodeId);
+                }} else {{
+                  chartMgr.openChart(nodeId, btnEl);
+                }}
+              }},
+            }});
+            if (chartMgr.setRenderer) chartMgr.setRenderer(renderer);
+            renderer.render(graph);
+          }} catch (err) {{
+            panel.dataset.rendered = '';
+            panel.innerHTML = '<div style="padding:1em;color:#e57373">Render error: ' + err.message + '</div>';
+            console.error('D3 panel render error:', err);
+          }}
         }});
       }});
     }});

--- a/scripts/semantic_graph_report.py
+++ b/scripts/semantic_graph_report.py
@@ -34,6 +34,7 @@ try:
 except ImportError:
     from scripts.graph_to_mermaid import semantic_graph_to_mermaid, load_theme
 
+from backend.semantic_graph.mathjs_converter import latex_to_mathjs
 from backend.semantic_graph.sympy_translator import latex_to_semantic_graph
 from tests.backend.semantic_graph.domains.test_domain_arithmetic import (
     ALL_EXPRESSIONS as ARITHMETIC_EXPRESSIONS,
@@ -203,9 +204,11 @@ def _page_template() -> str:
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"
       onload="renderMathInElement(document.body, {{delimiters:[{{left:'$$',right:'$$',display:true}},{{left:'$',right:'$',display:false}}]}});"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjs@13.0.0/lib/browser/math.js"></script>
     <script type="importmap">{{
       "imports": {{
-        "/labels.js": "data:text/javascript,export function makeAiAskButton(){{return document.createElement('span')}}"
+        "/labels.js": "data:text/javascript,export function makeAiAskButton(){{return document.createElement('span')}}",
+        "/expr.js": "data:text/javascript,const m=math.create(math.all);m.import({{binomial:(n,k)=>m.combinations(n,k),erfc:x=>1-m.erf(x),beta:(a,b)=>m.gamma(a)*m.gamma(b)/m.gamma(a%2Bb),conjugate:x=>m.conj(x)}});export function compileExpr(s){{return m.compile(s)}}export function evalExpr(c,t,opts){{const scope=opts%26%26opts.extraScope?{{...opts.extraScope}}:{{}};return c.evaluate(scope)}}"
       }}
     }}</script>
     <script>
@@ -675,6 +678,24 @@ def _page_template() -> str:
     """)
 
 
+def _precompute_chart_scripts(graph_dict: dict[str, Any]) -> None:
+    """Pre-compute mathjs scripts for nodes that have ``subexpr``.
+
+    Mutates *graph_dict* in-place, adding a ``chartScript`` key to each
+    eligible node.  Errors are silently skipped — nodes without a
+    ``chartScript`` will simply not offer charting in the report.
+    """
+    for node in graph_dict.get("nodes", []):
+        subexpr = node.get("subexpr")
+        if not subexpr:
+            continue
+        try:
+            script, variables = latex_to_mathjs(subexpr)
+            node["chartScript"] = {"script": script, "variables": variables}
+        except Exception:
+            pass  # silently skip — chart button just won't appear
+
+
 def _render_row(
     test_id: str,
     latex: str,
@@ -693,6 +714,7 @@ def _render_row(
     try:
         graph_obj = latex_to_semantic_graph(latex, domain=domain)
         graph_dict = graph_obj.model_dump(by_alias=True, exclude_none=True)
+        _precompute_chart_scripts(graph_dict)
         mermaid_src = semantic_graph_to_mermaid(graph_dict, theme=theme)
         graph_json = json.dumps(graph_dict, indent=2, ensure_ascii=False)
 
@@ -860,6 +882,10 @@ def generate_report(
     chart_js_dst = output.parent / "sg-chart.js"
     shutil.copy2(chart_js_src, chart_js_dst)
 
+    chart_script_src = _PROJECT_ROOT / "static" / "graph-panel" / "sg-chart-script.js"
+    chart_script_dst = output.parent / "sg-chart-script.js"
+    shutil.copy2(chart_script_src, chart_script_dst)
+
     html, _, _ = _build_report_html(
         sections, graph_theme=graph_theme, theme=theme, colors=colors,
         d3_module_url="./d3-semantic-graph.js",
@@ -929,6 +955,10 @@ def generate_site(
     chart_js_src = _PROJECT_ROOT / "static" / "graph-panel" / "sg-chart.js"
     chart_js_dst = outdir / "sg-chart.js"
     shutil.copy2(chart_js_src, chart_js_dst)
+
+    chart_script_src = _PROJECT_ROOT / "static" / "graph-panel" / "sg-chart-script.js"
+    chart_script_dst = outdir / "sg-chart-script.js"
+    shutil.copy2(chart_script_src, chart_script_dst)
 
     theme = load_theme(graph_theme)
     color_mode = theme.get("mode", "dark")

--- a/scripts/semantic_graph_report.py
+++ b/scripts/semantic_graph_report.py
@@ -655,11 +655,8 @@ def _page_template() -> str:
               katex: window.katex || null,
               onTransformChange: function(t) {{ chartMgr.setTransform(t); }},
               onChartClick: function(nodeId, nodeData, btnEl) {{
-                if (chartMgr.charts.has(nodeId)) {{
-                  chartMgr.closeChart(nodeId);
-                }} else {{
-                  chartMgr.openChart(nodeId, btnEl);
-                }}
+                // Always open — never toggle.  Only the × button closes.
+                chartMgr.openChart(nodeId, btnEl);
               }},
             }});
             if (chartMgr.setRenderer) chartMgr.setRenderer(renderer);

--- a/scripts/semantic_graph_report.py
+++ b/scripts/semantic_graph_report.py
@@ -185,6 +185,12 @@ def _load_d3_css() -> str:
     return css_path.read_text(encoding="utf-8")
 
 
+def _load_chart_css() -> str:
+    """Read the chart overlay CSS and return it for inline embedding."""
+    css_path = _PROJECT_ROOT / "static" / "graph-panel" / "sg-chart.css"
+    return css_path.read_text(encoding="utf-8")
+
+
 def _page_template() -> str:
     return textwrap.dedent("""\
     <!DOCTYPE html>
@@ -550,6 +556,7 @@ def _page_template() -> str:
         font-size: 0.85rem;
       }}
       {d3_css}
+      {chart_css}
     </style>
     </head>
     <body>
@@ -615,8 +622,12 @@ def _page_template() -> str:
       }};
     }})();
 
-    import('{d3_module_url}').then(function(mod) {{
-      var D3SemanticGraphRenderer = mod.D3SemanticGraphRenderer;
+    Promise.all([
+      import('{d3_module_url}'),
+      import('{chart_module_url}'),
+    ]).then(function(mods) {{
+      var D3SemanticGraphRenderer = mods[0].D3SemanticGraphRenderer;
+      var SgChartManager = mods[1].SgChartManager;
       document.querySelectorAll('.row-toggle-d3').forEach(function(btn) {{
         btn.addEventListener('click', function() {{
           var row = btn.closest('.row');
@@ -630,11 +641,22 @@ def _page_template() -> str:
           if (!graphJson) return;
           panel.innerHTML = '';
           var graph = JSON.parse(graphJson);
+          var chartMgr = new SgChartManager(panel, graph, {{
+            katex: window.katex || null,
+          }});
           var renderer = new D3SemanticGraphRenderer(panel, {{
             direction: '{d3_direction}',
             labels: 'description',
             theme: '{d3_theme}',
             katex: window.katex || null,
+            onTransformChange: function(t) {{ chartMgr.setTransform(t); }},
+            onChartClick: function(nodeId, nodeData, btnEl) {{
+              if (chartMgr.charts.has(nodeId)) {{
+                chartMgr.closeChart(nodeId);
+              }} else {{
+                chartMgr.openChart(nodeId, btnEl);
+              }}
+            }},
           }});
           renderer.render(graph);
         }});
@@ -739,6 +761,7 @@ def _build_report_html(
     theme: dict[str, Any],
     colors: dict[str, str],
     d3_module_url: str | None = None,
+    chart_module_url: str | None = None,
 ) -> tuple[str, int, int]:
     """Build report HTML body and return (html, ok_count, err_count)."""
     import datetime
@@ -776,6 +799,7 @@ def _build_report_html(
     meta = f"Generated {now} &middot; theme: {graph_theme} &middot; {total} expressions"
 
     d3_css = _load_d3_css()
+    chart_css = _load_chart_css()
     theme_json_str = json.dumps(theme, ensure_ascii=False)
     d3_direction = theme.get("direction", "LR")
     # Mermaid reverses edge direction (child→parent), so its LR puts
@@ -785,13 +809,16 @@ def _build_report_html(
     dir_map = {"LR": "right-left", "RL": "left-right", "TB": "bottom-up", "BT": "top-down"}
     d3_direction_full = dir_map.get(d3_direction, "right-left")
     effective_d3_url = d3_module_url or _D3_MODULE_URL
+    effective_chart_url = chart_module_url or "./sg-chart.js"
 
     html = _page_template().format(
         body="\n".join(body_parts),
         meta=meta,
         theme_json=theme_json_str,
         d3_css=d3_css,
+        chart_css=chart_css,
         d3_module_url=effective_d3_url,
+        chart_module_url=effective_chart_url,
         d3_direction=d3_direction_full,
         d3_theme=graph_theme,
         **colors,
@@ -822,9 +849,14 @@ def generate_report(
     d3_js_dst = output.parent / "d3-semantic-graph.js"
     shutil.copy2(d3_js_src, d3_js_dst)
 
+    chart_js_src = _PROJECT_ROOT / "static" / "graph-panel" / "sg-chart.js"
+    chart_js_dst = output.parent / "sg-chart.js"
+    shutil.copy2(chart_js_src, chart_js_dst)
+
     html, _, _ = _build_report_html(
         sections, graph_theme=graph_theme, theme=theme, colors=colors,
         d3_module_url="./d3-semantic-graph.js",
+        chart_module_url="./sg-chart.js",
     )
 
     output.write_text(html, encoding="utf-8")
@@ -887,6 +919,10 @@ def generate_site(
     d3_js_dst = outdir / "d3-semantic-graph.js"
     shutil.copy2(d3_js_src, d3_js_dst)
 
+    chart_js_src = _PROJECT_ROOT / "static" / "graph-panel" / "sg-chart.js"
+    chart_js_dst = outdir / "sg-chart.js"
+    shutil.copy2(chart_js_src, chart_js_dst)
+
     theme = load_theme(graph_theme)
     color_mode = theme.get("mode", "dark")
     colors = THEMES[color_mode]
@@ -904,6 +940,7 @@ def generate_site(
             [(section_name, expressions)],
             graph_theme=graph_theme, theme=theme, colors=colors,
             d3_module_url="./d3-semantic-graph.js",
+            chart_module_url="./sg-chart.js",
         )
         (outdir / filename).write_text(html, encoding="utf-8")
         total_ok += ok

--- a/static/expr.js
+++ b/static/expr.js
@@ -31,6 +31,22 @@ const _MATHJS_EXTENSIONS = {
         const val = row[String(column)];
         return val != null ? val : 0;
     },
+
+    // ── SymPy jscode compatibility ──────────────────────────────────────
+    // SymPy's jscode(strict=False) emits bare function names for functions
+    // it can't map to Math.*. These aliases ensure mathjs can evaluate them.
+
+    // binomial(n, k) — SymPy emits this; mathjs has combinations()
+    binomial: (n, k) => _mathjs.combinations(n, k),
+
+    // erfc(x) — complementary error function: 1 − erf(x)
+    erfc: (x) => 1 - _mathjs.erf(x),
+
+    // beta(a, b) — Euler beta function: Γ(a)Γ(b) / Γ(a+b)
+    beta: (a, b) => _mathjs.gamma(a) * _mathjs.gamma(b) / _mathjs.gamma(a + b),
+
+    // conjugate(x) — SymPy emits this; mathjs has conj()
+    conjugate: (x) => _mathjs.conj(x),
 };
 
 _mathjs.import({

--- a/static/graph-panel/d3-semantic-graph.css
+++ b/static/graph-panel/d3-semantic-graph.css
@@ -212,7 +212,7 @@ svg.d3-semantic-graph {
 /* Edge semantics legend — bottom-left of graph viewport */
 .d3sg-edge-legend {
     position: absolute;
-    left: 8px;
+    right: 8px;
     bottom: 8px;
     display: flex;
     flex-direction: column;

--- a/static/graph-panel/d3-semantic-graph.css
+++ b/static/graph-panel/d3-semantic-graph.css
@@ -209,11 +209,12 @@ svg.d3-semantic-graph {
     color: #c0c8ff;
 }
 
-/* Edge semantics legend — bottom-left of graph viewport
-   (chart legend/slider panels occupy the bottom-right) */
+/* Edge semantics legend — bottom-right corner of graph viewport.
+   The chart legend panel docks to its left and the enrichment-progress
+   indicator stacks on top (see sg-chart.css / graph-view.js). */
 .d3sg-edge-legend {
     position: absolute;
-    left: 8px;
+    right: 8px;
     bottom: 8px;
     display: flex;
     flex-direction: column;

--- a/static/graph-panel/d3-semantic-graph.css
+++ b/static/graph-panel/d3-semantic-graph.css
@@ -209,10 +209,11 @@ svg.d3-semantic-graph {
     color: #c0c8ff;
 }
 
-/* Edge semantics legend — bottom-left of graph viewport */
+/* Edge semantics legend — bottom-left of graph viewport
+   (chart legend/slider panels occupy the bottom-right) */
 .d3sg-edge-legend {
     position: absolute;
-    right: 8px;
+    left: 8px;
     bottom: 8px;
     display: flex;
     flex-direction: column;

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -1345,6 +1345,7 @@ export class D3SemanticGraphRenderer {
             }
 
             this._appendChevron(group, d, true);
+            if (data.subexpr || data.chartScript) this._appendChartBtn(group, d);
             return;
         }
 
@@ -1374,6 +1375,8 @@ export class D3SemanticGraphRenderer {
 
         if (isOp && data._childIds && data._childIds.length > 0) {
             this._appendChevron(group, d, false);
+        }
+        if (data.subexpr || data.chartScript) {
             this._appendChartBtn(group, d);
         }
     }

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -656,14 +656,28 @@ export class D3SemanticGraphRenderer {
         const bbox = vpNode.getBBox();
         if (!bbox.width || !bbox.height) return;
 
+        // Charts pinned at the top dock over the graph; reserve their vertical
+        // band so the fit only uses the space left beneath them.
+        const card = svgNode.parentNode;
+        const pinned = card && card.querySelector('.sgc-pinned-panel');
+        let topInset = 0;
+        if (pinned && pinned.offsetParent !== null) {
+            const cardTop = card.getBoundingClientRect().top;
+            const pinnedRect = pinned.getBoundingClientRect();
+            // distance from the card's top edge to the bottom of the pinned band
+            topInset = Math.max(0, pinnedRect.bottom - cardTop);
+        }
+
         const pad = 40;
+        const availH = svgH - topInset;
         const scale = Math.min(
             (svgW - pad * 2) / bbox.width,
-            (svgH - pad * 2) / bbox.height,
+            (availH - pad * 2) / bbox.height,
             5
         );
         const tx = svgW / 2 - scale * (bbox.x + bbox.width / 2);
-        const ty = svgH / 2 - scale * (bbox.y + bbox.height / 2);
+        // Center within the region below the pinned charts.
+        const ty = topInset + availH / 2 - scale * (bbox.y + bbox.height / 2);
 
         const t = d3.zoomIdentity.translate(tx, ty).scale(scale);
         if (animate) {

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -365,6 +365,8 @@ export class D3SemanticGraphRenderer {
         this.onBackgroundClick = opts.onBackgroundClick || null;
 
         this.onZoomChange = opts.onZoomChange || null;
+        this.onTransformChange = opts.onTransformChange || null;
+        this.onChartClick = opts.onChartClick || null;
 
         this._graph = null;
         this._theme = null;
@@ -606,6 +608,9 @@ export class D3SemanticGraphRenderer {
                 this._viewport.attr('transform', event.transform);
                 if (this.onZoomChange) {
                     this.onZoomChange(Math.round(event.transform.k * 100));
+                }
+                if (this.onTransformChange) {
+                    this.onTransformChange(event.transform);
                 }
             });
 
@@ -1256,6 +1261,51 @@ export class D3SemanticGraphRenderer {
         return g;
     }
 
+    _chartBtnPos(shape) {
+        const sz = 14, half = sz / 2;
+        const dir = this.direction;
+        if (shape.type === 'rect' || shape.type === 'stadium') {
+            if (dir === 'left-right')  return { x: -shape.hw - half, y: -half };
+            if (dir === 'right-left')  return { x: shape.hw - half, y: -half };
+            if (dir === 'bottom-up')   return { x: -half, y: shape.hh - half };
+            return { x: -half, y: -shape.hh - half };
+        }
+        const r = shape.r || 26;
+        if (dir === 'left-right')  return { x: -r - half, y: -half };
+        if (dir === 'right-left')  return { x: r - half, y: -half };
+        if (dir === 'bottom-up')   return { x: -half, y: r - half };
+        return { x: -half, y: -r - half };
+    }
+
+    _appendChartBtn(group, d) {
+        const shape = this._nodeShape(d);
+        const pos = this._chartBtnPos(shape);
+        const self = this;
+        const sz = 14;
+        const g = group.append('g')
+            .attr('class', 'd3sg-chart-btn')
+            .attr('transform', `translate(${pos.x},${pos.y})`)
+            .on('click', function (event) {
+                event.stopPropagation();
+                if (self.onChartClick) self.onChartClick(d.data.id, d.data, this);
+            });
+        g.append('rect')
+            .attr('x', 0).attr('y', 0)
+            .attr('width', sz).attr('height', sz)
+            .attr('rx', 2)
+            .attr('fill', '#1a2440')
+            .attr('stroke', '#42a5f5')
+            .attr('stroke-width', 1);
+        g.append('path')
+            .attr('d', `M3,${sz-3} L5,5 L8,8 L${sz-3},3`)
+            .attr('fill', 'none')
+            .attr('stroke', '#42a5f5')
+            .attr('stroke-width', 1.5)
+            .attr('stroke-linecap', 'round')
+            .attr('stroke-linejoin', 'round');
+        return g;
+    }
+
     _drawNode(group, d) {
         group.selectAll('*').remove();
         const data = d.data;
@@ -1324,6 +1374,7 @@ export class D3SemanticGraphRenderer {
 
         if (isOp && data._childIds && data._childIds.length > 0) {
             this._appendChevron(group, d, false);
+            this._appendChartBtn(group, d);
         }
     }
 

--- a/static/graph-panel/sg-chart-script.js
+++ b/static/graph-panel/sg-chart-script.js
@@ -1,0 +1,105 @@
+/**
+ * SgChartScript — fetches or retrieves mathjs scripts for semantic graph nodes.
+ *
+ * Isolates script generation (backend API calls, caching, pre-computed
+ * lookups) from chart rendering.  The chart manager only ever sees
+ * ``{ script, variables }`` results.
+ *
+ * Two paths:
+ *   1. **Pre-computed** — node.chartScript is already populated (offline
+ *      reports embed scripts at generation time).
+ *   2. **Backend API** — POST /api/graph/generate-mathjs with the node's
+ *      ``subexpr`` (LaTeX).  Backend handles relation detection, LHS−RHS
+ *      construction, and SymPy→mathjs conversion.
+ */
+
+export class SgChartScript {
+    /**
+     * @param {Object} graph - Semantic graph JSON ({ nodes, edges })
+     */
+    constructor(graph) {
+        /** @type {Map<string, Object>} nodeId → node data */
+        this._nodeById = new Map();
+        for (const n of (graph.nodes || [])) {
+            this._nodeById.set(n.id, n);
+        }
+
+        /** @type {Map<string, {script:string, variables:string[]}|{error:string}>} */
+        this._cache = new Map();
+    }
+
+    /**
+     * Check if a node can potentially produce a chart script.
+     * @param {string} nodeId
+     * @returns {boolean}
+     */
+    canChart(nodeId) {
+        const n = this._nodeById.get(nodeId);
+        if (!n) return false;
+        // Pre-computed script available?
+        if (n.chartScript && n.chartScript.script) return true;
+        // Has a subexpr we can send to the backend?
+        if (n.subexpr) return true;
+        return false;
+    }
+
+    /**
+     * Get a mathjs script for the given node.
+     *
+     * @param {string} nodeId
+     * @returns {Promise<{script:string, variables:string[]}|{error:string}>}
+     */
+    async getScript(nodeId) {
+        // Return cached result if available.
+        if (this._cache.has(nodeId)) return this._cache.get(nodeId);
+
+        const n = this._nodeById.get(nodeId);
+        if (!n) {
+            const err = { error: `Node "${nodeId}" not found` };
+            this._cache.set(nodeId, err);
+            return err;
+        }
+
+        // Path 1: pre-computed (offline reports).
+        if (n.chartScript && n.chartScript.script) {
+            const result = {
+                script: n.chartScript.script,
+                variables: n.chartScript.variables || [],
+            };
+            this._cache.set(nodeId, result);
+            return result;
+        }
+
+        // Path 2: backend API.
+        const subexpr = n.subexpr;
+        if (!subexpr) {
+            const err = { error: 'Node has no subexpr' };
+            this._cache.set(nodeId, err);
+            return err;
+        }
+
+        try {
+            const resp = await fetch('/api/graph/generate-mathjs', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ subexpr }),
+            });
+
+            const data = await resp.json();
+
+            if (!resp.ok || data.error) {
+                const err = { error: data.error || `HTTP ${resp.status}`, detail: data.detail || '' };
+                this._cache.set(nodeId, err);
+                return err;
+            }
+
+            const result = { script: data.script, variables: data.variables || [] };
+            this._cache.set(nodeId, result);
+            return result;
+        } catch (e) {
+            const err = { error: `Network error: ${e.message}` };
+            this._cache.set(nodeId, err);
+            return err;
+        }
+    }
+}

--- a/static/graph-panel/sg-chart.css
+++ b/static/graph-panel/sg-chart.css
@@ -1,0 +1,310 @@
+/* SgChartManager — chart plotting overlay for semantic graph nodes */
+
+/* ── Chart button on nodes ──────────────────────────────────────────── */
+.d3sg-chart-btn {
+    opacity: 0;
+    cursor: pointer;
+    pointer-events: all;
+    transition: opacity 0.12s ease-out;
+}
+.d3sg-node:hover .d3sg-chart-btn {
+    opacity: 0.7;
+}
+.d3sg-chart-btn:hover {
+    opacity: 1 !important;
+}
+
+/* ── Chart box (inline or pinned) ───────────────────────────────────── */
+.sgc-chart-box {
+    width: 340px;
+    background: rgba(10, 12, 26, 0.92);
+    border: 1px solid rgba(110, 124, 180, 0.35);
+    border-radius: 8px;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    overflow: hidden;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+    transition: box-shadow 0.2s ease;
+}
+.sgc-chart-box:hover {
+    box-shadow: 0 6px 28px rgba(0, 0, 0, 0.55);
+}
+
+.sgc-chart-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 10px;
+    border-bottom: 1px solid rgba(110, 124, 180, 0.2);
+    gap: 8px;
+    min-height: 36px;
+}
+.sgc-chart-box:not(.sgc-pinned) .sgc-chart-header {
+    cursor: grab;
+}
+.sgc-chart-box:not(.sgc-pinned) .sgc-chart-header:active {
+    cursor: grabbing;
+}
+
+.sgc-chart-title {
+    font-size: 0.78rem;
+    color: #dde6ff;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 1;
+    min-width: 0;
+}
+.sgc-chart-title .katex {
+    font-size: 0.85em;
+}
+
+.sgc-chart-controls {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+}
+
+.sgc-x-select {
+    background: rgba(30, 40, 70, 0.8);
+    border: 1px solid rgba(110, 124, 180, 0.3);
+    border-radius: 4px;
+    color: #aebbd1;
+    font-size: 0.7rem;
+    padding: 2px 4px;
+    cursor: pointer;
+    outline: none;
+    max-width: 70px;
+}
+.sgc-x-select:hover {
+    border-color: rgba(110, 124, 180, 0.6);
+    color: #dde6ff;
+}
+.sgc-x-select:focus {
+    border-color: #42a5f5;
+}
+
+.sgc-btn {
+    background: none;
+    border: 1px solid rgba(110, 124, 180, 0.25);
+    border-radius: 4px;
+    color: #7e8aa3;
+    cursor: pointer;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    padding: 0;
+    transition: all 0.12s ease;
+}
+.sgc-btn:hover {
+    background: rgba(110, 124, 180, 0.15);
+    border-color: rgba(110, 124, 180, 0.5);
+    color: #dde6ff;
+}
+
+.sgc-pin-btn {
+    font-size: 0.65rem;
+}
+
+.sgc-close-btn {
+    font-size: 1rem;
+    line-height: 1;
+}
+
+.sgc-canvas-wrap {
+    position: relative;
+    height: 200px;
+    padding: 6px 8px 8px 4px;
+}
+.sgc-canvas-wrap canvas {
+    width: 100% !important;
+    height: 100% !important;
+}
+
+/* ── Pinned charts panel — top of viewport, stacks left→right ─────── */
+.sgc-pinned-panel {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    right: 8px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    z-index: 30;
+    pointer-events: none;
+}
+.sgc-pinned-panel:empty {
+    display: none;
+}
+
+.sgc-chart-box.sgc-pinned {
+    pointer-events: all;
+    flex-shrink: 0;
+    position: relative;
+}
+
+/* ── Resize handle for pinned charts ───────────────────────────────── */
+.sgc-resize-handle {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 18px;
+    height: 18px;
+    cursor: nwse-resize;
+    z-index: 5;
+}
+.sgc-resize-handle::after {
+    content: '';
+    position: absolute;
+    bottom: 4px;
+    right: 4px;
+    width: 8px;
+    height: 8px;
+    border-right: 2px solid rgba(110, 124, 180, 0.4);
+    border-bottom: 2px solid rgba(110, 124, 180, 0.4);
+}
+.sgc-resize-handle:hover::after {
+    border-color: rgba(140, 160, 220, 0.7);
+}
+
+/* ── Slider panel — bottom-left ───────────────────────────────────── */
+.sgc-slider-panel {
+    position: absolute;
+    left: 8px;
+    bottom: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 10px 12px;
+    background: rgba(10, 12, 26, 0.82);
+    border: 1px solid rgba(110, 124, 180, 0.35);
+    border-radius: 6px;
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    z-index: 25;
+    min-width: 200px;
+    max-width: 300px;
+    pointer-events: all;
+}
+.sgc-slider-panel.hidden {
+    display: none;
+}
+
+.sgc-slider-title {
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(210, 218, 245, 0.55);
+    margin-bottom: 2px;
+}
+
+.sgc-slider-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.sgc-slider-label {
+    font-size: 0.78rem;
+    color: #aebbd1;
+    min-width: 28px;
+    text-align: right;
+    flex-shrink: 0;
+}
+.sgc-slider-label .katex {
+    font-size: 0.85em;
+}
+
+.sgc-slider {
+    flex: 1;
+    -webkit-appearance: none;
+    appearance: none;
+    height: 4px;
+    background: rgba(110, 124, 180, 0.25);
+    border-radius: 2px;
+    outline: none;
+    cursor: pointer;
+}
+.sgc-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #42a5f5;
+    border: 2px solid rgba(10, 12, 26, 0.8);
+    cursor: pointer;
+    transition: background 0.12s;
+}
+.sgc-slider::-webkit-slider-thumb:hover {
+    background: #64b5f6;
+}
+.sgc-slider::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #42a5f5;
+    border: 2px solid rgba(10, 12, 26, 0.8);
+    cursor: pointer;
+}
+
+.sgc-slider-value {
+    font-size: 0.7rem;
+    color: #7e8aa3;
+    min-width: 42px;
+    text-align: left;
+    font-variant-numeric: tabular-nums;
+}
+
+/* ── Legend panel — bottom-right ──────────────────────────────────── */
+.sgc-legend-panel {
+    position: absolute;
+    right: 8px;
+    bottom: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px 10px;
+    background: rgba(10, 12, 26, 0.82);
+    border: 1px solid rgba(110, 124, 180, 0.35);
+    border-radius: 6px;
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    z-index: 25;
+    pointer-events: none;
+}
+.sgc-legend-panel.hidden {
+    display: none;
+}
+
+.sgc-legend-title {
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(210, 218, 245, 0.55);
+    margin-bottom: 2px;
+}
+
+.sgc-legend-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.sgc-legend-swatch {
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+    flex-shrink: 0;
+}
+
+.sgc-legend-name {
+    font-size: 0.72rem;
+    color: rgba(210, 218, 245, 0.9);
+}
+.sgc-legend-name .katex {
+    font-size: 0.85em;
+}

--- a/static/graph-panel/sg-chart.css
+++ b/static/graph-panel/sg-chart.css
@@ -64,6 +64,7 @@
     align-items: center;
     gap: 4px;
     flex-shrink: 0;
+    position: relative;
 }
 
 .sgc-x-select {
@@ -312,4 +313,52 @@
 }
 .sgc-legend-name .katex {
     font-size: 0.85em;
+}
+
+/* ── Code button (show mathjs script) ────────────────────────────── */
+.sgc-code-btn {
+    font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+    font-size: 0.65rem;
+    letter-spacing: -0.03em;
+}
+
+/* ── Script tooltip popover ──────────────────────────────────────── */
+.sgc-script-tooltip {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 4px;
+    padding: 8px 10px;
+    background: rgba(18, 22, 40, 0.96);
+    border: 1px solid rgba(110, 124, 180, 0.4);
+    border-radius: 6px;
+    color: #b8c8e8;
+    font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+    font-size: 0.72rem;
+    line-height: 1.45;
+    white-space: pre-wrap;
+    word-break: break-all;
+    max-width: 320px;
+    min-width: 140px;
+    z-index: 50;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+    pointer-events: auto;
+}
+
+/* ── Error state in canvas area ──────────────────────────────────── */
+.sgc-canvas-wrap.sgc-chart-error {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(239, 83, 80, 0.06);
+    border-top: 1px solid rgba(239, 83, 80, 0.15);
+}
+
+.sgc-error-message {
+    padding: 16px 20px;
+    color: rgba(239, 130, 128, 0.85);
+    font-size: 0.75rem;
+    line-height: 1.5;
+    text-align: center;
+    max-width: 90%;
 }

--- a/static/graph-panel/sg-chart.css
+++ b/static/graph-panel/sg-chart.css
@@ -109,6 +109,11 @@
 .sgc-pin-btn {
     font-size: 0.65rem;
 }
+.sgc-pin-btn.sgc-pin-active {
+    background: rgba(66, 165, 245, 0.25);
+    border-color: rgba(66, 165, 245, 0.5);
+    color: #42a5f5;
+}
 
 .sgc-close-btn {
     font-size: 1rem;

--- a/static/graph-panel/sg-chart.js
+++ b/static/graph-panel/sg-chart.js
@@ -1102,6 +1102,17 @@ export class SgChartManager {
 
         this._legendPanel.classList.remove('hidden');
 
+        // Dock the chart legend immediately to the LEFT of the edge-semantics
+        // legend (which sits in the bottom-right corner). When the edge legend
+        // is absent or hidden, fall back to the corner ourselves.
+        const parent = this._legendPanel.parentElement;
+        const edgeLegend = parent ? parent.querySelector('.d3sg-edge-legend') : null;
+        const edgeVisible = edgeLegend && !edgeLegend.classList.contains('hidden')
+            && edgeLegend.offsetParent !== null;
+        this._legendPanel.style.right = edgeVisible
+            ? `${edgeLegend.offsetWidth + 16}px`
+            : '8px';
+
         const title = document.createElement('div');
         title.className = 'sgc-legend-title';
         title.textContent = 'CHARTS';

--- a/static/graph-panel/sg-chart.js
+++ b/static/graph-panel/sg-chart.js
@@ -23,8 +23,8 @@ const GRID_COLS = 6;
 const GRID_ROWS = 4;
 const GRID_GAP = 8;
 
-// Greek letter names → Unicode characters for plain-text contexts
-// (dropdown options, axis titles, tooltips).
+// Greek letter & math symbol names → Unicode characters for plain-text
+// contexts (dropdown options, axis titles, tooltips).
 const _GREEK_UNICODE = new Map([
     ['alpha', 'α'], ['beta', 'β'], ['gamma', 'γ'],
     ['delta', 'δ'], ['epsilon', 'ε'], ['zeta', 'ζ'],
@@ -37,9 +37,12 @@ const _GREEK_UNICODE = new Map([
     ['Gamma', 'Γ'], ['Delta', 'Δ'], ['Theta', 'Θ'],
     ['Lambda', 'Λ'], ['Pi', 'Π'], ['Sigma', 'Σ'],
     ['Phi', 'Φ'], ['Psi', 'Ψ'], ['Omega', 'Ω'],
+    // Common math symbols emitted by parse_latex
+    ['nabla', '∇'], ['partial', '∂'], ['infty', '∞'],
+    ['hbar', 'ℏ'], ['ell', 'ℓ'],
 ]);
 
-// Greek letter names → LaTeX commands for KaTeX rendering.
+// Greek letter & math symbol names → LaTeX commands for KaTeX rendering.
 const _GREEK_LATEX = new Map([
     ['alpha', '\\alpha'], ['beta', '\\beta'], ['gamma', '\\gamma'],
     ['delta', '\\delta'], ['epsilon', '\\epsilon'], ['zeta', '\\zeta'],
@@ -52,27 +55,51 @@ const _GREEK_LATEX = new Map([
     ['Gamma', '\\Gamma'], ['Delta', '\\Delta'], ['Theta', '\\Theta'],
     ['Lambda', '\\Lambda'], ['Pi', '\\Pi'], ['Sigma', '\\Sigma'],
     ['Phi', '\\Phi'], ['Psi', '\\Psi'], ['Omega', '\\Omega'],
+    // Common math symbols emitted by parse_latex
+    ['nabla', '\\nabla'], ['partial', '\\partial'], ['infty', '\\infty'],
+    ['hbar', '\\hbar'], ['ell', '\\ell'],
+    ['vec', '\\vec{v}'],
 ]);
 
 // Convert sanitized variable names back to display-friendly form.
-// u_prime → u', u_dprime → u'', gamma → γ (Unicode).
+// u_prime → u', u_dprime → u'', gamma → γ, mu_0 → μ₀ (Unicode).
 // Used for plain-text contexts (dropdowns, axis titles, tooltips).
 function _displayVar(name) {
     let out = name
         .replace(/_tprime$/, "'''")
         .replace(/_dprime$/, "''")
         .replace(/_prime$/, "'");
-    return _GREEK_UNICODE.get(out) || out;
+    // Exact match first (e.g. "gamma" → "γ")
+    if (_GREEK_UNICODE.has(out)) return _GREEK_UNICODE.get(out);
+    // Subscripted Greek: "mu_0" → "μ₀", "epsilon_0" → "ε₀"
+    const uIdx = out.indexOf('_');
+    if (uIdx > 0) {
+        const base = out.slice(0, uIdx);
+        const sub = out.slice(uIdx + 1);
+        const greek = _GREEK_UNICODE.get(base);
+        if (greek) return `${greek}_${sub}`;
+    }
+    return out;
 }
 
 // Convert variable name to LaTeX for KaTeX rendering.
-// gamma → \gamma, u_prime → u', etc.
+// gamma → \gamma, u_prime → u', mu_0 → \mu_{0}, etc.
 function _latexVar(name) {
     let out = name
         .replace(/_tprime$/, "'''")
         .replace(/_dprime$/, "''")
         .replace(/_prime$/, "'");
-    return _GREEK_LATEX.get(out) || out;
+    // Exact match first (e.g. "gamma" → "\\gamma")
+    if (_GREEK_LATEX.has(out)) return _GREEK_LATEX.get(out);
+    // Subscripted Greek: "mu_0" → "\\mu_{0}", "epsilon_0" → "\\epsilon_{0}"
+    const uIdx = out.indexOf('_');
+    if (uIdx > 0) {
+        const base = out.slice(0, uIdx);
+        const sub = out.slice(uIdx + 1);
+        const greek = _GREEK_LATEX.get(base);
+        if (greek) return `${greek}_{${sub}}`;
+    }
+    return out;
 }
 
 // Relation operators that trigger LHS−RHS conversion in the backend.

--- a/static/graph-panel/sg-chart.js
+++ b/static/graph-panel/sg-chart.js
@@ -1,13 +1,15 @@
 /**
  * SgChartManager — interactive Chart.js plots for semantic graph nodes.
  *
- * Evaluates sub-expressions by walking the semantic graph DAG, renders
- * Chart.js line charts with variable selection, and supports pinning
- * charts to a floating overlay at the top of the viewport.
+ * Expression evaluation is handled by the backend (SymPy→mathjs pipeline)
+ * and evaluated client-side via expr.js.  Chart.js renders the results.
  *
  * Slider panel sits bottom-left, legend bottom-right (matching the 3D
  * viewport layout convention).
  */
+
+import { SgChartScript } from './sg-chart-script.js';
+import { compileExpr, evalExpr } from '/expr.js';
 
 const CHART_JS_CDN = 'https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js';
 const NUM_POINTS = 200;
@@ -35,207 +37,6 @@ function loadChartJs() {
     });
     _chartJsPromise.catch(() => { _chartJsPromise = null; });
     return _chartJsPromise;
-}
-
-// ── Expression evaluator via graph DAG walk ──────────────────────────
-
-const MATH_OPS = {
-    add:       (a, b) => a + b,
-    subtract:  (a, b) => a - b,
-    multiply:  (a, b) => a * b,
-    divide:    (a, b) => b === 0 ? NaN : a / b,
-    power:     (a, b) => Math.pow(a, b),
-    negation:  (a) => -a,
-    sin:       (a) => Math.sin(a),
-    cos:       (a) => Math.cos(a),
-    tan:       (a) => Math.tan(a),
-    sqrt:      (a) => a < 0 ? NaN : Math.sqrt(a),
-    abs:       (a) => Math.abs(a),
-    Abs:       (a) => Math.abs(a),
-    log:       (a) => a <= 0 ? NaN : Math.log(a),
-    logarithm: (a) => a <= 0 ? NaN : Math.log(a),
-    exp:       (a) => Math.exp(a),
-    factorial: (a) => {
-        if (a < 0 || !Number.isInteger(a)) return NaN;
-        let r = 1; for (let i = 2; i <= a; i++) r *= i; return r;
-    },
-};
-
-const KNOWN_CONSTANTS = {
-    pi: Math.PI, 'π': Math.PI,
-    e: Math.E,
-    i: NaN,
-    phi: (1 + Math.sqrt(5)) / 2,
-    tau: 2 * Math.PI,
-    inf: Infinity,
-};
-
-function extractVariables(graph, rootId) {
-    const nodeById = Object.create(null);
-    for (const n of graph.nodes) nodeById[n.id] = n;
-    const childrenOf = Object.create(null);
-    const edgeRoles = Object.create(null);
-    for (const e of graph.edges) {
-        if (!childrenOf[e.to]) childrenOf[e.to] = [];
-        childrenOf[e.to].push(e.from);
-        edgeRoles[`${e.from}->${e.to}`] = e;
-    }
-
-    const vars = new Set();
-    const visited = new Set();
-    const queue = [rootId];
-    while (queue.length) {
-        const id = queue.shift();
-        if (visited.has(id)) continue;
-        visited.add(id);
-        const n = nodeById[id];
-        if (!n) continue;
-        const isOp = n.type === 'operator' || n.type === 'relation' || n.type === 'function';
-        if (!isOp && n.type !== 'number' && n.type !== 'constant') {
-            if (n.value == null || typeof n.value === 'string') {
-                const name = n.label || n.latex || n.id;
-                if (name && !KNOWN_CONSTANTS[name]) vars.add(name);
-            }
-        }
-        for (const child of (childrenOf[id] || [])) queue.push(child);
-    }
-    return [...vars];
-}
-
-function evaluateNode(graph, nodeId, vars, cache) {
-    if (cache.has(nodeId)) return cache.get(nodeId);
-
-    const nodeById = Object.create(null);
-    for (const n of graph.nodes) nodeById[n.id] = n;
-    const childrenOf = Object.create(null);
-    const edgeDetails = Object.create(null);
-    for (const e of graph.edges) {
-        if (!childrenOf[e.to]) childrenOf[e.to] = [];
-        childrenOf[e.to].push(e.from);
-        edgeDetails[`${e.from}->${e.to}`] = e;
-    }
-
-    function _eval(id) {
-        if (cache.has(id)) return cache.get(id);
-        const n = nodeById[id];
-        if (!n) { cache.set(id, NaN); return NaN; }
-
-        const isOp = n.type === 'operator' || n.type === 'relation' || n.type === 'function';
-
-        if (!isOp) {
-            if (n.value != null && typeof n.value === 'number') {
-                cache.set(id, n.value);
-                return n.value;
-            }
-            if (n.type === 'number') {
-                const v = parseFloat(n.label || n.latex || n.id);
-                cache.set(id, isNaN(v) ? 0 : v);
-                return cache.get(id);
-            }
-            if (n.type === 'constant') {
-                const name = n.label || n.latex || n.id;
-                if (KNOWN_CONSTANTS[name] != null) {
-                    cache.set(id, KNOWN_CONSTANTS[name]);
-                    return cache.get(id);
-                }
-                if (vars[name] != null) {
-                    cache.set(id, vars[name]);
-                    return vars[name];
-                }
-                cache.set(id, NaN);
-                return NaN;
-            }
-            const name = n.label || n.latex || n.id;
-            if (vars[name] != null) {
-                cache.set(id, vars[name]);
-                return vars[name];
-            }
-            cache.set(id, NaN);
-            return NaN;
-        }
-
-        const children = childrenOf[id] || [];
-        const op = n.op || '';
-
-        if (op === 'equals' || op === 'greater_than' || op === 'less_than' ||
-            op === 'greater_equal' || op === 'less_equal' || op === 'not_equal') {
-            if (children.length >= 2) {
-                const sorted = sortChildrenByRole(children, id, edgeDetails);
-                const lhs = _eval(sorted[0]);
-                const rhs = _eval(sorted[1]);
-                cache.set(id, lhs - rhs);
-                return lhs - rhs;
-            }
-        }
-
-        if (op === 'power') {
-            if (n.exponent != null) {
-                const expVal = parseFloat(n.exponent);
-                if (children.length >= 1) {
-                    const base = _eval(children[0]);
-                    const result = Math.pow(base, isNaN(expVal) ? 2 : expVal);
-                    cache.set(id, result);
-                    return result;
-                }
-            }
-            if (children.length >= 2) {
-                const sorted = sortChildrenByRole(children, id, edgeDetails);
-                const base = _eval(sorted[0]);
-                const exp = _eval(sorted[1]);
-                const result = Math.pow(base, exp);
-                cache.set(id, result);
-                return result;
-            }
-        }
-
-        const fn = MATH_OPS[op];
-        if (fn) {
-            const childVals = children.map(c => _eval(c));
-            if (fn.length === 1 && childVals.length >= 1) {
-                const result = fn(childVals[0]);
-                cache.set(id, result);
-                return result;
-            }
-            if (fn.length === 2 && childVals.length >= 2) {
-                let result = childVals[0];
-                for (let i = 1; i < childVals.length; i++) {
-                    result = fn(result, childVals[i]);
-                }
-                cache.set(id, result);
-                return result;
-            }
-            if (childVals.length === 1) {
-                cache.set(id, childVals[0]);
-                return childVals[0];
-            }
-        }
-
-        if (children.length === 1) {
-            const v = _eval(children[0]);
-            cache.set(id, v);
-            return v;
-        }
-
-        cache.set(id, NaN);
-        return NaN;
-    }
-
-    function sortChildrenByRole(children, parentId, edges) {
-        const withRole = children.map(c => {
-            const e = edges[`${c}->${parentId}`];
-            return { id: c, role: e?.role };
-        });
-        withRole.sort((a, b) => {
-            if (a.role === 'base' || a.role === 'lhs') return -1;
-            if (b.role === 'base' || b.role === 'lhs') return 1;
-            if (a.role === 'exp' || a.role === 'rhs') return 1;
-            if (b.role === 'exp' || b.role === 'rhs') return -1;
-            return 0;
-        });
-        return withRole.map(w => w.id);
-    }
-
-    return _eval(nodeId);
 }
 
 // ── Auto-range heuristics ────────────────────────────────────────────
@@ -279,6 +80,9 @@ export class SgChartManager {
         this._renderer = null;
         this._rafId = null;
         this._resizeObserver = null;
+
+        this._scriptService = new SgChartScript(graph);
+        this._compiledScripts = new Map();
 
         this._buildNodeIndex();
     }
@@ -395,20 +199,11 @@ export class SgChartManager {
     }
 
     hasExpression(nodeId) {
-        const n = this._nodeById[nodeId];
-        if (!n) return false;
-        const isOp = n.type === 'operator' || n.type === 'relation' || n.type === 'function';
-        if (isOp) {
-            const children = this._childrenOf[nodeId] || [];
-            return children.length > 0;
-        }
-        return false;
+        return this._scriptService.canChart(nodeId);
     }
 
     canChart(nodeId) {
-        if (!this._nodeById[nodeId]) return false;
-        const vars = extractVariables(this.graph, nodeId);
-        return vars.length > 0;
+        return this._scriptService.canChart(nodeId);
     }
 
     async openChart(nodeId, anchorEl) {
@@ -418,11 +213,25 @@ export class SgChartManager {
         const n = this._nodeById[nodeId];
         if (!n) return;
 
-        const vars = extractVariables(this.graph, nodeId);
-        if (vars.length === 0) return;
+        // ── Fetch mathjs script from backend (or pre-computed) ───────
+        const result = await this._scriptService.getScript(nodeId);
+        const hasError = !result || result.error;
+        const vars = hasError ? [] : result.variables;
+        const scriptText = hasError ? null : result.script;
+
+        // Compile the mathjs script via expr.js
+        let compiled = null;
+        if (scriptText) {
+            try {
+                compiled = compileExpr(scriptText);
+                this._compiledScripts.set(nodeId, compiled);
+            } catch (e) {
+                console.warn(`[SgChart] compile error for "${nodeId}":`, e);
+            }
+        }
 
         const chartId = `sgc-${++_chartIdCounter}`;
-        const xVar = vars[0];
+        const xVar = vars.length > 0 ? vars[0] : null;
 
         for (const v of vars) {
             this._allVariables.add(v);
@@ -469,6 +278,13 @@ export class SgChartManager {
             xSelect.appendChild(opt);
         }
 
+        // ── { } code button ─────────────────────────────────────────
+        const codeBtn = document.createElement('button');
+        codeBtn.className = 'sgc-btn sgc-code-btn';
+        codeBtn.title = 'Show mathjs script';
+        codeBtn.textContent = '{ }';
+        codeBtn.addEventListener('click', () => this._toggleScriptTooltip(nodeId, codeBtn));
+
         const pinBtn = document.createElement('button');
         pinBtn.className = 'sgc-btn sgc-pin-btn';
         pinBtn.title = 'Pin chart to overlay';
@@ -480,6 +296,7 @@ export class SgChartManager {
         closeBtn.textContent = '×';
 
         controls.appendChild(xSelect);
+        controls.appendChild(codeBtn);
         controls.appendChild(pinBtn);
         controls.appendChild(closeBtn);
         header.appendChild(title);
@@ -488,10 +305,79 @@ export class SgChartManager {
 
         const canvasWrap = document.createElement('div');
         canvasWrap.className = 'sgc-canvas-wrap';
-        const canvas = document.createElement('canvas');
-        canvasWrap.appendChild(canvas);
-        box.appendChild(canvasWrap);
 
+        // ── Error state or canvas ────────────────────────────────────
+        let chart = null;
+        if (hasError || !compiled) {
+            canvasWrap.classList.add('sgc-chart-error');
+            const errMsg = document.createElement('div');
+            errMsg.className = 'sgc-error-message';
+            errMsg.textContent = result?.error || result?.detail || 'Could not generate expression';
+            canvasWrap.appendChild(errMsg);
+            xSelect.style.display = 'none';
+            codeBtn.style.display = 'none';
+        } else {
+            const canvas = document.createElement('canvas');
+            canvasWrap.appendChild(canvas);
+
+            const { data } = this._computeData(nodeId, xVar, vars);
+
+            const colorIdx = _chartIdCounter % CHART_PALETTE.length;
+            const chartColor = CHART_PALETTE[colorIdx];
+
+            chart = new Chart(canvas, {
+                type: 'line',
+                data: {
+                    labels: data.map(p => p.x),
+                    datasets: [{
+                        label: label,
+                        data: data.map(p => p.y),
+                        borderColor: chartColor,
+                        backgroundColor: chartColor + '22',
+                        borderWidth: 2,
+                        pointRadius: 0,
+                        pointHitRadius: 6,
+                        fill: true,
+                        tension: 0.3,
+                    }],
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    animation: { duration: 200 },
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: {
+                            backgroundColor: 'rgba(10, 12, 26, 0.9)',
+                            titleColor: '#dde6ff',
+                            bodyColor: '#aebbd1',
+                            borderColor: 'rgba(110, 124, 180, 0.35)',
+                            borderWidth: 1,
+                            callbacks: {
+                                label: (ctx) => `y = ${ctx.parsed.y?.toFixed(4)}`,
+                                title: (items) => `${xVar} = ${items[0]?.parsed.x?.toFixed(4)}`,
+                            },
+                        },
+                    },
+                    scales: {
+                        x: {
+                            type: 'linear',
+                            title: { display: true, text: xVar, color: '#8fa8c8' },
+                            ticks: { color: '#7e8aa3', maxTicksLimit: 8, callback: v => +v.toFixed(3) },
+                            grid: { color: 'rgba(110, 124, 180, 0.12)' },
+                        },
+                        y: {
+                            title: { display: true, text: 'f(' + xVar + ')', color: '#8fa8c8' },
+                            ticks: { color: '#7e8aa3', maxTicksLimit: 6, callback: v => +v.toFixed(3) },
+                            grid: { color: 'rgba(110, 124, 180, 0.12)' },
+                        },
+                    },
+                    interaction: { mode: 'index', intersect: false },
+                },
+            });
+        }
+
+        box.appendChild(canvasWrap);
         card.appendChild(box);
 
         const boxW = 340, boxH = 248;
@@ -550,67 +436,15 @@ export class SgChartManager {
         const colorIdx = _chartIdCounter % CHART_PALETTE.length;
         const chartColor = CHART_PALETTE[colorIdx];
 
-        const { data, xLabel } = this._computeData(nodeId, xVar, vars);
-
-        const chart = new Chart(canvas, {
-            type: 'line',
-            data: {
-                labels: data.map(p => p.x),
-                datasets: [{
-                    label: label,
-                    data: data.map(p => p.y),
-                    borderColor: chartColor,
-                    backgroundColor: chartColor + '22',
-                    borderWidth: 2,
-                    pointRadius: 0,
-                    pointHitRadius: 6,
-                    fill: true,
-                    tension: 0.3,
-                }],
-            },
-            options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                animation: { duration: 200 },
-                plugins: {
-                    legend: { display: false },
-                    tooltip: {
-                        backgroundColor: 'rgba(10, 12, 26, 0.9)',
-                        titleColor: '#dde6ff',
-                        bodyColor: '#aebbd1',
-                        borderColor: 'rgba(110, 124, 180, 0.35)',
-                        borderWidth: 1,
-                        callbacks: {
-                            label: (ctx) => `y = ${ctx.parsed.y?.toFixed(4)}`,
-                            title: (items) => `${xVar} = ${items[0]?.parsed.x?.toFixed(4)}`,
-                        },
-                    },
-                },
-                scales: {
-                    x: {
-                        type: 'linear',
-                        title: { display: true, text: xVar, color: '#8fa8c8' },
-                        ticks: { color: '#7e8aa3', maxTicksLimit: 8, callback: v => +v.toFixed(3) },
-                        grid: { color: 'rgba(110, 124, 180, 0.12)' },
-                    },
-                    y: {
-                        title: { display: true, text: 'f(' + xVar + ')', color: '#8fa8c8' },
-                        ticks: { color: '#7e8aa3', maxTicksLimit: 6, callback: v => +v.toFixed(3) },
-                        grid: { color: 'rgba(110, 124, 180, 0.12)' },
-                    },
-                },
-                interaction: { mode: 'index', intersect: false },
-            },
-        });
-
         const entry = {
             chartId,
             nodeId,
             chart,
             box,
-            canvas,
+            canvas: box.querySelector('canvas'),
             xVar,
             vars,
+            scriptText,
             color: chartColor,
             pinned: false,
             graphX: _graphX,
@@ -620,7 +454,7 @@ export class SgChartManager {
         };
         this.charts.set(nodeId, entry);
 
-        this._makeDraggable(entry);
+        if (chart) this._makeDraggable(entry);
 
         xSelect.addEventListener('change', () => {
             entry.xVar = xSelect.value;
@@ -643,14 +477,42 @@ export class SgChartManager {
         this._updateLegend();
     }
 
+    // ── Script tooltip ──────────────────────────────────────────────
+
+    _toggleScriptTooltip(nodeId, btnEl) {
+        // Close any existing tooltip
+        const existing = btnEl.parentElement?.querySelector('.sgc-script-tooltip');
+        if (existing) { existing.remove(); return; }
+
+        const entry = this.charts.get(nodeId);
+        const text = entry?.scriptText || '(no script)';
+
+        const tip = document.createElement('div');
+        tip.className = 'sgc-script-tooltip';
+        tip.textContent = text;
+
+        // Position below the button
+        btnEl.parentElement.appendChild(tip);
+
+        // Auto-close when clicking elsewhere
+        const close = (e) => {
+            if (!tip.contains(e.target) && e.target !== btnEl) {
+                tip.remove();
+                document.removeEventListener('click', close, true);
+            }
+        };
+        setTimeout(() => document.addEventListener('click', close, true), 0);
+    }
+
     closeChart(nodeId) {
         const entry = this.charts.get(nodeId);
         if (!entry) return;
         if (entry._dragCleanup) entry._dragCleanup();
         if (entry._resizeCleanup) entry._resizeCleanup();
-        entry.chart.destroy();
+        if (entry.chart) entry.chart.destroy();
         entry.box.remove();
         this.charts.delete(nodeId);
+        this._compiledScripts.delete(nodeId);
         this._unpinChart(nodeId);
         this._rebuildVariableSet();
         this._updateSliders();
@@ -682,7 +544,7 @@ export class SgChartManager {
         }
 
         this.pinnedCharts.push(nodeId);
-        entry.chart.resize();
+        if (entry.chart) entry.chart.resize();
     }
 
     _unpinChart(nodeId) {
@@ -727,7 +589,7 @@ export class SgChartManager {
 
         this._unpinChart(nodeId);
         this._makeDraggable(entry);
-        entry.chart.resize();
+        if (entry.chart) entry.chart.resize();
     }
 
     _makeDraggable(entry) {
@@ -846,21 +708,26 @@ export class SgChartManager {
         };
     }
 
-    _computeData(nodeId, xVar, vars) {
+    _computeData(nodeId, xVar, _vars) {
+        const compiled = this._compiledScripts.get(nodeId);
+        if (!compiled) return { data: [], xLabel: xVar };
+
         const range = autoRange(xVar);
         const points = [];
         const step = (range.max - range.min) / NUM_POINTS;
 
         for (let i = 0; i <= NUM_POINTS; i++) {
             const xVal = range.min + step * i;
-            const varValues = { ...this.sliderValues };
-            varValues[xVar] = xVal;
+            const scope = { ...this.sliderValues };
+            scope[xVar] = xVal;
 
-            const cache = new Map();
-            const y = evaluateNode(this.graph, nodeId, varValues, cache);
-
-            if (Number.isFinite(y)) {
-                points.push({ x: +xVal.toFixed(6), y: +y.toFixed(6) });
+            try {
+                const y = evalExpr(compiled, 0, { extraScope: scope });
+                if (Number.isFinite(y)) {
+                    points.push({ x: +xVal.toFixed(6), y: +y.toFixed(6) });
+                }
+            } catch (_) {
+                // skip point on evaluation error
             }
         }
 
@@ -868,6 +735,7 @@ export class SgChartManager {
     }
 
     _updateChart(entry) {
+        if (!entry.chart) return;
         const { data } = this._computeData(entry.nodeId, entry.xVar, entry.vars);
         entry.chart.data.labels = data.map(p => p.x);
         entry.chart.data.datasets[0].data = data.map(p => p.y);
@@ -1017,10 +885,11 @@ export class SgChartManager {
         for (const entry of this.charts.values()) {
             if (entry._dragCleanup) entry._dragCleanup();
             if (entry._resizeCleanup) entry._resizeCleanup();
-            entry.chart.destroy();
+            if (entry.chart) entry.chart.destroy();
             entry.box.remove();
         }
         this.charts.clear();
+        this._compiledScripts.clear();
         this.pinnedCharts = [];
         if (this._sliderPanel) this._sliderPanel.remove();
         if (this._pinnedPanel) this._pinnedPanel.remove();

--- a/static/graph-panel/sg-chart.js
+++ b/static/graph-panel/sg-chart.js
@@ -19,7 +19,7 @@ const CHART_PALETTE = [
     '#ffa726', '#26c6da', '#ec407a', '#8d6e63',
 ];
 
-const GRID_COLS = 6;
+const GRID_COLS = 8;
 const GRID_ROWS = 4;
 const GRID_GAP = 8;
 

--- a/static/graph-panel/sg-chart.js
+++ b/static/graph-panel/sg-chart.js
@@ -370,8 +370,6 @@ export class SgChartManager {
         // default x-variable is not already taken by an existing chart.
         const existing = this._chartsForNode(nodeId);
         if (existing.some(e => e.xVar === xVar)) return;
-        const rawLabel = n.subexpr || n.latex || n.label || n.id;
-        const isRelation = _RELATION_RE.test(rawLabel);
 
         for (const v of vars) {
             this._allVariables.add(v);
@@ -393,21 +391,14 @@ export class SgChartManager {
 
         const title = document.createElement('span');
         title.className = 'sgc-chart-title';
-        let label = n.subexpr || n.latex || n.label || n.id;
+        let exprLabel = n.subexpr || n.latex || n.label || n.id;
         // If the backend converted a relation (=, ≤, ≥, …) to LHS−RHS,
         // reflect that in the chart title so it matches what is plotted.
-        if ((n.subexpr || n.latex) && _RELATION_RE.test(label)) {
-            label = _relationToLhsMinusRhs(label);
+        const isRelation = (n.subexpr || n.latex) && _RELATION_RE.test(exprLabel);
+        if (isRelation) {
+            exprLabel = _relationToLhsMinusRhs(exprLabel);
         }
-        if (this.katex && (n.subexpr || n.latex)) {
-            try {
-                this.katex.render(label, title, { throwOnError: false, displayMode: false });
-            } catch (_) {
-                title.textContent = label;
-            }
-        } else {
-            title.textContent = label;
-        }
+        this._renderTitle(title, exprLabel, xVar, isRelation);
 
         const controls = document.createElement('div');
         controls.className = 'sgc-chart-controls';
@@ -476,7 +467,7 @@ export class SgChartManager {
                 data: {
                     labels: data.map(p => p.x),
                     datasets: [{
-                        label: label,
+                        label: exprLabel,
                         data: data.map(p => p.y),
                         borderColor: chartColor,
                         backgroundColor: chartColor + '22',
@@ -591,6 +582,8 @@ export class SgChartManager {
             chart,
             box,
             canvas: box.querySelector('canvas'),
+            titleEl: title,
+            exprLabel,
             xVar,
             vars,
             scriptText,
@@ -859,6 +852,25 @@ export class SgChartManager {
         };
     }
 
+    /**
+     * Render the chart header title as ``f(xVar) = expression`` so the
+     * user can see what the vertical axis represents.  Uses KaTeX when
+     * available.
+     */
+    _renderTitle(el, exprLabel, xVar, _isRelation) {
+        const xLatex = _latexVar(xVar);
+        const fullLatex = `f(${xLatex}) = ${exprLabel}`;
+        if (this.katex) {
+            try {
+                this.katex.render(fullLatex, el, { throwOnError: false, displayMode: false });
+                return;
+            } catch (_) { /* fall through */ }
+        }
+        // Plain-text fallback
+        const xDisp = _displayVar(xVar);
+        el.textContent = `f(${xDisp}) = ${exprLabel}`;
+    }
+
     _computeData(nodeId, xVar, _vars) {
         const compiled = this._compiledScripts.get(nodeId);
         if (!compiled) return { data: [], xLabel: xVar };
@@ -900,6 +912,10 @@ export class SgChartManager {
         entry.chart.options.plugins.tooltip.callbacks.title =
             (items) => `${dv} = ${items[0]?.parsed.x?.toFixed(4)}`;
         entry.chart.update('none');
+        // Refresh the header title to reflect the current x-variable.
+        if (entry.titleEl) {
+            this._renderTitle(entry.titleEl, entry.exprLabel, entry.xVar, entry.isRelation);
+        }
     }
 
     _updateAllCharts() {

--- a/static/graph-panel/sg-chart.js
+++ b/static/graph-panel/sg-chart.js
@@ -1,0 +1,960 @@
+/**
+ * SgChartManager — interactive Chart.js plots for semantic graph nodes.
+ *
+ * Evaluates sub-expressions by walking the semantic graph DAG, renders
+ * Chart.js line charts with variable selection, and supports pinning
+ * charts to a floating overlay at the top of the viewport.
+ *
+ * Slider panel sits bottom-left, legend bottom-right (matching the 3D
+ * viewport layout convention).
+ */
+
+const CHART_JS_CDN = 'https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js';
+const NUM_POINTS = 200;
+
+const CHART_PALETTE = [
+    '#42a5f5', '#66bb6a', '#ef5350', '#ab47bc',
+    '#ffa726', '#26c6da', '#ec407a', '#8d6e63',
+];
+
+const GRID_COLS = 6;
+const GRID_ROWS = 4;
+const GRID_GAP = 8;
+
+let _chartJsLoaded = false;
+let _chartJsPromise = null;
+function loadChartJs() {
+    if (_chartJsLoaded) return Promise.resolve();
+    if (_chartJsPromise) return _chartJsPromise;
+    _chartJsPromise = new Promise((resolve, reject) => {
+        const s = document.createElement('script');
+        s.src = CHART_JS_CDN;
+        s.onload = () => { _chartJsLoaded = true; resolve(); };
+        s.onerror = reject;
+        document.head.appendChild(s);
+    });
+    _chartJsPromise.catch(() => { _chartJsPromise = null; });
+    return _chartJsPromise;
+}
+
+// ── Expression evaluator via graph DAG walk ──────────────────────────
+
+const MATH_OPS = {
+    add:       (a, b) => a + b,
+    subtract:  (a, b) => a - b,
+    multiply:  (a, b) => a * b,
+    divide:    (a, b) => b === 0 ? NaN : a / b,
+    power:     (a, b) => Math.pow(a, b),
+    negation:  (a) => -a,
+    sin:       (a) => Math.sin(a),
+    cos:       (a) => Math.cos(a),
+    tan:       (a) => Math.tan(a),
+    sqrt:      (a) => a < 0 ? NaN : Math.sqrt(a),
+    abs:       (a) => Math.abs(a),
+    Abs:       (a) => Math.abs(a),
+    log:       (a) => a <= 0 ? NaN : Math.log(a),
+    logarithm: (a) => a <= 0 ? NaN : Math.log(a),
+    exp:       (a) => Math.exp(a),
+    factorial: (a) => {
+        if (a < 0 || !Number.isInteger(a)) return NaN;
+        let r = 1; for (let i = 2; i <= a; i++) r *= i; return r;
+    },
+};
+
+const KNOWN_CONSTANTS = {
+    pi: Math.PI, 'π': Math.PI,
+    e: Math.E,
+    i: NaN,
+    phi: (1 + Math.sqrt(5)) / 2,
+    tau: 2 * Math.PI,
+    inf: Infinity,
+};
+
+function extractVariables(graph, rootId) {
+    const nodeById = Object.create(null);
+    for (const n of graph.nodes) nodeById[n.id] = n;
+    const childrenOf = Object.create(null);
+    const edgeRoles = Object.create(null);
+    for (const e of graph.edges) {
+        if (!childrenOf[e.to]) childrenOf[e.to] = [];
+        childrenOf[e.to].push(e.from);
+        edgeRoles[`${e.from}->${e.to}`] = e;
+    }
+
+    const vars = new Set();
+    const visited = new Set();
+    const queue = [rootId];
+    while (queue.length) {
+        const id = queue.shift();
+        if (visited.has(id)) continue;
+        visited.add(id);
+        const n = nodeById[id];
+        if (!n) continue;
+        const isOp = n.type === 'operator' || n.type === 'relation' || n.type === 'function';
+        if (!isOp && n.type !== 'number' && n.type !== 'constant') {
+            if (n.value == null || typeof n.value === 'string') {
+                const name = n.label || n.latex || n.id;
+                if (name && !KNOWN_CONSTANTS[name]) vars.add(name);
+            }
+        }
+        for (const child of (childrenOf[id] || [])) queue.push(child);
+    }
+    return [...vars];
+}
+
+function evaluateNode(graph, nodeId, vars, cache) {
+    if (cache.has(nodeId)) return cache.get(nodeId);
+
+    const nodeById = Object.create(null);
+    for (const n of graph.nodes) nodeById[n.id] = n;
+    const childrenOf = Object.create(null);
+    const edgeDetails = Object.create(null);
+    for (const e of graph.edges) {
+        if (!childrenOf[e.to]) childrenOf[e.to] = [];
+        childrenOf[e.to].push(e.from);
+        edgeDetails[`${e.from}->${e.to}`] = e;
+    }
+
+    function _eval(id) {
+        if (cache.has(id)) return cache.get(id);
+        const n = nodeById[id];
+        if (!n) { cache.set(id, NaN); return NaN; }
+
+        const isOp = n.type === 'operator' || n.type === 'relation' || n.type === 'function';
+
+        if (!isOp) {
+            if (n.value != null && typeof n.value === 'number') {
+                cache.set(id, n.value);
+                return n.value;
+            }
+            if (n.type === 'number') {
+                const v = parseFloat(n.label || n.latex || n.id);
+                cache.set(id, isNaN(v) ? 0 : v);
+                return cache.get(id);
+            }
+            if (n.type === 'constant') {
+                const name = n.label || n.latex || n.id;
+                if (KNOWN_CONSTANTS[name] != null) {
+                    cache.set(id, KNOWN_CONSTANTS[name]);
+                    return cache.get(id);
+                }
+                if (vars[name] != null) {
+                    cache.set(id, vars[name]);
+                    return vars[name];
+                }
+                cache.set(id, NaN);
+                return NaN;
+            }
+            const name = n.label || n.latex || n.id;
+            if (vars[name] != null) {
+                cache.set(id, vars[name]);
+                return vars[name];
+            }
+            cache.set(id, NaN);
+            return NaN;
+        }
+
+        const children = childrenOf[id] || [];
+        const op = n.op || '';
+
+        if (op === 'equals' || op === 'greater_than' || op === 'less_than' ||
+            op === 'greater_equal' || op === 'less_equal' || op === 'not_equal') {
+            if (children.length >= 2) {
+                const sorted = sortChildrenByRole(children, id, edgeDetails);
+                const lhs = _eval(sorted[0]);
+                const rhs = _eval(sorted[1]);
+                cache.set(id, lhs - rhs);
+                return lhs - rhs;
+            }
+        }
+
+        if (op === 'power') {
+            if (n.exponent != null) {
+                const expVal = parseFloat(n.exponent);
+                if (children.length >= 1) {
+                    const base = _eval(children[0]);
+                    const result = Math.pow(base, isNaN(expVal) ? 2 : expVal);
+                    cache.set(id, result);
+                    return result;
+                }
+            }
+            if (children.length >= 2) {
+                const sorted = sortChildrenByRole(children, id, edgeDetails);
+                const base = _eval(sorted[0]);
+                const exp = _eval(sorted[1]);
+                const result = Math.pow(base, exp);
+                cache.set(id, result);
+                return result;
+            }
+        }
+
+        const fn = MATH_OPS[op];
+        if (fn) {
+            const childVals = children.map(c => _eval(c));
+            if (fn.length === 1 && childVals.length >= 1) {
+                const result = fn(childVals[0]);
+                cache.set(id, result);
+                return result;
+            }
+            if (fn.length === 2 && childVals.length >= 2) {
+                let result = childVals[0];
+                for (let i = 1; i < childVals.length; i++) {
+                    result = fn(result, childVals[i]);
+                }
+                cache.set(id, result);
+                return result;
+            }
+            if (childVals.length === 1) {
+                cache.set(id, childVals[0]);
+                return childVals[0];
+            }
+        }
+
+        if (children.length === 1) {
+            const v = _eval(children[0]);
+            cache.set(id, v);
+            return v;
+        }
+
+        cache.set(id, NaN);
+        return NaN;
+    }
+
+    function sortChildrenByRole(children, parentId, edges) {
+        const withRole = children.map(c => {
+            const e = edges[`${c}->${parentId}`];
+            return { id: c, role: e?.role };
+        });
+        withRole.sort((a, b) => {
+            if (a.role === 'base' || a.role === 'lhs') return -1;
+            if (b.role === 'base' || b.role === 'lhs') return 1;
+            if (a.role === 'exp' || a.role === 'rhs') return 1;
+            if (b.role === 'exp' || b.role === 'rhs') return -1;
+            return 0;
+        });
+        return withRole.map(w => w.id);
+    }
+
+    return _eval(nodeId);
+}
+
+// ── Auto-range heuristics ────────────────────────────────────────────
+
+function autoRange(varName) {
+    const lower = varName.toLowerCase();
+    if (lower.includes('angle') || lower === 'θ' || lower === 'theta' ||
+        lower === 'φ' || lower === 'phi' || lower === 'α' || lower === 'β') {
+        return { min: 0, max: 2 * Math.PI, step: 0.01, default: Math.PI / 4 };
+    }
+    if (lower === 't' || lower === 'time') {
+        return { min: 0, max: 10, step: 0.01, default: 1 };
+    }
+    if (lower === 'r' || lower === 'radius') {
+        return { min: 0, max: 5, step: 0.01, default: 1 };
+    }
+    if (lower === 'n' || lower === 'k') {
+        return { min: 0, max: 20, step: 1, default: 1 };
+    }
+    return { min: -5, max: 5, step: 0.01, default: 1 };
+}
+
+// ── Chart manager ────────────────────────────────────────────────────
+
+let _chartIdCounter = 0;
+
+export class SgChartManager {
+    constructor(container, graph, opts = {}) {
+        this.container = container;
+        this.graph = graph;
+        this.katex = opts.katex || (typeof window !== 'undefined' && window.katex);
+        this.charts = new Map();
+        this.pinnedCharts = [];
+        this.sliderValues = {};
+        this._allVariables = new Set();
+        this._ready = false;
+        this._sliderPanel = null;
+        this._pinnedPanel = null;
+        this._legendPanel = null;
+        this._transform = { x: 0, y: 0, k: 1 };
+
+        this._buildNodeIndex();
+    }
+
+    _buildNodeIndex() {
+        this._nodeById = Object.create(null);
+        for (const n of this.graph.nodes) this._nodeById[n.id] = n;
+        this._childrenOf = Object.create(null);
+        for (const e of this.graph.edges) {
+            if (!this._childrenOf[e.to]) this._childrenOf[e.to] = [];
+            this._childrenOf[e.to].push(e.from);
+        }
+    }
+
+    setTransform(t) {
+        this._transform = t || { x: 0, y: 0, k: 1 };
+        this._updateUnpinnedPositions();
+    }
+
+    _updateUnpinnedPositions() {
+        const card = this.container.querySelector('.d3-graph-card') || this.container;
+        const rect = card.getBoundingClientRect();
+        const { x: tx, y: ty, k } = this._transform;
+        for (const entry of this.charts.values()) {
+            if (entry.pinned) continue;
+            const screenX = entry.graphX * k + tx;
+            const screenY = entry.graphY * k + ty;
+            const left = Math.max(4, Math.min(screenX, rect.width - entry.box.offsetWidth - 4));
+            const top = Math.max(4, Math.min(screenY, rect.height - entry.box.offsetHeight - 4));
+            entry.box.style.left = `${left}px`;
+            entry.box.style.top = `${top}px`;
+        }
+    }
+
+    async init() {
+        await loadChartJs();
+        this._ready = true;
+        this._ensureOverlays();
+    }
+
+    _ensureOverlays() {
+        const card = this.container.querySelector('.d3-graph-card') || this.container;
+
+        if (!this._sliderPanel) {
+            this._sliderPanel = document.createElement('div');
+            this._sliderPanel.className = 'sgc-slider-panel';
+            card.appendChild(this._sliderPanel);
+        }
+
+        if (!this._pinnedPanel) {
+            this._pinnedPanel = document.createElement('div');
+            this._pinnedPanel.className = 'sgc-pinned-panel';
+            card.appendChild(this._pinnedPanel);
+        }
+
+        if (!this._legendPanel) {
+            this._legendPanel = document.createElement('div');
+            this._legendPanel.className = 'sgc-legend-panel';
+            card.appendChild(this._legendPanel);
+        }
+    }
+
+    hasExpression(nodeId) {
+        const n = this._nodeById[nodeId];
+        if (!n) return false;
+        const isOp = n.type === 'operator' || n.type === 'relation' || n.type === 'function';
+        if (isOp) {
+            const children = this._childrenOf[nodeId] || [];
+            return children.length > 0;
+        }
+        return false;
+    }
+
+    canChart(nodeId) {
+        if (!this._nodeById[nodeId]) return false;
+        const vars = extractVariables(this.graph, nodeId);
+        return vars.length > 0;
+    }
+
+    async openChart(nodeId, anchorEl) {
+        if (!this._ready) await this.init();
+        if (this.charts.has(nodeId)) return;
+
+        const n = this._nodeById[nodeId];
+        if (!n) return;
+
+        const vars = extractVariables(this.graph, nodeId);
+        if (vars.length === 0) return;
+
+        const chartId = `sgc-${++_chartIdCounter}`;
+        const xVar = vars[0];
+
+        for (const v of vars) {
+            this._allVariables.add(v);
+            if (this.sliderValues[v] == null) {
+                const range = autoRange(v);
+                this.sliderValues[v] = range.default != null ? range.default : (range.min + range.max) / 2;
+            }
+        }
+
+        const card = this.container.querySelector('.d3-graph-card') || this.container;
+
+        const box = document.createElement('div');
+        box.className = 'sgc-chart-box';
+        box.id = chartId;
+        box.dataset.nodeId = nodeId;
+
+        const header = document.createElement('div');
+        header.className = 'sgc-chart-header';
+
+        const title = document.createElement('span');
+        title.className = 'sgc-chart-title';
+        const label = n.subexpr || n.latex || n.label || n.id;
+        if (this.katex && (n.subexpr || n.latex)) {
+            try {
+                this.katex.render(label, title, { throwOnError: false, displayMode: false });
+            } catch (_) {
+                title.textContent = label;
+            }
+        } else {
+            title.textContent = label;
+        }
+
+        const controls = document.createElement('div');
+        controls.className = 'sgc-chart-controls';
+
+        const xSelect = document.createElement('select');
+        xSelect.className = 'sgc-x-select';
+        xSelect.title = 'X-axis variable';
+        for (const v of vars) {
+            const opt = document.createElement('option');
+            opt.value = v;
+            opt.textContent = v;
+            if (v === xVar) opt.selected = true;
+            xSelect.appendChild(opt);
+        }
+
+        const pinBtn = document.createElement('button');
+        pinBtn.className = 'sgc-btn sgc-pin-btn';
+        pinBtn.title = 'Pin chart to overlay';
+        pinBtn.innerHTML = '&#x1F4CC;';
+
+        const closeBtn = document.createElement('button');
+        closeBtn.className = 'sgc-btn sgc-close-btn';
+        closeBtn.title = 'Close chart';
+        closeBtn.textContent = '×';
+
+        controls.appendChild(xSelect);
+        controls.appendChild(pinBtn);
+        controls.appendChild(closeBtn);
+        header.appendChild(title);
+        header.appendChild(controls);
+        box.appendChild(header);
+
+        const canvasWrap = document.createElement('div');
+        canvasWrap.className = 'sgc-canvas-wrap';
+        const canvas = document.createElement('canvas');
+        canvasWrap.appendChild(canvas);
+        box.appendChild(canvasWrap);
+
+        card.appendChild(box);
+
+        const boxW = 340, boxH = 248;
+        let left = 4, top = 4;
+        {
+            const containerRect = card.getBoundingClientRect();
+            if (anchorEl) {
+                const rect = anchorEl.getBoundingClientRect();
+                left = rect.right - containerRect.left + 8;
+                top = rect.top - containerRect.top;
+            }
+            left = Math.max(4, Math.min(left, containerRect.width - boxW - 4));
+            top = Math.max(4, Math.min(top, containerRect.height - boxH - 4));
+
+            const occupied = [];
+            for (const existing of this.charts.values()) {
+                if (existing.pinned) continue;
+                const er = existing.box.getBoundingClientRect();
+                occupied.push({
+                    left: er.left - containerRect.left,
+                    top: er.top - containerRect.top,
+                    right: er.right - containerRect.left,
+                    bottom: er.bottom - containerRect.top,
+                });
+            }
+            for (let attempt = 0; attempt < 6; attempt++) {
+                const myRight = left + boxW;
+                const myBottom = top + boxH;
+                let collision = false;
+                for (const o of occupied) {
+                    if (left < o.right && myRight > o.left && top < o.bottom && myBottom > o.top) {
+                        collision = true;
+                        top = o.bottom + 4;
+                        if (top + boxH > containerRect.height - 4) {
+                            top = 4;
+                            left = o.right + 4;
+                        }
+                        break;
+                    }
+                }
+                if (!collision) break;
+                left = Math.max(4, Math.min(left, containerRect.width - boxW - 4));
+                top = Math.max(4, Math.min(top, containerRect.height - boxH - 4));
+            }
+
+            box.style.position = 'absolute';
+            box.style.left = `${left}px`;
+            box.style.top = `${top}px`;
+            box.style.zIndex = '20';
+        }
+
+        const { x: tx, y: ty, k } = this._transform;
+        const _graphX = (left - tx) / k;
+        const _graphY = (top - ty) / k;
+
+        const colorIdx = _chartIdCounter % CHART_PALETTE.length;
+        const chartColor = CHART_PALETTE[colorIdx];
+
+        const { data, xLabel } = this._computeData(nodeId, xVar, vars);
+
+        const chart = new Chart(canvas, {
+            type: 'line',
+            data: {
+                labels: data.map(p => p.x),
+                datasets: [{
+                    label: label,
+                    data: data.map(p => p.y),
+                    borderColor: chartColor,
+                    backgroundColor: chartColor + '22',
+                    borderWidth: 2,
+                    pointRadius: 0,
+                    pointHitRadius: 6,
+                    fill: true,
+                    tension: 0.3,
+                }],
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                animation: { duration: 200 },
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        backgroundColor: 'rgba(10, 12, 26, 0.9)',
+                        titleColor: '#dde6ff',
+                        bodyColor: '#aebbd1',
+                        borderColor: 'rgba(110, 124, 180, 0.35)',
+                        borderWidth: 1,
+                        callbacks: {
+                            label: (ctx) => `y = ${ctx.parsed.y?.toFixed(4)}`,
+                            title: (items) => `${xVar} = ${items[0]?.parsed.x?.toFixed(4)}`,
+                        },
+                    },
+                },
+                scales: {
+                    x: {
+                        type: 'linear',
+                        title: { display: true, text: xVar, color: '#8fa8c8' },
+                        ticks: { color: '#7e8aa3', maxTicksLimit: 8, callback: v => +v.toFixed(3) },
+                        grid: { color: 'rgba(110, 124, 180, 0.12)' },
+                    },
+                    y: {
+                        title: { display: true, text: 'f(' + xVar + ')', color: '#8fa8c8' },
+                        ticks: { color: '#7e8aa3', maxTicksLimit: 6, callback: v => +v.toFixed(3) },
+                        grid: { color: 'rgba(110, 124, 180, 0.12)' },
+                    },
+                },
+                interaction: { mode: 'index', intersect: false },
+            },
+        });
+
+        const entry = {
+            chartId,
+            nodeId,
+            chart,
+            box,
+            canvas,
+            xVar,
+            vars,
+            color: chartColor,
+            pinned: false,
+            graphX: _graphX,
+            graphY: _graphY,
+            colSpan: 2,
+            rowSpan: 2,
+        };
+        this.charts.set(nodeId, entry);
+
+        this._makeDraggable(entry);
+
+        xSelect.addEventListener('change', () => {
+            entry.xVar = xSelect.value;
+            this._updateChart(entry);
+            this._updateSliders();
+        });
+
+        pinBtn.addEventListener('click', () => this._pinChart(nodeId));
+        closeBtn.addEventListener('click', () => this.closeChart(nodeId));
+
+        this._updateSliders();
+        this._updateLegend();
+    }
+
+    closeChart(nodeId) {
+        const entry = this.charts.get(nodeId);
+        if (!entry) return;
+        if (entry._dragCleanup) entry._dragCleanup();
+        if (entry._resizeCleanup) entry._resizeCleanup();
+        entry.chart.destroy();
+        entry.box.remove();
+        this.charts.delete(nodeId);
+        this._unpinChart(nodeId);
+        this._rebuildVariableSet();
+        this._updateSliders();
+        this._updateLegend();
+    }
+
+    _pinChart(nodeId) {
+        const entry = this.charts.get(nodeId);
+        if (!entry || entry.pinned) return;
+        entry.pinned = true;
+
+        if (entry._dragCleanup) { entry._dragCleanup(); entry._dragCleanup = null; }
+
+        entry.box.classList.add('sgc-pinned');
+        entry.box.style.position = '';
+        entry.box.style.left = '';
+        entry.box.style.top = '';
+        entry.box.style.zIndex = '';
+
+        this._pinnedPanel.appendChild(entry.box);
+        this._applyPinnedSize(entry);
+        this._addResizeHandle(entry);
+
+        const pinBtn = entry.box.querySelector('.sgc-pin-btn');
+        if (pinBtn) {
+            pinBtn.innerHTML = '&#x2716;';
+            pinBtn.title = 'Unpin from overlay';
+            pinBtn.onclick = () => this._unpinAndRestore(nodeId);
+        }
+
+        this.pinnedCharts.push(nodeId);
+        entry.chart.resize();
+    }
+
+    _unpinChart(nodeId) {
+        const idx = this.pinnedCharts.indexOf(nodeId);
+        if (idx >= 0) this.pinnedCharts.splice(idx, 1);
+    }
+
+    _unpinAndRestore(nodeId) {
+        const entry = this.charts.get(nodeId);
+        if (!entry) return;
+        entry.pinned = false;
+        entry.box.classList.remove('sgc-pinned');
+
+        if (entry._resizeCleanup) { entry._resizeCleanup(); entry._resizeCleanup = null; }
+
+        const card = this.container.querySelector('.d3-graph-card') || this.container;
+        card.appendChild(entry.box);
+
+        entry.box.style.position = 'absolute';
+        entry.box.style.width = '340px';
+        entry.box.style.height = '';
+        entry.box.style.zIndex = '20';
+
+        const wrap = entry.box.querySelector('.sgc-canvas-wrap');
+        if (wrap) wrap.style.height = '200px';
+
+        const rect = card.getBoundingClientRect();
+        const { x: tx, y: ty, k } = this._transform;
+        let left = entry.graphX * k + tx;
+        let top = entry.graphY * k + ty;
+        left = Math.max(4, Math.min(left, rect.width - 340 - 4));
+        top = Math.max(4, Math.min(top, rect.height - 248 - 4));
+        entry.box.style.left = `${left}px`;
+        entry.box.style.top = `${top}px`;
+
+        const pinBtn = entry.box.querySelector('.sgc-pin-btn');
+        if (pinBtn) {
+            pinBtn.innerHTML = '&#x1F4CC;';
+            pinBtn.title = 'Pin chart to overlay';
+            pinBtn.onclick = () => this._pinChart(nodeId);
+        }
+
+        this._unpinChart(nodeId);
+        this._makeDraggable(entry);
+        entry.chart.resize();
+    }
+
+    _makeDraggable(entry) {
+        const header = entry.box.querySelector('.sgc-chart-header');
+        if (!header) return;
+        let startX, startY, startLeft, startTop;
+
+        const onMouseDown = (e) => {
+            if (e.target.closest('.sgc-chart-controls')) return;
+            e.preventDefault();
+            const card = this.container.querySelector('.d3-graph-card') || this.container;
+            const boxRect = entry.box.getBoundingClientRect();
+            const cardRect = card.getBoundingClientRect();
+            startX = e.clientX;
+            startY = e.clientY;
+            startLeft = boxRect.left - cardRect.left;
+            startTop = boxRect.top - cardRect.top;
+            document.addEventListener('mousemove', onMouseMove);
+            document.addEventListener('mouseup', onMouseUp);
+            header.style.cursor = 'grabbing';
+        };
+
+        const onMouseMove = (e) => {
+            const dx = e.clientX - startX;
+            const dy = e.clientY - startY;
+            const card = this.container.querySelector('.d3-graph-card') || this.container;
+            const cardRect = card.getBoundingClientRect();
+            const boxW = entry.box.offsetWidth;
+            const boxH = entry.box.offsetHeight;
+            const newLeft = Math.max(4, Math.min(startLeft + dx, cardRect.width - boxW - 4));
+            const newTop = Math.max(4, Math.min(startTop + dy, cardRect.height - boxH - 4));
+            entry.box.style.left = `${newLeft}px`;
+            entry.box.style.top = `${newTop}px`;
+            const { x: tx, y: ty, k } = this._transform;
+            entry.graphX = (newLeft - tx) / k;
+            entry.graphY = (newTop - ty) / k;
+        };
+
+        const onMouseUp = () => {
+            document.removeEventListener('mousemove', onMouseMove);
+            document.removeEventListener('mouseup', onMouseUp);
+            header.style.cursor = '';
+        };
+
+        header.addEventListener('mousedown', onMouseDown);
+        entry._dragCleanup = () => header.removeEventListener('mousedown', onMouseDown);
+    }
+
+    _getGridSteps() {
+        const card = this.container.querySelector('.d3-graph-card') || this.container;
+        const rect = card.getBoundingClientRect();
+        const availW = rect.width - 16;
+        const availH = rect.height - 16;
+        return {
+            w: Math.floor((availW - (GRID_COLS - 1) * GRID_GAP) / GRID_COLS),
+            h: Math.floor((availH - (GRID_ROWS - 1) * GRID_GAP) / GRID_ROWS),
+        };
+    }
+
+    _applyPinnedSize(entry) {
+        const step = this._getGridSteps();
+        const w = entry.colSpan * step.w + (entry.colSpan - 1) * GRID_GAP;
+        const h = entry.rowSpan * step.h + (entry.rowSpan - 1) * GRID_GAP;
+        entry.box.style.width = `${w}px`;
+        entry.box.style.height = `${h}px`;
+        const header = entry.box.querySelector('.sgc-chart-header');
+        const headerH = header ? header.offsetHeight : 36;
+        const wrap = entry.box.querySelector('.sgc-canvas-wrap');
+        if (wrap) wrap.style.height = `${h - headerH - 2}px`;
+    }
+
+    _addResizeHandle(entry) {
+        if (entry.box.querySelector('.sgc-resize-handle')) return;
+        const handle = document.createElement('div');
+        handle.className = 'sgc-resize-handle';
+        entry.box.appendChild(handle);
+
+        let startX, startY, startColSpan, startRowSpan;
+
+        const onMouseDown = (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            startX = e.clientX;
+            startY = e.clientY;
+            startColSpan = entry.colSpan;
+            startRowSpan = entry.rowSpan;
+            document.addEventListener('mousemove', onMouseMove);
+            document.addEventListener('mouseup', onMouseUp);
+        };
+
+        const onMouseMove = (e) => {
+            const step = this._getGridSteps();
+            const unitW = step.w + GRID_GAP;
+            const unitH = step.h + GRID_GAP;
+            const dx = e.clientX - startX;
+            const dy = e.clientY - startY;
+            const colSpan = Math.max(1, Math.min(GRID_COLS, startColSpan + Math.round(dx / unitW)));
+            const rowSpan = Math.max(1, Math.min(GRID_ROWS, startRowSpan + Math.round(dy / unitH)));
+            if (colSpan !== entry.colSpan || rowSpan !== entry.rowSpan) {
+                entry.colSpan = colSpan;
+                entry.rowSpan = rowSpan;
+                this._applyPinnedSize(entry);
+                entry.chart.resize();
+            }
+        };
+
+        const onMouseUp = () => {
+            document.removeEventListener('mousemove', onMouseMove);
+            document.removeEventListener('mouseup', onMouseUp);
+        };
+
+        handle.addEventListener('mousedown', onMouseDown);
+        entry._resizeCleanup = () => {
+            handle.removeEventListener('mousedown', onMouseDown);
+            handle.remove();
+        };
+    }
+
+    _computeData(nodeId, xVar, vars) {
+        const range = autoRange(xVar);
+        const points = [];
+        const step = (range.max - range.min) / NUM_POINTS;
+
+        for (let i = 0; i <= NUM_POINTS; i++) {
+            const xVal = range.min + step * i;
+            const varValues = { ...this.sliderValues };
+            varValues[xVar] = xVal;
+
+            const cache = new Map();
+            const y = evaluateNode(this.graph, nodeId, varValues, cache);
+
+            if (Number.isFinite(y)) {
+                points.push({ x: +xVal.toFixed(6), y: +y.toFixed(6) });
+            }
+        }
+
+        return { data: points, xLabel: xVar };
+    }
+
+    _updateChart(entry) {
+        const { data } = this._computeData(entry.nodeId, entry.xVar, entry.vars);
+        entry.chart.data.labels = data.map(p => p.x);
+        entry.chart.data.datasets[0].data = data.map(p => p.y);
+        entry.chart.options.scales.x.title.text = entry.xVar;
+        entry.chart.options.scales.y.title.text = `f(${entry.xVar})`;
+        entry.chart.options.plugins.tooltip.callbacks.title =
+            (items) => `${entry.xVar} = ${items[0]?.parsed.x?.toFixed(4)}`;
+        entry.chart.update('none');
+    }
+
+    _updateAllCharts() {
+        for (const entry of this.charts.values()) {
+            this._updateChart(entry);
+        }
+    }
+
+    _rebuildVariableSet() {
+        this._allVariables.clear();
+        for (const entry of this.charts.values()) {
+            for (const v of entry.vars) this._allVariables.add(v);
+        }
+    }
+
+    _updateSliders() {
+        if (!this._sliderPanel) return;
+        this._sliderPanel.innerHTML = '';
+
+        const activeVars = new Set();
+        for (const entry of this.charts.values()) {
+            for (const v of entry.vars) {
+                if (v !== entry.xVar) activeVars.add(v);
+            }
+        }
+
+        if (activeVars.size === 0) {
+            this._sliderPanel.classList.add('hidden');
+            return;
+        }
+        this._sliderPanel.classList.remove('hidden');
+
+        const title = document.createElement('div');
+        title.className = 'sgc-slider-title';
+        title.textContent = 'PARAMETERS';
+        this._sliderPanel.appendChild(title);
+
+        for (const v of [...activeVars].sort()) {
+            const range = autoRange(v);
+            if (this.sliderValues[v] == null) {
+                this.sliderValues[v] = range.default != null ? range.default : (range.min + range.max) / 2;
+            }
+
+            const row = document.createElement('div');
+            row.className = 'sgc-slider-row';
+
+            const label = document.createElement('span');
+            label.className = 'sgc-slider-label';
+            if (this.katex) {
+                try {
+                    this.katex.render(v, label, { throwOnError: false, displayMode: false });
+                } catch (_) {
+                    label.textContent = v;
+                }
+            } else {
+                label.textContent = v;
+            }
+
+            const input = document.createElement('input');
+            input.type = 'range';
+            input.className = 'sgc-slider';
+            input.min = range.min;
+            input.max = range.max;
+            input.step = range.step;
+            input.value = this.sliderValues[v];
+
+            const val = document.createElement('span');
+            val.className = 'sgc-slider-value';
+            val.textContent = (+this.sliderValues[v]).toFixed(2);
+
+            input.addEventListener('input', () => {
+                this.sliderValues[v] = parseFloat(input.value);
+                val.textContent = (+input.value).toFixed(2);
+                this._updateAllCharts();
+            });
+
+            row.appendChild(label);
+            row.appendChild(input);
+            row.appendChild(val);
+            this._sliderPanel.appendChild(row);
+        }
+    }
+
+    _updateLegend() {
+        if (!this._legendPanel) return;
+        this._legendPanel.innerHTML = '';
+
+        if (this.charts.size === 0) {
+            this._legendPanel.classList.add('hidden');
+            return;
+        }
+
+        if (this.charts.size < 2) {
+            this._legendPanel.classList.add('hidden');
+            return;
+        }
+
+        this._legendPanel.classList.remove('hidden');
+
+        const title = document.createElement('div');
+        title.className = 'sgc-legend-title';
+        title.textContent = 'CHARTS';
+        this._legendPanel.appendChild(title);
+
+        for (const entry of this.charts.values()) {
+            const item = document.createElement('div');
+            item.className = 'sgc-legend-item';
+
+            const swatch = document.createElement('span');
+            swatch.className = 'sgc-legend-swatch';
+            swatch.style.background = entry.color;
+
+            const name = document.createElement('span');
+            name.className = 'sgc-legend-name';
+            const n = this._nodeById[entry.nodeId];
+            const lbl = n?.label || n?.latex || entry.nodeId;
+            if (this.katex && (n?.latex || n?.subexpr)) {
+                try {
+                    this.katex.render(n.latex || n.subexpr, name, { throwOnError: false, displayMode: false });
+                } catch (_) {
+                    name.textContent = lbl;
+                }
+            } else {
+                name.textContent = lbl;
+            }
+
+            item.appendChild(swatch);
+            item.appendChild(name);
+            this._legendPanel.appendChild(item);
+        }
+    }
+
+    destroy() {
+        for (const entry of this.charts.values()) {
+            if (entry._dragCleanup) entry._dragCleanup();
+            if (entry._resizeCleanup) entry._resizeCleanup();
+            entry.chart.destroy();
+            entry.box.remove();
+        }
+        this.charts.clear();
+        this.pinnedCharts = [];
+        if (this._sliderPanel) this._sliderPanel.remove();
+        if (this._pinnedPanel) this._pinnedPanel.remove();
+        if (this._legendPanel) this._legendPanel.remove();
+    }
+}

--- a/static/graph-panel/sg-chart.js
+++ b/static/graph-panel/sg-chart.js
@@ -20,7 +20,7 @@ const CHART_PALETTE = [
 ];
 
 const GRID_COLS = 8;
-const GRID_ROWS = 4;
+const GRID_ROWS = 8;
 const GRID_GAP = 8;
 
 // Greek letter & math symbol names → Unicode characters for plain-text
@@ -253,14 +253,13 @@ export class SgChartManager {
         if (this._resizeObserver) return;    // already observing
         const card = this.container.querySelector('.d3-graph-card') || this.container;
         this._resizeObserver = new ResizeObserver(() => {
-            // Reflow pinned charts (grid steps depend on viewport size)
+            // Rescale every chart — grid steps depend on the card width, so
+            // both pinned and inline charts must recompute their pixel size.
             for (const entry of this.charts.values()) {
-                if (entry.pinned) {
-                    this._applyGridSize(entry);
-                    entry.chart.resize();
-                }
+                this._applyGridSize(entry);
+                if (entry.chart) entry.chart.resize();
             }
-            // Reclamp unpinned charts to the new container bounds
+            // Reclamp inline (unpinned) charts to the new container bounds
             this._updateUnpinnedPositions();
         });
         this._resizeObserver.observe(card);
@@ -604,8 +603,8 @@ export class SgChartManager {
             pinned: false,
             graphX: _graphX,
             graphY: _graphY,
-            colSpan: 2,
-            rowSpan: 2,
+            colSpan: 3,
+            rowSpan: 3,
             isRelation,
         };
         this.charts.set(chartId, entry);

--- a/static/graph-panel/sg-chart.js
+++ b/static/graph-panel/sg-chart.js
@@ -276,6 +276,9 @@ export class SgChartManager {
         this._pinnedPanel = null;
         this._legendPanel = null;
         this._transform = { x: 0, y: 0, k: 1 };
+        this._renderer = null;
+        this._rafId = null;
+        this._resizeObserver = null;
 
         this._buildNodeIndex();
     }
@@ -293,6 +296,59 @@ export class SgChartManager {
     setTransform(t) {
         this._transform = t || { x: 0, y: 0, k: 1 };
         this._updateUnpinnedPositions();
+    }
+
+    /**
+     * Connect to a D3SemanticGraphRenderer so the chart manager can poll
+     * its _currentTransform on every animation frame.  This catches ALL
+     * transform sources (drag-pan, trackpad, scrollbar, zoomToFit, …)
+     * regardless of whether the callback chain fires.
+     */
+    setRenderer(renderer) {
+        this._renderer = renderer;
+        this._startTransformPolling();
+        this._observeContainerResize();
+    }
+
+    _startTransformPolling() {
+        if (this._rafId) return;             // already running
+        const poll = () => {
+            this._rafId = requestAnimationFrame(poll);
+            if (!this._renderer) return;
+            const rt = this._renderer._currentTransform;
+            if (!rt) return;
+            const cur = this._transform;
+            if (rt.x !== cur.x || rt.y !== cur.y || rt.k !== cur.k) {
+                this._transform = { x: rt.x, y: rt.y, k: rt.k };
+                this._updateUnpinnedPositions();
+            }
+        };
+        this._rafId = requestAnimationFrame(poll);
+    }
+
+    _stopTransformPolling() {
+        if (this._rafId) {
+            cancelAnimationFrame(this._rafId);
+            this._rafId = null;
+        }
+    }
+
+    /** Watch the graph card for size changes and realign all charts. */
+    _observeContainerResize() {
+        if (this._resizeObserver) return;    // already observing
+        const card = this.container.querySelector('.d3-graph-card') || this.container;
+        this._resizeObserver = new ResizeObserver(() => {
+            // Reflow pinned charts (grid steps depend on viewport size)
+            for (const entry of this.charts.values()) {
+                if (entry.pinned) {
+                    this._applyPinnedSize(entry);
+                    entry.chart.resize();
+                }
+            }
+            // Reclamp unpinned charts to the new container bounds
+            this._updateUnpinnedPositions();
+        });
+        this._resizeObserver.observe(card);
     }
 
     _updateUnpinnedPositions() {
@@ -572,7 +628,15 @@ export class SgChartManager {
             this._updateSliders();
         });
 
-        pinBtn.addEventListener('click', () => this._pinChart(nodeId));
+        pinBtn.addEventListener('click', () => {
+            const e = this.charts.get(nodeId);
+            if (!e) return;
+            if (e.pinned) {
+                this._unpinAndRestore(nodeId);
+            } else {
+                this._pinChart(nodeId);
+            }
+        });
         closeBtn.addEventListener('click', () => this.closeChart(nodeId));
 
         this._updateSliders();
@@ -612,9 +676,9 @@ export class SgChartManager {
 
         const pinBtn = entry.box.querySelector('.sgc-pin-btn');
         if (pinBtn) {
-            pinBtn.innerHTML = '&#x2716;';
+            pinBtn.innerHTML = '&#x1F4CC;';
             pinBtn.title = 'Unpin from overlay';
-            pinBtn.onclick = () => this._unpinAndRestore(nodeId);
+            pinBtn.classList.add('sgc-pin-active');
         }
 
         this.pinnedCharts.push(nodeId);
@@ -658,7 +722,7 @@ export class SgChartManager {
         if (pinBtn) {
             pinBtn.innerHTML = '&#x1F4CC;';
             pinBtn.title = 'Pin chart to overlay';
-            pinBtn.onclick = () => this._pinChart(nodeId);
+            pinBtn.classList.remove('sgc-pin-active');
         }
 
         this._unpinChart(nodeId);
@@ -945,6 +1009,11 @@ export class SgChartManager {
     }
 
     destroy() {
+        this._stopTransformPolling();
+        if (this._resizeObserver) {
+            this._resizeObserver.disconnect();
+            this._resizeObserver = null;
+        }
         for (const entry of this.charts.values()) {
             if (entry._dragCleanup) entry._dragCleanup();
             if (entry._resizeCleanup) entry._resizeCleanup();

--- a/static/graph-panel/sg-chart.js
+++ b/static/graph-panel/sg-chart.js
@@ -84,6 +84,9 @@ export class SgChartManager {
         this._scriptService = new SgChartScript(graph);
         this._compiledScripts = new Map();
 
+        // Cross-chart hover synchronization plugin
+        this._crosshairPlugin = this._createCrosshairPlugin();
+
         this._buildNodeIndex();
     }
 
@@ -327,6 +330,7 @@ export class SgChartManager {
 
             chart = new Chart(canvas, {
                 type: 'line',
+                plugins: [this._crosshairPlugin],
                 data: {
                     labels: data.map(p => p.x),
                     datasets: [{
@@ -824,6 +828,72 @@ export class SgChartManager {
             row.appendChild(input);
             row.appendChild(val);
             this._sliderPanel.appendChild(row);
+        }
+    }
+
+    // ── Cross-chart hover synchronization ────────────────────────────
+
+    _createCrosshairPlugin() {
+        const mgr = this;
+        return {
+            id: 'sgcCrosshair',
+            afterEvent(chart, args) {
+                const event = args.event;
+                if (event.type === 'mousemove') {
+                    const elements = chart.getElementsAtEventForMode(
+                        event, 'index', { intersect: false }, false,
+                    );
+                    if (elements.length > 0) {
+                        mgr._syncCrosshair(chart, elements[0].index);
+                    }
+                } else if (event.type === 'mouseout') {
+                    mgr._clearCrosshair(chart);
+                }
+            },
+            afterDraw(chart) {
+                if (chart._sgcSyncIndex == null) return;
+                const meta = chart.getDatasetMeta(0);
+                if (!meta || !meta.data) return;
+                const point = meta.data[chart._sgcSyncIndex];
+                if (!point) return;
+                const { top, bottom } = chart.chartArea;
+                const ctx = chart.ctx;
+                ctx.save();
+                ctx.strokeStyle = 'rgba(150, 170, 220, 0.4)';
+                ctx.lineWidth = 1;
+                ctx.setLineDash([4, 4]);
+                ctx.beginPath();
+                ctx.moveTo(point.x, top);
+                ctx.lineTo(point.x, bottom);
+                ctx.stroke();
+                ctx.restore();
+            },
+        };
+    }
+
+    _syncCrosshair(sourceChart, index) {
+        for (const entry of this.charts.values()) {
+            if (!entry.chart || entry.chart === sourceChart) continue;
+            const dsLen = entry.chart.data.datasets[0]?.data?.length || 0;
+            if (index >= dsLen) continue;
+            entry.chart._sgcSyncIndex = index;
+            entry.chart.setActiveElements([{ datasetIndex: 0, index }]);
+            entry.chart.tooltip.setActiveElements(
+                [{ datasetIndex: 0, index }],
+                { x: 0, y: 0 },
+            );
+            entry.chart.update('none');
+        }
+    }
+
+    _clearCrosshair(sourceChart) {
+        for (const entry of this.charts.values()) {
+            if (!entry.chart || entry.chart === sourceChart) continue;
+            if (entry.chart._sgcSyncIndex == null) continue;
+            entry.chart._sgcSyncIndex = null;
+            entry.chart.setActiveElements([]);
+            entry.chart.tooltip.setActiveElements([], { x: 0, y: 0 });
+            entry.chart.update('none');
         }
     }
 

--- a/static/graph-panel/sg-chart.js
+++ b/static/graph-panel/sg-chart.js
@@ -23,13 +23,74 @@ const GRID_COLS = 6;
 const GRID_ROWS = 4;
 const GRID_GAP = 8;
 
-// Convert sanitized variable names back to display-friendly LaTeX.
-// u_prime → u', u_dprime → u'', u_tprime → u''', etc.
+// Greek letter names → Unicode characters for plain-text contexts
+// (dropdown options, axis titles, tooltips).
+const _GREEK_UNICODE = new Map([
+    ['alpha', 'α'], ['beta', 'β'], ['gamma', 'γ'],
+    ['delta', 'δ'], ['epsilon', 'ε'], ['zeta', 'ζ'],
+    ['eta', 'η'], ['theta', 'θ'], ['iota', 'ι'],
+    ['kappa', 'κ'], ['lambda', 'λ'], ['mu', 'μ'],
+    ['nu', 'ν'], ['xi', 'ξ'], ['pi', 'π'],
+    ['rho', 'ρ'], ['sigma', 'σ'], ['tau', 'τ'],
+    ['upsilon', 'υ'], ['phi', 'φ'], ['chi', 'χ'],
+    ['psi', 'ψ'], ['omega', 'ω'],
+    ['Gamma', 'Γ'], ['Delta', 'Δ'], ['Theta', 'Θ'],
+    ['Lambda', 'Λ'], ['Pi', 'Π'], ['Sigma', 'Σ'],
+    ['Phi', 'Φ'], ['Psi', 'Ψ'], ['Omega', 'Ω'],
+]);
+
+// Greek letter names → LaTeX commands for KaTeX rendering.
+const _GREEK_LATEX = new Map([
+    ['alpha', '\\alpha'], ['beta', '\\beta'], ['gamma', '\\gamma'],
+    ['delta', '\\delta'], ['epsilon', '\\epsilon'], ['zeta', '\\zeta'],
+    ['eta', '\\eta'], ['theta', '\\theta'], ['iota', '\\iota'],
+    ['kappa', '\\kappa'], ['lambda', '\\lambda'], ['mu', '\\mu'],
+    ['nu', '\\nu'], ['xi', '\\xi'], ['pi', '\\pi'],
+    ['rho', '\\rho'], ['sigma', '\\sigma'], ['tau', '\\tau'],
+    ['upsilon', '\\upsilon'], ['phi', '\\phi'], ['chi', '\\chi'],
+    ['psi', '\\psi'], ['omega', '\\omega'],
+    ['Gamma', '\\Gamma'], ['Delta', '\\Delta'], ['Theta', '\\Theta'],
+    ['Lambda', '\\Lambda'], ['Pi', '\\Pi'], ['Sigma', '\\Sigma'],
+    ['Phi', '\\Phi'], ['Psi', '\\Psi'], ['Omega', '\\Omega'],
+]);
+
+// Convert sanitized variable names back to display-friendly form.
+// u_prime → u', u_dprime → u'', gamma → γ (Unicode).
+// Used for plain-text contexts (dropdowns, axis titles, tooltips).
 function _displayVar(name) {
-    return name
+    let out = name
         .replace(/_tprime$/, "'''")
         .replace(/_dprime$/, "''")
         .replace(/_prime$/, "'");
+    return _GREEK_UNICODE.get(out) || out;
+}
+
+// Convert variable name to LaTeX for KaTeX rendering.
+// gamma → \gamma, u_prime → u', etc.
+function _latexVar(name) {
+    let out = name
+        .replace(/_tprime$/, "'''")
+        .replace(/_dprime$/, "''")
+        .replace(/_prime$/, "'");
+    return _GREEK_LATEX.get(out) || out;
+}
+
+// Relation operators that trigger LHS−RHS conversion in the backend.
+const _RELATION_RE = /(?:^|[^\\])=|\\(?:leq|geq|neq|lt|gt|le|ge)\b|[<>]/;
+
+// Convert an equation LaTeX into "LHS − (RHS)" display form.
+function _relationToLhsMinusRhs(latex) {
+    // Split on the first top-level relation operator.
+    // Try simple '=' first, then LaTeX commands.
+    for (const sep of ['=', '\\leq', '\\geq', '\\neq', '\\le', '\\ge', '<', '>']) {
+        const idx = latex.indexOf(sep);
+        if (idx >= 0) {
+            const lhs = latex.slice(0, idx).trim();
+            const rhs = latex.slice(idx + sep.length).trim();
+            if (lhs && rhs) return `${lhs} - \\left(${rhs}\\right)`;
+        }
+    }
+    return latex;
 }
 
 let _chartJsLoaded = false;
@@ -157,7 +218,7 @@ export class SgChartManager {
             // Reflow pinned charts (grid steps depend on viewport size)
             for (const entry of this.charts.values()) {
                 if (entry.pinned) {
-                    this._applyPinnedSize(entry);
+                    this._applyGridSize(entry);
                     entry.chart.resize();
                 }
             }
@@ -241,9 +302,17 @@ export class SgChartManager {
         return this._scriptService.canChart(nodeId);
     }
 
+    /** Return all chart entries belonging to a given node. */
+    _chartsForNode(nodeId) {
+        const result = [];
+        for (const entry of this.charts.values()) {
+            if (entry.nodeId === nodeId) result.push(entry);
+        }
+        return result;
+    }
+
     async openChart(nodeId, anchorEl) {
         if (!this._ready) await this.init();
-        if (this.charts.has(nodeId)) return;
 
         const n = this._nodeById[nodeId];
         if (!n) return;
@@ -268,6 +337,15 @@ export class SgChartManager {
         const chartId = `sgc-${++_chartIdCounter}`;
         const xVar = vars.length > 0 ? vars[0] : null;
 
+        // ── Dedup: skip if a chart for this node already uses xVar ───
+        // Each node can have at most one chart per independent variable.
+        // Clicking the chart button again only adds a new chart if the
+        // default x-variable is not already taken by an existing chart.
+        const existing = this._chartsForNode(nodeId);
+        if (existing.some(e => e.xVar === xVar)) return;
+        const rawLabel = n.subexpr || n.latex || n.label || n.id;
+        const isRelation = _RELATION_RE.test(rawLabel);
+
         for (const v of vars) {
             this._allVariables.add(v);
             if (this.sliderValues[v] == null) {
@@ -288,7 +366,12 @@ export class SgChartManager {
 
         const title = document.createElement('span');
         title.className = 'sgc-chart-title';
-        const label = n.subexpr || n.latex || n.label || n.id;
+        let label = n.subexpr || n.latex || n.label || n.id;
+        // If the backend converted a relation (=, ≤, ≥, …) to LHS−RHS,
+        // reflect that in the chart title so it matches what is plotted.
+        if ((n.subexpr || n.latex) && _RELATION_RE.test(label)) {
+            label = _relationToLhsMinusRhs(label);
+        }
         if (this.katex && (n.subexpr || n.latex)) {
             try {
                 this.katex.render(label, title, { throwOnError: false, displayMode: false });
@@ -318,7 +401,7 @@ export class SgChartManager {
         codeBtn.className = 'sgc-btn sgc-code-btn';
         codeBtn.title = 'Show mathjs script';
         codeBtn.textContent = '{ }';
-        codeBtn.addEventListener('click', () => this._toggleScriptTooltip(nodeId, codeBtn));
+        codeBtn.addEventListener('click', () => this._toggleScriptTooltip(chartId, codeBtn));
 
         const pinBtn = document.createElement('button');
         pinBtn.className = 'sgc-btn sgc-pin-btn';
@@ -375,6 +458,7 @@ export class SgChartManager {
                         pointHitRadius: 6,
                         fill: true,
                         tension: 0.3,
+                        spanGaps: false,
                     }],
                 },
                 options: {
@@ -403,7 +487,7 @@ export class SgChartManager {
                             grid: { color: 'rgba(110, 124, 180, 0.12)' },
                         },
                         y: {
-                            title: { display: true, text: 'f(' + _displayVar(xVar) + ')', color: '#8fa8c8' },
+                            title: { display: true, text: isRelation ? 'LHS − RHS' : 'f(' + _displayVar(xVar) + ')', color: '#8fa8c8' },
                             ticks: { color: '#7e8aa3', maxTicksLimit: 6, callback: v => +v.toFixed(3) },
                             grid: { color: 'rgba(110, 124, 180, 0.12)' },
                         },
@@ -416,7 +500,9 @@ export class SgChartManager {
         box.appendChild(canvasWrap);
         card.appendChild(box);
 
-        const boxW = 340, boxH = 248;
+        const step = this._getGridSteps();
+        const boxW = 2 * step.w + GRID_GAP;
+        const boxH = 2 * step.h + GRID_GAP;
         let left = 4, top = 4;
         {
             const containerRect = card.getBoundingClientRect();
@@ -487,10 +573,13 @@ export class SgChartManager {
             graphY: _graphY,
             colSpan: 2,
             rowSpan: 2,
+            isRelation,
         };
-        this.charts.set(nodeId, entry);
+        this.charts.set(chartId, entry);
 
+        this._applyGridSize(entry);
         this._makeDraggable(entry);
+        this._addResizeHandle(entry);
 
         xSelect.addEventListener('change', () => {
             entry.xVar = xSelect.value;
@@ -499,15 +588,15 @@ export class SgChartManager {
         });
 
         pinBtn.addEventListener('click', () => {
-            const e = this.charts.get(nodeId);
+            const e = this.charts.get(chartId);
             if (!e) return;
             if (e.pinned) {
-                this._unpinAndRestore(nodeId);
+                this._unpinAndRestore(chartId);
             } else {
-                this._pinChart(nodeId);
+                this._pinChart(chartId);
             }
         });
-        closeBtn.addEventListener('click', () => this.closeChart(nodeId));
+        closeBtn.addEventListener('click', () => this.closeChart(chartId));
 
         this._updateSliders();
         this._updateLegend();
@@ -515,12 +604,12 @@ export class SgChartManager {
 
     // ── Script tooltip ──────────────────────────────────────────────
 
-    _toggleScriptTooltip(nodeId, btnEl) {
+    _toggleScriptTooltip(chartId, btnEl) {
         // Close any existing tooltip
         const existing = btnEl.parentElement?.querySelector('.sgc-script-tooltip');
         if (existing) { existing.remove(); return; }
 
-        const entry = this.charts.get(nodeId);
+        const entry = this.charts.get(chartId);
         const text = entry?.scriptText || '(no script)';
 
         const tip = document.createElement('div');
@@ -540,23 +629,26 @@ export class SgChartManager {
         setTimeout(() => document.addEventListener('click', close, true), 0);
     }
 
-    closeChart(nodeId) {
-        const entry = this.charts.get(nodeId);
+    closeChart(chartId) {
+        const entry = this.charts.get(chartId);
         if (!entry) return;
         if (entry._dragCleanup) entry._dragCleanup();
         if (entry._resizeCleanup) entry._resizeCleanup();
         if (entry.chart) entry.chart.destroy();
         entry.box.remove();
-        this.charts.delete(nodeId);
-        this._compiledScripts.delete(nodeId);
-        this._unpinChart(nodeId);
+        this.charts.delete(chartId);
+        // Only delete compiled script if no other charts for the same node
+        if (this._chartsForNode(entry.nodeId).length === 0) {
+            this._compiledScripts.delete(entry.nodeId);
+        }
+        this._unpinChart(chartId);
         this._rebuildVariableSet();
         this._updateSliders();
         this._updateLegend();
     }
 
-    _pinChart(nodeId) {
-        const entry = this.charts.get(nodeId);
+    _pinChart(chartId) {
+        const entry = this.charts.get(chartId);
         if (!entry || entry.pinned) return;
         entry.pinned = true;
 
@@ -569,7 +661,7 @@ export class SgChartManager {
         entry.box.style.zIndex = '';
 
         this._pinnedPanel.appendChild(entry.box);
-        this._applyPinnedSize(entry);
+        this._applyGridSize(entry);
         this._addResizeHandle(entry);
 
         const pinBtn = entry.box.querySelector('.sgc-pin-btn');
@@ -579,40 +671,36 @@ export class SgChartManager {
             pinBtn.classList.add('sgc-pin-active');
         }
 
-        this.pinnedCharts.push(nodeId);
+        this.pinnedCharts.push(chartId);
         if (entry.chart) entry.chart.resize();
     }
 
-    _unpinChart(nodeId) {
-        const idx = this.pinnedCharts.indexOf(nodeId);
+    _unpinChart(chartId) {
+        const idx = this.pinnedCharts.indexOf(chartId);
         if (idx >= 0) this.pinnedCharts.splice(idx, 1);
     }
 
-    _unpinAndRestore(nodeId) {
-        const entry = this.charts.get(nodeId);
+    _unpinAndRestore(chartId) {
+        const entry = this.charts.get(chartId);
         if (!entry) return;
         entry.pinned = false;
         entry.box.classList.remove('sgc-pinned');
-
-        if (entry._resizeCleanup) { entry._resizeCleanup(); entry._resizeCleanup = null; }
 
         const card = this.container.querySelector('.d3-graph-card') || this.container;
         card.appendChild(entry.box);
 
         entry.box.style.position = 'absolute';
-        entry.box.style.width = '340px';
-        entry.box.style.height = '';
         entry.box.style.zIndex = '20';
-
-        const wrap = entry.box.querySelector('.sgc-canvas-wrap');
-        if (wrap) wrap.style.height = '200px';
+        this._applyGridSize(entry);
 
         const rect = card.getBoundingClientRect();
+        const boxW = entry.box.offsetWidth;
+        const boxH = entry.box.offsetHeight;
         const { x: tx, y: ty, k } = this._transform;
         let left = entry.graphX * k + tx;
         let top = entry.graphY * k + ty;
-        left = Math.max(4, Math.min(left, rect.width - 340 - 4));
-        top = Math.max(4, Math.min(top, rect.height - 248 - 4));
+        left = Math.max(4, Math.min(left, rect.width - boxW - 4));
+        top = Math.max(4, Math.min(top, rect.height - boxH - 4));
         entry.box.style.left = `${left}px`;
         entry.box.style.top = `${top}px`;
 
@@ -623,7 +711,7 @@ export class SgChartManager {
             pinBtn.classList.remove('sgc-pin-active');
         }
 
-        this._unpinChart(nodeId);
+        this._unpinChart(chartId);
         this._makeDraggable(entry);
         if (entry.chart) entry.chart.resize();
     }
@@ -685,7 +773,7 @@ export class SgChartManager {
         };
     }
 
-    _applyPinnedSize(entry) {
+    _applyGridSize(entry) {
         const step = this._getGridSteps();
         const w = entry.colSpan * step.w + (entry.colSpan - 1) * GRID_GAP;
         const h = entry.rowSpan * step.h + (entry.rowSpan - 1) * GRID_GAP;
@@ -727,8 +815,8 @@ export class SgChartManager {
             if (colSpan !== entry.colSpan || rowSpan !== entry.rowSpan) {
                 entry.colSpan = colSpan;
                 entry.rowSpan = rowSpan;
-                this._applyPinnedSize(entry);
-                entry.chart.resize();
+                this._applyGridSize(entry);
+                if (entry.chart) entry.chart.resize();
             }
         };
 
@@ -761,9 +849,13 @@ export class SgChartManager {
                 const y = evalExpr(compiled, 0, { extraScope: scope });
                 if (Number.isFinite(y)) {
                     points.push({ x: +xVal.toFixed(6), y: +y.toFixed(6) });
+                } else {
+                    // Insert null to break the line at discontinuities
+                    // (asymptotes, division by zero, etc.)
+                    points.push({ x: +xVal.toFixed(6), y: null });
                 }
             } catch (_) {
-                // skip point on evaluation error
+                points.push({ x: +xVal.toFixed(6), y: null });
             }
         }
 
@@ -777,7 +869,7 @@ export class SgChartManager {
         entry.chart.data.datasets[0].data = data.map(p => p.y);
         const dv = _displayVar(entry.xVar);
         entry.chart.options.scales.x.title.text = dv;
-        entry.chart.options.scales.y.title.text = `f(${dv})`;
+        entry.chart.options.scales.y.title.text = entry.isRelation ? 'LHS − RHS' : `f(${dv})`;
         entry.chart.options.plugins.tooltip.callbacks.title =
             (items) => `${dv} = ${items[0]?.parsed.x?.toFixed(4)}`;
         entry.chart.update('none');
@@ -829,15 +921,14 @@ export class SgChartManager {
 
             const label = document.createElement('span');
             label.className = 'sgc-slider-label';
-            const displayName = _displayVar(v);
             if (this.katex) {
                 try {
-                    this.katex.render(displayName, label, { throwOnError: false, displayMode: false });
+                    this.katex.render(_latexVar(v), label, { throwOnError: false, displayMode: false });
                 } catch (_) {
-                    label.textContent = displayName;
+                    label.textContent = _displayVar(v);
                 }
             } else {
-                label.textContent = displayName;
+                label.textContent = _displayVar(v);
             }
 
             const input = document.createElement('input');
@@ -906,8 +997,16 @@ export class SgChartManager {
     }
 
     _syncCrosshair(sourceChart, index) {
+        // Find the source chart's x-axis variable so we only sync charts
+        // that share the same independent variable.
+        let sourceXVar = null;
+        for (const entry of this.charts.values()) {
+            if (entry.chart === sourceChart) { sourceXVar = entry.xVar; break; }
+        }
         for (const entry of this.charts.values()) {
             if (!entry.chart || entry.chart === sourceChart) continue;
+            // Only sync charts with the same x-axis variable
+            if (entry.xVar !== sourceXVar) continue;
             const dsLen = entry.chart.data.datasets[0]?.data?.length || 0;
             if (index >= dsLen) continue;
             entry.chart._sgcSyncIndex = index;

--- a/static/graph-panel/sg-chart.js
+++ b/static/graph-panel/sg-chart.js
@@ -23,6 +23,15 @@ const GRID_COLS = 6;
 const GRID_ROWS = 4;
 const GRID_GAP = 8;
 
+// Convert sanitized variable names back to display-friendly LaTeX.
+// u_prime → u', u_dprime → u'', u_tprime → u''', etc.
+function _displayVar(name) {
+    return name
+        .replace(/_tprime$/, "'''")
+        .replace(/_dprime$/, "''")
+        .replace(/_prime$/, "'");
+}
+
 let _chartJsLoaded = false;
 let _chartJsPromise = null;
 function loadChartJs() {
@@ -162,12 +171,35 @@ export class SgChartManager {
         const card = this.container.querySelector('.d3-graph-card') || this.container;
         const rect = card.getBoundingClientRect();
         const { x: tx, y: ty, k } = this._transform;
+        const placed = [];
         for (const entry of this.charts.values()) {
             if (entry.pinned) continue;
-            const screenX = entry.graphX * k + tx;
-            const screenY = entry.graphY * k + ty;
-            const left = Math.max(4, Math.min(screenX, rect.width - entry.box.offsetWidth - 4));
-            const top = Math.max(4, Math.min(screenY, rect.height - entry.box.offsetHeight - 4));
+            const boxW = entry.box.offsetWidth;
+            const boxH = entry.box.offsetHeight;
+            let left = entry.graphX * k + tx;
+            let top = entry.graphY * k + ty;
+            left = Math.max(4, Math.min(left, rect.width - boxW - 4));
+            top = Math.max(4, Math.min(top, rect.height - boxH - 4));
+            // Resolve collisions with previously placed charts
+            for (let attempt = 0; attempt < 4; attempt++) {
+                let collision = false;
+                for (const p of placed) {
+                    if (left < p.right && left + boxW > p.left &&
+                        top < p.bottom && top + boxH > p.top) {
+                        collision = true;
+                        top = p.bottom + 4;
+                        if (top + boxH > rect.height - 4) {
+                            top = 4;
+                            left = p.right + 4;
+                        }
+                        break;
+                    }
+                }
+                if (!collision) break;
+                left = Math.max(4, Math.min(left, rect.width - boxW - 4));
+                top = Math.max(4, Math.min(top, rect.height - boxH - 4));
+            }
+            placed.push({ left, top, right: left + boxW, bottom: top + boxH });
             entry.box.style.left = `${left}px`;
             entry.box.style.top = `${top}px`;
         }
@@ -276,7 +308,7 @@ export class SgChartManager {
         for (const v of vars) {
             const opt = document.createElement('option');
             opt.value = v;
-            opt.textContent = v;
+            opt.textContent = _displayVar(v);
             if (v === xVar) opt.selected = true;
             xSelect.appendChild(opt);
         }
@@ -359,19 +391,19 @@ export class SgChartManager {
                             borderWidth: 1,
                             callbacks: {
                                 label: (ctx) => `y = ${ctx.parsed.y?.toFixed(4)}`,
-                                title: (items) => `${xVar} = ${items[0]?.parsed.x?.toFixed(4)}`,
+                                title: (items) => `${_displayVar(xVar)} = ${items[0]?.parsed.x?.toFixed(4)}`,
                             },
                         },
                     },
                     scales: {
                         x: {
                             type: 'linear',
-                            title: { display: true, text: xVar, color: '#8fa8c8' },
+                            title: { display: true, text: _displayVar(xVar), color: '#8fa8c8' },
                             ticks: { color: '#7e8aa3', maxTicksLimit: 8, callback: v => +v.toFixed(3) },
                             grid: { color: 'rgba(110, 124, 180, 0.12)' },
                         },
                         y: {
-                            title: { display: true, text: 'f(' + xVar + ')', color: '#8fa8c8' },
+                            title: { display: true, text: 'f(' + _displayVar(xVar) + ')', color: '#8fa8c8' },
                             ticks: { color: '#7e8aa3', maxTicksLimit: 6, callback: v => +v.toFixed(3) },
                             grid: { color: 'rgba(110, 124, 180, 0.12)' },
                         },
@@ -458,7 +490,7 @@ export class SgChartManager {
         };
         this.charts.set(nodeId, entry);
 
-        if (chart) this._makeDraggable(entry);
+        this._makeDraggable(entry);
 
         xSelect.addEventListener('change', () => {
             entry.xVar = xSelect.value;
@@ -743,10 +775,11 @@ export class SgChartManager {
         const { data } = this._computeData(entry.nodeId, entry.xVar, entry.vars);
         entry.chart.data.labels = data.map(p => p.x);
         entry.chart.data.datasets[0].data = data.map(p => p.y);
-        entry.chart.options.scales.x.title.text = entry.xVar;
-        entry.chart.options.scales.y.title.text = `f(${entry.xVar})`;
+        const dv = _displayVar(entry.xVar);
+        entry.chart.options.scales.x.title.text = dv;
+        entry.chart.options.scales.y.title.text = `f(${dv})`;
         entry.chart.options.plugins.tooltip.callbacks.title =
-            (items) => `${entry.xVar} = ${items[0]?.parsed.x?.toFixed(4)}`;
+            (items) => `${dv} = ${items[0]?.parsed.x?.toFixed(4)}`;
         entry.chart.update('none');
     }
 
@@ -796,14 +829,15 @@ export class SgChartManager {
 
             const label = document.createElement('span');
             label.className = 'sgc-slider-label';
+            const displayName = _displayVar(v);
             if (this.katex) {
                 try {
-                    this.katex.render(v, label, { throwOnError: false, displayMode: false });
+                    this.katex.render(displayName, label, { throwOnError: false, displayMode: false });
                 } catch (_) {
-                    label.textContent = v;
+                    label.textContent = displayName;
                 }
             } else {
-                label.textContent = v;
+                label.textContent = displayName;
             }
 
             const input = document.createElement('input');

--- a/static/graph-panel/sg-chart.js
+++ b/static/graph-panel/sg-chart.js
@@ -1090,13 +1090,9 @@ export class SgChartManager {
         if (!this._legendPanel) return;
         this._legendPanel.innerHTML = '';
 
-        if (this.charts.size === 0) {
-            this._legendPanel.classList.add('hidden');
-            return;
-        }
-
         if (this.charts.size < 2) {
             this._legendPanel.classList.add('hidden');
+            this._emitLegendChange();
             return;
         }
 
@@ -1144,6 +1140,18 @@ export class SgChartManager {
             item.appendChild(name);
             this._legendPanel.appendChild(item);
         }
+
+        this._emitLegendChange();
+    }
+
+    // Notify graph-view.js (which owns the enrichment-progress stack in a
+    // sibling container) that the legend strip changed, so it can re-stack the
+    // enrichment pills above the new legend height. Decoupled via a DOM event
+    // to avoid a circular import between this module and graph-view.js.
+    _emitLegendChange() {
+        try {
+            document.dispatchEvent(new CustomEvent('sgc:legend-change'));
+        } catch (_) { /* no-op */ }
     }
 
     destroy() {

--- a/static/graph-panel/sg-chart.js
+++ b/static/graph-panel/sg-chart.js
@@ -107,15 +107,25 @@ const _RELATION_RE = /(?:^|[^\\])=|\\(?:leq|geq|neq|lt|gt|le|ge)\b|[<>]/;
 
 // Convert an equation LaTeX into "LHS − (RHS)" display form.
 function _relationToLhsMinusRhs(latex) {
-    // Split on the first top-level relation operator.
-    // Try simple '=' first, then LaTeX commands.
-    for (const sep of ['=', '\\leq', '\\geq', '\\neq', '\\le', '\\ge', '<', '>']) {
-        const idx = latex.indexOf(sep);
-        if (idx >= 0) {
-            const lhs = latex.slice(0, idx).trim();
-            const rhs = latex.slice(idx + sep.length).trim();
-            if (lhs && rhs) return `${lhs} - \\left(${rhs}\\right)`;
+    // Find the first top-level relation operator using the same matcher as
+    // detection (_RELATION_RE) so escaped operators (e.g. "\=") are ignored.
+    // Capture the operator separately to know how much to slice off.
+    const splitRe = /(?:^|[^\\])(=)|\\(leq|geq|neq|lt|gt|le|ge)\b|([<>])/;
+    const m = splitRe.exec(latex);
+    if (m) {
+        const op = m[0];
+        const opIdx = m.index;
+        // m[1] = bare '=', m[2] = LaTeX word op, m[3] = bare '<'/'>'.
+        // For the '=' branch the match may include a leading non-backslash char.
+        let sepStart = opIdx;
+        let sepEnd = opIdx + op.length;
+        if (m[1] && op.length > 1) {
+            // Leading char captured before '='; keep it on the LHS.
+            sepStart = opIdx + op.length - 1;
         }
+        const lhs = latex.slice(0, sepStart).trim();
+        const rhs = latex.slice(sepEnd).trim();
+        if (lhs && rhs) return `${lhs} - \\left(${rhs}\\right)`;
     }
     return latex;
 }
@@ -177,6 +187,7 @@ export class SgChartManager {
         this._renderer = null;
         this._rafId = null;
         this._resizeObserver = null;
+        this._destroyed = false;
 
         this._scriptService = new SgChartScript(graph);
         this._compiledScripts = new Map();
@@ -340,12 +351,14 @@ export class SgChartManager {
 
     async openChart(nodeId, anchorEl) {
         if (!this._ready) await this.init();
+        if (this._destroyed) return;
 
         const n = this._nodeById[nodeId];
         if (!n) return;
 
         // ── Fetch mathjs script from backend (or pre-computed) ───────
         const result = await this._scriptService.getScript(nodeId);
+        if (this._destroyed) return;
         const hasError = !result || result.error;
         const vars = hasError ? [] : result.variables;
         const scriptText = hasError ? null : result.script;
@@ -1123,6 +1136,7 @@ export class SgChartManager {
     }
 
     destroy() {
+        this._destroyed = true;
         this._stopTransformPolling();
         if (this._resizeObserver) {
             this._resizeObserver.disconnect();

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -19,6 +19,7 @@
 import { state } from '/state.js';
 import { SemanticGraphPanel } from '/graph-panel/graph-panel.js';
 import { D3SemanticGraphRenderer, nodeLongLabel } from '/graph-panel/d3-semantic-graph.js';
+import { SgChartManager } from '/graph-panel/sg-chart.js';
 import { makeAiAskButton, renderKaTeX } from '/labels.js';
 
 let _currentGraphPanel = null;
@@ -26,6 +27,7 @@ let _currentSemanticKey = null;
 let _activeStepForPanel = null;
 let _initDone = false;
 let _currentD3Renderer = null;
+let _currentChartManager = null;
 let _d3NodeAskBtn = null;
 let _d3NodeAskHideTimer = null;
 let _d3HoveredNodeId = null;
@@ -715,6 +717,10 @@ function clearGraph() {
         try { _currentGraphPanel.destroy(); } catch {}
         _currentGraphPanel = null;
     }
+    if (_currentChartManager) {
+        try { _currentChartManager.destroy(); } catch {}
+        _currentChartManager = null;
+    }
     if (_currentD3Renderer) {
         try { _currentD3Renderer.destroy(); } catch {}
         _currentD3Renderer = null;
@@ -788,6 +794,13 @@ async function _renderWithD3(container, graph, step, key) {
 
     _d3ActiveGraph = graph;
 
+    if (_currentChartManager) {
+        try { _currentChartManager.destroy(); } catch {}
+    }
+    _currentChartManager = new SgChartManager(container, graph, {
+        katex: window.katex,
+    });
+
     // Reuse or create D3 renderer
     if (!_currentD3Renderer || _currentD3Renderer._destroyed) {
         _currentD3Renderer = new D3SemanticGraphRenderer(container, {
@@ -818,6 +831,17 @@ async function _renderWithD3(container, graph, step, key) {
             onZoomChange: (pct) => {
                 const label = document.getElementById('graph-zoom-level');
                 if (label) label.textContent = `${pct}%`;
+            },
+            onTransformChange: (t) => {
+                if (_currentChartManager) _currentChartManager.setTransform(t);
+            },
+            onChartClick: (nodeId, nodeData, btnEl) => {
+                if (!_currentChartManager) return;
+                if (_currentChartManager.charts.has(nodeId)) {
+                    _currentChartManager.closeChart(nodeId);
+                } else {
+                    _currentChartManager.openChart(nodeId, btnEl);
+                }
             },
         });
     } else {

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -1511,9 +1511,35 @@ function showEnrichmentIndicator(step) {
     text.textContent = 'Enriching graph…';
     el.append(dots, text);
     stack.appendChild(el);
+    positionEnrichmentStack();
     refreshEnrichmentIndicatorVisibility();
     return el;
 }
+
+// Raise the enrichment-indicator stack so it sits directly above whatever
+// legends are docked in the bottom-right of the viewport (the edge-semantics
+// legend and/or the chart legend, which live inside .d3-graph-card). They
+// share the viewport corner, so without this the pills would overlap them.
+function positionEnrichmentStack() {
+    const viewport = document.getElementById('graph-viewport');
+    if (!viewport) return;
+    const stack = viewport.querySelector('.graph-enrich-indicator-stack');
+    if (!stack) return;
+    const vpRect = viewport.getBoundingClientRect();
+    let reach = 0; // px the tallest docked legend rises from the viewport bottom
+    for (const sel of ['.d3sg-edge-legend', '.sgc-legend-panel']) {
+        const el = viewport.querySelector(sel);
+        if (!el || el.classList.contains('hidden') || el.offsetParent === null) continue;
+        const r = el.getBoundingClientRect();
+        reach = Math.max(reach, vpRect.bottom - r.top);
+    }
+    stack.style.bottom = reach > 0 ? `${Math.round(reach) + 8}px` : '8px';
+}
+
+// The chart legend (managed by SgChartManager) appears, grows and disappears
+// independently of enrichment. It fires this event whenever it re-lays-out so
+// we can re-stack the enrichment pills above the new legend height.
+document.addEventListener('sgc:legend-change', positionEnrichmentStack);
 
 function refreshEnrichmentIndicatorVisibility() {
     const viewport = document.getElementById('graph-viewport');

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -1526,14 +1526,21 @@ function positionEnrichmentStack() {
     const stack = viewport.querySelector('.graph-enrich-indicator-stack');
     if (!stack) return;
     const vpRect = viewport.getBoundingClientRect();
-    let reach = 0; // px the tallest docked legend rises from the viewport bottom
+    let reach = 0;        // px the tallest docked legend rises from the viewport bottom
+    let rightGap = null;  // smallest gap from viewport right edge to a legend's right edge
     for (const sel of ['.d3sg-edge-legend', '.sgc-legend-panel']) {
         const el = viewport.querySelector(sel);
         if (!el || el.classList.contains('hidden') || el.offsetParent === null) continue;
         const r = el.getBoundingClientRect();
         reach = Math.max(reach, vpRect.bottom - r.top);
+        const gap = vpRect.right - r.right;
+        rightGap = rightGap === null ? gap : Math.min(rightGap, gap);
     }
-    stack.style.bottom = reach > 0 ? `${Math.round(reach) + 8}px` : '8px';
+    // Pad above the legend strip and right-align the pills with the legends'
+    // right edge (falling back to the 8px corner when no legend is docked).
+    const TOP_PAD = 14;
+    stack.style.bottom = reach > 0 ? `${Math.round(reach) + TOP_PAD}px` : '8px';
+    stack.style.right = rightGap !== null ? `${Math.round(rightGap)}px` : '8px';
 }
 
 // The chart legend (managed by SgChartManager) appears, grows and disappears

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -837,11 +837,8 @@ async function _renderWithD3(container, graph, step, key) {
             },
             onChartClick: (nodeId, nodeData, btnEl) => {
                 if (!_currentChartManager) return;
-                if (_currentChartManager.charts.has(nodeId)) {
-                    _currentChartManager.closeChart(nodeId);
-                } else {
-                    _currentChartManager.openChart(nodeId, btnEl);
-                }
+                // Always open — never toggle.  Only the × button closes.
+                _currentChartManager.openChart(nodeId, btnEl);
             },
         });
     } else {

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -848,6 +848,11 @@ async function _renderWithD3(container, graph, step, key) {
         await _currentD3Renderer.update({ direction: _currentDirection, labels: _currentLabels, theme: _currentTheme });
     }
 
+    // Connect chart manager to renderer for transform polling + resize observation
+    if (_currentChartManager && _currentD3Renderer) {
+        _currentChartManager.setRenderer(_currentD3Renderer);
+    }
+
     const stepKey = stableStepKey(step);
     if (_currentD3Renderer && _d3LastStepKey && _d3LastStepKey !== stepKey) {
         _d3StepStates.set(_d3LastStepKey, _currentD3Renderer.saveState());

--- a/static/index.html
+++ b/static/index.html
@@ -20,6 +20,7 @@
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/graph-panel/graph-panel.css">
 <link rel="stylesheet" href="/graph-panel/d3-semantic-graph.css">
+<link rel="stylesheet" href="/graph-panel/sg-chart.css">
 </head>
 <body data-debug-mode="__DEBUG_MODE__">
 <div id="app">

--- a/static/style.css
+++ b/static/style.css
@@ -3917,6 +3917,7 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
     bottom: 8px;
     display: flex;
     flex-direction: column-reverse;
+    align-items: flex-end;
     gap: 8px;
     z-index: 3;
     pointer-events: none;

--- a/static/style.css
+++ b/static/style.css
@@ -3911,7 +3911,10 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 .graph-enrich-indicator-stack {
     position: absolute;
     right: 8px;
-    bottom: 8px;
+    /* Sit above the edge-semantics / chart legends that dock to the
+       bottom-right of the graph viewport, so all three stack vertically
+       without overlapping. */
+    bottom: 116px;
     display: flex;
     flex-direction: column-reverse;
     gap: 8px;

--- a/static/style.css
+++ b/static/style.css
@@ -3911,10 +3911,10 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 .graph-enrich-indicator-stack {
     position: absolute;
     right: 8px;
-    /* Sit above the edge-semantics / chart legends that dock to the
-       bottom-right of the graph viewport, so all three stack vertically
-       without overlapping. */
-    bottom: 116px;
+    /* Base position is the bottom-right corner; positionEnrichmentStack()
+       in graph-view.js raises `bottom` at runtime so the pills sit above
+       whatever edge-semantics / chart legends are docked there. */
+    bottom: 8px;
     display: flex;
     flex-direction: column-reverse;
     gap: 8px;

--- a/tests/backend/semantic_graph/test_mathjs_converter.py
+++ b/tests/backend/semantic_graph/test_mathjs_converter.py
@@ -236,3 +236,40 @@ class TestLatexToMathjs:
         """Empty LaTeX should raise rather than silently succeed."""
         with pytest.raises((ValueError, Exception)):
             latex_to_mathjs("")
+
+    # -- Primed variable sanitization --
+
+    def test_prime_variable(self):
+        """``u'`` should be sanitized to ``u_prime``."""
+        script, variables = latex_to_mathjs(r"u'")
+        assert script == "u_prime"
+        assert variables == ["u_prime"]
+
+    def test_prime_product(self):
+        """``u' \\cdot v`` should produce ``u_prime*v``."""
+        script, variables = latex_to_mathjs(r"u' \cdot v")
+        assert "u_prime" in script
+        assert "v" in script
+        assert sorted(variables) == ["u_prime", "v"]
+
+    def test_double_prime(self):
+        """``u''`` should be sanitized to ``u_dprime``."""
+        script, variables = latex_to_mathjs(r"u''")
+        assert script == "u_dprime"
+        assert variables == ["u_dprime"]
+
+    def test_multiple_primed_vars(self):
+        """Multiple primed variables in one expression."""
+        script, variables = latex_to_mathjs(r"x' + y'")
+        assert "x_prime" in script
+        assert "y_prime" in script
+        assert sorted(variables) == ["x_prime", "y_prime"]
+
+    def test_prime_in_fraction(self):
+        """Primed variable inside a fraction — the velocity addition formula."""
+        script, variables = latex_to_mathjs(
+            r"\frac{u' + v}{1 + \frac{u' v}{c^2}}"
+        )
+        assert "u_prime" in script
+        assert "'" not in script
+        assert sorted(variables) == ["c", "u_prime", "v"]

--- a/tests/backend/semantic_graph/test_mathjs_converter.py
+++ b/tests/backend/semantic_graph/test_mathjs_converter.py
@@ -1,0 +1,238 @@
+"""Tests for backend.semantic_graph.mathjs_converter — LaTeX → mathjs pipeline."""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.semantic_graph.mathjs_converter import jscode_to_mathjs, latex_to_mathjs
+
+
+# ── jscode → mathjs string conversion ─────────────────────────────────
+
+class TestJscodeToMathjs:
+    """Unit tests for the regex-based jscode → mathjs conversion."""
+
+    # -- Function prefix stripping --
+
+    def test_sin(self):
+        assert jscode_to_mathjs("Math.sin(x)") == "sin(x)"
+
+    def test_cos(self):
+        assert jscode_to_mathjs("Math.cos(x)") == "cos(x)"
+
+    def test_tan(self):
+        assert jscode_to_mathjs("Math.tan(x)") == "tan(x)"
+
+    def test_sqrt(self):
+        assert jscode_to_mathjs("Math.sqrt(x)") == "sqrt(x)"
+
+    def test_abs(self):
+        assert jscode_to_mathjs("Math.abs(x)") == "abs(x)"
+
+    def test_exp(self):
+        assert jscode_to_mathjs("Math.exp(x)") == "exp(x)"
+
+    def test_log(self):
+        assert jscode_to_mathjs("Math.log(x)") == "log(x)"
+
+    def test_pow(self):
+        assert jscode_to_mathjs("Math.pow(x, 2)") == "pow(x, 2)"
+
+    def test_floor(self):
+        assert jscode_to_mathjs("Math.floor(x)") == "floor(x)"
+
+    def test_ceil(self):
+        assert jscode_to_mathjs("Math.ceil(x)") == "ceil(x)"
+
+    def test_sign(self):
+        assert jscode_to_mathjs("Math.sign(x)") == "sign(x)"
+
+    def test_asin(self):
+        assert jscode_to_mathjs("Math.asin(x)") == "asin(x)"
+
+    def test_atan2(self):
+        assert jscode_to_mathjs("Math.atan2(y, x)") == "atan2(y, x)"
+
+    # -- Constants --
+
+    def test_pi(self):
+        assert jscode_to_mathjs("Math.PI") == "pi"
+
+    def test_euler_e(self):
+        assert jscode_to_mathjs("Math.E") == "e"
+
+    def test_ln2(self):
+        assert jscode_to_mathjs("Math.LN2") == "ln2"
+
+    # -- Nested / composite expressions --
+
+    def test_nested(self):
+        assert jscode_to_mathjs("Math.sin(Math.pow(x, 2))") == "sin(pow(x, 2))"
+
+    def test_complex_expression(self):
+        result = jscode_to_mathjs("Math.pow(x, 2) + Math.sin(x)")
+        assert result == "pow(x, 2) + sin(x)"
+
+    def test_expression_with_pi(self):
+        result = jscode_to_mathjs("Math.sin(Math.PI*x)")
+        assert result == "sin(pi*x)"
+
+    # -- Passthrough (no Math. prefix) --
+
+    def test_bare_variable(self):
+        assert jscode_to_mathjs("x + y") == "x + y"
+
+    def test_negation(self):
+        assert jscode_to_mathjs("-x") == "-x"
+
+    def test_division(self):
+        assert jscode_to_mathjs("x/y") == "x/y"
+
+    def test_integer_literal(self):
+        assert jscode_to_mathjs("42") == "42"
+
+    # -- Comment stripping (jscode strict=False output) --
+
+    def test_strips_comment_lines(self):
+        js = "// Not supported in JavaScript:\n// factorial\nfactorial(x)"
+        assert jscode_to_mathjs(js) == "factorial(x)"
+
+    def test_strips_inline_comment(self):
+        js = "x + y // some comment\n"
+        result = jscode_to_mathjs(js)
+        assert "//" not in result
+        assert "x + y" in result
+
+
+# ── Full LaTeX → mathjs pipeline ──────────────────────────────────────
+
+class TestLatexToMathjs:
+    """End-to-end tests for the LaTeX → mathjs conversion pipeline."""
+
+    # -- Basic expressions --
+
+    def test_polynomial(self):
+        script, variables = latex_to_mathjs(r"x^2 + 3x + 1")
+        assert "pow(x, 2)" in script
+        assert "3*x" in script
+        assert variables == ["x"]
+
+    def test_single_variable(self):
+        script, variables = latex_to_mathjs(r"x")
+        assert script == "x"
+        assert variables == ["x"]
+
+    def test_constant_number(self):
+        script, variables = latex_to_mathjs(r"42")
+        assert script == "42"
+        assert variables == []
+
+    # -- Trigonometric --
+
+    def test_sin(self):
+        script, variables = latex_to_mathjs(r"\sin(x)")
+        assert script == "sin(x)"
+        assert variables == ["x"]
+
+    def test_cos(self):
+        script, variables = latex_to_mathjs(r"\cos(x)")
+        assert script == "cos(x)"
+        assert variables == ["x"]
+
+    def test_sin_squared(self):
+        script, variables = latex_to_mathjs(r"\sin^2(x) + \cos^2(x)")
+        assert "pow(sin(x), 2)" in script
+        assert "pow(cos(x), 2)" in script
+        assert variables == ["x"]
+
+    # -- Exponential / logarithmic --
+
+    def test_exp(self):
+        script, variables = latex_to_mathjs(r"\exp(x)")
+        assert script == "exp(x)"
+        assert variables == ["x"]
+
+    def test_e_to_x(self):
+        """``e^{x}`` — Symbol('e') should become Euler's number."""
+        script, variables = latex_to_mathjs(r"e^{x}")
+        assert script == "exp(x)"
+        assert variables == ["x"]  # 'e' should NOT appear as a variable
+
+    def test_ln(self):
+        script, variables = latex_to_mathjs(r"\ln(x)")
+        assert script == "log(x)"
+        assert variables == ["x"]
+
+    def test_log_base_10(self):
+        script, variables = latex_to_mathjs(r"\log_{10}(x)")
+        assert variables == ["x"]
+        # jscode emits log(x)/log(10) which is valid in mathjs
+        assert "log" in script
+
+    # -- Constants --
+
+    def test_pi_constant(self):
+        """``\\pi`` should be treated as the constant π, not a variable."""
+        script, variables = latex_to_mathjs(r"\sin(\pi x)")
+        assert "sin(pi*x)" in script or "sin(x*pi)" in script
+        assert "pi" not in variables  # pi should NOT be a free variable
+
+    # -- Fractions / division --
+
+    def test_fraction(self):
+        script, variables = latex_to_mathjs(r"\frac{x}{y}")
+        assert variables == ["x", "y"]
+        assert "x" in script and "y" in script
+
+    # -- Square root --
+
+    def test_sqrt(self):
+        script, variables = latex_to_mathjs(r"\sqrt{x}")
+        assert script == "sqrt(x)"
+        assert variables == ["x"]
+
+    # -- Multiple variables --
+
+    def test_multivar(self):
+        script, variables = latex_to_mathjs(r"x^2 + y^2")
+        assert "x" in variables
+        assert "y" in variables
+        assert len(variables) == 2
+
+    # -- Relations → LHS − RHS --
+
+    def test_equality(self):
+        """``x = y`` should produce ``x - y``."""
+        script, variables = latex_to_mathjs(r"x = y")
+        assert script == "x - y"
+        assert sorted(variables) == ["x", "y"]
+
+    def test_equation_with_subexprs(self):
+        """``x^2 + y^2 = r^2`` should produce ``x^2 + y^2 - r^2``."""
+        script, variables = latex_to_mathjs(r"x^2 + y^2 = r^2")
+        assert "pow(x, 2)" in script
+        assert "pow(y, 2)" in script
+        assert "pow(r, 2)" in script
+        assert sorted(variables) == ["r", "x", "y"]
+
+    def test_inequality_gt(self):
+        script, variables = latex_to_mathjs(r"x > y")
+        assert script == "x - y"
+
+    def test_inequality_leq(self):
+        script, variables = latex_to_mathjs(r"x \leq y")
+        assert script == "x - y"
+
+    # -- Error handling --
+
+    def test_invalid_latex_raises(self):
+        """Malformed LaTeX that parse_latex cannot handle."""
+        # parse_latex is lenient — unknown commands become Symbols.
+        # Structurally broken input triggers LaTeXParsingError → ValueError.
+        with pytest.raises((ValueError, Exception)):
+            latex_to_mathjs(r"\frac{}")  # incomplete fraction
+
+    def test_empty_string(self):
+        """Empty LaTeX should raise rather than silently succeed."""
+        with pytest.raises((ValueError, Exception)):
+            latex_to_mathjs("")

--- a/tests/backend/semantic_graph/test_mathjs_converter.py
+++ b/tests/backend/semantic_graph/test_mathjs_converter.py
@@ -103,6 +103,14 @@ class TestJscodeToMathjs:
         assert "//" not in result
         assert "x + y" in result
 
+    # -- Subscript brace stripping --
+
+    def test_strips_subscript_braces(self):
+        assert jscode_to_mathjs("p_{i}*x_{i}") == "p_i*x_i"
+
+    def test_strips_nested_subscript_braces(self):
+        assert jscode_to_mathjs("a_{ij} + b_{12}") == "a_ij + b_12"
+
 
 # ── Full LaTeX → mathjs pipeline ──────────────────────────────────────
 
@@ -273,3 +281,26 @@ class TestLatexToMathjs:
         assert "u_prime" in script
         assert "'" not in script
         assert sorted(variables) == ["c", "u_prime", "v"]
+
+    # -- Subscript brace sanitization --
+
+    def test_subscripted_variable(self):
+        """``x_i`` should not have LaTeX braces in the output."""
+        script, variables = latex_to_mathjs(r"x_i")
+        assert "{" not in script
+        assert "}" not in script
+        assert variables == ["x_i"]
+
+    def test_subscripted_product(self):
+        """``x_i p_i`` — subscripted variables in a product."""
+        script, variables = latex_to_mathjs(r"x_i p_i")
+        assert "{" not in script
+        assert "}" not in script
+        assert sorted(variables) == ["p_i", "x_i"]
+
+    def test_subscript_in_equation(self):
+        """Subscripted variables in an equation."""
+        script, variables = latex_to_mathjs(r"a_1 + a_2 = b")
+        assert "{" not in script
+        assert "}" not in script
+        assert "b" in variables


### PR DESCRIPTION
## Summary

Adds interactive, in-browser chart plotting to semantic graph nodes. Clicking a node's chart button plots its expression as `f(x)` over an auto-ranged domain, with live sliders for the remaining free variables.

Expression compilation moves to the backend: a node's `subexpr` (LaTeX) is parsed with SymPy, emitted as JavaScript via `jscode()`, and converted to mathjs syntax — replacing the hand-rolled client-side DAG evaluator that only handled a fraction of the operators the graph can emit.

## What changed

**Backend**
- New `backend/semantic_graph/mathjs_converter.py` — `latex_to_mathjs()` pipeline (`parse_latex` → SymPy → `jscode` → mathjs string) plus `jscode_to_mathjs()` regex conversion. Handles relation auto-conversion to `LHS − RHS`, primed-variable sanitization (`u'` → `u_prime`), and subscript-brace stripping (`x_{i}` → `x_i`).
- New `POST /api/graph/generate-mathjs` endpoint in `backend/server.py`.
- Full unit-test suite (`tests/backend/semantic_graph/test_mathjs_converter.py`, 55 tests).

**Frontend**
- New `static/graph-panel/sg-chart.js` — chart manager: Chart.js rendering, draggable/resizable/pinnable chart boxes, per-variable dedup (one chart per independent variable per node), sliders, cross-chart hover sync, and a `{ }` button to inspect the mathjs script.
- New `static/graph-panel/sg-chart-script.js` — script fetch/cache service (uses pre-computed `chartScript` for offline reports, else hits the API).
- New `static/expr.js` — shared `compileExpr`/`evalExpr` wrapper around mathjs (the single extensibility point for all math evaluation).
- `d3-semantic-graph.js` / `graph-view.js` — chart buttons on nodes (incl. collapsed), wired to always-open (only × closes).
- Chart titles render as `f(x) = expression` via KaTeX so the vertical axis is self-documenting; slider/axis labels decode Greek + math symbols (`mu_0` → μ₀, `nabla` → ∇, etc.).

**Reports**
- `scripts/semantic_graph_report.py` pre-computes `chartScript` per node and ships a mathjs CDN + `/expr.js` import-map shim so charts work fully offline.

## Reviewer notes
- Verified end-to-end in the sg-report preview (electromagnetism domain): charts render, sliders show proper Greek symbols, `f(x) =` titles update when the x-variable is changed, 15/15 expressions render with no errors.
- The client no longer interprets the graph DAG directly — all evaluation flows through `expr.js`, so new functions are added in one place.

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>