### PR TITLE
fix(security): address code scanning alert #116 - polynomial ReDoS [HIGH]

### DIFF
--- a/backend/semantic_graph/sympy_translator.py
+++ b/backend/semantic_graph/sympy_translator.py
@@ -310,7 +310,36 @@ def _rewrite_conditional_bar(latex: str) -> tuple[str, set[str]]:
                 body = latex[body_start:body_end]
 
                 # Normalize \mid → | ONLY within this function body.
-                body = re.sub(r"\s*\\mid\b\s*", "|", body)
+                # Avoid polynomial ReDoS: use string search instead of
+                # regex (CodeQL: polynomial-redos).
+                if r"\mid" in body:
+                    _mid_parts: list[str] = []
+                    _pos = 0
+                    while True:
+                        _idx = body.find(r"\mid", _pos)
+                        if _idx == -1:
+                            _mid_parts.append(body[_pos:])
+                            break
+                        _after = _idx + 4
+                        # Word boundary: skip \mid that is a prefix of a
+                        # longer command (e.g. \middle).
+                        if _after < len(body) and (
+                            body[_after].isalnum() or body[_after] == "_"
+                        ):
+                            _mid_parts.append(body[_pos : _idx + 1])
+                            _pos = _idx + 1
+                            continue
+                        # Strip whitespace immediately before \mid.
+                        _start = _idx
+                        while _start > _pos and body[_start - 1] in " \t\n\r":
+                            _start -= 1
+                        _mid_parts.append(body[_pos:_start])
+                        _mid_parts.append("|")
+                        # Skip whitespace immediately after \mid.
+                        _pos = _after
+                        while _pos < len(body) and body[_pos] in " \t\n\r":
+                            _pos += 1
+                    body = "".join(_mid_parts)
 
                 # Count bare pipes in body (not inside nested parens).
                 # Detect: is there exactly one unpaired |?

--- a/tests/backend/semantic_graph/test_conditional_bar.py
+++ b/tests/backend/semantic_graph/test_conditional_bar.py
@@ -78,6 +78,20 @@ class TestRewriteConditionalBar:
         _, funcs = _rewrite_conditional_bar(r"E(X) + P(A)")
         assert funcs == set()
 
+    def test_mid_command_rewrite(self):
+        r"""``\mid`` form is normalized to a conditional bar."""
+        result, funcs = _rewrite_conditional_bar(r"P(A \mid B)")
+        assert result == r"P(A, B)"
+        assert funcs == {"P"}
+
+    def test_mid_command_no_polynomial_redos(self):
+        r"""Many spaces before ``\mid`` must not cause catastrophic backtracking."""
+        # 500 spaces before \mid — would be O(n²) with the old regex.
+        padded = r"P(A" + " " * 500 + r"\mid B)"
+        result, funcs = _rewrite_conditional_bar(padded)
+        assert result == r"P(A, B)"
+        assert funcs == {"P"}
+
 
 # ── Unit tests: _restore_conditional_bar_in_subexpr ────────────────────
 


### PR DESCRIPTION
## Security Alert Triage

### Alerts Addressed
- **Alert #116** (`py/polynomial-redos`, HIGH): `_rewrite_conditional_bar` in `backend/semantic_graph/sympy_translator.py:313` used `re.sub(r"\s*\\mid\b\s*", "|", body)` where `body` is derived from user-supplied LaTeX. The leading `\s*` causes O(n²) backtracking when the input contains many spaces not followed by `\mid` (e.g. a crafted string of 500 spaces).

### Changes
- **`backend/semantic_graph/sympy_translator.py`**: Replaced the polynomial regex with a linear-time `str.find()` loop — the same pattern already in use at the `\begin{cases}` parser (line 1747, comment "Use simple string search instead of regex to avoid polynomial backtracking on crafted input"). The replacement correctly handles word-boundary semantics (skips `\middle`, strips surrounding whitespace) and is functionally equivalent.
- **`tests/backend/semantic_graph/test_conditional_bar.py`**: Added `test_mid_command_rewrite` (verifies `P(A \mid B)` → `P(A, B)`) and `test_mid_command_no_polynomial_redos` (500 spaces before `\mid` — regression guard for the ReDoS case).

### Test Plan
- [x] Exhaustive test suite passed (`--exhaustive`, 4683 passed, 0 failed, ~149s)
- [x] Server smoke test passed: `/api/health`, `/api/scenes`, `/api/domains`, `/api/graph/themes` all returned 200
- [x] Fix directly addresses the flagged code path (alert #116, `sympy_translator.py:313`)

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>