### PR TITLE
feat(scene): productionize quantum-states Bloch Sphere lesson

### DIFF
--- a/scenes/quantum-states.json
+++ b/scenes/quantum-states.json
@@ -1,0 +1,4368 @@
+{
+  "title": "Quantum States on the Bloch Sphere",
+  "scenes": [
+    {
+      "title": "A Qubit Lives in $\\mathbb{C}^2$",
+      "description": "Every two-level quantum system — an electron spin, a photon polarization, a superconducting circuit — is described by two complex amplitudes.",
+      "markdown": "# A Qubit Lives in $\\mathbb{C}^2$\n\nConsider an electron passing through a Stern–Gerlach magnet. The beam splits into exactly **two** spots: spin-up and spin-down. Before measurement, the electron is in a superposition\n\n$$|\\psi\\rangle = \\alpha|{\\uparrow}\\rangle + \\beta|{\\downarrow}\\rangle$$\n\nwhere $\\alpha$ and $\\beta$ are **complex numbers** satisfying $|\\alpha|^2+|\\beta|^2=1$.\n\nThe same math describes photon polarization ($|H\\rangle, |V\\rangle$), superconducting qubits ($|0\\rangle, |1\\rangle$), and any other two-level quantum system.\n\n## Same qubit, different hardware\n\nOnce a basis is chosen, the symbols mean the same mathematical thing in every platform, but their physical interpretation changes:\n\n| System | Basis states | $\\alpha, \\beta$ encode | $\\theta$ encodes | $\\phi$ encodes |\n|--------|--------------|-------------------------|-------------------|-----------------|\n| Electron spin | $|\\uparrow_z\\rangle, |\\downarrow_z\\rangle$ | Spin-up / spin-down amplitudes in the $z$ basis | Tilt away from the $+z$ axis, which sets the spin-up vs spin-down population balance | Azimuth of the spin direction; affects $x$- and $y$-basis measurements |\n| Photon polarization | $|H\\rangle, |V\\rangle$ | Horizontal / vertical field amplitudes | How much of the state is in $H$ versus $V$ | Phase delay between $H$ and $V$, setting linear vs elliptical/circular polarization |\n| Two-level atom | $|g\\rangle, |e\\rangle$ | Ground / excited-state amplitudes | Population balance between $|g\\rangle$ and $|e\\rangle$ | Phase of the atomic coherence (dipole oscillation) |\n| Superconducting qubit | $|0\\rangle, |1\\rangle$ | Amplitudes of the two logical energy eigenstates | Ground-versus-excited occupation | Relative phase seen in coherent control and Ramsey interference |\n| Interferometer path qubit | $|A\\rangle, |B\\rangle$ | Probability amplitudes for the two paths | How strongly the state favors path $A$ or path $B$ | Optical phase difference accumulated between the paths |\n\nAcross all of these examples, $\\alpha$ and $\\beta$ are the raw complex amplitudes in the chosen basis. After imposing normalization and discarding global phase, the same state can always be written with two real angles:\n\n$$|\\psi\\rangle = \\cos\\left(\\frac{\\theta}{2}\\right)|0\\rangle + e^{i\\phi}\\sin\\left(\\frac{\\theta}{2}\\right)|1\\rangle.$$\n\nHere $\\theta$ determines the population balance in the chosen basis, while $\\phi$ determines the relative phase that shows up in interference and in measurements away from that basis.\n\n## From four real numbers to two\n\nTwo complex numbers have **four** real parameters. But:\n1. **Normalization** ($|\\alpha|^2+|\\beta|^2=1$) removes one.\n2. **Global phase** ($e^{i\\gamma}|\\psi\\rangle$ is the same state as $|\\psi\\rangle$) removes another.\n\nTwo real parameters remain — just enough to specify a point on a **sphere**.",
+      "prompt": "Start from a physical example (electron spin in Stern-Gerlach). Build the connection: physical system → two complex amplitudes → normalization constraint → global phase invariance → two real parameters → sphere. Keep the colors consistent: cyan for alpha/|0>, coral for beta/|1>, gold for the state, green for the normalization circle.",
+      "range": [
+        [
+          -1.3,
+          1.3
+        ],
+        [
+          -1.3,
+          1.3
+        ],
+        [
+          -1.3,
+          1.3
+        ]
+      ],
+      "camera": {
+        "position": [
+          0,
+          0,
+          5
+        ],
+        "target": [
+          0,
+          0,
+          0
+        ]
+      },
+      "views": [
+        {
+          "name": "Face On",
+          "position": [
+            0,
+            0,
+            5
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "description": "Complex plane view"
+        },
+        {
+          "name": "Iso",
+          "position": [
+            3,
+            2,
+            3
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "description": "Three-dimensional perspective"
+        }
+      ],
+      "elements": [
+        {
+          "id": "s0_axis_re",
+          "type": "axis",
+          "axis": "x",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": "#ff4444",
+          "width": 1.2,
+          "label": "$\\text{Re}$"
+        },
+        {
+          "id": "s0_axis_im",
+          "type": "axis",
+          "axis": "y",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": "#4488ff",
+          "width": 1.2,
+          "label": "$\\text{Im}$"
+        },
+        {
+          "id": "s0_grid",
+          "type": "grid",
+          "plane": "xy",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": [
+            0.28,
+            0.28,
+            0.45
+          ],
+          "opacity": 0.15,
+          "divisions": 12
+        }
+      ],
+      "steps": [
+        {
+          "title": "Two outcomes",
+          "description": "An electron in a magnetic field can only be measured spin-up or spin-down. Before measurement, the state is a superposition $|\\psi\\rangle = \\alpha|{\\uparrow}\\rangle + \\beta|{\\downarrow}\\rangle$, where $\\alpha$ and $\\beta$ are each complex numbers — together they form a vector in $\\mathbb{C}^2$, a four-real-dimensional space. We show them in one diagram for convenience, but remember each lives in its own copy of $\\mathbb{C}$.",
+          "prompt": "Introduce the Stern-Gerlach experiment. Two spots on the screen → two basis states. But before measurement, the electron doesn't have a definite spin. Emphasize that alpha and beta each live in their own copy of C — together they form a vector in C^2, which has four real dimensions. We are drawing both in one complex plane for visual convenience, not because they share a single plane.",
+          "add": [
+            {
+              "id": "s0_alpha_vec",
+              "type": "vector",
+              "from": [
+                0,
+                0,
+                0
+              ],
+              "to": [
+                1,
+                0,
+                0
+              ],
+              "color": "#66d9ff",
+              "width": 4,
+              "label": "$\\alpha$"
+            },
+            {
+              "id": "s0_beta_vec",
+              "type": "vector",
+              "from": [
+                0,
+                0,
+                0
+              ],
+              "to": [
+                0,
+                0.4,
+                0
+              ],
+              "color": "#ff7b72",
+              "width": 4,
+              "label": "$\\beta$",
+              "labelOffset": [
+                -0.25,
+                0.05,
+                0
+              ]
+            }
+          ],
+          "info": [
+            {
+              "id": "s0_state_info",
+              "position": "top-right",
+              "content": "$$\\lvert\\psi\\rangle = \\alpha\\lvert{\\uparrow}\\rangle + \\beta\\lvert{\\downarrow}\\rangle$$\n$$\\alpha, \\beta \\in \\mathbb{C} \\quad\\text{(each a complex number)}$$\n$$(\\alpha, \\beta) \\in \\mathbb{C}^2 \\;\\text{— four real dimensions}$$"
+            }
+          ]
+        },
+        {
+          "title": "Same math, different physics",
+          "description": "A photon passing through a polarizer also has two outcomes: horizontal $|H\\rangle$ or vertical $|V\\rangle$. Before measurement, $|\\psi\\rangle = \\alpha|H\\rangle + \\beta|V\\rangle$ — the same two complex amplitudes.",
+          "prompt": "Show that photon polarization is exactly the same math. The cyan vector is the H amplitude, the coral vector is the V amplitude. Mention that diagonal polarization is an equal superposition, and circular polarization is when beta has a phase of pi/2.",
+          "remove": [
+            {
+              "id": "s0_state_info"
+            }
+          ],
+          "info": [
+            {
+              "id": "s0_photon_info",
+              "position": "top-right",
+              "content": "**Photon polarization**\n$$\\lvert\\psi\\rangle = \\alpha\\lvert H\\rangle + \\beta\\lvert V\\rangle$$\n$\\alpha = 1, \\beta = 0$ → horizontal\n$\\alpha = 0, \\beta = 1$ → vertical\n$\\alpha = \\beta = 1/\\sqrt{2}$ → diagonal"
+            }
+          ]
+        },
+        {
+          "title": "One framework, many systems",
+          "description": "Superconducting circuits, trapped ions, nitrogen-vacancy centers — every two-level quantum system maps to the same $\\alpha|0\\rangle + \\beta|1\\rangle$.",
+          "prompt": "Drive home the universality: electron spin, photon polarization, superconducting transmon, trapped ion, NV center — all are the same two-complex-number problem. This is why the qubit abstraction is so powerful. Use the standard |0>, |1> labels from here on.",
+          "remove": [
+            {
+              "id": "s0_photon_info"
+            }
+          ],
+          "info": [
+            {
+              "id": "s0_universal_info",
+              "position": "top-right",
+              "content": "**The qubit abstraction**\n$$\\lvert\\psi\\rangle = \\alpha\\lvert 0\\rangle + \\beta\\lvert 1\\rangle$$\n\n| System | $\\lvert 0\\rangle$ | $\\lvert 1\\rangle$ |\n|--------|-----------|----------|\n| Electron spin | $\\lvert{\\uparrow}\\rangle$ | $\\lvert{\\downarrow}\\rangle$ |\n| Photon | $\\lvert H\\rangle$ | $\\lvert V\\rangle$ |\n| Transmon | ground | excited |\n| Trapped ion | $S_{1/2}$ | $D_{5/2}$ |"
+            }
+          ]
+        },
+        {
+          "title": "Global phase — fixing the gauge",
+          "description": "If you rotate both $\\alpha$ and $\\beta$ by the exact same angle (a 'global phase'), nothing physical changes — no measurement can tell the difference. Because of this, we can always rotate our perspective until $\\alpha$ lands on the real axis. Physicists call this choice **gauge fixing**: picking one representative from a family of physically identical states. It doesn't lose any information; it just strips away the one dimension that the universe doesn't care about.",
+          "prompt": "Explain global phase intuitively: multiplying the whole state by e^{i gamma} is like rotating both arrows by the same angle — all relative relationships stay the same, so no experiment can detect it. We exploit this by choosing gamma so that alpha lands on the positive real axis. Introduce the term 'gauge fixing' — choosing a convention to eliminate redundancy. This removes one of our four real parameters, leaving three. The next step (normalization) will remove one more."
+        },
+        {
+          "title": "Normalization",
+          "description": "The total probability must be 1, so $|\\alpha|^2 + |\\beta|^2 = 1$. With global phase already removed, this constraint reduces our three remaining parameters to two — just enough for a point on a sphere.",
+          "prompt": "Show the normalization constraint geometrically. Explain that in the full four-real-dimensional space, |alpha|^2+|beta|^2=1 defines S^3. We simplify the picture by gauge-fixing alpha to be real (choosing a global phase), so the circle you see is a slice of S^3, not the whole constraint surface. The tip of alpha traces part of this circle, and beta gets whatever is left. Four real numbers minus normalization minus global phase = two real parameters.",
+          "add": [
+            {
+              "id": "s0_norm_circle",
+              "type": "parametric_curve",
+              "x": "cos(t)",
+              "y": "sin(t)",
+              "z": "0",
+              "range": [
+                0,
+                6.283185307179586
+              ],
+              "samples": 120,
+              "color": "#7bd389",
+              "width": 2,
+              "opacity": 0.5
+            }
+          ],
+          "remove": [
+            {
+              "id": "s0_alpha_vec"
+            },
+            {
+              "id": "s0_beta_vec"
+            },
+            {
+              "id": "s0_state_info"
+            }
+          ],
+          "sliders": [
+            {
+              "id": "s0_theta",
+              "label": "$\\theta$",
+              "min": 0,
+              "max": 3.141592653589793,
+              "step": 0.01,
+              "default": 0.8
+            }
+          ],
+          "info": [
+            {
+              "id": "s0_norm_info",
+              "position": "top-right",
+              "content": "$$\\lvert\\alpha\\rvert^2 + \\lvert\\beta\\rvert^2 = 1 \\;\\text{(defines } S^3 \\text{ in } \\mathbb{C}^2\\text{)}$$\n$$\\text{Gauge fix: choose } \\alpha \\text{ real} \\geq 0$$\n$$\\alpha = \\cos\\left(\\frac{\\theta}{2}\\right) = {{toFixed(cos(s0_theta/2),3)}}$$\n$$\\lvert\\beta\\rvert = \\sin\\left(\\frac{\\theta}{2}\\right) = {{toFixed(sin(s0_theta/2),3)}}$$\n$$p(0) = \\cos^2(\\theta/2) = {{toFixed(cos(s0_theta/2)^2,3)}},\\; p(1) = \\sin^2(\\theta/2) = {{toFixed(sin(s0_theta/2)^2,3)}}$$"
+            }
+          ]
+        },
+        {
+          "title": "Explore amplitudes",
+          "description": "Slide $\\theta$ to trade amplitude between $\\alpha$ and $\\beta$. At $\\theta=0$ the state is pure $|0\\rangle$; at $\\theta=\\pi$ it is pure $|1\\rangle$. Remember, $\\alpha$ is shown along the real axis because we gauge-fixed the global phase.",
+          "prompt": "Let the student play with the slider. Point out theta=0 → all alpha, theta=pi → all beta, theta=pi/2 → equal superposition. The cyan vector shrinks as the coral one grows. Note that alpha lies on the real axis because we chose the global phase to make it real — this is a convention, not a physical constraint.",
+          "add": [
+            {
+              "id": "s0_alpha_anim",
+              "type": "animated_vector",
+              "from": [
+                0,
+                0,
+                0
+              ],
+              "expr": [
+                "cos(s0_theta/2)",
+                "0",
+                "0"
+              ],
+              "color": "#66d9ff",
+              "width": 2,
+              "label": "$\\alpha = \\cos(\\theta/2)$"
+            },
+            {
+              "id": "s0_beta_anim",
+              "type": "animated_vector",
+              "from": [
+                0,
+                0,
+                0
+              ],
+              "expr": [
+                "0",
+                "sin(s0_theta/2)",
+                "0"
+              ],
+              "color": "#ff7b72",
+              "width": 2,
+              "label": "$\\beta = \\sin(\\theta/2)$"
+            }
+          ]
+        },
+        {
+          "title": "Relative phase",
+          "description": "Now let $\\beta$ become complex: $\\beta = e^{i\\phi}\\sin(\\theta/2)$. The phase $\\phi$ rotates $\\beta$ in its own complex plane without changing its magnitude. Because $\\alpha$ is gauge-fixed real, this is the **relative** phase between the two amplitudes — the only phase with physical meaning.",
+          "prompt": "Add the phi slider. Show that phi rotates the beta vector in its own complex plane without changing its length. The normalization circle stays the same. Emphasize this is a relative phase — it matters because alpha has been fixed real, so all the physically meaningful phase lives in beta. This is the second and final real parameter.",
+          "remove": [
+            {
+              "id": "s0_beta_anim"
+            }
+          ],
+          "sliders": [
+            {
+              "id": "s0_phi",
+              "label": "$\\phi$",
+              "min": 0,
+              "max": 6.283185307179586,
+              "step": 0.01,
+              "default": 0.7
+            }
+          ],
+          "add": [
+            {
+              "id": "s0_beta_phase",
+              "type": "animated_vector",
+              "from": [
+                0,
+                0,
+                0
+              ],
+              "expr": [
+                "sin(s0_theta/2)*cos(s0_phi)",
+                "sin(s0_theta/2)*sin(s0_phi)",
+                "0"
+              ],
+              "color": "#ff7b72",
+              "width": 2,
+              "label": "$\\beta = e^{i\\phi}\\sin(\\theta/2)$"
+            },
+            {
+              "id": "s0_phase_arc",
+              "type": "parametric_curve",
+              "x": "sin(s0_theta/2)*cos(t)",
+              "y": "sin(s0_theta/2)*sin(t)",
+              "z": "0",
+              "range": [
+                0,
+                6.283185307179586
+              ],
+              "samples": 80,
+              "color": "#c77dff",
+              "width": 1.5,
+              "opacity": 0.35
+            }
+          ],
+          "info": [
+            {
+              "id": "s0_phase_info",
+              "position": "top-right",
+              "content": "$$\\alpha = \\cos\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(cos(s0_theta/2),3)}}$$\n$$\\beta = e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)$$\n$$\\lvert\\beta\\rvert = {{toFixed(sin(s0_theta/2),3)}}, \\quad \\phi = {{toFixed(s0_phi,2)}}$$"
+            }
+          ]
+        },
+        {
+          "title": "Two parameters, one sphere",
+          "description": "Two real numbers $\\theta \\in [0,\\pi]$ and $\\phi \\in [0,2\\pi)$ specify every pure qubit state. These are exactly the polar and azimuthal angles of a sphere — the **Bloch sphere**.",
+          "prompt": "This is the first bridge. Summarize: we started with 4 real parameters, removed 2 (normalization + global phase), and arrived at theta and phi. The next scene puts the physical electron beside its Hilbert-space description; the scene after that turns those same parameters into the Bloch sphere.",
+          "info": [
+            {
+              "id": "s0_summary",
+              "position": "top-right",
+              "content": "$$\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle$$\n$$\\theta = {{toFixed(s0_theta,2)}}, \\quad \\phi = {{toFixed(s0_phi,2)}}$$\n$$\\text{Two angles} \\longrightarrow \\text{one sphere}$$"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "From Electron Spin to Hilbert Space",
+      "description": "The electron on the left is the physical system; the ket on the right is the abstract Hilbert-space description used to predict what a spin measurement can return.",
+      "markdown": "# From Electron Spin to Hilbert Space\n\nA Stern-Gerlach experiment asks a concrete physical question: if we measure spin along the $z$ axis, do we get **up** or **down**?\n\nThat laboratory question defines a basis:\n\n$$\\lvert\\uparrow_z\\rangle, \\qquad \\lvert\\downarrow_z\\rangle.$$\n\nOnce that basis is chosen, we represent the **same physical electron** by a vector in a two-dimensional complex Hilbert space:\n\n$$\\lvert\\psi\\rangle = \\alpha\\lvert\\uparrow_z\\rangle + \\beta\\lvert\\downarrow_z\\rangle.$$\n\nThe left panel shows the laboratory picture. The right panel shows the Hilbert-space coordinates. Those coordinates are **not** a position in ordinary space; they are amplitudes that encode measurement probabilities and relative phase.\n\nFor a pure qubit, normalization and the irrelevance of global phase reduce the description to two real parameters. That reduction is what makes the Bloch-sphere picture possible in the next scene.",
+      "prompt": "Teach this as the conceptual bridge the lesson needs. Left panel: real laboratory system and the chosen z-basis measurement. Right panel: the same state written in Hilbert-space coordinates. Be explicit that Hilbert space is not physical space; it is the abstract state space used to predict outcomes. Use cyan for the up basis component, coral for the down basis component, gold for the state, and magenta for relative phase.",
+      "range": [
+        [
+          -5.2,
+          5.2
+        ],
+        [
+          -5.2,
+          5.2
+        ],
+        [
+          -5.2,
+          5.2
+        ]
+      ],
+      "camera": {
+        "position": [
+          0,
+          -8,
+          0.8
+        ],
+        "target": [
+          0,
+          0,
+          0
+        ],
+        "up": [
+          0,
+          0,
+          1
+        ]
+      },
+      "views": [
+        {
+          "name": "Side By Side",
+          "position": [
+            0,
+            -8,
+            0.8
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            0,
+            1
+          ],
+          "description": "Compare the physical system and the Hilbert-space picture"
+        },
+        {
+          "name": "Physical",
+          "position": [
+            -3.2,
+            -5.2,
+            0.8
+          ],
+          "target": [
+            -3.2,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            0,
+            1
+          ],
+          "description": "Focus on the electron and the measurement axis"
+        },
+        {
+          "name": "Hilbert",
+          "position": [
+            2.6,
+            -5.2,
+            0.6
+          ],
+          "target": [
+            2.6,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            0,
+            1
+          ],
+          "description": "Focus on the ket and its amplitudes"
+        },
+        {
+          "name": "Top",
+          "position": [
+            0,
+            0,
+            6
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            1,
+            0
+          ],
+          "description": "See the azimuthal phase rotation in the Hilbert-space panel"
+        }
+      ],
+      "elements": [
+        {
+          "id": "hs_divider",
+          "type": "line",
+          "from": [
+            0,
+            0,
+            -1.9
+          ],
+          "to": [
+            0,
+            0,
+            1.9
+          ],
+          "color": "#5c667a",
+          "width": 1.2,
+          "opacity": 0.6
+        },
+        {
+          "id": "hs_left_title",
+          "type": "text",
+          "position": [
+            -3.2,
+            0,
+            1.95
+          ],
+          "text": "Physical system",
+          "color": "#ffd166",
+          "size": 13
+        },
+        {
+          "id": "hs_right_title",
+          "type": "text",
+          "position": [
+            2.6,
+            0,
+            1.95
+          ],
+          "text": "Hilbert-space state",
+          "color": "#a6c8ff",
+          "size": 13
+        }
+      ],
+      "steps": [
+        {
+          "title": "A real experiment gives two outcomes",
+          "description": "On the left is the physical electron. A Stern-Gerlach measurement along $z$ can only return spin-up or spin-down, so the laboratory setup defines a two-state basis.",
+          "prompt": "Start with the laboratory picture only. Say explicitly that the apparatus asks a yes-no question about spin along z, and that the two answers become the basis states.",
+          "add": [
+            {
+              "id": "hs_lab_axis",
+              "type": "line",
+              "from": [
+                -3.2,
+                0,
+                -1.35
+              ],
+              "to": [
+                -3.2,
+                0,
+                1.35
+              ],
+              "color": "#4488ff",
+              "width": 1.6
+            },
+            {
+              "id": "hs_up_state",
+              "type": "point",
+              "position": [
+                -3.2,
+                0,
+                1.2
+              ],
+              "color": "#66d9ff",
+              "size": 9
+            },
+            {
+              "id": "hs_up_label",
+              "type": "text",
+              "position": [
+                -3.55,
+                0,
+                1.05
+              ],
+              "text": "$\\lvert\\uparrow_z\\rangle$",
+              "color": "#66d9ff",
+              "size": 11
+            },
+            {
+              "id": "hs_down_state",
+              "type": "point",
+              "position": [
+                -3.2,
+                0,
+                -1.2
+              ],
+              "color": "#ff7b72",
+              "size": 9
+            },
+            {
+              "id": "hs_down_label",
+              "type": "text",
+              "position": [
+                -3.62,
+                0,
+                -1.05
+              ],
+              "text": "$\\lvert\\downarrow_z\\rangle$",
+              "color": "#ff7b72",
+              "size": 11
+            },
+            {
+              "id": "hs_electron",
+              "type": "point",
+              "position": [
+                -3.2,
+                0,
+                0
+              ],
+              "color": "#ffd166",
+              "size": 10
+            },
+            {
+              "id": "hs_spin_fixed",
+              "type": "vector",
+              "from": [
+                -3.2,
+                0,
+                0
+              ],
+              "to": [
+                -2.35,
+                0,
+                0.92
+              ],
+              "color": "#ffd166",
+              "width": 1
+            },
+            {
+              "id": "hs_spin_fixed_label",
+              "type": "text",
+              "position": [
+                -2.35,
+                0,
+                0.18
+              ],
+              "text": "spin state",
+              "color": "#ffd166",
+              "size": 11
+            }
+          ],
+          "info": [
+            {
+              "id": "hs_lab_info",
+              "position": "top-right",
+              "content": "**Laboratory question**\n$$\\text{Measure spin along } z$$\n$$\\text{Possible outcomes: } \\lvert\\uparrow_z\\rangle,\\ \\lvert\\downarrow_z\\rangle$$"
+            }
+          ]
+        },
+        {
+          "title": "Write the same state as a ket",
+          "description": "Now place the Hilbert-space description next to the laboratory picture. The electron is still the same system, but on the right we encode it by amplitudes in the chosen basis.",
+          "prompt": "Introduce the right panel as an abstract coordinate system, not as a second physical object. The student should understand that the ket is the mathematical representation of the same electron.",
+          "add": [
+            {
+              "id": "hs_top_slot",
+              "type": "line",
+              "from": [
+                1.8,
+                0,
+                0.8
+              ],
+              "to": [
+                3.9,
+                0,
+                0.8
+              ],
+              "color": "#66d9ff44",
+              "width": 3
+            },
+            {
+              "id": "hs_bottom_slot",
+              "type": "line",
+              "from": [
+                1.8,
+                0,
+                -0.8
+              ],
+              "to": [
+                3.9,
+                0,
+                -0.8
+              ],
+              "color": "#ff7b7244",
+              "width": 3
+            },
+            {
+              "id": "hs_top_basis",
+              "type": "text",
+              "position": [
+                0.7,
+                0,
+                0.92
+              ],
+              "text": "up basis",
+              "color": "#66d9ff",
+              "size": 11
+            },
+            {
+              "id": "hs_bottom_basis",
+              "type": "text",
+              "position": [
+                0.7,
+                0,
+                -0.68
+              ],
+              "text": "down basis",
+              "color": "#ff7b72",
+              "size": 11
+            },
+            {
+              "id": "hs_alpha_fixed",
+              "type": "vector",
+              "from": [
+                1.8,
+                0,
+                0.8
+              ],
+              "to": [
+                3.6165,
+                0,
+                0.8
+              ],
+              "color": "#66d9ff",
+              "width": 1.5
+            },
+            {
+              "id": "hs_alpha_fixed_label",
+              "type": "text",
+              "position": [
+                2.62,
+                0,
+                1.02
+              ],
+              "text": "$\\alpha$",
+              "color": "#66d9ff",
+              "size": 12
+            },
+            {
+              "id": "hs_beta_fixed",
+              "type": "vector",
+              "from": [
+                1.8,
+                0,
+                -0.8
+              ],
+              "to": [
+                2.852,
+                0,
+                -0.8
+              ],
+              "color": "#ff7b72",
+              "width": 1.5
+            },
+            {
+              "id": "hs_beta_fixed_label",
+              "type": "text",
+              "position": [
+                2.18,
+                0,
+                -0.58
+              ],
+              "text": "$\\beta$",
+              "color": "#ff7b72",
+              "size": 12
+            }
+          ],
+          "info": [
+            {
+              "id": "hs_ket_info",
+              "position": "top-right",
+              "content": "$$\\lvert\\psi\\rangle = \\alpha\\lvert\\uparrow_z\\rangle + \\beta\\lvert\\downarrow_z\\rangle$$\n$$\\alpha,\\beta\\in\\mathbb{C}, \\qquad |\\alpha|^2 + |\\beta|^2 = 1$$\n$$\\text{Right panel = abstract Hilbert-space coordinates}$$"
+            }
+          ]
+        },
+        {
+          "title": "One physical state, two amplitudes",
+          "description": "Changing the state on the left changes the amplitudes on the right. The physical electron and the Hilbert-space ket are two views of the same state, not two different systems.",
+          "prompt": "Add theta as the bridge parameter. As the physical spin tilts, the Hilbert-space amplitudes change in lockstep. Emphasize that theta sets the population balance in the chosen z basis.",
+          "remove": [
+            {
+              "id": "hs_spin_fixed"
+            },
+            {
+              "id": "hs_spin_fixed_label"
+            },
+            {
+              "id": "hs_alpha_fixed"
+            },
+            {
+              "id": "hs_alpha_fixed_label"
+            },
+            {
+              "id": "hs_beta_fixed"
+            },
+            {
+              "id": "hs_beta_fixed_label"
+            }
+          ],
+          "sliders": [
+            {
+              "id": "hs_theta",
+              "label": "$\\theta$",
+              "min": 0,
+              "max": 3.141592653589793,
+              "step": 0.01,
+              "default": 1.05
+            }
+          ],
+          "add": [
+            {
+              "id": "hs_spin_theta",
+              "type": "animated_vector",
+              "from": [
+                -3.2,
+                0,
+                0
+              ],
+              "expr": [
+                "-3.2 + 1.05*sin(hs_theta)",
+                "0",
+                "1.05*cos(hs_theta)"
+              ],
+              "color": "#ffd166",
+              "width": 1
+            },
+            {
+              "id": "hs_spin_theta_label",
+              "type": "text",
+              "positionExpr": [
+                "-2.3 + 0.55*sin(hs_theta)",
+                "0",
+                "0.18 + 0.25*cos(hs_theta)"
+              ],
+              "text": "same state",
+              "color": "#ffd166",
+              "size": 11
+            },
+            {
+              "id": "hs_alpha_bar",
+              "type": "animated_vector",
+              "from": [
+                1.8,
+                0,
+                0.8
+              ],
+              "expr": [
+                "1.8 + 2.1*cos(hs_theta/2)",
+                "0",
+                "0.8"
+              ],
+              "color": "#66d9ff",
+              "width": 1.5
+            },
+            {
+              "id": "hs_alpha_bar_label",
+              "type": "text",
+              "positionExpr": [
+                "2.05 + 1.0*cos(hs_theta/2)",
+                "0",
+                "1.02"
+              ],
+              "text": "$\\alpha$",
+              "color": "#66d9ff",
+              "size": 12
+            },
+            {
+              "id": "hs_beta_bar",
+              "type": "animated_vector",
+              "from": [
+                1.8,
+                0,
+                -0.8
+              ],
+              "expr": [
+                "1.8 + 2.1*sin(hs_theta/2)",
+                "0",
+                "-0.8"
+              ],
+              "color": "#ff7b72",
+              "width": 1.5
+            },
+            {
+              "id": "hs_beta_bar_label",
+              "type": "text",
+              "positionExpr": [
+                "2.05 + 1.0*sin(hs_theta/2)",
+                "0",
+                "-0.58"
+              ],
+              "text": "$|\\beta|$",
+              "color": "#ff7b72",
+              "size": 12
+            }
+          ],
+          "info": [
+            {
+              "id": "hs_theta_info",
+              "position": "top-right",
+              "content": "$$\\alpha = \\cos\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(cos(hs_theta/2), 3)}}$$\n$$|\\beta| = \\sin\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(sin(hs_theta/2), 3)}}$$\n$$\\theta = {{toFixed(hs_theta, 2)}}\\ \\text{controls the up/down balance}$$\n$$p(0) = \\cos^2(\\theta/2) = {{toFixed(cos(hs_theta/2)^2,3)}},\\; p(1) = \\sin^2(\\theta/2) = {{toFixed(sin(hs_theta/2)^2,3)}}$$"
+            }
+          ]
+        },
+        {
+          "title": "Relative phase completes the ket",
+          "description": "The amplitudes are complex, so magnitude is not the whole story. The relative phase $\\phi$ lives naturally in Hilbert space and, for electron spin, also changes the spin direction in a physically meaningful way.",
+          "prompt": "Add phi carefully. The right panel should make clear that beta is complex, not just a positive length. Since this is electron spin, you can also let the left arrow rotate with phi and point out that this direct geometric reading is special to some systems.",
+          "remove": [
+            {
+              "id": "hs_spin_theta"
+            },
+            {
+              "id": "hs_spin_theta_label"
+            }
+          ],
+          "sliders": [
+            {
+              "id": "hs_phi",
+              "label": "$\\phi$",
+              "min": 0,
+              "max": 6.283185307179586,
+              "step": 0.01,
+              "default": 0.9
+            }
+          ],
+          "add": [
+            {
+              "id": "hs_spin_full",
+              "type": "animated_vector",
+              "from": [
+                -3.2,
+                0,
+                0
+              ],
+              "expr": [
+                "-3.2 + 1.05*sin(hs_theta)*cos(hs_phi)",
+                "1.05*sin(hs_theta)*sin(hs_phi)",
+                "1.05*cos(hs_theta)"
+              ],
+              "color": "#ffd166",
+              "width": 1
+            },
+            {
+              "id": "hs_spin_full_label",
+              "type": "text",
+              "positionExpr": [
+                "-2.3 + 0.55*sin(hs_theta)*cos(hs_phi)",
+                "0",
+                "0.18 + 0.25*cos(hs_theta)"
+              ],
+              "text": "spin direction",
+              "color": "#ffd166",
+              "size": 11
+            },
+            {
+              "id": "hs_phase_disk",
+              "type": "parametric_curve",
+              "x": "1.8 + 2.1*sin(hs_theta/2)",
+              "y": "0.32*cos(t)",
+              "z": "-0.8 + 0.32*sin(t)",
+              "range": [
+                0,
+                6.283185307179586
+              ],
+              "samples": 80,
+              "color": "#c77dff",
+              "width": 1.5,
+              "opacity": 0.4
+            },
+            {
+              "id": "hs_beta_phase",
+              "type": "animated_vector",
+              "fromExpr": [
+                "1.8 + 2.1*sin(hs_theta/2)",
+                "0",
+                "-0.8"
+              ],
+              "expr": [
+                "1.8 + 2.1*sin(hs_theta/2)",
+                "0.32*cos(hs_phi)",
+                "-0.8 + 0.32*sin(hs_phi)"
+              ],
+              "color": "#c77dff",
+              "width": 2
+            },
+            {
+              "id": "hs_beta_phase_label",
+              "type": "text",
+              "positionExpr": [
+                "1.8 + 2.1*sin(hs_theta/2)",
+                "0.32*cos(hs_phi)",
+                "-0.8 + 0.32*sin(hs_phi)"
+              ],
+              "text": "$\\phi$",
+              "color": "#c77dff",
+              "size": 12
+            }
+          ],
+          "info": [
+            {
+              "id": "hs_phase_info",
+              "position": "top-right",
+              "content": "$$\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert\\uparrow_z\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert\\downarrow_z\\rangle$$\n$$\\theta = {{toFixed(hs_theta, 2)}},\\qquad \\phi = {{toFixed(hs_phi, 2)}}$$\n$$\\text{Hilbert space keeps track of both population balance and relative phase}$$"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "From Hilbert Space to the Bloch Sphere",
+      "description": "The amplitudes on the left and the Bloch vector on the right are two pictures of the same pure qubit state.",
+      "markdown": "# From Hilbert Space to the Bloch Sphere\n\nOn the left, a pure qubit is written in Hilbert space as\n\n$$\\lvert\\psi\\rangle = \\alpha\\lvert 0\\rangle + \\beta\\lvert 1\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle.$$\n\nOn the right, the **same state** is represented by a Bloch vector\n\n$$\\vec r = (\\sin\\theta\\cos\\phi,\\; \\sin\\theta\\sin\\phi,\\; \\cos\\theta).$$\n\nThis is not a change of physics; it is a change of coordinates.\n\n- In the Hilbert-space picture, $\\alpha$ and $\\beta$ are complex amplitudes.\n- In the Bloch-sphere picture, the same information is compressed into a point on the unit sphere.\n- $\\theta$ controls the balance between $\\lvert 0\\rangle$ and $\\lvert 1\\rangle$.\n- $\\phi$ controls the relative phase.\n\nSo the Bloch sphere is a geometric summary of the pure-state Hilbert-space data for one qubit.",
+      "prompt": "Teach this as a true coordinate-change scene. Left panel: Hilbert-space amplitudes. Right panel: Bloch-sphere geometry. Keep saying 'same state, different representation.' Use cyan for the |0>/alpha channel, coral for the |1>/beta channel, gold for the state, green for latitude/z information, and magenta for phase/azimuth.",
+      "range": [
+        [
+          -5.2,
+          5.2
+        ],
+        [
+          -5.2,
+          5.2
+        ],
+        [
+          -5.2,
+          5.2
+        ]
+      ],
+      "camera": {
+        "position": [
+          0,
+          -8,
+          0.8
+        ],
+        "target": [
+          0,
+          0,
+          0
+        ],
+        "up": [
+          0,
+          0,
+          1
+        ]
+      },
+      "views": [
+        {
+          "name": "Side By Side",
+          "position": [
+            0,
+            -8,
+            0.8
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            0,
+            1
+          ],
+          "description": "Compare Hilbert amplitudes and the Bloch vector"
+        },
+        {
+          "name": "Hilbert",
+          "position": [
+            -2.6,
+            -5.5,
+            0.6
+          ],
+          "target": [
+            -2.6,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            0,
+            1
+          ],
+          "description": "Focus on the amplitude picture"
+        },
+        {
+          "name": "Bloch",
+          "position": [
+            2.6,
+            -5.5,
+            0.6
+          ],
+          "target": [
+            2.6,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            0,
+            1
+          ],
+          "description": "Focus on the sphere picture"
+        },
+        {
+          "name": "Top",
+          "position": [
+            2.6,
+            0,
+            6
+          ],
+          "target": [
+            2.6,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            1,
+            0
+          ],
+          "description": "Look down the Bloch z-axis to see azimuth"
+        }
+      ],
+      "elements": [
+        {
+          "id": "hb_divider",
+          "type": "line",
+          "from": [
+            0,
+            0,
+            -2.0
+          ],
+          "to": [
+            0,
+            0,
+            2.0
+          ],
+          "color": "#5c667a",
+          "width": 1.2,
+          "opacity": 0.6
+        },
+        {
+          "id": "hb_left_title",
+          "type": "text",
+          "position": [
+            -2.6,
+            0,
+            1.95
+          ],
+          "text": "Hilbert-space coordinates",
+          "color": "#a6c8ff",
+          "size": 13
+        },
+        {
+          "id": "hb_right_title",
+          "type": "text",
+          "position": [
+            2.6,
+            0,
+            1.95
+          ],
+          "text": "Bloch-sphere picture",
+          "color": "#ffd166",
+          "size": 13
+        }
+      ],
+      "steps": [
+        {
+          "title": "The ket already has the needed data",
+          "description": "Hilbert space stores the state in two complex amplitudes. Those amplitudes already contain everything the Bloch sphere will show geometrically.",
+          "prompt": "Start from the left panel. The key idea is that we are not adding information when we go to the Bloch sphere; we are reorganizing it.",
+          "add": [
+            {
+              "id": "hb_top_slot",
+              "type": "line",
+              "from": [
+                -3.8,
+                0,
+                0.8
+              ],
+              "to": [
+                -1.7,
+                0,
+                0.8
+              ],
+              "color": "#66d9ff44",
+              "width": 3
+            },
+            {
+              "id": "hb_bottom_slot",
+              "type": "line",
+              "from": [
+                -3.8,
+                0,
+                -0.8
+              ],
+              "to": [
+                -1.7,
+                0,
+                -0.8
+              ],
+              "color": "#ff7b7244",
+              "width": 3
+            },
+            {
+              "id": "hb_top_basis",
+              "type": "text",
+              "position": [
+                -4.9,
+                0,
+                0.92
+              ],
+              "text": "|0> channel",
+              "color": "#66d9ff",
+              "size": 11
+            },
+            {
+              "id": "hb_bottom_basis",
+              "type": "text",
+              "position": [
+                -4.95,
+                0,
+                -0.68
+              ],
+              "text": "|1> channel",
+              "color": "#ff7b72",
+              "size": 11
+            },
+            {
+              "id": "hb_alpha_fixed",
+              "type": "vector",
+              "from": [
+                -3.8,
+                0,
+                0.8
+              ],
+              "to": [
+                -1.98,
+                0,
+                0.8
+              ],
+              "color": "#66d9ff",
+              "width": 1.5
+            },
+            {
+              "id": "hb_alpha_fixed_label",
+              "type": "text",
+              "position": [
+                -2.95,
+                0,
+                1.03
+              ],
+              "text": "$\\alpha$",
+              "color": "#66d9ff",
+              "size": 12
+            },
+            {
+              "id": "hb_beta_fixed",
+              "type": "vector",
+              "from": [
+                -3.8,
+                0,
+                -0.8
+              ],
+              "to": [
+                -2.75,
+                0,
+                -0.8
+              ],
+              "color": "#ff7b72",
+              "width": 1.5
+            },
+            {
+              "id": "hb_beta_fixed_label",
+              "type": "text",
+              "position": [
+                -3.38,
+                0,
+                -0.58
+              ],
+              "text": "$\\beta$",
+              "color": "#ff7b72",
+              "size": 12
+            },
+            {
+              "id": "hb_bloch_axis",
+              "type": "line",
+              "from": [
+                2.6,
+                0,
+                -1.2
+              ],
+              "to": [
+                2.6,
+                0,
+                1.2
+              ],
+              "color": "#4488ff",
+              "width": 1.4
+            },
+            {
+              "id": "hb_ket0",
+              "type": "point",
+              "position": [
+                2.6,
+                0,
+                1.0
+              ],
+              "color": "#66d9ff",
+              "size": 8
+            },
+            {
+              "id": "hb_ket0_label",
+              "type": "text",
+              "position": [
+                2.95,
+                0,
+                1.0
+              ],
+              "text": "$|0\\rangle$",
+              "color": "#66d9ff",
+              "size": 11
+            },
+            {
+              "id": "hb_ket1",
+              "type": "point",
+              "position": [
+                2.6,
+                0,
+                -1.0
+              ],
+              "color": "#ff7b72",
+              "size": 8
+            },
+            {
+              "id": "hb_ket1_label",
+              "type": "text",
+              "position": [
+                2.95,
+                0,
+                -1.0
+              ],
+              "text": "$|1\\rangle$",
+              "color": "#ff7b72",
+              "size": 11
+            },
+            {
+              "id": "hb_state_fixed",
+              "type": "vector",
+              "from": [
+                2.6,
+                0,
+                0
+              ],
+              "to": [
+                3.47,
+                0,
+                0.5
+              ],
+              "color": "#ffd166",
+              "width": 1.2
+            },
+            {
+              "id": "hb_state_fixed_label",
+              "type": "text",
+              "position": [
+                3.05,
+                0,
+                0.18
+              ],
+              "text": "same state",
+              "color": "#ffd166",
+              "size": 11
+            }
+          ],
+          "info": [
+            {
+              "id": "hb_intro_info",
+              "position": "top-right",
+              "content": "$$\\lvert\\psi\\rangle = \\alpha\\lvert 0\\rangle + \\beta\\lvert 1\\rangle$$\n$$\\alpha = \\cos\\!\\left(\\frac{\\theta}{2}\\right), \\qquad \\beta = e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)$$"
+            }
+          ]
+        },
+        {
+          "title": "$\\theta$ becomes latitude",
+          "description": "The magnitudes of $\\alpha$ and $\\beta$ determine how far up or down the Bloch vector sits. As $\\theta$ changes, the Hilbert-space bars and the Bloch latitude move together.",
+          "prompt": "Make theta the first visible bridge. On the left, alpha shrinks while beta grows. On the right, the Bloch vector slides from north pole to south pole.",
+          "remove": [
+            {
+              "id": "hb_alpha_fixed"
+            },
+            {
+              "id": "hb_alpha_fixed_label"
+            },
+            {
+              "id": "hb_beta_fixed"
+            },
+            {
+              "id": "hb_beta_fixed_label"
+            },
+            {
+              "id": "hb_state_fixed"
+            },
+            {
+              "id": "hb_state_fixed_label"
+            }
+          ],
+          "sliders": [
+            {
+              "id": "hb_theta",
+              "label": "$\\theta$",
+              "min": 0,
+              "max": 3.141592653589793,
+              "step": 0.01,
+              "default": 1.05
+            }
+          ],
+          "add": [
+            {
+              "id": "hb_alpha_bar",
+              "type": "animated_vector",
+              "from": [
+                -3.8,
+                0,
+                0.8
+              ],
+              "expr": [
+                "-3.8 + 2.1*cos(hb_theta/2)",
+                "0",
+                "0.8"
+              ],
+              "color": "#66d9ff",
+              "width": 1.5
+            },
+            {
+              "id": "hb_alpha_bar_label",
+              "type": "text",
+              "positionExpr": [
+                "-3.55 + 1.0*cos(hb_theta/2)",
+                "0",
+                "1.03"
+              ],
+              "text": "$\\alpha$",
+              "color": "#66d9ff",
+              "size": 12
+            },
+            {
+              "id": "hb_beta_bar",
+              "type": "animated_vector",
+              "from": [
+                -3.8,
+                0,
+                -0.8
+              ],
+              "expr": [
+                "-3.8 + 2.1*sin(hb_theta/2)",
+                "0",
+                "-0.8"
+              ],
+              "color": "#ff7b72",
+              "width": 1.5
+            },
+            {
+              "id": "hb_beta_bar_label",
+              "type": "text",
+              "positionExpr": [
+                "-3.55 + 1.0*sin(hb_theta/2)",
+                "0",
+                "-0.58"
+              ],
+              "text": "$|\\beta|$",
+              "color": "#ff7b72",
+              "size": 12
+            },
+            {
+              "id": "hb_sphere",
+              "type": "sphere",
+              "center": [
+                2.6,
+                0,
+                0
+              ],
+              "radius": 1,
+              "color": "#334466",
+              "opacity": 0.15,
+              "segments": 64,
+              "rings": 48,
+              "shader": {
+                "depthWrite": false
+              }
+            },
+            {
+              "id": "hb_meridian",
+              "type": "parametric_curve",
+              "x": "2.6 + sin(t)",
+              "y": "0",
+              "z": "cos(t)",
+              "range": [
+                0,
+                3.141592653589793
+              ],
+              "samples": 80,
+              "color": "#7bd389",
+              "width": 2,
+              "opacity": 0.6
+            },
+            {
+              "id": "hb_state_theta",
+              "type": "animated_vector",
+              "from": [
+                2.6,
+                0,
+                0
+              ],
+              "expr": [
+                "2.6 + sin(hb_theta)",
+                "0",
+                "cos(hb_theta)"
+              ],
+              "color": "#ffd166",
+              "width": 1.2
+            },
+            {
+              "id": "hb_state_theta_label",
+              "type": "text",
+              "positionExpr": [
+                "3.0 + 0.45*sin(hb_theta)",
+                "0",
+                "0.18 + 0.25*cos(hb_theta)"
+              ],
+              "text": "same state",
+              "color": "#ffd166",
+              "size": 11
+            },
+            {
+              "id": "hb_zproj",
+              "type": "animated_vector",
+              "from": [
+                2.6,
+                0,
+                0
+              ],
+              "expr": [
+                "2.6",
+                "0",
+                "cos(hb_theta)"
+              ],
+              "color": "#7bd389",
+              "width": 1.5,
+              "opacity": 0.5
+            }
+          ],
+          "info": [
+            {
+              "id": "hb_theta_info",
+              "position": "top-right",
+              "content": "$$\\alpha = \\cos\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(cos(hb_theta/2), 3)}}$$\n$$|\\beta| = \\sin\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(sin(hb_theta/2), 3)}}$$\n$$z = \\cos\\theta = {{toFixed(cos(hb_theta), 3)}}$$\n$$p(0) = \\cos^2(\\theta/2) = {{toFixed(cos(hb_theta/2)^2,3)}},\\; p(1) = \\sin^2(\\theta/2) = {{toFixed(sin(hb_theta/2)^2,3)}}$$"
+            }
+          ]
+        },
+        {
+          "title": "$\\phi$ becomes azimuth",
+          "description": "The relative phase rotates the state around the Bloch z-axis. On the left it is the phase of the lower amplitude; on the right it is the azimuthal angle of the Bloch vector.",
+          "prompt": "Add phi as the second bridge. Left panel: beta carries phase around a small phase circle. Right panel: the Bloch vector sweeps around the sphere at fixed latitude.",
+          "remove": [
+            {
+              "id": "hb_state_theta"
+            },
+            {
+              "id": "hb_state_theta_label"
+            },
+            {
+              "id": "hb_zproj"
+            }
+          ],
+          "sliders": [
+            {
+              "id": "hb_phi",
+              "label": "$\\phi$",
+              "min": 0,
+              "max": 6.283185307179586,
+              "step": 0.01,
+              "default": 0.9
+            }
+          ],
+          "add": [
+            {
+              "id": "hb_phase_disk",
+              "type": "parametric_curve",
+              "x": "-3.8 + 2.1*sin(hb_theta/2)",
+              "y": "0.32*cos(t)",
+              "z": "-0.8 + 0.32*sin(t)",
+              "range": [
+                0,
+                6.283185307179586
+              ],
+              "samples": 80,
+              "color": "#c77dff",
+              "width": 1.5,
+              "opacity": 0.4
+            },
+            {
+              "id": "hb_beta_phase",
+              "type": "animated_vector",
+              "fromExpr": [
+                "-3.8 + 2.1*sin(hb_theta/2)",
+                "0",
+                "-0.8"
+              ],
+              "expr": [
+                "-3.8 + 2.1*sin(hb_theta/2)",
+                "0.32*cos(hb_phi)",
+                "-0.8 + 0.32*sin(hb_phi)"
+              ],
+              "color": "#c77dff",
+              "width": 2
+            },
+            {
+              "id": "hb_beta_phase_label",
+              "type": "text",
+              "positionExpr": [
+                "-3.8 + 2.1*sin(hb_theta/2)",
+                "0.32*cos(hb_phi)",
+                "-0.8 + 0.32*sin(hb_phi)"
+              ],
+              "text": "$\\phi$",
+              "color": "#c77dff",
+              "size": 12
+            },
+            {
+              "id": "hb_equator",
+              "type": "parametric_curve",
+              "x": "2.6 + cos(t)",
+              "y": "sin(t)",
+              "z": "0",
+              "range": [
+                0,
+                6.283185307179586
+              ],
+              "samples": 120,
+              "color": "#c77dff",
+              "width": 2,
+              "opacity": 0.4
+            },
+            {
+              "id": "hb_state_full",
+              "type": "animated_vector",
+              "from": [
+                2.6,
+                0,
+                0
+              ],
+              "expr": [
+                "2.6 + sin(hb_theta)*cos(hb_phi)",
+                "sin(hb_theta)*sin(hb_phi)",
+                "cos(hb_theta)"
+              ],
+              "color": "#ffd166",
+              "width": 1.2
+            },
+            {
+              "id": "hb_state_full_label",
+              "type": "text",
+              "positionExpr": [
+                "3.0 + 0.42*sin(hb_theta)*cos(hb_phi)",
+                "0",
+                "0.18 + 0.25*cos(hb_theta)"
+              ],
+              "text": "same state",
+              "color": "#ffd166",
+              "size": 11
+            },
+            {
+              "id": "hb_phi_arc",
+              "type": "parametric_curve",
+              "x": "2.6 + sin(hb_theta)*cos(t)",
+              "y": "sin(hb_theta)*sin(t)",
+              "z": "cos(hb_theta)",
+              "range": [
+                0,
+                6.283185307179586
+              ],
+              "samples": 80,
+              "color": "#c77dff",
+              "width": 1.5,
+              "opacity": 0.35
+            }
+          ],
+          "info": [
+            {
+              "id": "hb_phi_info",
+              "position": "top-right",
+              "content": "$$\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle$$\n$$\\vec r = (\\sin\\theta\\cos\\phi,\\; \\sin\\theta\\sin\\phi,\\; \\cos\\theta)$$\n$$\\phi = {{toFixed(hb_phi, 2)}}\\ \\text{is phase on the left and azimuth on the right}$$"
+            }
+          ]
+        },
+        {
+          "title": "One state, two coordinate systems",
+          "description": "For a pure qubit, the Hilbert-space amplitudes and the Bloch vector contain exactly the same physical information. The next scene will zoom in on the Bloch sphere alone.",
+          "prompt": "Close the bridge clearly: Hilbert space and the Bloch sphere are two coordinate systems for the same pure state. The next scene can now focus purely on the sphere geometry.",
+          "info": [
+            {
+              "id": "hb_summary",
+              "position": "top-right",
+              "content": "**Same pure qubit state**\n$$\\alpha,\\beta \\quad \\Longleftrightarrow \\quad (\\theta,\\phi) \\quad \\Longleftrightarrow \\quad \\vec r \\in S^2$$\n$$\\text{Hilbert-space data} \\longleftrightarrow \\text{Bloch-sphere geometry}$$"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "From Amplitudes to Probabilities",
+      "description": "Hilbert-space amplitudes are not themselves probabilities; Born's rule says to square their magnitudes.",
+      "markdown": "# From Amplitudes to Probabilities\n\nA pure qubit written in Hilbert space has the form\n\n$$\\lvert\\psi\\rangle = \\alpha\\lvert 0\\rangle + \\beta\\lvert 1\\rangle.$$\n\nThe numbers $\\alpha$ and $\\beta$ are **probability amplitudes**, not probabilities themselves. The actual measurement probabilities are given by **Born's rule**:\n\n$$p(0)=|\\alpha|^2, \\qquad p(1)=|\\beta|^2.$$\n\nFor the Bloch-sphere parameterization,\n\n$$\\alpha = \\cos\\!\\left(\\frac{\\theta}{2}\\right), \\qquad \\beta = e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right),$$\n\nso the probabilities become\n\n$$p(0)=\\cos^2\\!\\left(\\frac{\\theta}{2}\\right), \\qquad p(1)=\\sin^2\\!\\left(\\frac{\\theta}{2}\\right).$$\n\nThe phase $\\phi$ changes interference in other bases, but it does **not** affect these computational-basis probabilities.",
+      "prompt": "Teach this as the Born's-rule bridge. Left panel: amplitudes in Hilbert space. Right panel: actual measurement probabilities. Be explicit that amplitudes are not probabilities; magnitudes squared are. Use cyan for alpha / p(0), coral for beta / p(1), and magenta only to show that phi does not change the computational-basis probabilities.",
+      "range": [
+        [
+          -5.2,
+          5.2
+        ],
+        [
+          -5.2,
+          5.2
+        ],
+        [
+          -5.2,
+          5.2
+        ]
+      ],
+      "camera": {
+        "position": [
+          0,
+          -8,
+          0.8
+        ],
+        "target": [
+          0,
+          0,
+          0
+        ],
+        "up": [
+          0,
+          0,
+          1
+        ]
+      },
+      "views": [
+        {
+          "name": "Side By Side",
+          "position": [
+            0,
+            -8,
+            0.8
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            0,
+            1
+          ],
+          "description": "Compare amplitudes and probabilities"
+        },
+        {
+          "name": "Amplitudes",
+          "position": [
+            -2.6,
+            -5.6,
+            0.7
+          ],
+          "target": [
+            -2.6,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            0,
+            1
+          ],
+          "description": "Focus on the Hilbert amplitudes"
+        },
+        {
+          "name": "Probabilities",
+          "position": [
+            2.6,
+            -5.6,
+            0.7
+          ],
+          "target": [
+            2.6,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            0,
+            1
+          ],
+          "description": "Focus on the measurable probabilities"
+        }
+      ],
+      "elements": [
+        {
+          "id": "ap_divider",
+          "type": "line",
+          "from": [
+            0,
+            0,
+            -2.0
+          ],
+          "to": [
+            0,
+            0,
+            2.0
+          ],
+          "color": "#5c667a",
+          "width": 1.2,
+          "opacity": 0.6
+        },
+        {
+          "id": "ap_left_title",
+          "type": "text",
+          "position": [
+            -2.6,
+            0,
+            1.95
+          ],
+          "text": "Hilbert amplitudes",
+          "color": "#a6c8ff",
+          "size": 13
+        },
+        {
+          "id": "ap_right_title",
+          "type": "text",
+          "position": [
+            2.6,
+            0,
+            1.95
+          ],
+          "text": "Measurement probabilities",
+          "color": "#ffd166",
+          "size": 13
+        }
+      ],
+      "steps": [
+        {
+          "title": "Amplitudes are not probabilities",
+          "description": "The Hilbert-space coordinates $\\alpha$ and $\\beta$ tell us the state, but the actual probabilities are their squared magnitudes.",
+          "prompt": "Start by contrasting the two panels. Left: amplitudes. Right: probabilities. Say explicitly that the right panel comes from Born's rule, not by renaming alpha and beta.",
+          "add": [
+            {
+              "id": "ap_amp_top_slot",
+              "type": "line",
+              "from": [
+                -3.8,
+                0,
+                0.8
+              ],
+              "to": [
+                -1.7,
+                0,
+                0.8
+              ],
+              "color": "#66d9ff44",
+              "width": 3
+            },
+            {
+              "id": "ap_amp_bottom_slot",
+              "type": "line",
+              "from": [
+                -3.8,
+                0,
+                -0.8
+              ],
+              "to": [
+                -1.7,
+                0,
+                -0.8
+              ],
+              "color": "#ff7b7244",
+              "width": 3
+            },
+            {
+              "id": "ap_prob_top_slot",
+              "type": "line",
+              "from": [
+                1.5,
+                0,
+                0.8
+              ],
+              "to": [
+                3.6,
+                0,
+                0.8
+              ],
+              "color": "#66d9ff44",
+              "width": 3
+            },
+            {
+              "id": "ap_prob_bottom_slot",
+              "type": "line",
+              "from": [
+                1.5,
+                0,
+                -0.8
+              ],
+              "to": [
+                3.6,
+                0,
+                -0.8
+              ],
+              "color": "#ff7b7244",
+              "width": 3
+            },
+            {
+              "id": "ap_amp_top_text",
+              "type": "text",
+              "position": [
+                -4.9,
+                0,
+                0.92
+              ],
+              "text": "$|0\\rangle$ amplitude",
+              "color": "#66d9ff",
+              "size": 11
+            },
+            {
+              "id": "ap_amp_bottom_text",
+              "type": "text",
+              "position": [
+                -4.9,
+                0,
+                -0.68
+              ],
+              "text": "$|1\\rangle$ amplitude",
+              "color": "#ff7b72",
+              "size": 11
+            },
+            {
+              "id": "ap_prob_top_text",
+              "type": "text",
+              "position": [
+                0.55,
+                0,
+                0.92
+              ],
+              "text": "$p(0)$",
+              "color": "#66d9ff",
+              "size": 11
+            },
+            {
+              "id": "ap_prob_bottom_text",
+              "type": "text",
+              "position": [
+                0.55,
+                0,
+                -0.68
+              ],
+              "text": "$p(1)$",
+              "color": "#ff7b72",
+              "size": 11
+            },
+            {
+              "id": "ap_alpha_fixed",
+              "type": "vector",
+              "from": [
+                -3.8,
+                0,
+                0.8
+              ],
+              "to": [
+                -1.98,
+                0,
+                0.8
+              ],
+              "color": "#66d9ff",
+              "width": 1.5
+            },
+            {
+              "id": "ap_alpha_fixed_label",
+              "type": "text",
+              "position": [
+                -2.95,
+                0,
+                1.03
+              ],
+              "text": "$|\\alpha|$",
+              "color": "#66d9ff",
+              "size": 12
+            },
+            {
+              "id": "ap_beta_fixed",
+              "type": "vector",
+              "from": [
+                -3.8,
+                0,
+                -0.8
+              ],
+              "to": [
+                -2.75,
+                0,
+                -0.8
+              ],
+              "color": "#ff7b72",
+              "width": 1.5
+            },
+            {
+              "id": "ap_beta_fixed_label",
+              "type": "text",
+              "position": [
+                -3.38,
+                0,
+                -0.58
+              ],
+              "text": "$|\\beta|$",
+              "color": "#ff7b72",
+              "size": 12
+            },
+            {
+              "id": "ap_p0_fixed",
+              "type": "vector",
+              "from": [
+                1.5,
+                0,
+                0.8
+              ],
+              "to": [
+                3.075,
+                0,
+                0.8
+              ],
+              "color": "#66d9ff",
+              "width": 1.5
+            },
+            {
+              "id": "ap_p0_fixed_label",
+              "type": "text",
+              "position": [
+                2.18,
+                0,
+                1.03
+              ],
+              "text": "$|\\alpha|^2$",
+              "color": "#66d9ff",
+              "size": 12
+            },
+            {
+              "id": "ap_p1_fixed",
+              "type": "vector",
+              "from": [
+                1.5,
+                0,
+                -0.8
+              ],
+              "to": [
+                2.025,
+                0,
+                -0.8
+              ],
+              "color": "#ff7b72",
+              "width": 1.5
+            },
+            {
+              "id": "ap_p1_fixed_label",
+              "type": "text",
+              "position": [
+                1.72,
+                0,
+                -0.58
+              ],
+              "text": "$|\\beta|^2$",
+              "color": "#ff7b72",
+              "size": 12
+            }
+          ],
+          "info": [
+            {
+              "id": "ap_intro_info",
+              "position": "top-right",
+              "content": "$$\\lvert\\psi\\rangle = \\alpha\\lvert 0\\rangle + \\beta\\lvert 1\\rangle$$\n$$p(0)=|\\alpha|^2, \\qquad p(1)=|\\beta|^2$$"
+            }
+          ]
+        },
+        {
+          "title": "$\\theta$ controls both panels",
+          "description": "As $\\theta$ changes, the amplitudes change on the left and the probabilities change on the right. The right panel always shows the squared magnitudes of the left panel.",
+          "prompt": "Make the squaring relationship visible. Students should see that shortening an amplitude bar by a little can shorten the corresponding probability bar by more.",
+          "remove": [
+            {
+              "id": "ap_alpha_fixed"
+            },
+            {
+              "id": "ap_alpha_fixed_label"
+            },
+            {
+              "id": "ap_beta_fixed"
+            },
+            {
+              "id": "ap_beta_fixed_label"
+            },
+            {
+              "id": "ap_p0_fixed"
+            },
+            {
+              "id": "ap_p0_fixed_label"
+            },
+            {
+              "id": "ap_p1_fixed"
+            },
+            {
+              "id": "ap_p1_fixed_label"
+            }
+          ],
+          "sliders": [
+            {
+              "id": "ap_theta",
+              "label": "$\\theta$",
+              "min": 0,
+              "max": 3.141592653589793,
+              "step": 0.01,
+              "default": 1.05
+            }
+          ],
+          "add": [
+            {
+              "id": "ap_plot_x_axis",
+              "type": "line",
+              "from": [
+                -0.8,
+                0,
+                -0.8
+              ],
+              "to": [
+                0.8,
+                0,
+                -0.8
+              ],
+              "color": "#5c667a",
+              "width": 1.0,
+              "opacity": 0.7
+            },
+            {
+              "id": "ap_plot_z_axis",
+              "type": "line",
+              "from": [
+                -0.8,
+                0,
+                -0.8
+              ],
+              "to": [
+                -0.8,
+                0,
+                0.8
+              ],
+              "color": "#5c667a",
+              "width": 1.0,
+              "opacity": 0.7
+            },
+            {
+              "id": "ap_plot_x_label",
+              "type": "text",
+              "position": [
+                0.0,
+                0,
+                -1.1
+              ],
+              "text": "$m$",
+              "color": "#8899aa",
+              "size": 11
+            },
+            {
+              "id": "ap_plot_z_label",
+              "type": "text",
+              "position": [
+                -1.15,
+                0,
+                0.0
+              ],
+              "text": "$p$",
+              "color": "#8899aa",
+              "size": 11
+            },
+            {
+              "id": "ap_plot_tick_m1",
+              "type": "text",
+              "position": [
+                0.8,
+                0,
+                -1.0
+              ],
+              "text": "1",
+              "color": "#5c667a",
+              "size": 9
+            },
+            {
+              "id": "ap_plot_tick_p1",
+              "type": "text",
+              "position": [
+                -1.0,
+                0,
+                0.8
+              ],
+              "text": "1",
+              "color": "#5c667a",
+              "size": 9
+            },
+            {
+              "id": "ap_linear_line",
+              "type": "line",
+              "from": [
+                -0.8,
+                0,
+                -0.8
+              ],
+              "to": [
+                0.8,
+                0,
+                0.8
+              ],
+              "color": "#5c667a44",
+              "width": 1.0
+            },
+            {
+              "id": "ap_squaring_curve",
+              "type": "parametric_curve",
+              "range": [
+                0,
+                1
+              ],
+              "color": "#ffd166",
+              "width": 2.5,
+              "samples": 64,
+              "x": "-0.8 + 1.6*t",
+              "y": "0",
+              "z": "-0.8 + 1.6*t*t"
+            },
+            {
+              "id": "ap_track_alpha",
+              "type": "animated_point",
+              "expr": [
+                "-0.8 + 1.6*cos(ap_theta/2)",
+                "0",
+                "-0.8 + 1.6*cos(ap_theta/2)^2"
+              ],
+              "color": "#66d9ff",
+              "size": 6
+            },
+            {
+              "id": "ap_track_beta",
+              "type": "animated_point",
+              "expr": [
+                "-0.8 + 1.6*sin(ap_theta/2)",
+                "0",
+                "-0.8 + 1.6*sin(ap_theta/2)^2"
+              ],
+              "color": "#ff7b72",
+              "size": 6
+            },
+            {
+              "id": "ap_plot_title",
+              "type": "text",
+              "position": [
+                0.0,
+                0,
+                1.1
+              ],
+              "text": "$p = m^2$",
+              "color": "#ffd166",
+              "size": 12
+            },
+            {
+              "id": "ap_alpha_bar",
+              "type": "animated_vector",
+              "from": [
+                -3.8,
+                0,
+                0.8
+              ],
+              "expr": [
+                "-3.8 + 2.1*cos(ap_theta/2)",
+                "0",
+                "0.8"
+              ],
+              "color": "#66d9ff",
+              "width": 1.5
+            },
+            {
+              "id": "ap_alpha_bar_label",
+              "type": "text",
+              "positionExpr": [
+                "-3.55 + 1.0*cos(ap_theta/2)",
+                "0",
+                "1.03"
+              ],
+              "text": "$|\\alpha|$",
+              "color": "#66d9ff",
+              "size": 12
+            },
+            {
+              "id": "ap_beta_bar",
+              "type": "animated_vector",
+              "from": [
+                -3.8,
+                0,
+                -0.8
+              ],
+              "expr": [
+                "-3.8 + 2.1*sin(ap_theta/2)",
+                "0",
+                "-0.8"
+              ],
+              "color": "#ff7b72",
+              "width": 1.5
+            },
+            {
+              "id": "ap_beta_bar_label",
+              "type": "text",
+              "positionExpr": [
+                "-3.55 + 1.0*sin(ap_theta/2)",
+                "0",
+                "-0.58"
+              ],
+              "text": "$|\\beta|$",
+              "color": "#ff7b72",
+              "size": 12
+            },
+            {
+              "id": "ap_p0_bar",
+              "type": "animated_vector",
+              "from": [
+                1.5,
+                0,
+                0.8
+              ],
+              "expr": [
+                "1.5 + 2.1*cos(ap_theta/2)^2",
+                "0",
+                "0.8"
+              ],
+              "color": "#66d9ff",
+              "width": 1.5
+            },
+            {
+              "id": "ap_p0_bar_label",
+              "type": "text",
+              "positionExpr": [
+                "1.78 + 1.0*cos(ap_theta/2)^2",
+                "0",
+                "1.03"
+              ],
+              "text": "$p(0)$",
+              "color": "#66d9ff",
+              "size": 12
+            },
+            {
+              "id": "ap_p1_bar",
+              "type": "animated_vector",
+              "from": [
+                1.5,
+                0,
+                -0.8
+              ],
+              "expr": [
+                "1.5 + 2.1*sin(ap_theta/2)^2",
+                "0",
+                "-0.8"
+              ],
+              "color": "#ff7b72",
+              "width": 1.5
+            },
+            {
+              "id": "ap_p1_bar_label",
+              "type": "text",
+              "positionExpr": [
+                "1.78 + 1.0*sin(ap_theta/2)^2",
+                "0",
+                "-0.58"
+              ],
+              "text": "$p(1)$",
+              "color": "#ff7b72",
+              "size": 12
+            }
+          ],
+          "info": [
+            {
+              "id": "ap_theta_info",
+              "position": "top-right",
+              "content": "$$|\\alpha| = \\cos\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(cos(ap_theta/2),3)}}$$\n$$|\\beta| = \\sin\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(sin(ap_theta/2),3)}}$$\n$$p(0)=|\\alpha|^2={{toFixed(cos(ap_theta/2)^2,3)}},\\quad p(1)=|\\beta|^2={{toFixed(sin(ap_theta/2)^2,3)}}$$"
+            }
+          ]
+        },
+        {
+          "title": "$\\phi$ does not change these probabilities",
+          "description": "Now add relative phase. The lower amplitude can rotate in Hilbert space, but the computational-basis probabilities stay fixed because only the magnitudes matter.",
+          "prompt": "Use this step to separate amplitude phase from measurement probability. The left panel gains a phase wheel; the right panel does not move.",
+          "sliders": [
+            {
+              "id": "ap_phi",
+              "label": "$\\phi$",
+              "min": 0,
+              "max": 6.283185307179586,
+              "step": 0.01,
+              "default": 0.9
+            }
+          ],
+          "add": [
+            {
+              "id": "ap_phase_disk",
+              "type": "parametric_curve",
+              "x": "-3.8 + 2.1*sin(ap_theta/2)",
+              "y": "0.32*cos(t)",
+              "z": "-0.8 + 0.32*sin(t)",
+              "range": [
+                0,
+                6.283185307179586
+              ],
+              "samples": 80,
+              "color": "#c77dff",
+              "width": 1.5,
+              "opacity": 0.4
+            },
+            {
+              "id": "ap_beta_phase",
+              "type": "animated_vector",
+              "fromExpr": [
+                "-3.8 + 2.1*sin(ap_theta/2)",
+                "0",
+                "-0.8"
+              ],
+              "expr": [
+                "-3.8 + 2.1*sin(ap_theta/2)",
+                "0.32*cos(ap_phi)",
+                "-0.8 + 0.32*sin(ap_phi)"
+              ],
+              "color": "#c77dff",
+              "width": 2
+            },
+            {
+              "id": "ap_beta_phase_label",
+              "type": "text",
+              "positionExpr": [
+                "-3.8 + 2.1*sin(ap_theta/2)",
+                "0.32*cos(ap_phi)",
+                "-0.8 + 0.32*sin(ap_phi)"
+              ],
+              "text": "$\\phi$",
+              "color": "#c77dff",
+              "size": 12
+            }
+          ],
+          "info": [
+            {
+              "id": "ap_phase_info",
+              "position": "top-right",
+              "content": "$$\\beta = e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)$$\n$$|\\beta| = \\sin\\!\\left(\\frac{\\theta}{2}\\right),\\qquad |\\beta|^2 = {{toFixed(sin(ap_theta/2)^2,3)}}$$\n$$\\text{Changing } \\phi \\text{ leaves } p(0),p(1) \\text{ unchanged.}$$"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "From Amplitudes to a Sphere",
+      "description": "After the side-by-side bridge, this scene zooms in on the Bloch sphere itself and lets the student explore its geometry directly.",
+      "markdown": "# From Amplitudes to a Sphere\n\nIn the previous scene we matched the Hilbert-space amplitudes to their Bloch-sphere image. Now we zoom in on the sphere itself.\n\nFor a pure qubit,\n\n$$\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle$$\n\nmaps to the **Bloch vector**\n\n$$\\vec{r} = (\\sin\\theta\\cos\\phi,\\; \\sin\\theta\\sin\\phi,\\; \\cos\\theta).$$\n\nThis is a unit vector in $\\mathbb{R}^3$ — a point on a sphere.\n\n- **$\\theta$** is the polar angle from the north pole. It controls the balance between $\\lvert 0\\rangle$ and $\\lvert 1\\rangle$.\n- **$\\phi$** is the azimuthal angle around the equator. It controls the relative phase.\n- **$z = \\cos\\theta$** directly gives the measurement probabilities: $p(0) = (1+z)/2$.",
+      "prompt": "This scene is now a zoom-in on the Bloch sphere after the side-by-side bridge. Focus on the sphere geometry itself rather than re-explaining the full coordinate change. Keep colors consistent: cyan for |0>/alpha, coral for |1>/beta, gold for the state vector, green for z-projection/meridian, magenta for equator/phase.",
+      "range": [
+        [
+          -1.35,
+          1.35
+        ],
+        [
+          -1.35,
+          1.35
+        ],
+        [
+          -1.35,
+          1.35
+        ]
+      ],
+      "camera": {
+        "position": [
+          2.8,
+          -2.4,
+          1.8
+        ],
+        "target": [
+          0,
+          0,
+          0
+        ],
+        "up": [
+          0,
+          0,
+          1
+        ]
+      },
+      "views": [
+        {
+          "name": "Iso",
+          "position": [
+            2.8,
+            -2.4,
+            1.8
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            0,
+            1
+          ],
+          "description": "See the full sphere and the state vector"
+        },
+        {
+          "name": "North Pole",
+          "position": [
+            0,
+            0,
+            4
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            1,
+            0
+          ],
+          "description": "Top-down view — see the azimuthal angle $\\phi$"
+        },
+        {
+          "name": "Equator",
+          "position": [
+            3.2,
+            0,
+            0
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            0,
+            1
+          ],
+          "description": "Side view — see the polar angle $\\theta$"
+        }
+      ],
+      "elements": [
+        {
+          "id": "sb_axis_x",
+          "type": "axis",
+          "axis": "x",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": "#ff4444",
+          "width": 1.2,
+          "label": "$x$"
+        },
+        {
+          "id": "sb_axis_y",
+          "type": "axis",
+          "axis": "y",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": "#44cc44",
+          "width": 1.2,
+          "label": "$y$"
+        },
+        {
+          "id": "sb_axis_z",
+          "type": "axis",
+          "axis": "z",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": "#4488ff",
+          "width": 1.2,
+          "label": "$z$"
+        },
+        {
+          "id": "sb_grid",
+          "type": "grid",
+          "plane": "xy",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": [
+            0.28,
+            0.28,
+            0.45
+          ],
+          "opacity": 0.15,
+          "divisions": 12
+        }
+      ],
+      "steps": [
+        {
+          "title": "Recall the amplitudes",
+          "description": "From the previous scene: $\\alpha = \\cos(\\theta/2)$ lives on the real axis, and $\\beta = e^{i\\phi}\\sin(\\theta/2)$ carries the phase. Two real numbers — where do they live geometrically?",
+          "prompt": "Recap the amplitude result. Show alpha along the z-axis (it controls the height) and tease that we're about to reveal the geometric picture.",
+          "add": [
+            {
+              "id": "sb_ket0",
+              "type": "point",
+              "position": [
+                0,
+                0,
+                1
+              ],
+              "color": "#66d9ff",
+              "size": 10,
+              "label": "$\\lvert 0\\rangle$"
+            },
+            {
+              "id": "sb_ket1",
+              "type": "point",
+              "position": [
+                0,
+                0,
+                -1
+              ],
+              "color": "#ff7b72",
+              "size": 10,
+              "label": "$\\lvert 1\\rangle$"
+            }
+          ],
+          "info": [
+            {
+              "id": "sb_recap_info",
+              "position": "top-right",
+              "content": "$$\\lvert\\psi\\rangle = \\underbrace{\\cos\\!\\left(\\frac{\\theta}{2}\\right)}_{\\alpha}\\lvert 0\\rangle + \\underbrace{e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)}_{\\beta}\\lvert 1\\rangle$$\n$$\\text{Two real parameters: } \\theta, \\phi$$"
+            }
+          ]
+        },
+        {
+          "title": "$\\theta$ sets the latitude",
+          "description": "The polar angle $\\theta$ sweeps from $\\lvert 0\\rangle$ at the north pole ($\\theta = 0$) to $\\lvert 1\\rangle$ at the south pole ($\\theta = \\pi$). Halfway ($\\theta = \\pi/2$) is an equal superposition.",
+          "prompt": "Show the meridian and let the student sweep theta. Connect it explicitly: theta=0 means alpha=1 beta=0, theta=pi means alpha=0 beta=1. The z-coordinate is cos(theta).",
+          "sliders": [
+            {
+              "id": "sb_theta",
+              "label": "$\\theta$",
+              "min": 0,
+              "max": 3.141592653589793,
+              "step": 0.01,
+              "default": 1.05
+            }
+          ],
+          "add": [
+            {
+              "id": "sb_meridian",
+              "type": "parametric_curve",
+              "x": "sin(t)",
+              "y": "0",
+              "z": "cos(t)",
+              "range": [
+                0,
+                3.141592653589793
+              ],
+              "samples": 80,
+              "color": "#7bd389",
+              "width": 2,
+              "opacity": 0.6
+            },
+            {
+              "id": "sb_state_vec",
+              "type": "animated_vector",
+              "from": [
+                0,
+                0,
+                0
+              ],
+              "expr": [
+                "sin(sb_theta)",
+                "0",
+                "cos(sb_theta)"
+              ],
+              "color": "#ffd166",
+              "width": 2,
+              "label": "$\\lvert\\psi\\rangle$"
+            },
+            {
+              "id": "sb_zproj",
+              "type": "animated_vector",
+              "from": [
+                0,
+                0,
+                0
+              ],
+              "expr": [
+                "0",
+                "0",
+                "cos(sb_theta)"
+              ],
+              "color": "#7bd389",
+              "width": 2,
+              "opacity": 0.6
+            }
+          ],
+          "info": [
+            {
+              "id": "sb_theta_info",
+              "position": "top-right",
+              "content": "$$\\theta = {{toFixed(sb_theta, 2)}}$$\n$$\\alpha = \\cos(\\theta/2) = {{toFixed(cos(sb_theta/2), 3)}}$$\n$$\\lvert\\beta\\rvert = \\sin(\\theta/2) = {{toFixed(sin(sb_theta/2), 3)}}$$\n$$z = \\cos\\theta = {{toFixed(cos(sb_theta), 3)}}$$\n$$p(0) = \\cos^2(\\theta/2) = {{toFixed(cos(sb_theta/2)^2,3)}},\\; p(1) = \\sin^2(\\theta/2) = {{toFixed(sin(sb_theta/2)^2,3)}}$$"
+            }
+          ]
+        },
+        {
+          "title": "The sphere appears",
+          "description": "All possible $\\theta$ values trace a meridian. Now reveal the full sphere — every point on this surface is a valid pure qubit state.",
+          "prompt": "Add the sphere. Emphasize that the meridian we've been sliding along is just one slice of the full picture. The sphere has room for the second parameter phi.",
+          "add": [
+            {
+              "id": "sb_sphere",
+              "type": "sphere",
+              "center": [
+                0,
+                0,
+                0
+              ],
+              "radius": 1,
+              "color": "#334466",
+              "opacity": 0.15,
+              "segments": 64,
+              "rings": 48,
+              "shader": {
+                "depthWrite": false
+              }
+            },
+            {
+              "id": "sb_equator",
+              "type": "parametric_curve",
+              "x": "cos(t)",
+              "y": "sin(t)",
+              "z": "0",
+              "range": [
+                0,
+                6.283185307179586
+              ],
+              "samples": 120,
+              "color": "#c77dff",
+              "width": 2,
+              "opacity": 0.5
+            }
+          ]
+        },
+        {
+          "title": "$\\phi$ sets the azimuth",
+          "description": "The relative phase $\\phi$ rotates the state around the z-axis. It sweeps out the equator and every latitude circle — this is the Bloch sphere.",
+          "prompt": "Add the phi slider. Now the state can reach any point on the sphere. Connect back to the amplitude picture: theta controlled |alpha| vs |beta|, phi controls the complex phase of beta. Together they cover every pure state.",
+          "remove": [
+            {
+              "id": "sb_state_vec"
+            },
+            {
+              "id": "sb_zproj"
+            }
+          ],
+          "sliders": [
+            {
+              "id": "sb_phi",
+              "label": "$\\phi$",
+              "min": 0,
+              "max": 6.283185307179586,
+              "step": 0.01,
+              "default": 0.7
+            }
+          ],
+          "add": [
+            {
+              "id": "sb_state_full",
+              "type": "animated_vector",
+              "from": [
+                0,
+                0,
+                0
+              ],
+              "expr": [
+                "sin(sb_theta)*cos(sb_phi)",
+                "sin(sb_theta)*sin(sb_phi)",
+                "cos(sb_theta)"
+              ],
+              "color": "#ffd166",
+              "width": 2,
+              "label": "$\\lvert\\psi\\rangle$"
+            },
+            {
+              "id": "sb_zproj_full",
+              "type": "animated_vector",
+              "from": [
+                0,
+                0,
+                0
+              ],
+              "expr": [
+                "0",
+                "0",
+                "cos(sb_theta)"
+              ],
+              "color": "#7bd389",
+              "width": 2,
+              "opacity": 0.5
+            },
+            {
+              "id": "sb_phi_arc",
+              "type": "parametric_curve",
+              "x": "sin(sb_theta)*cos(t)",
+              "y": "sin(sb_theta)*sin(t)",
+              "z": "cos(sb_theta)",
+              "range": [
+                0,
+                6.283185307179586
+              ],
+              "samples": 80,
+              "color": "#c77dff",
+              "width": 1.5,
+              "opacity": 0.35
+            }
+          ],
+          "info": [
+            {
+              "id": "sb_full_info",
+              "position": "top-right",
+              "content": "$$\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle$$\n$$\\theta = {{toFixed(sb_theta, 2)}}, \\quad \\phi = {{toFixed(sb_phi, 2)}}$$\n$$\\vec{r} = ({{toFixed(sin(sb_theta)*cos(sb_phi),2)}},\\; {{toFixed(sin(sb_theta)*sin(sb_phi),2)}},\\; {{toFixed(cos(sb_theta),2)}})$$"
+            }
+          ]
+        },
+        {
+          "title": "The complete Bloch sphere",
+          "description": "Every pure qubit state is a point on this sphere. The amplitudes $\\alpha$ and $\\beta$ from the Hilbert space map one-to-one to the angles $\\theta$ and $\\phi$ on the Bloch sphere.",
+          "prompt": "Wrap up the bridge. The student now knows: ℂ² amplitudes → two angles → Bloch sphere. Every subsequent scene will work directly on the sphere. Mention that mixed states (statistical mixtures) live inside the sphere, but this lesson stays on the surface.",
+          "info": [
+            {
+              "id": "sb_summary",
+              "position": "top-right",
+              "content": "**The Bloch sphere map**\n$$\\mathbb{C}^2 \\longrightarrow S^2$$\n$\\alpha, \\beta$ (complex amplitudes)\n$\\quad\\downarrow$ normalization + global phase\n$\\theta, \\phi$ (two real angles)\n$\\quad\\downarrow$ spherical coordinates\nOne point on the Bloch sphere"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "From Bit to Bloch Sphere",
+      "description": "A qubit is not just 0 or 1. Pure one-qubit states fill the Bloch sphere, with $|0\\rangle$ and $|1\\rangle$ at the poles.",
+      "markdown": "# From Bit to Bloch Sphere\n\nA classical bit has two pure states: $0$ and $1$. A **qubit** has basis states $|0\\rangle$ and $|1\\rangle$, but any normalized superposition\n\n$$|\\psi\\rangle = \\alpha |0\\rangle + \\beta |1\\rangle, \\qquad |\\alpha|^2 + |\\beta|^2 = 1$$\n\nis also a valid pure state.\n\nFor a single qubit, global phase does not affect measurements, so every pure state can be represented by a point on the **Bloch sphere**. The north pole is $|0\\rangle$, the south pole is $|1\\rangle$, and intermediate points represent superpositions.\n\nThis draft lesson focuses on **pure one-qubit states** because they admit a clean 3D picture. Mixed states live inside the sphere rather than on its surface.",
+      "prompt": "Teach this scene as the jump from classical states to pure qubit states. Gold is always the current state, cyan is |0>, coral is |1>, and magenta is reserved for phase-related circles. Emphasize that the Bloch sphere visualizes pure states of a two-level system, not all quantum states in full generality.",
+      "range": [
+        [
+          -1.35,
+          1.35
+        ],
+        [
+          -1.35,
+          1.35
+        ],
+        [
+          -1.35,
+          1.35
+        ]
+      ],
+      "camera": {
+        "position": [
+          2.7,
+          -2.7,
+          1.8
+        ],
+        "target": [
+          0,
+          0,
+          0
+        ],
+        "up": [
+          0,
+          0,
+          1
+        ]
+      },
+      "views": [
+        {
+          "name": "Iso",
+          "position": [
+            2.7,
+            -2.7,
+            1.8
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            0,
+            1
+          ],
+          "description": "Three-dimensional view of the Bloch sphere"
+        },
+        {
+          "name": "Face On",
+          "position": [
+            0,
+            -4,
+            0
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            0,
+            1
+          ],
+          "description": "Look directly at the x-z cross-section"
+        },
+        {
+          "name": "North Pole",
+          "position": [
+            0,
+            0,
+            4
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            1,
+            0
+          ],
+          "description": "Focus on the $|0\\rangle$ pole"
+        },
+        {
+          "name": "Equator",
+          "position": [
+            3.2,
+            0,
+            0
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            0,
+            1
+          ],
+          "description": "Side view of equatorial superpositions"
+        }
+      ],
+      "elements": [
+        {
+          "id": "s1_sphere",
+          "type": "sphere",
+          "center": [
+            0,
+            0,
+            0
+          ],
+          "radius": 1,
+          "color": "#5c7cfa",
+          "opacity": 0.12,
+          "segments": 64,
+          "rings": 48
+        },
+        {
+          "id": "s1_axis_x",
+          "type": "axis",
+          "axis": "x",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": "#ff4444",
+          "width": 1.2,
+          "label": "$x$"
+        },
+        {
+          "id": "s1_axis_y",
+          "type": "axis",
+          "axis": "y",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": "#44cc44",
+          "width": 1.2,
+          "label": "$y$"
+        },
+        {
+          "id": "s1_axis_z",
+          "type": "axis",
+          "axis": "z",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": "#4488ff",
+          "width": 1.2,
+          "label": "$z$"
+        },
+        {
+          "id": "s1_grid_xy",
+          "type": "grid",
+          "plane": "xy",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": [
+            0.28,
+            0.28,
+            0.45
+          ],
+          "opacity": 0.12,
+          "divisions": 8
+        }
+      ],
+      "steps": [
+        {
+          "title": "Classical endpoints",
+          "description": "Start with the computational basis states. In this basis, $|0\\rangle$ is certainly 0 and $|1\\rangle$ is certainly 1, just like the two pure states of a classical bit.",
+          "prompt": "Anchor the scene in the two poles first. Connect them to definite computational-basis outcomes and to the classical idea of two pure alternatives.",
+          "add": [
+            {
+              "id": "s1_ket0",
+              "type": "point",
+              "position": [
+                0,
+                0,
+                1
+              ],
+              "color": "#66d9ff",
+              "size": 10,
+              "label": "$|0\\rangle$"
+            },
+            {
+              "id": "s1_ket1",
+              "type": "point",
+              "position": [
+                0,
+                0,
+                -1
+              ],
+              "color": "#ff7b72",
+              "size": 10,
+              "label": "$|1\\rangle$"
+            }
+          ]
+        },
+        {
+          "title": "A superposition appears",
+          "description": "Now move to the equator. This state is neither pole, so it is not 'just 0' or 'just 1'; it is a balanced superposition.",
+          "prompt": "Use the equator state to break the classical analogy. Stress that equal amplitudes do not mean a classical halfway state.",
+          "add": [
+            {
+              "id": "s1_plusx_vec",
+              "type": "vector",
+              "from": [
+                0,
+                0,
+                0
+              ],
+              "to": [
+                1,
+                0,
+                0
+              ],
+              "color": "#ffd166",
+              "width": 4,
+              "label": "$|+x\\rangle$"
+            },
+            {
+              "id": "s1_plusx_pt",
+              "type": "point",
+              "position": [
+                1,
+                0,
+                0
+              ],
+              "color": "#ffd166",
+              "size": 8
+            }
+          ]
+        },
+        {
+          "title": "Generic pure state",
+          "description": "A general pure qubit can point anywhere on the sphere. This sample state has both a latitude and an azimuth, so it needs more than a single 'probability of 1' number to describe it.",
+          "prompt": "Introduce the idea that one angle sets the balance between |0> and |1>, while another controls relative phase. Keep it qualitative here and save formulas for the next scene.",
+          "remove": [
+            {
+              "id": "s1_plusx_vec"
+            },
+            {
+              "id": "s1_plusx_pt"
+            }
+          ],
+          "add": [
+            {
+              "id": "s1_generic_vec",
+              "type": "vector",
+              "from": [
+                0,
+                0,
+                0
+              ],
+              "to": [
+                0.612,
+                0.612,
+                0.5
+              ],
+              "color": "#ffd166",
+              "width": 4,
+              "label": "$|\\psi\\rangle$"
+            },
+            {
+              "id": "s1_generic_pt",
+              "type": "point",
+              "position": [
+                0.612,
+                0.612,
+                0.5
+              ],
+              "color": "#ffd166",
+              "size": 8
+            }
+          ]
+        },
+        {
+          "title": "The whole sphere matters",
+          "description": "The equator and the meridian show that there is a continuous family of pure states. Quantum state space is richer than a two-point classical menu.",
+          "prompt": "Close by naming the key visual fact: the poles are special cases, but pure states occupy the full surface. Prepare the student for angle coordinates next.",
+          "add": [
+            {
+              "id": "s1_equator",
+              "type": "parametric_curve",
+              "x": "cos(t)",
+              "y": "sin(t)",
+              "z": "0",
+              "range": [
+                0,
+                6.283185307179586
+              ],
+              "samples": 180,
+              "color": "#c77dff",
+              "width": 2,
+              "opacity": 0.65
+            },
+            {
+              "id": "s1_meridian",
+              "type": "parametric_curve",
+              "x": "sin(t)",
+              "y": "0",
+              "z": "cos(t)",
+              "range": [
+                0,
+                3.141592653589793
+              ],
+              "samples": 120,
+              "color": "#7bd389",
+              "width": 2,
+              "opacity": 0.65
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Angles Encode Amplitudes",
+      "description": "Two angles, $\\theta$ and $\\phi$, locate a pure qubit on the Bloch sphere and encode its amplitudes.",
+      "markdown": "# Angles Encode Amplitudes\n\nFor a pure one-qubit state, the Bloch sphere coordinates are usually written as\n\n$$|\\psi\\rangle = \\cos\\left(\\frac{\\theta}{2}\\right)|0\\rangle + e^{i\\phi}\\sin\\left(\\frac{\\theta}{2}\\right)|1\\rangle.$$\n\nThe Bloch point has coordinates\n\n$$r=(x,y,z)=\\bigl(\\sin\\theta\\cos\\phi,\\;\\sin\\theta\\sin\\phi,\\;\\cos\\theta\\bigr).$$\n\nSo:\n\n- $\\theta$ controls the **latitude** and therefore the balance between $|0\\rangle$ and $|1\\rangle$.\n- $\\phi$ controls the **azimuth** and therefore the **relative phase** between those basis states.\n\nThis is the standard pure-state parameterization for qubits; it is the geometric version of the normalized state-vector description.",
+      "prompt": "Teach this scene as the algebra-geometry bridge. Keep gold for the active state, cyan for |0>, coral for |1>, green for the meridian, and magenta for azimuth/equator cues. Emphasize that theta controls amplitude magnitudes while phi controls relative phase.",
+      "range": [
+        [
+          -1.35,
+          1.35
+        ],
+        [
+          -1.35,
+          1.35
+        ],
+        [
+          -1.35,
+          1.35
+        ]
+      ],
+      "camera": {
+        "position": [
+          2.9,
+          -2.4,
+          1.7
+        ],
+        "target": [
+          0,
+          0,
+          0
+        ],
+        "up": [
+          0,
+          0,
+          1
+        ]
+      },
+      "views": [
+        {
+          "name": "Iso",
+          "position": [
+            2.9,
+            -2.4,
+            1.7
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            0,
+            1
+          ],
+          "description": "See both latitude and azimuth"
+        },
+        {
+          "name": "Meridian",
+          "position": [
+            0,
+            -4,
+            0
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            0,
+            1
+          ],
+          "description": "Best view for changing $\\theta$ at fixed $\\phi=0$"
+        },
+        {
+          "name": "Top Down",
+          "position": [
+            0,
+            0,
+            4
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            1,
+            0
+          ],
+          "description": "Look straight down to see the azimuth angle $\\phi$"
+        }
+      ],
+      "elements": [
+        {
+          "id": "s2_sphere",
+          "type": "sphere",
+          "center": [
+            0,
+            0,
+            0
+          ],
+          "radius": 1,
+          "color": "#5c7cfa",
+          "opacity": 0.12,
+          "segments": 64,
+          "rings": 48
+        },
+        {
+          "id": "s2_axis_x",
+          "type": "axis",
+          "axis": "x",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": "#ff4444",
+          "width": 1.2,
+          "label": "$x$"
+        },
+        {
+          "id": "s2_axis_y",
+          "type": "axis",
+          "axis": "y",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": "#44cc44",
+          "width": 1.2,
+          "label": "$y$"
+        },
+        {
+          "id": "s2_axis_z",
+          "type": "axis",
+          "axis": "z",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": "#4488ff",
+          "width": 1.2,
+          "label": "$z$"
+        },
+        {
+          "id": "s2_grid_xy",
+          "type": "grid",
+          "plane": "xy",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": [
+            0.28,
+            0.28,
+            0.45
+          ],
+          "opacity": 0.12,
+          "divisions": 8
+        },
+        {
+          "id": "s2_ket0",
+          "type": "point",
+          "position": [
+            0,
+            0,
+            1
+          ],
+          "color": "#66d9ff",
+          "size": 10,
+          "label": "$|0\\rangle$"
+        },
+        {
+          "id": "s2_ket1",
+          "type": "point",
+          "position": [
+            0,
+            0,
+            -1
+          ],
+          "color": "#ff7b72",
+          "size": 10,
+          "label": "$|1\\rangle$"
+        }
+      ],
+      "steps": [
+        {
+          "title": "Polar angle $\\theta$",
+          "description": "Start on a single meridian with $\\phi=0$. As $\\theta$ increases from 0 to $\\pi$, the state slides from $|0\\rangle$ down to $|1\\rangle$.",
+          "prompt": "Connect theta to north-versus-south balance. Point out that theta alone already tells the student how much of |0> and |1> appears in the amplitudes.",
+          "sliders": [
+            {
+              "id": "q2_theta",
+              "label": "$\\theta$",
+              "min": 0,
+              "max": 3.141592653589793,
+              "step": 0.01,
+              "default": 1.05
+            }
+          ],
+          "add": [
+            {
+              "id": "s2_meridian",
+              "type": "parametric_curve",
+              "x": "sin(t)",
+              "y": "0",
+              "z": "cos(t)",
+              "range": [
+                0,
+                3.141592653589793
+              ],
+              "samples": 120,
+              "color": "#7bd389",
+              "width": 2,
+              "opacity": 0.65
+            },
+            {
+              "id": "s2_theta_vec",
+              "type": "animated_vector",
+              "from": [
+                0,
+                0,
+                0
+              ],
+              "expr": [
+                "sin(q2_theta)",
+                "0",
+                "cos(q2_theta)"
+              ],
+              "color": "#ffd166",
+              "width": 2.0,
+              "label": "$|\\psi(\\theta)\\rangle$"
+            },
+            {
+              "id": "s2_theta_pt",
+              "type": "animated_point",
+              "expr": [
+                "sin(q2_theta)",
+                "0",
+                "cos(q2_theta)"
+              ],
+              "color": "#ffd166",
+              "size": 1.0
+            }
+          ],
+          "info": [
+            {
+              "id": "s2_theta_info",
+              "position": "top-right",
+              "content": "$$\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + \\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle$$\n$$\\theta={{toFixed(q2_theta,2)}}\\ \\text{rad},\\quad z=\\cos\\theta={{toFixed(cos(q2_theta),2)}}$$\n$$p(0) = \\cos^2(\\theta/2) = {{toFixed(cos(q2_theta/2)^2,3)}},\\; p(1) = \\sin^2(\\theta/2) = {{toFixed(sin(q2_theta/2)^2,3)}}$$"
+            }
+          ]
+        },
+        {
+          "title": "Azimuth $\\phi$",
+          "description": "Now let the state swing around the sphere. Changing $\\phi$ rotates the state around the z-axis while keeping the latitude fixed.",
+          "prompt": "Name phi as the azimuth angle and the source of relative phase. Do not claim that phi changes z-basis probabilities; save that comparison for later.",
+          "remove": [
+            {
+              "id": "s2_theta_vec"
+            },
+            {
+              "id": "s2_theta_pt"
+            }
+          ],
+          "sliders": [
+            {
+              "id": "q2_phi",
+              "label": "$\\phi$",
+              "min": 0,
+              "max": 6.283185307179586,
+              "step": 0.01,
+              "default": 0.79
+            }
+          ],
+          "add": [
+            {
+              "id": "s2_full_vec",
+              "type": "animated_vector",
+              "from": [
+                0,
+                0,
+                0
+              ],
+              "expr": [
+                "sin(q2_theta)*cos(q2_phi)",
+                "sin(q2_theta)*sin(q2_phi)",
+                "cos(q2_theta)"
+              ],
+              "color": "#ffd166",
+              "width": 2.0,
+              "label": "$|\\psi(\\theta,\\phi)\\rangle$"
+            },
+            {
+              "id": "s2_full_pt",
+              "type": "animated_point",
+              "expr": [
+                "sin(q2_theta)*cos(q2_phi)",
+                "sin(q2_theta)*sin(q2_phi)",
+                "cos(q2_theta)"
+              ],
+              "color": "#ffd166",
+              "size": 1.0
+            }
+          ]
+        },
+        {
+          "title": "Read off amplitudes",
+          "description": "The latitude controls the magnitudes of the amplitudes, while the azimuth controls their relative phase. The Bloch point packages both into one geometric picture.",
+          "prompt": "Connect the geometry to the ket formula explicitly. Mention that the magnitudes come from theta over 2 and the relative phase from phi.",
+          "add": [
+            {
+              "id": "s2_equator",
+              "type": "parametric_curve",
+              "x": "cos(t)",
+              "y": "sin(t)",
+              "z": "0",
+              "range": [
+                0,
+                6.283185307179586
+              ],
+              "samples": 180,
+              "color": "#c77dff",
+              "width": 2,
+              "opacity": 0.55
+            }
+          ],
+          "info": [
+            {
+              "id": "s2_formula",
+              "position": "top-right",
+              "content": "$$\\lvert\\psi\\rangle = \\alpha\\lvert 0\\rangle + \\beta\\lvert 1\\rangle,\\qquad \\alpha=\\cos\\!\\left(\\frac{\\theta}{2}\\right),\\ \\beta=e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)$$\n$$\\lvert\\alpha\\rvert^2={{toFixed(cos(q2_theta/2)^2,3)}},\\qquad \\lvert\\beta\\rvert^2={{toFixed(sin(q2_theta/2)^2,3)}}$$"
+            }
+          ]
+        }
+      ],
+      "proof": [
+        {
+          "id": "s2_bloch_parameterization",
+          "title": "Deriving the Bloch parameterization",
+          "technique": "derivation",
+          "techniqueHint": "Start from a general normalized state and absorb the global phase to arrive at the standard Bloch parameterization.",
+          "goal": "Show that every pure qubit state can be written as $\\cos(\\theta/2)\\lvert 0\\rangle + e^{i\\phi}\\sin(\\theta/2)\\lvert 1\\rangle$.",
+          "sceneStep": 0,
+          "prompt": "Guide the student through the algebraic steps that reduce a general complex 2-vector to two real angles. Emphasize why global phase is unphysical.",
+          "steps": [
+            {
+              "type": "given",
+              "label": "Start with a general qubit",
+              "math": "\\htmlClass{hl-gen}{\\lvert\\psi\\rangle = \\alpha\\lvert 0\\rangle + \\beta\\lvert 1\\rangle}, \\quad \\alpha,\\beta\\in\\mathbb{C}, \\quad \\lvert\\alpha\\rvert^2 + \\lvert\\beta\\rvert^2 = 1",
+              "highlights": {
+                "gen": {
+                  "color": "cyan",
+                  "label": "Any normalized two-component complex vector"
+                }
+              },
+              "justification": "A qubit lives in $\\mathbb{C}^2$ with unit norm.",
+              "explanation": "Two complex numbers give four real parameters, but normalization removes one.",
+              "prompt": "Emphasize the count: 4 real parameters minus 1 normalization = 3, but we will lose one more to global phase.",
+              "sceneStep": 0
+            },
+            {
+              "type": "step",
+              "label": "Write amplitudes in polar form",
+              "math": "\\alpha = \\htmlClass{hl-ra}{r_\\alpha\\, e^{i\\gamma_\\alpha}}, \\quad \\beta = \\htmlClass{hl-rb}{r_\\beta\\, e^{i\\gamma_\\beta}}, \\quad r_\\alpha^2 + r_\\beta^2 = 1",
+              "highlights": {
+                "ra": {
+                  "color": "green",
+                  "label": "Magnitude and phase of $\\alpha$"
+                },
+                "rb": {
+                  "color": "orange",
+                  "label": "Magnitude and phase of $\\beta$"
+                }
+              },
+              "justification": "Every complex number $z$ can be written as $|z|e^{i\\arg z}$.",
+              "explanation": "Now we have two magnitudes ($r_\\alpha, r_\\beta$) and two phases ($\\gamma_\\alpha, \\gamma_\\beta$). Normalization constrains the magnitudes.",
+              "prompt": "Point out that the magnitudes are non-negative and live on a unit circle in the $(r_\\alpha, r_\\beta)$ plane.",
+              "sceneStep": 0
+            },
+            {
+              "type": "step",
+              "label": "Factor out the global phase",
+              "math": "\\lvert\\psi\\rangle = \\htmlClass{hl-global}{e^{i\\gamma_\\alpha}} \\bigl( r_\\alpha\\lvert 0\\rangle + r_\\beta\\, e^{i(\\gamma_\\beta - \\gamma_\\alpha)}\\lvert 1\\rangle \\bigr)",
+              "highlights": {
+                "global": {
+                  "color": "gray",
+                  "label": "Global phase — physically unobservable"
+                }
+              },
+              "justification": "Pull $e^{i\\gamma_\\alpha}$ out of both terms.",
+              "explanation": "Global phase has no effect on any measurement outcome, so we drop it. Only the relative phase $\\phi = \\gamma_\\beta - \\gamma_\\alpha$ matters.",
+              "prompt": "This is the key physical insight: two states that differ only by a global phase are the same state. That removes one more parameter: 3 → 2.",
+              "sceneStep": 1
+            },
+            {
+              "type": "step",
+              "label": "Parameterize the magnitudes",
+              "math": "r_\\alpha^2 + r_\\beta^2 = 1 \\;\\Longrightarrow\\; r_\\alpha = \\htmlClass{hl-cosH}{\\cos\\!\\left(\\frac{\\theta}{2}\\right)}, \\; r_\\beta = \\htmlClass{hl-sinH}{\\sin\\!\\left(\\frac{\\theta}{2}\\right)}",
+              "highlights": {
+                "cosH": {
+                  "color": "green",
+                  "label": "$r_\\alpha$ as cosine of half-angle"
+                },
+                "sinH": {
+                  "color": "orange",
+                  "label": "$r_\\beta$ as sine of half-angle"
+                }
+              },
+              "justification": "Any point on the unit circle $(r_\\alpha, r_\\beta)$ with $r_\\alpha, r_\\beta \\geq 0$ can be written as $(\\cos\\eta, \\sin\\eta)$ for $\\eta \\in [0, \\pi/2]$. Set $\\eta = \\theta/2$ so $\\theta$ ranges over $[0, \\pi]$.",
+              "explanation": "The half-angle $\\theta/2$ is chosen so that $\\theta$ spans the full polar range of the sphere.",
+              "prompt": "Explain why we use theta/2 instead of theta: we want theta in [0, pi] to cover north pole to south pole, so the half-angle lives in [0, pi/2] where both cos and sin are non-negative.",
+              "sceneStep": 1
+            },
+            {
+              "type": "conclusion",
+              "label": "The Bloch parameterization",
+              "math": "\\htmlClass{hl-final}{\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle}",
+              "highlights": {
+                "final": {
+                  "color": "gold",
+                  "label": "Two real angles parameterize all pure qubit states"
+                }
+              },
+              "justification": "Substitute $r_\\alpha$, $r_\\beta$, and $\\phi = \\gamma_\\beta - \\gamma_\\alpha$ into the state.",
+              "explanation": "Every pure qubit maps to a unique point $(\\theta, \\phi)$ on the unit sphere. The half-angle ensures the north pole ($\\theta=0$) is $\\lvert 0\\rangle$ and the south pole ($\\theta=\\pi$) is $\\lvert 1\\rangle$.",
+              "prompt": "Tie back to the visualization: theta is the gold vector's polar angle, phi is its azimuth. Two angles, one sphere, all pure states.",
+              "sceneStep": 2
+            }
+          ]
+        },
+        {
+          "title": "Deriving the Bloch z-component from the state vector",
+          "technique": "derivation",
+          "techniqueHint": "Compute the expectation value of the Pauli Z operator to extract the z-coordinate from the ket.",
+          "goal": "Show that $z = \\langle\\psi\\lvert Z\\rvert\\psi\\rangle = \\cos\\theta$ for the Bloch parameterization.",
+          "sceneStep": 0,
+          "prompt": "Walk the student through the density-matrix / expectation-value route. Emphasize that z is not arbitrary — it is a measurable quantity tied to the Pauli Z operator.",
+          "steps": [
+            {
+              "type": "given",
+              "label": "Bloch parameterization",
+              "math": "\\htmlClass{hl-ket}{\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle}",
+              "highlights": {
+                "ket": {
+                  "color": "cyan",
+                  "label": "General pure qubit state"
+                }
+              },
+              "justification": "Standard parameterization of a normalized single-qubit state.",
+              "explanation": "This is the state whose Bloch coordinates we want to derive.",
+              "prompt": "Remind the student that theta and phi are the polar and azimuthal angles on the sphere.",
+              "sceneStep": 0
+            },
+            {
+              "type": "step",
+              "label": "Recall the Pauli Z operator",
+              "math": "\\htmlClass{hl-Z}{Z} = \\begin{pmatrix} 1 & 0 \\\\ 0 & -1 \\end{pmatrix}, \\quad Z\\lvert 0\\rangle = \\lvert 0\\rangle,\\; Z\\lvert 1\\rangle = -\\lvert 1\\rangle",
+              "highlights": {
+                "Z": {
+                  "color": "blue",
+                  "label": "Pauli Z matrix"
+                }
+              },
+              "justification": "Z is diagonal in the computational basis with eigenvalues +1 and −1.",
+              "explanation": "The eigenstates of Z are exactly the north and south poles of the Bloch sphere.",
+              "prompt": "Connect the eigenvalues +1 and -1 to the poles at z=+1 and z=-1.",
+              "sceneStep": 0
+            },
+            {
+              "type": "step",
+              "label": "Compute the expectation value",
+              "math": "\\langle\\psi\\lvert Z\\rvert\\psi\\rangle = \\htmlClass{hl-cos2}{\\cos^2\\!\\left(\\frac{\\theta}{2}\\right)} \\cdot(+1) + \\htmlClass{hl-sin2}{\\sin^2\\!\\left(\\frac{\\theta}{2}\\right)} \\cdot(-1)",
+              "highlights": {
+                "cos2": {
+                  "color": "green",
+                  "label": "Probability of $\\lvert 0\\rangle$ (eigenvalue +1)"
+                },
+                "sin2": {
+                  "color": "orange",
+                  "label": "Probability of $\\lvert 1\\rangle$ (eigenvalue −1)"
+                }
+              },
+              "justification": "The expectation value of Z is the weighted sum of its eigenvalues, weighted by the Born-rule probabilities.",
+              "explanation": "The phase $e^{i\\phi}$ drops out because $\\lvert e^{i\\phi}\\rvert^2 = 1$.",
+              "prompt": "Point out that this is the same Born's rule calculation as in the next scene, but framed as an expectation value.",
+              "sceneStep": 1
+            },
+            {
+              "type": "step",
+              "label": "Apply the double-angle identity",
+              "math": "\\cos^2\\!\\left(\\frac{\\theta}{2}\\right) - \\sin^2\\!\\left(\\frac{\\theta}{2}\\right) = \\htmlClass{hl-costheta}{\\cos\\theta}",
+              "highlights": {
+                "costheta": {
+                  "color": "blue",
+                  "label": "The familiar cosine double-angle formula"
+                }
+              },
+              "justification": "Use $\\cos^2(\\alpha) - \\sin^2(\\alpha) = \\cos(2\\alpha)$ with $\\alpha = \\theta/2$.",
+              "explanation": "This collapses two terms into a single trigonometric function of the polar angle.",
+              "prompt": "Emphasize that this is why the parameterization uses theta/2 — so that the Bloch z-coordinate comes out as simply cos(theta).",
+              "sceneStep": 1
+            },
+            {
+              "type": "conclusion",
+              "label": "The z-coordinate is an expectation value",
+              "math": "\\htmlClass{hl-result}{z = \\langle\\psi\\lvert Z\\rvert\\psi\\rangle = \\cos\\theta}",
+              "highlights": {
+                "result": {
+                  "color": "green",
+                  "label": "Height on the Bloch sphere = expectation of Pauli Z"
+                }
+              },
+              "justification": "Combining the previous steps.",
+              "explanation": "The Bloch z-coordinate is not an arbitrary label — it is the physical expectation value of the Z measurement. The same logic gives $x = \\langle X\\rangle$ and $y = \\langle Y\\rangle$.",
+              "prompt": "Close by noting that all three Bloch coordinates come from Pauli expectation values: x from X, y from Y, z from Z. This is why the Bloch sphere is physically meaningful.",
+              "sceneStep": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Measurement Reads Latitude",
+      "description": "In the computational basis, measurement probabilities depend only on how far up or down the Bloch sphere the state sits.",
+      "markdown": "# Measurement Reads Latitude\n\nFor the Bloch-sphere parameterization\n\n$$|\\psi\\rangle = \\cos\\left(\\frac{\\theta}{2}\\right)|0\\rangle + e^{i\\phi}\\sin\\left(\\frac{\\theta}{2}\\right)|1\\rangle,$$\n\nBorn's rule gives\n\n$$p(0)=|\\langle 0|\\psi\\rangle|^2 = \\cos^2\\left(\\frac{\\theta}{2}\\right),\\qquad p(1)=|\\langle 1|\\psi\\rangle|^2 = \\sin^2\\left(\\frac{\\theta}{2}\\right).$$\n\nBecause the Bloch z-coordinate is $z=\\cos\\theta$, the half-angle identities turn those into\n\n$$p(0)=\\frac{1+z}{2},\\qquad p(1)=\\frac{1-z}{2}.$$\n\nSo a computational-basis measurement only reads the state's **height** on the sphere. The azimuth $\\phi$ matters for other measurement bases, but not for this one.",
+      "prompt": "Teach this scene as the first real predictive payoff of the Bloch sphere. Green is the z projection, gold is the state, and magenta is the horizontal gap between the state and its projection. Emphasize that phi is irrelevant for computational-basis measurement.",
+      "range": [
+        [
+          -1.35,
+          1.35
+        ],
+        [
+          -1.35,
+          1.35
+        ],
+        [
+          -1.35,
+          1.35
+        ]
+      ],
+      "camera": {
+        "position": [
+          2.8,
+          -2.4,
+          1.8
+        ],
+        "target": [
+          0,
+          0,
+          0
+        ],
+        "up": [
+          0,
+          0,
+          1
+        ]
+      },
+      "views": [
+        {
+          "name": "Iso",
+          "position": [
+            2.8,
+            -2.4,
+            1.8
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            0,
+            1
+          ],
+          "description": "See the full state and its projection"
+        },
+        {
+          "name": "Meridian",
+          "position": [
+            0,
+            -4,
+            0
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            0,
+            1
+          ],
+          "description": "Look directly at the x-z plane"
+        }
+      ],
+      "elements": [
+        {
+          "id": "s3_sphere",
+          "type": "sphere",
+          "center": [
+            0,
+            0,
+            0
+          ],
+          "radius": 1,
+          "color": "#5c7cfa",
+          "opacity": 0.12,
+          "segments": 64,
+          "rings": 48
+        },
+        {
+          "id": "s3_axis_x",
+          "type": "axis",
+          "axis": "x",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": "#ff4444",
+          "width": 1.2,
+          "label": "$x$"
+        },
+        {
+          "id": "s3_axis_y",
+          "type": "axis",
+          "axis": "y",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": "#44cc44",
+          "width": 1.2,
+          "label": "$y$"
+        },
+        {
+          "id": "s3_axis_z",
+          "type": "axis",
+          "axis": "z",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": "#4488ff",
+          "width": 1.2,
+          "label": "$z$"
+        },
+        {
+          "id": "s3_grid_xy",
+          "type": "grid",
+          "plane": "xy",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": [
+            0.28,
+            0.28,
+            0.45
+          ],
+          "opacity": 0.12,
+          "divisions": 8
+        },
+        {
+          "id": "s3_ket0",
+          "type": "point",
+          "position": [
+            0,
+            0,
+            1
+          ],
+          "color": "#66d9ff",
+          "size": 10,
+          "label": "$|0\\rangle$"
+        },
+        {
+          "id": "s3_ket1",
+          "type": "point",
+          "position": [
+            0,
+            0,
+            -1
+          ],
+          "color": "#ff7b72",
+          "size": 10,
+          "label": "$|1\\rangle$"
+        }
+      ],
+      "steps": [
+        {
+          "title": "Set the latitude",
+          "description": "Choose a state on the x-z meridian. Sliding $\\theta$ changes the state's height and therefore its computational-basis bias.",
+          "prompt": "Make the student track height first. Explain that we are freezing phi because computational-basis measurement only cares about the z coordinate.",
+          "sliders": [
+            {
+              "id": "q3_theta",
+              "label": "$\\theta$",
+              "min": 0,
+              "max": 3.141592653589793,
+              "step": 0.01,
+              "default": 1.2
+            }
+          ],
+          "add": [
+            {
+              "id": "s3_state_vec",
+              "type": "animated_vector",
+              "from": [
+                0,
+                0,
+                0
+              ],
+              "expr": [
+                "sin(q3_theta)",
+                "0",
+                "cos(q3_theta)"
+              ],
+              "color": "#ffd166",
+              "width": 2.0,
+              "label": "$|\\psi\\rangle$"
+            },
+            {
+              "id": "s3_state_pt",
+              "type": "animated_point",
+              "expr": [
+                "sin(q3_theta)",
+                "0",
+                "cos(q3_theta)"
+              ],
+              "color": "#ffd166",
+              "size": 1.0
+            }
+          ]
+        },
+        {
+          "title": "Project onto $z$",
+          "description": "The green projection on the z-axis is the quantity that matters. At the north pole $z=1$, at the south pole $z=-1$, and on the equator $z=0$.",
+          "prompt": "Explain why the green segment captures everything needed for computational-basis measurement. Tie z equals cosine theta to the student's slider intuition.",
+          "add": [
+            {
+              "id": "s3_zproj_vec",
+              "type": "animated_vector",
+              "from": [
+                0,
+                0,
+                0
+              ],
+              "expr": [
+                "0",
+                "0",
+                "cos(q3_theta)"
+              ],
+              "color": "#7bd389",
+              "width": 2.0,
+              "label": "$z$"
+            },
+            {
+              "id": "s3_gap_vec",
+              "type": "animated_vector",
+              "fromExpr": [
+                "0",
+                "0",
+                "cos(q3_theta)"
+              ],
+              "expr": [
+                "sin(q3_theta)",
+                "0",
+                "cos(q3_theta)"
+              ],
+              "color": "#c77dff",
+              "width": 1.0,
+              "opacity": 0.5,
+              "arrow": false
+            }
+          ],
+          "info": [
+            {
+              "id": "s3_probs",
+              "position": "top-right",
+              "content": "$$z=\\cos\\theta={{toFixed(cos(q3_theta),3)}}$$\n$$p(0)=\\cos^2\\left(\\frac{\\theta}{2}\\right)={{toFixed(cos(q3_theta/2)^2,3)}}$$\n$$p(1)=\\sin^2\\left(\\frac{\\theta}{2}\\right)={{toFixed(sin(q3_theta/2)^2,3)}}$$"
+            }
+          ]
+        },
+        {
+          "title": "Rewrite with $z$",
+          "description": "Using the half-angle identities, the probabilities become linear in the Bloch z-coordinate. That is why a computational-basis measurement can be read directly from the state's height.",
+          "prompt": "Tie the algebra back to the picture. The goal is not just to manipulate identities, but to see why latitude predicts measurement.",
+          "info": [
+            {
+              "id": "s3_linear",
+              "position": "top-right",
+              "content": "$$p(0)=\\frac{1+z}{2}={{toFixed((1+cos(q3_theta))/2,3)}},\\qquad p(1)=\\frac{1-z}{2}={{toFixed((1-cos(q3_theta))/2,3)}}$$"
+            }
+          ]
+        }
+      ],
+      "proof": {
+        "id": "s3_z_measurement_derivation",
+        "title": "Deriving basis probabilities from the Bloch z-component",
+        "technique": "derivation",
+        "techniqueHint": "This is a short derivation: apply Born's rule to the Bloch-sphere parameterization and then use the half-angle identities.",
+        "goal": "Show that $p(0)=\\frac{1+z}{2}$ and $p(1)=\\frac{1-z}{2}$ when $z=\\cos\\theta$.",
+        "sceneStep": 0,
+        "prompt": "Walk the student from the ket formula to the probability formula. Keep the visual link explicit: z is the state's height on the sphere.",
+        "steps": [
+          {
+            "type": "given",
+            "label": "Start from the Bloch parameterization",
+            "math": "\\htmlClass{hl-state}{\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle}",
+            "highlights": {
+              "state": {
+                "color": "cyan",
+                "label": "A general pure qubit state"
+              }
+            },
+            "justification": "Use the standard parameterization of a pure qubit on the Bloch sphere.",
+            "explanation": "The coefficients already tell us the amplitudes for the computational basis states.",
+            "prompt": "Remind the student that the north and south poles correspond to pure |0> and |1>.",
+            "sceneStep": 0
+          },
+          {
+            "type": "step",
+            "label": "Apply Born's rule",
+            "math": "p(0)=\\lvert\\langle 0\\vert\\psi\\rangle\\rvert^2=\\htmlClass{hl-p0}{\\cos^2\\!\\left(\\frac{\\theta}{2}\\right)} \\\\ p(1)=\\lvert\\langle 1\\vert\\psi\\rangle\\rvert^2=\\htmlClass{hl-p1}{\\sin^2\\!\\left(\\frac{\\theta}{2}\\right)}",
+            "highlights": {
+              "p0": {
+                "color": "green",
+                "label": "$|0\\rangle$ probability"
+              },
+              "p1": {
+                "color": "orange",
+                "label": "$|1\\rangle$ probability"
+              }
+            },
+            "justification": "Project the state onto each basis vector and square the magnitude of the amplitude.",
+            "explanation": "The phase factor $e^{i\\phi}$ disappears from the magnitude, so $\\phi$ does not affect this measurement basis.",
+            "prompt": "Point out explicitly that the global magnitude of the complex phase is 1, so it drops out of the probabilities.",
+            "sceneStep": 1
+          },
+          {
+            "type": "step",
+            "label": "Use the half-angle identities",
+            "math": "\\cos^2\\left(\\frac{\\theta}{2}\\right)=\\frac{1+\\htmlClass{hl-z}{\\cos\\theta}}{2},\\qquad \\sin^2\\left(\\frac{\\theta}{2}\\right)=\\frac{1-\\htmlClass{hl-z2}{\\cos\\theta}}{2}",
+            "highlights": {
+              "z": {
+                "color": "blue",
+                "label": "$\\cos\\theta$ becomes the Bloch z-coordinate"
+              },
+              "z2": {
+                "color": "blue",
+                "label": "Same z-coordinate in the second probability"
+              }
+            },
+            "justification": "Use $\\cos^2(\\theta/2)=(1+\\cos\\theta)/2$ and $\\sin^2(\\theta/2)=(1-\\cos\\theta)/2$.",
+            "explanation": "This is the algebraic bridge from amplitudes to geometry.",
+            "prompt": "Make the phrase 'height on the sphere' explicit when you replace cos theta by z.",
+            "sceneStep": 2
+          },
+          {
+            "type": "conclusion",
+            "label": "Read height as probability",
+            "math": "z=\\cos\\theta\\ \\Longrightarrow\\ p(0)=\\frac{1+\\htmlClass{hl-zfinal}{z}}{2},\\qquad p(1)=\\frac{1-\\htmlClass{hl-zfinal2}{z}}{2}",
+            "highlights": {
+              "zfinal": {
+                "color": "green",
+                "label": "Positive z favors $|0\\rangle$"
+              },
+              "zfinal2": {
+                "color": "orange",
+                "label": "Negative z favors $|1\\rangle$"
+              }
+            },
+            "justification": "Substitute the Bloch coordinate $z$ for $\\cos\\theta$.",
+            "explanation": "A computational-basis measurement only needs the state's z-coordinate, so latitude alone predicts the outcome probabilities.",
+            "prompt": "End by tying the final formula directly to the green projection in the scene.",
+            "sceneStep": 2
+          }
+        ]
+      }
+    },
+    {
+      "title": "Relative Phase Changes Other Measurements",
+      "description": "Equator states all look identical to a z-basis measurement, but their relative phase changes what other bases can see.",
+      "markdown": "# Relative Phase Changes Other Measurements\n\nOn the equator of the Bloch sphere, $\\theta=\\pi/2$, so the state takes the form\n\n$$|\\psi(\\phi)\\rangle = \\frac{|0\\rangle + e^{i\\phi}|1\\rangle}{\\sqrt{2}}.$$\n\nEvery such state has\n\n$$p_z(0)=p_z(1)=\\frac{1}{2},$$\n\nso a computational-basis measurement cannot distinguish them.\n\nBut other bases can. For the x basis,\n\n$$p(+x)=\\frac{1+\\cos\\phi}{2},\\qquad p(-x)=\\frac{1-\\cos\\phi}{2},$$\n\nand for the y basis,\n\n$$p(+y)=\\frac{1+\\sin\\phi}{2},\\qquad p(-y)=\\frac{1-\\sin\\phi}{2}.$$\n\nThis is why **relative phase matters**. By contrast, multiplying the entire ket by $e^{i\\gamma}$ leaves the Bloch point unchanged, so **global phase is physically invisible** for a single qubit.",
+      "prompt": "Teach this scene as the payoff for relative phase. The z-basis probabilities stay flat at one half, while x and y measurements change with phi. Keep the distinction between relative phase and global phase crisp and explicit.",
+      "range": [
+        [
+          -1.35,
+          1.35
+        ],
+        [
+          -1.35,
+          1.35
+        ],
+        [
+          -1.35,
+          1.35
+        ]
+      ],
+      "camera": {
+        "position": [
+          2.8,
+          -2.4,
+          1.8
+        ],
+        "target": [
+          0,
+          0,
+          0
+        ],
+        "up": [
+          0,
+          0,
+          1
+        ]
+      },
+      "views": [
+        {
+          "name": "Iso",
+          "position": [
+            2.8,
+            -2.4,
+            1.8
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            0,
+            1
+          ],
+          "description": "See the equator and the x, y, z axes together"
+        },
+        {
+          "name": "Top Down",
+          "position": [
+            0,
+            0,
+            4
+          ],
+          "target": [
+            0,
+            0,
+            0
+          ],
+          "up": [
+            0,
+            1,
+            0
+          ],
+          "description": "Watch $\\phi$ sweep the equator from above"
+        }
+      ],
+      "elements": [
+        {
+          "id": "s4_sphere",
+          "type": "sphere",
+          "center": [
+            0,
+            0,
+            0
+          ],
+          "radius": 1,
+          "color": "#5c7cfa",
+          "opacity": 0.12,
+          "segments": 64,
+          "rings": 48
+        },
+        {
+          "id": "s4_axis_x",
+          "type": "axis",
+          "axis": "x",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": "#ff4444",
+          "width": 1.2,
+          "label": "$x$"
+        },
+        {
+          "id": "s4_axis_y",
+          "type": "axis",
+          "axis": "y",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": "#44cc44",
+          "width": 1.2,
+          "label": "$y$"
+        },
+        {
+          "id": "s4_axis_z",
+          "type": "axis",
+          "axis": "z",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": "#4488ff",
+          "width": 1.2,
+          "label": "$z$"
+        },
+        {
+          "id": "s4_grid_xy",
+          "type": "grid",
+          "plane": "xy",
+          "range": [
+            -1.2,
+            1.2
+          ],
+          "color": [
+            0.28,
+            0.28,
+            0.45
+          ],
+          "opacity": 0.12,
+          "divisions": 8
+        }
+      ],
+      "steps": [
+        {
+          "title": "Walk the equator",
+          "description": "Set $\\theta=\\pi/2$ and change only $\\phi$. The state moves around the equator, but its z-coordinate stays at zero, so a z-basis measurement always gives 50%-50%.",
+          "prompt": "Say explicitly that the equator means z equals zero. Use that to justify the flat z-basis probabilities before discussing any other basis.",
+          "sliders": [
+            {
+              "id": "q4_phi",
+              "label": "$\\phi$",
+              "min": 0,
+              "max": 6.283185307179586,
+              "step": 0.01,
+              "default": 0,
+              "animate": true,
+              "duration": 5000
+            }
+          ],
+          "add": [
+            {
+              "id": "s4_equator",
+              "type": "parametric_curve",
+              "x": "cos(t)",
+              "y": "sin(t)",
+              "z": "0",
+              "range": [
+                0,
+                6.283185307179586
+              ],
+              "samples": 180,
+              "color": "#c77dff",
+              "width": 2,
+              "opacity": 0.6
+            },
+            {
+              "id": "s4_state_vec",
+              "type": "animated_vector",
+              "from": [
+                0,
+                0,
+                0
+              ],
+              "expr": [
+                "cos(q4_phi)",
+                "sin(q4_phi)",
+                "0"
+              ],
+              "color": "#ffd166",
+              "width": 2.0,
+              "label": "$|\\psi(\\phi)\\rangle$"
+            },
+            {
+              "id": "s4_state_pt",
+              "type": "animated_point",
+              "expr": [
+                "cos(q4_phi)",
+                "sin(q4_phi)",
+                "0"
+              ],
+              "color": "#ffd166",
+              "size": 1.0
+            }
+          ],
+          "info": [
+            {
+              "id": "s4_zflat",
+              "position": "top-right",
+              "content": "$$\\lvert\\psi(\\phi)\\rangle = \\frac{\\lvert 0\\rangle + e^{i\\phi}\\lvert 1\\rangle}{\\sqrt{2}}$$\n$$p_z(0)=p_z(1)=0.5$$"
+            }
+          ]
+        },
+        {
+          "title": "Measure in the x basis",
+          "description": "Now ask a different question: is the state aligned with $|+x\\rangle$ or $|-x\\rangle$? As $\\phi$ changes, those probabilities change even though the z-basis probabilities do not.",
+          "prompt": "Use this step to make basis dependence vivid. Relative phase becomes visible when we rotate the measurement basis.",
+          "add": [
+            {
+              "id": "s4_plusx",
+              "type": "point",
+              "position": [
+                1,
+                0,
+                0
+              ],
+              "color": "#66d9ff",
+              "size": 10,
+              "label": "$|+x\\rangle$"
+            },
+            {
+              "id": "s4_minusx",
+              "type": "point",
+              "position": [
+                -1,
+                0,
+                0
+              ],
+              "color": "#ff7b72",
+              "size": 10,
+              "label": "$|-x\\rangle$"
+            }
+          ],
+          "info": [
+            {
+              "id": "s4_xbasis",
+              "position": "top-right",
+              "content": "$$p(+x)=\\frac{1+\\cos\\phi}{2}={{toFixed((1+cos(q4_phi))/2,3)}}$$\n$$p(-x)=\\frac{1-\\cos\\phi}{2}={{toFixed((1-cos(q4_phi))/2,3)}}$$"
+            }
+          ]
+        },
+        {
+          "title": "Measure in the y basis",
+          "description": "The y basis sees a different slice of the same circle. As the state moves around the equator, the y-basis probabilities rise and fall with $\\sin\\phi$.",
+          "prompt": "Show that x and y measurements are complementary ways of reading the azimuth. This cements the idea that relative phase is geometric information on the Bloch sphere.",
+          "add": [
+            {
+              "id": "s4_plusy",
+              "type": "point",
+              "position": [
+                0,
+                1,
+                0
+              ],
+              "color": "#7bd389",
+              "size": 10,
+              "label": "$|+y\\rangle$"
+            },
+            {
+              "id": "s4_minusy",
+              "type": "point",
+              "position": [
+                0,
+                -1,
+                0
+              ],
+              "color": "#c77dff",
+              "size": 10,
+              "label": "$|-y\\rangle$"
+            }
+          ],
+          "info": [
+            {
+              "id": "s4_ybasis",
+              "position": "top-right",
+              "content": "$$p(+y)=\\frac{1+\\sin\\phi}{2}={{toFixed((1+sin(q4_phi))/2,3)}}$$\n$$p(-y)=\\frac{1-\\sin\\phi}{2}={{toFixed((1-sin(q4_phi))/2,3)}}$$"
+            }
+          ]
+        },
+        {
+          "title": "Global phase is invisible",
+          "description": "Multiplying the entire ket by $e^{i\\gamma}$ does not move the Bloch point or change any measurement probability. Only the relative phase between the basis amplitudes changes the state geometry.",
+          "prompt": "Students often confuse relative phase with global phase. State the distinction plainly: relative phase moves the Bloch point; global phase does not.",
+          "info": [
+            {
+              "id": "s4_global_phase",
+              "position": "top-right",
+              "content": "$$e^{i\\gamma}\\lvert\\psi\\rangle\\ \\text{and}\\ \\lvert\\psi\\rangle\\ \\text{represent the same physical state}$$\n$$\\text{Only the relative phase }\\phi\\text{ changes the Bloch point.}$$"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Promotes `scenes/draft/quantum-states.json` to production as `scenes/quantum-states.json`
- 9-scene lesson: "A Qubit Lives in C²" — covers qubit superposition, Hilbert space mapping, Bloch sphere parameterization, measurement probabilities, amplitude encoding, and relative phase effects
- 4368 lines, 266 expressions (all safe), 3 proofs with 14 steps, 29 overlays
- Validated: schema ✓, content ✓, lint ✓, expression audit ✓, test suite (3081 passed)

## Test plan
- [x] Schema validation passed
- [x] Content validation passed (213 expressions, 37 remove IDs, 3 proofs/14 steps)
- [x] Lint check passed
- [x] Expression audit: 266 safe, 0 unsafe
- [x] Full test suite: 3081 passed, 0 failed
- [x] Browser preview: Bloch sphere renders correctly, scene navigation works, no console errors

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>