### PR TITLE
fix: stop scene loads from starving the health check (event-loop offload) + loading indicator

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -1399,7 +1399,10 @@ def create_app(initial_scene_path=None, debug=False,
         do not ship an explicit ``semanticGraph`` field.
         """
         try:
-            graph = _graph_service.derive(req.latex, domain=req.domain)
+            # Offload the synchronous parse to a worker thread so a burst of
+            # graph derivations can't monopolize the event loop and starve
+            # /api/health (Render's probe). See also _load_scene callers below.
+            graph = await asyncio.to_thread(_graph_service.derive, req.latex, domain=req.domain)
             return JSONResponse({"graph": graph.model_dump(by_alias=True, exclude_none=True) if graph else None})
         except (ValueError, SyntaxError, KeyError) as e:
             print(f"   ⚠️ /api/graph/from-latex parse error: {e}", flush=True)
@@ -1424,7 +1427,8 @@ def create_app(initial_scene_path=None, debug=False,
         from backend.semantic_graph.mathjs_converter import latex_to_mathjs
 
         try:
-            script, variables = latex_to_mathjs(req.subexpr)
+            # CPU-bound LaTeX→mathjs conversion — keep it off the event loop.
+            script, variables = await asyncio.to_thread(latex_to_mathjs, req.subexpr)
             return JSONResponse({"script": script, "variables": variables})
         except (ValueError, SyntaxError) as e:
             print(f"   ⚠️  /api/graph/generate-mathjs: conversion failed: {e}")
@@ -1592,7 +1596,8 @@ def create_app(initial_scene_path=None, debug=False,
                 theme = dict(theme)
                 theme["direction"] = req.direction
             show_set = set(req.show) if req.show else None
-            mermaid_src = g2m.semantic_graph_to_mermaid(
+            mermaid_src = await asyncio.to_thread(
+                g2m.semantic_graph_to_mermaid,
                 req.graph or {}, theme=theme, show=show_set,
             )
             # ``edgeStyles`` is forwarded so the client can paint a legend
@@ -1687,7 +1692,10 @@ def create_app(initial_scene_path=None, debug=False,
             return JSONResponse({"error": "Scene file not found"}, status_code=404)
         try:
             # resolve_scene_path_safe already confined this to scenes/ — load directly.
-            scene = _load_scene(resolved_path, trusted=True)
+            # _load_scene runs _autofill_semantic_graphs, which derives a graph per
+            # proof step (seconds for a large lesson). Offload to a worker thread so
+            # the load can't block the event loop and time out Render's health check.
+            scene = await asyncio.to_thread(_load_scene, resolved_path, trusted=True)
             # Return a project-root-relative path ("scenes/<name>") so the
             # ?scene= URL the frontend writes round-trips: resolve_scene_path_safe
             # rejects absolute paths, so echoing an absolute path would 404 on
@@ -1753,7 +1761,7 @@ def create_app(initial_scene_path=None, debug=False,
     async def get_current_scene():
         if current_spec_path[0]:
             try:
-                current_spec[0] = _load_scene(current_spec_path[0], trusted=True)
+                current_spec[0] = await asyncio.to_thread(_load_scene, current_spec_path[0], trusted=True)
             except Exception:
                 pass
         return JSONResponse(current_spec[0] if current_spec[0] else {})
@@ -1953,7 +1961,7 @@ def create_app(initial_scene_path=None, debug=False,
         body = await request.body()
         try:
             new_spec = json.loads(body)
-            current_spec[0] = _load_scene(new_spec)
+            current_spec[0] = await asyncio.to_thread(_load_scene, new_spec)
             return JSONResponse({"status": "loaded"})
         except json.JSONDecodeError:
             return JSONResponse({"error": "Invalid JSON"}, status_code=400)

--- a/backend/server.py
+++ b/backend/server.py
@@ -1752,7 +1752,10 @@ def create_app(initial_scene_path=None, debug=False,
 
     @fastapp.get("/scenes/{name:path}")
     async def get_scene(name: str):
-        scene = load_builtin_scene(name)
+        # load_builtin_scene → _load_scene runs the per-step graph backfill,
+        # so offload it too (same reason as the other _load_scene callers) —
+        # otherwise selecting a large built-in lesson re-blocks the event loop.
+        scene = await asyncio.to_thread(load_builtin_scene, name)
         if scene:
             return JSONResponse(scene)
         return Response(content=b'Scene not found', status_code=404)

--- a/static/index.html
+++ b/static/index.html
@@ -112,6 +112,10 @@
             </div>
             <div id="controls-hint">Drag: rotate &middot; Shift+drag: pan &middot; Zoom: pinch/wheel &middot; &#8997;+drag: roll</div>
             <div id="drop-overlay">Drop JSON file here</div>
+            <div id="scene-loading" aria-live="polite" aria-busy="false">
+                <div class="scene-loading-spinner"></div>
+                <div class="scene-loading-text">Loading scene&hellip;</div>
+            </div>
             <div id="empty-state">
                 <h2>AlgeBench</h2>
                 <p>Drag &amp; drop a scene JSON, or use the toolbar above</p>

--- a/static/style.css
+++ b/static/style.css
@@ -1659,6 +1659,45 @@ body.rotating, body.rotating * { cursor: grabbing !important; }
 
 #drop-overlay.active { display: flex; }
 
+/* Scene loading overlay — shown while a scene file is fetched/parsed
+   (the server derives a semantic graph per proof step, which can take a
+   few seconds for a large lesson). Toggled via the .active class. */
+#scene-loading {
+    display: none;
+    position: absolute;
+    top: 0; left: 0;
+    width: 100%; height: 100%;
+    background: rgba(10, 12, 24, 0.55);
+    backdrop-filter: blur(2px);
+    z-index: 350;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    color: rgba(180, 185, 255, 0.95);
+    font-size: 1.05em;
+    letter-spacing: 0.02em;
+}
+
+#scene-loading.active { display: flex; }
+
+.scene-loading-spinner {
+    width: 38px;
+    height: 38px;
+    border: 3px solid rgba(120, 120, 255, 0.25);
+    border-top-color: rgba(140, 140, 255, 0.95);
+    border-radius: 50%;
+    animation: sceneLoadingSpin 0.8s linear infinite;
+}
+
+@keyframes sceneLoadingSpin {
+    to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .scene-loading-spinner { animation-duration: 2s; }
+}
+
 #file-input { display: none; }
 
 /* Scene Dock */

--- a/static/ui.js
+++ b/static/ui.js
@@ -6,6 +6,32 @@
 import { state } from '/state.js';
 import { loadLesson, loadScene, stopAutoPlay } from '/scene-loader.js';
 
+// ----- Scene Loading Indicator -----
+// Shown while a scene is fetched + parsed. The server derives a semantic
+// graph per proof step on load, which can take a few seconds for a large
+// lesson, so we surface progress instead of leaving the UI frozen-looking.
+// Ref-counted so overlapping loads don't hide it early.
+let _sceneLoadingCount = 0;
+
+export function showSceneLoading() {
+    _sceneLoadingCount++;
+    const el = document.getElementById('scene-loading');
+    if (el) {
+        el.classList.add('active');
+        el.setAttribute('aria-busy', 'true');
+    }
+}
+
+export function hideSceneLoading() {
+    _sceneLoadingCount = Math.max(0, _sceneLoadingCount - 1);
+    if (_sceneLoadingCount > 0) return;
+    const el = document.getElementById('scene-loading');
+    if (el) {
+        el.classList.remove('active');
+        el.setAttribute('aria-busy', 'false');
+    }
+}
+
 // ----- Built-in Scenes Dropdown -----
 
 export async function loadBuiltinScenesList() {
@@ -38,6 +64,7 @@ export async function loadBuiltinScenesList() {
 }
 
 export async function loadBuiltinScene(name) {
+    showSceneLoading();
     try {
         const resp = await fetch('/scenes/' + encodeURIComponent(name), { cache: 'no-store' });
         if (!resp.ok) {
@@ -55,23 +82,30 @@ export async function loadBuiltinScene(name) {
     } catch (e) {
         console.error('Failed to load scene:', name, e);
         return false;
+    } finally {
+        hideSceneLoading();
     }
 }
 
 export async function loadSceneFromPath(path) {
-    const resp = await fetch('/api/scene_file?path=' + encodeURIComponent(path), { cache: 'no-store' });
-    if (!resp.ok) {
-        throw new Error(`HTTP ${resp.status} loading scene file`);
+    showSceneLoading();
+    try {
+        const resp = await fetch('/api/scene_file?path=' + encodeURIComponent(path), { cache: 'no-store' });
+        if (!resp.ok) {
+            throw new Error(`HTTP ${resp.status} loading scene file`);
+        }
+        const data = await resp.json();
+        if (!data || typeof data.spec !== 'object') {
+            throw new Error('Invalid scene payload');
+        }
+        state.currentSceneSourceLabel = data.label || path.split(/[\\/]/).pop() || path;
+        state.currentSceneSourcePath = data.path || path;
+        stopAutoPlay();
+        loadLesson(data.spec);
+        updateSceneUrl({ path: state.currentSceneSourcePath });
+    } finally {
+        hideSceneLoading();
     }
-    const data = await resp.json();
-    if (!data || typeof data.spec !== 'object') {
-        throw new Error('Invalid scene payload');
-    }
-    state.currentSceneSourceLabel = data.label || path.split(/[\\/]/).pop() || path;
-    state.currentSceneSourcePath = data.path || path;
-    stopAutoPlay();
-    loadLesson(data.spec);
-    updateSceneUrl({ path: state.currentSceneSourcePath });
 }
 
 export function updateSceneUrl(opts = {}) {
@@ -98,6 +132,7 @@ export async function loadInitialSceneFromQuery() {
         if (loaded) return;
     }
     if (!scenePath) {
+        showSceneLoading();
         try {
             const res = await fetch('/api/scene', { cache: 'no-store' });
             if (res.ok) {
@@ -107,7 +142,9 @@ export async function loadInitialSceneFromQuery() {
                     return;
                 }
             }
-        } catch {}
+        } catch {} finally {
+            hideSceneLoading();
+        }
         loadScene(null);
         return;
     }


### PR DESCRIPTION
## Problem

Render marked the service unhealthy and restarted it (`HTTP health check failed (timed out after 5 seconds)` → later `connection refused`) **right after loading a large lesson** (e.g. atmospheric-entry).

### Root cause
`uvicorn backend.asgi:app` runs **one worker, one event loop**, and **every route is `async def`** — so any synchronous CPU work inside a handler runs inline on the single loop thread and blocks everything, including `/api/health`.

Loading a scene goes `/api/scene_file` → `_load_scene` → `_autofill_semantic_graphs`, which calls `_graph_service.derive(...)` **once per proof step**. The atmospheric-entry lesson ships **zero pre-baked graphs**, so ~79 are derived fresh on every load — **~4.8s locally, ~15–25s on Render's free shared CPU** — all in one blocking call. During that window the loop can't answer the health probe → restart → `connection refused`.

## Fix

### 1. Offload blocking work off the event loop (`backend/server.py`)
Wrap the synchronous calls in `asyncio.to_thread` — the same pattern `/api/chat` and `/api/tts/stream` already use:

| Route | Offloaded call |
|---|---|
| `/api/scene_file`, `/api/scene`, `/api/load` | `_load_scene` |
| `/api/graph/from-latex` | `derive` |
| `/api/graph/generate-mathjs` | `latex_to_mathjs` |
| `/api/graph/mermaid` | `semantic_graph_to_mermaid` |

CPython releases the GIL frequently enough that the trivial health handler is served promptly while the derive work runs in a worker thread.

### 2. Loading indicator (`static/`)
A multi-second load left the UI looking frozen. Added a spinner + "Loading scene…" overlay shown on the async server-fetch load paths and hidden when the load settles (ref-counted, `try/finally` so it always clears).

## Verification
- **Concurrency test:** during a full ~5s atmospheric-entry load, `/api/health` was served **139× with a 52ms worst case** (previously frozen for the whole window).
- **Preview:** lesson renders fully, no console errors; offloaded endpoints return correct payloads in ~25ms (`/api/health` in ~1ms).
- **Indicator:** verified in-browser — activates immediately on a real scene load and auto-hides on completion; zero console errors.

## Notes for reviewer
- Behavior is unchanged; this only moves *where* the work runs.
- Pre-baking graphs into scene JSON was considered and **intentionally skipped** per request.
- Drag-drop / file-picker loads are synchronous client-side and left untouched (a spinner there wouldn't paint without artificial deferral).

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>