### PR TITLE
chore(deploy): unify Render Blueprint on main (prod + staging)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,8 +1,31 @@
+# Render Blueprint defining BOTH environments. This file is intentionally
+# identical on the deploy/on-render and deploy/on-render-staging branches so
+# the two never diverge (promoting staging -> prod stays a clean merge).
+#
+# A single Blueprint manages both services; each deploys from the branch it
+# pins via `branch:`, regardless of which branch the Blueprint reads this file
+# from. Per-environment secrets (GEMINI_API_KEY, ALGEBENCH_TTS_REALTIME,
+# ALGEBENCH_RATELIMIT_*) are set in each service's dashboard, not here.
 services:
+  # --- Production: deploys from deploy/on-render ---
   - type: web
-    name: algebench-graph
+    name: algebench-prod
     runtime: python
     plan: free
+    branch: deploy/on-render
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn backend.asgi:app --host 0.0.0.0 --port $PORT
+    healthCheckPath: /api/health
+    envVars:
+      - key: PYTHON_VERSION
+        value: "3.12.7"
+
+  # --- Staging: deploys from deploy/on-render-staging ---
+  - type: web
+    name: algebench-staging
+    runtime: python
+    plan: free
+    branch: deploy/on-render-staging
     buildCommand: pip install -r requirements.txt
     startCommand: uvicorn backend.asgi:app --host 0.0.0.0 --port $PORT
     healthCheckPath: /api/health


### PR DESCRIPTION
## Summary
- Bring the combined two-service Render Blueprint onto `main`, so `render.yaml` is byte-identical across `main`, `deploy/on-render` (prod), and `deploy/on-render-staging` (staging).
- Each service pins its own deploy branch via `branch:`; per-environment secrets (`GEMINI_API_KEY`, `ALGEBENCH_TTS_REALTIME`, `ALGEBENCH_RATELIMIT_*`) live in each service's Render dashboard, not in the repo.

## Why
Keeps future `main → deploy/*` merges and the staging → prod promotion conflict-free — the deploy branches no longer carry a unique `render.yaml`, so they never diverge from `main`.

## Test plan
- [x] `render.yaml` parses as valid Blueprint YAML
- [x] Both Render services (`algebench-prod`, `algebench-staging`) already deployed and healthy from this config
- [x] Confirm no Render Blueprint re-sync side effects after merge

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>