### PR TITLE
feat(prebake): semantic-graph prebake tool + skill; prebake atmospheric lesson

### DIFF
--- a/.agents/skills/algebench-prebake-graphs/SKILL.md
+++ b/.agents/skills/algebench-prebake-graphs/SKILL.md
@@ -118,12 +118,17 @@ Use `AskUserQuestion`. Only offer baking when there is something to bake
 - **No — leave as is** — stop without writing (the natural default when
   `strategy` is `skip`).
 
-> **Heads-up on the diff:** `--write` rewrites the whole file via
-> `json.load`→`json.dump`, so Python re-emits *every* numeric literal in its
-> canonical form (e.g. `0.00007292115` → `7.292115e-05`). These are **cosmetic
-> and numerically identical** — no value changes — but they add noise beyond
-> the added `semanticGraph` blocks. Mention this when presenting the diff so a
-> reviewer isn't alarmed by "changed" physics constants.
+> **Heads-up on the diff:** `--write` rewrites the whole file with a
+> *compact-leaves* serializer — the scene hierarchy stays indented, but each
+> leaf object/array (graph nodes, edges, small value arrays) collapses onto a
+> single line (~3× fewer lines than plain `indent=2`). Two cosmetic effects to
+> call out so a reviewer isn't alarmed:
+> - **Numeric literals** are re-emitted in Python's canonical form (e.g.
+>   `0.00007292115` → `7.292115e-05`) — numerically identical, no value changes.
+> - **Existing multi-line arrays/objects may re-flow** onto one line.
+>
+> The write is round-trip-checked (`json.loads(new) == spec`) before saving, so
+> formatting never changes the data.
 
 ### Step 4 — Bake
 

--- a/.agents/skills/algebench-prebake-graphs/SKILL.md
+++ b/.agents/skills/algebench-prebake-graphs/SKILL.md
@@ -48,18 +48,24 @@ the JSON report:
 
 The report classifies every proof step that has `math`:
 
-| Status    | Meaning                                                        |
-|-----------|----------------------------------------------------------------|
-| `valid`   | A baked graph exists and matches a fresh derivation — leave it |
-| `stale`   | A baked graph exists but **differs** (math or parser changed) — needs rebaking |
-| `missing` | Derivable but **not yet baked** — baking would speed up loads  |
-| `error`   | Derivation fails (unsupported LaTeX) — **cannot** be baked     |
+| Status         | Meaning                                                   |
+|----------------|-----------------------------------------------------------|
+| `valid`        | A baked graph exists and matches a fresh derivation — leave it |
+| `stale`        | A baked graph exists but **differs** (math or parser changed) — needs rebaking |
+| `missing`      | Derivable but **not yet baked** — baking would speed up loads |
+| `errorBroken`  | **Had** a baked graph that no longer derives — a committed graph the parser can't reproduce (regression) |
+| `errorUnbaked` | Never baked, parser can't derive it (unsupported LaTeX) — expected; fails the same at runtime |
 
-Key fields: `counts`, `needsPrebake` (= stale + missing), `deriveSeconds`
-(cost to derive *everything* — the full bake cost), `runtimeDeriveSeconds`
-(cost the server still pays on every load — i.e. the steps that aren't
-validly baked; this is what baking eliminates), `recommendPrebake`, and
-`recommendReason`.
+Key fields: `counts`, `needsPrebake` (= stale + missing), `outOfSync`
+(= stale + errorBroken — committed graphs the current parser can't reproduce;
+the CI gate), `deriveSeconds` (full bake cost), `runtimeDeriveSeconds` (cost
+the server still pays on every load — what baking eliminates), `recommendPrebake`,
+and `recommendReason`.
+
+> **CI:** `--validate --fail-on-stale` exits non-zero **only** when
+> `outOfSync > 0`. The `validate-prebaked-graphs.yml` workflow runs it on
+> changed scenes (and all baked scenes when the parser changes) and posts a
+> compact PR comment. `missing`/`errorUnbaked` never fail.
 
 ### Step 2 — Present the assessment
 
@@ -70,8 +76,10 @@ Report to the user, clearly separating the categories:
   (`scene.proof.step` + math preview). These are the riskiest: the lesson is
   shipping graphs that disagree with their expressions.
 - **Missing** (N) — derivable steps with no baked graph; list a few.
-- **Error** (N) — steps the parser can't handle; these will be derived (and
-  fail fast) at runtime regardless — they can't be prebaked. Just note them.
+- **errorBroken** (N) — a committed graph that no longer derives. **Flag these
+  loudly** — a shipped lesson is carrying a graph the parser can't reproduce.
+- **errorUnbaked** (N) — steps the parser can't handle and were never baked;
+  they fail-fast at runtime regardless and can't be prebaked. Just note the count.
 
 If `needsPrebake == 0` (everything already baked), say so and **stop** — do not
 write. Otherwise continue to Step 2b to get a data-driven recommendation.

--- a/.agents/skills/algebench-prebake-graphs/SKILL.md
+++ b/.agents/skills/algebench-prebake-graphs/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: algebench-prebake-graphs
+description: Check an AlgeBench lesson for semantic-graph prebaking — validate which baked graphs are still correct, identify which steps need (re)baking, and bake them into the JSON so the server doesn't derive them at request time.
+triggers:
+  - prebake
+  - prebake graphs
+  - prebake semantic graphs
+  - bake graphs
+  - check graph prebaking
+  - validate prebaked graphs
+---
+
+# Prebake Semantic Graphs
+
+At runtime the AlgeBench server derives a semantic graph for **every proof
+step that has `math` but no `semanticGraph`** (`_autofill_semantic_graphs` in
+`backend/server.py`). For a large lesson that is dozens of derivations on
+every load — several seconds of CPU, far worse on a constrained host (a free
+Render instance can take ~60s for a big lesson). **Prebaking** runs those
+derivations once, offline, and writes the `{"graph": {…}}` blocks into the
+scene JSON so the server skips them and the lesson loads near-instantly.
+
+Prebaking **overwrites** the `semanticGraph` of each step it touches, so this
+skill always runs a **validate pass first**: it re-derives each step and
+compares against any already-baked graph, classifying every step before
+anything is written. The user is asked before any file is modified.
+
+The skill is a thin orchestrator around `scripts/prebake_semantic_graphs.py`
+(which reuses the backend's exact derivation + highlight pipeline, so a baked
+graph is byte-identical to what the server would produce — baking changes
+*when* the work happens, never the result).
+
+## Inputs
+
+- A scene/lesson JSON path (e.g. `scenes/atmospheric-entry-physics.json`).
+  If the user didn't name one, ask which file to check.
+
+## Workflow
+
+### Step 1 — Validate (read-only)
+
+Always start here. Run the validate pass (explicit `--validate`) and capture
+the JSON report:
+
+```bash
+./run.sh scripts/prebake_semantic_graphs.py <scene.json> --validate --json
+```
+
+The report classifies every proof step that has `math`:
+
+| Status    | Meaning                                                        |
+|-----------|----------------------------------------------------------------|
+| `valid`   | A baked graph exists and matches a fresh derivation — leave it |
+| `stale`   | A baked graph exists but **differs** (math or parser changed) — needs rebaking |
+| `missing` | Derivable but **not yet baked** — baking would speed up loads  |
+| `error`   | Derivation fails (unsupported LaTeX) — **cannot** be baked     |
+
+Key fields: `counts`, `needsPrebake` (= stale + missing), `deriveSeconds`
+(cost to derive *everything* — the full bake cost), `runtimeDeriveSeconds`
+(cost the server still pays on every load — i.e. the steps that aren't
+validly baked; this is what baking eliminates), `recommendPrebake`, and
+`recommendReason`.
+
+### Step 2 — Present the assessment
+
+Report to the user, clearly separating the categories:
+
+- **Valid** (N) — already baked and correct; nothing to do.
+- **Stale** (N) — baked graphs that no longer match the math; list them
+  (`scene.proof.step` + math preview). These are the riskiest: the lesson is
+  shipping graphs that disagree with their expressions.
+- **Missing** (N) — derivable steps with no baked graph; list a few.
+- **Error** (N) — steps the parser can't handle; these will be derived (and
+  fail fast) at runtime regardless — they can't be prebaked. Just note them.
+
+Then state the **recommendation**:
+
+- **Prebake suggested** when `needsPrebake > 0` (there are stale or missing
+  graphs); the script sets `recommendPrebake` accordingly. Mention the
+  load-time win: baking removes ~`runtimeDeriveSeconds` of work from every
+  scene load (and several times that on a constrained host like a free
+  Render instance).
+- **No prebake needed** when everything is already baked (`needsPrebake == 0`).
+  Say so and stop — do not write. (A fully-baked lesson derives ~0s at runtime
+  regardless of how long a full re-derive would take.)
+
+### Step 3 — Ask before writing
+
+Prebaking overwrites data, so **never write without explicit confirmation.**
+Use `AskUserQuestion`. Only offer baking when there is something to bake
+(`needsPrebake > 0`, or the user explicitly wants a full rebake):
+
+- **Bake missing + stale** (recommended) — writes only the steps that need it,
+  keeping the *graph* changes minimal. Maps to `--write`.
+- **Rebake everything** — rewrites every derivable step (use when the parser
+  changed and you want a clean, uniform pass). Maps to `--write --all`.
+- **No — leave as is** — stop without writing.
+
+> **Heads-up on the diff:** `--write` rewrites the whole file via
+> `json.load`→`json.dump`, so Python re-emits *every* numeric literal in its
+> canonical form (e.g. `0.00007292115` → `7.292115e-05`). These are **cosmetic
+> and numerically identical** — no value changes — but they add noise beyond
+> the added `semanticGraph` blocks. Mention this when presenting the diff so a
+> reviewer isn't alarmed by "changed" physics constants.
+
+If the user wants to preview the exact change first, run with `--write
+--dry-run` (reports what would change, writes nothing).
+
+### Step 4 — Bake
+
+Run the chosen write command:
+
+```bash
+# missing + stale only (minimal diff)
+./run.sh scripts/prebake_semantic_graphs.py <scene.json> --write
+
+# full rebake
+./run.sh scripts/prebake_semantic_graphs.py <scene.json> --write --all
+```
+
+### Step 5 — Verify
+
+Re-run the validate pass and confirm the result:
+
+```bash
+./run.sh scripts/prebake_semantic_graphs.py <scene.json> --validate --json
+```
+
+After baking, expect `missing = 0`, `stale = 0` (only `valid` and any
+`error` steps remain), and `needsPrebake = 0`. Report the before/after counts.
+
+Optionally confirm the load-time win by timing the server autofill — it should
+now skip the baked steps:
+
+```bash
+./run.sh -c "import json,time; from backend.server import _autofill_semantic_graphs; s=json.load(open('<scene.json>')); t=time.time(); _autofill_semantic_graphs(s); print('autofill: %.3fs'%(time.time()-t))"
+```
+
+## Important rules
+
+- **Validate before writing — always.** The validate pass is the safety check
+  that tells the user which baked graphs are still correct vs. stale.
+- **Never write without explicit confirmation** (prebaking overwrites the
+  `semanticGraph` blocks). Use `AskUserQuestion`, not a plain prompt.
+- **`error` steps are expected and fine** — they can't be parsed, so they're
+  left for the runtime path (which fails fast). Don't treat them as blockers.
+  A per-step failure never aborts the run: each one is caught, counted as
+  `error`, and the rest of the lesson still processes.
+- **Expect numeric-literal reformatting in the diff** — `--write` re-emits the
+  whole file, so floats get Python's canonical form (cosmetic, values
+  unchanged). Don't try to "fix" it; call it out when reviewing the diff.
+- **Prefer "missing + stale"** over a full rebake unless the parser/derivation
+  logic changed — it keeps the *graph* changes in the diff reviewable.
+- Baked graphs match server output exactly; if a re-validate ever shows
+  `stale` right after baking, that's a bug in the derivation pipeline, not the
+  scene — surface it rather than rebaking in a loop.

--- a/.agents/skills/algebench-prebake-graphs/SKILL.md
+++ b/.agents/skills/algebench-prebake-graphs/SKILL.md
@@ -118,17 +118,7 @@ Use `AskUserQuestion`. Only offer baking when there is something to bake
 - **No — leave as is** — stop without writing (the natural default when
   `strategy` is `skip`).
 
-> **Heads-up on the diff:** `--write` rewrites the whole file with a
-> *compact-leaves* serializer — the scene hierarchy stays indented, but each
-> leaf object/array (graph nodes, edges, small value arrays) collapses onto a
-> single line (~3× fewer lines than plain `indent=2`). Two cosmetic effects to
-> call out so a reviewer isn't alarmed:
-> - **Numeric literals** are re-emitted in Python's canonical form (e.g.
->   `0.00007292115` → `7.292115e-05`) — numerically identical, no value changes.
-> - **Existing multi-line arrays/objects may re-flow** onto one line.
->
-> The write is round-trip-checked (`json.loads(new) == spec`) before saving, so
-> formatting never changes the data.
+> **Heads-up on the diff:** `--write` re-serializes the whole file (compact-leaves layout + canonical number formatting), so call out that the cosmetic reformatting is data-identical — it's round-trip-checked before saving.
 
 ### Step 4 — Bake
 

--- a/.agents/skills/algebench-prebake-graphs/SKILL.md
+++ b/.agents/skills/algebench-prebake-graphs/SKILL.md
@@ -65,7 +65,9 @@ and `recommendReason`.
 > **CI:** `--validate --fail-on-stale` exits non-zero **only** when
 > `outOfSync > 0`. The `validate-prebaked-graphs.yml` workflow runs it on
 > changed scenes (and all baked scenes when the parser changes) and posts a
-> compact PR comment. `missing`/`errorUnbaked` never fail.
+> compact PR comment — a TOTAL row + per-scene table, plus non-blocking
+> **prebake suggestions** for un-baked scenes whose parse cost clears the
+> threshold (`recommendPrebake`). `missing`/`errorUnbaked` never fail.
 
 ### Step 2 — Present the assessment
 

--- a/.agents/skills/algebench-prebake-graphs/SKILL.md
+++ b/.agents/skills/algebench-prebake-graphs/SKILL.md
@@ -73,28 +73,50 @@ Report to the user, clearly separating the categories:
 - **Error** (N) — steps the parser can't handle; these will be derived (and
   fail fast) at runtime regardless — they can't be prebaked. Just note them.
 
-Then state the **recommendation**:
+If `needsPrebake == 0` (everything already baked), say so and **stop** — do not
+write. Otherwise continue to Step 2b to get a data-driven recommendation.
 
-- **Prebake suggested** when `needsPrebake > 0` (there are stale or missing
-  graphs); the script sets `recommendPrebake` accordingly. Mention the
-  load-time win: baking removes ~`runtimeDeriveSeconds` of work from every
-  scene load (and several times that on a constrained host like a free
-  Render instance).
-- **No prebake needed** when everything is already baked (`needsPrebake == 0`).
-  Say so and stop — do not write. (A fully-baked lesson derives ~0s at runtime
-  regardless of how long a full re-derive would take.)
+### Step 2b — Get the strategy proposal (dry-run)
+
+When there's something to bake, run a dry-run to measure the actual trade-off
+and let the script **propose the best strategy** from it:
+
+```bash
+./run.sh scripts/prebake_semantic_graphs.py <scene.json> --write --dry-run --json
+```
+
+This computes (without writing):
+
+- `load` — server parse time before → after (a real scene-load simulation),
+  plus `speedup`.
+- `sizes` — file size before → after with `pctIncrease`.
+- `strategy` — `{recommendation, rationale}`, one of:
+  - **`prebake`** — the load win (locally, and ~12× more on a free host)
+    clearly outweighs the size growth. Recommend baking.
+  - **`skip`** — load is already fast; baking mostly just adds bytes.
+    Recommend leaving it (unless the user is targeting a very constrained host).
+  - **`noop`** — nothing to bake.
+
+**Present the strategy verbatim** — the rationale already quotes both the load
+win and the size cost (e.g. *"Load 4.6s→0.05s locally (~55s→~0.6s on a free
+host) for +269% size — the load win clearly outweighs the size cost"*). Lead
+your recommendation with `strategy.recommendation`; don't second-guess it.
 
 ### Step 3 — Ask before writing
 
-Prebaking overwrites data, so **never write without explicit confirmation.**
+Frame the question around the proposed `strategy.recommendation` (make the
+recommended action the first option). Prebaking overwrites data, so **never
+write without explicit confirmation.**
 Use `AskUserQuestion`. Only offer baking when there is something to bake
 (`needsPrebake > 0`, or the user explicitly wants a full rebake):
 
-- **Bake missing + stale** (recommended) — writes only the steps that need it,
-  keeping the *graph* changes minimal. Maps to `--write`.
+- **Bake missing + stale** (recommended when `strategy` is `prebake`) — writes
+  only the steps that need it, keeping the *graph* changes minimal. Maps to
+  `--write`.
 - **Rebake everything** — rewrites every derivable step (use when the parser
   changed and you want a clean, uniform pass). Maps to `--write --all`.
-- **No — leave as is** — stop without writing.
+- **No — leave as is** — stop without writing (the natural default when
+  `strategy` is `skip`).
 
 > **Heads-up on the diff:** `--write` rewrites the whole file via
 > `json.load`→`json.dump`, so Python re-emits *every* numeric literal in its
@@ -102,9 +124,6 @@ Use `AskUserQuestion`. Only offer baking when there is something to bake
 > and numerically identical** — no value changes — but they add noise beyond
 > the added `semanticGraph` blocks. Mention this when presenting the diff so a
 > reviewer isn't alarmed by "changed" physics constants.
-
-If the user wants to preview the exact change first, run with `--write
---dry-run` (reports what would change, writes nothing).
 
 ### Step 4 — Bake
 
@@ -118,6 +137,16 @@ Run the chosen write command:
 ./run.sh scripts/prebake_semantic_graphs.py <scene.json> --write --all
 ```
 
+`--write` reports the payoff directly:
+- **load (server parse):** before → after, simulating a real scene load
+  (`_autofill_semantic_graphs`, parse-if-missing) on the file before vs after
+  baking, with the speedup (e.g. `5.19s → 0.06s (86× faster)`).
+- **size:** before → after with % growth (graphs inline the JSON, so expect a
+  meaningful size increase — e.g. `+269%` for a graph-dense lesson).
+
+Relay both to the user — the trade is "bigger file, far faster load."
+`--write --dry-run` reports the same numbers as a projection without writing.
+
 ### Step 5 — Verify
 
 Re-run the validate pass and confirm the result:
@@ -129,12 +158,9 @@ Re-run the validate pass and confirm the result:
 After baking, expect `missing = 0`, `stale = 0` (only `valid` and any
 `error` steps remain), and `needsPrebake = 0`. Report the before/after counts.
 
-Optionally confirm the load-time win by timing the server autofill — it should
-now skip the baked steps:
-
-```bash
-./run.sh -c "import json,time; from backend.server import _autofill_semantic_graphs; s=json.load(open('<scene.json>')); t=time.time(); _autofill_semantic_graphs(s); print('autofill: %.3fs'%(time.time()-t))"
-```
+The load-time win was already measured and reported by `--write` in Step 4
+(the before/after `load (server parse)` line), so no separate timing run is
+needed.
 
 ## Important rules
 

--- a/.claude/skills/algebench-prebake-graphs
+++ b/.claude/skills/algebench-prebake-graphs
@@ -1,1 +1,1 @@
-/Users/ibenian/dev/algebench/.agents/skills/algebench-prebake-graphs
+../../.agents/skills/algebench-prebake-graphs

--- a/.claude/skills/algebench-prebake-graphs
+++ b/.claude/skills/algebench-prebake-graphs
@@ -1,0 +1,1 @@
+/Users/ibenian/dev/algebench/.agents/skills/algebench-prebake-graphs

--- a/.claude/skills/deploy-to-render
+++ b/.claude/skills/deploy-to-render
@@ -1,1 +1,1 @@
-/Users/ibenian/dev/algebench/.agents/skills/deploy-to-render
+../../.agents/skills/deploy-to-render

--- a/.claude/skills/issue-triage
+++ b/.claude/skills/issue-triage
@@ -1,1 +1,1 @@
-/Users/ibenian/dev/algebench/.agents/skills/issue-triage
+../../.agents/skills/issue-triage

--- a/.github/workflows/validate-prebaked-graphs.yml
+++ b/.github/workflows/validate-prebaked-graphs.yml
@@ -1,0 +1,114 @@
+name: Validate Prebaked Graphs
+
+# Asserts that committed (baked) semantic graphs are still in sync with their
+# `math` — i.e. the current parser still reproduces them. Fails only on a
+# committed graph that can't be reproduced (stale or broken); never-baked or
+# unsupported steps are non-blocking. Runs when a scene changes (check that
+# scene) or when the graph parser changes (re-check every baked scene).
+
+on:
+  pull_request:
+    paths:
+      - 'scenes/**/*.json'
+      - 'scenes/*.json'
+      - 'backend/semantic_graph/**'
+      - 'backend/model/semantic_graph.py'
+      - 'scripts/prebake_semantic_graphs.py'
+  workflow_dispatch:
+
+jobs:
+  validate-prebaked:
+    name: Prebaked Graphs In Sync
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up venv (installs backend deps once)
+        run: ./run.sh -c "import backend.server; print('venv ready')"
+
+      - name: Resolve baked scenes to check
+        id: scenes
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            DIFF=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...HEAD)
+            CANDIDATES=$(echo "$DIFF" | grep -E '^scenes/[^/]+\.json$' || true)
+            # A parser/script change can stale *any* baked scene → re-check all.
+            if echo "$DIFF" | grep -qE '^(backend/semantic_graph/|backend/model/semantic_graph\.py|scripts/prebake_semantic_graphs\.py)'; then
+              CANDIDATES=$(find scenes -maxdepth 1 -name '*.json')
+            fi
+          else
+            CANDIDATES=$(find scenes -maxdepth 1 -name '*.json')
+          fi
+          # Only scenes that actually contain baked graphs are worth checking.
+          BAKED=""
+          for f in $CANDIDATES; do
+            grep -q '"semanticGraph"' "$f" 2>/dev/null && BAKED="$BAKED $f"
+          done
+          echo "list=$(echo $BAKED | xargs)" >> "$GITHUB_OUTPUT"
+
+      - name: Validate prebaked graphs
+        id: check
+        if: steps.scenes.outputs.list != ''
+        run: |
+          FAILED=0
+          : > /tmp/prebake-out.txt
+          for f in ${{ steps.scenes.outputs.list }}; do
+            ./run.sh scripts/prebake_semantic_graphs.py "$f" --validate --fail-on-stale > /tmp/one.txt 2>&1
+            code=$?
+            # Keep only the summary lines (counts + any out-of-sync notice).
+            grep -E 'valid=|out of sync' /tmp/one.txt >> /tmp/prebake-out.txt || echo "  (no graphs)" >> /tmp/prebake-out.txt
+            [ "$code" != "0" ] && FAILED=1
+          done
+          echo "exit_code=${FAILED}" >> "$GITHUB_OUTPUT"
+
+      - name: Post report as PR comment
+        if: github.event_name == 'pull_request' && steps.scenes.outputs.list != '' && always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OUT=$(cat /tmp/prebake-out.txt 2>/dev/null || echo "(no output)")
+          if [ "${{ steps.check.outputs.exit_code }}" = "0" ]; then
+            HEADER="✅ Prebaked Graphs — in sync"
+          else
+            HEADER="❌ Prebaked Graphs — out of sync (a committed graph no longer matches its math)"
+          fi
+          BODY="<!-- prebaked-graphs-report -->
+          **${HEADER}**
+
+          <details><summary>baked scenes checked</summary>
+
+          \`\`\`
+          ${OUT}
+          \`\`\`
+
+          </details>
+
+          <sub>Fails only on **stale**/**broken** (a committed graph the parser can't reproduce). \`missing\` (un-baked) and \`unsupported\` (unparseable) steps are non-blocking — re-bake with \`scripts/prebake_semantic_graphs.py <scene> --write\`.</sub>"
+
+          gh pr comment "${{ github.event.pull_request.number }}" --body "$BODY" --edit-last 2>/dev/null || \
+          gh pr comment "${{ github.event.pull_request.number }}" --body "$BODY"
+
+      - name: Fail if any baked graph is out of sync
+        if: steps.scenes.outputs.list != '' && always()
+        run: |
+          if [ "${{ steps.check.outputs.exit_code }}" != "0" ]; then
+            echo "❌ A committed graph is out of sync — re-bake the scene. See the PR comment."
+            exit 1
+          fi
+          echo "✅ All baked graphs in sync."
+
+      - name: No baked scenes changed
+        if: steps.scenes.outputs.list == ''
+        run: echo "No changed scenes contain baked graphs — nothing to validate."

--- a/.github/workflows/validate-prebaked-graphs.yml
+++ b/.github/workflows/validate-prebaked-graphs.yml
@@ -51,52 +51,34 @@ jobs:
           else
             CANDIDATES=$(find scenes -maxdepth 1 -name '*.json')
           fi
-          # Only scenes that actually contain baked graphs are worth checking.
-          BAKED=""
+          # Keep scenes that have proof steps (where graphs come from) — covers
+          # both baked scenes (staleness) and un-baked ones (prebake suggestion).
+          RELEVANT=""
           for f in $CANDIDATES; do
-            grep -q '"semanticGraph"' "$f" 2>/dev/null && BAKED="$BAKED $f"
+            grep -q '"proof"' "$f" 2>/dev/null && RELEVANT="$RELEVANT $f"
           done
-          echo "list=$(echo $BAKED | xargs)" >> "$GITHUB_OUTPUT"
+          echo "list=$(echo $RELEVANT | xargs)" >> "$GITHUB_OUTPUT"
 
-      - name: Validate prebaked graphs
+      - name: Validate prebaked graphs (sync + prebake suggestions)
         id: check
         if: steps.scenes.outputs.list != ''
         run: |
-          FAILED=0
-          : > /tmp/prebake-out.txt
-          for f in ${{ steps.scenes.outputs.list }}; do
-            ./run.sh scripts/prebake_semantic_graphs.py "$f" --validate --fail-on-stale > /tmp/one.txt 2>&1
-            code=$?
-            # Keep only the summary lines (counts + any out-of-sync notice).
-            grep -E 'valid=|out of sync' /tmp/one.txt >> /tmp/prebake-out.txt || echo "  (no graphs)" >> /tmp/prebake-out.txt
-            [ "$code" != "0" ] && FAILED=1
-          done
-          echo "exit_code=${FAILED}" >> "$GITHUB_OUTPUT"
+          # The helper aggregates a TOTAL row + per-scene table + prebake
+          # suggestions, and exits 1 iff a committed graph is out of sync.
+          # Capture its exit without tripping `set -e` so we still post the comment.
+          set +e
+          ./run.sh scripts/ci_validate_prebaked.py ${{ steps.scenes.outputs.list }} > /tmp/comment.md
+          code=$?
+          set -e
+          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+          cat /tmp/comment.md
 
       - name: Post report as PR comment
         if: github.event_name == 'pull_request' && steps.scenes.outputs.list != '' && always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          OUT=$(cat /tmp/prebake-out.txt 2>/dev/null || echo "(no output)")
-          if [ "${{ steps.check.outputs.exit_code }}" = "0" ]; then
-            HEADER="✅ Prebaked Graphs — in sync"
-          else
-            HEADER="❌ Prebaked Graphs — out of sync (a committed graph no longer matches its math)"
-          fi
-          BODY="<!-- prebaked-graphs-report -->
-          **${HEADER}**
-
-          <details><summary>baked scenes checked</summary>
-
-          \`\`\`
-          ${OUT}
-          \`\`\`
-
-          </details>
-
-          <sub>Fails only on **stale**/**broken** (a committed graph the parser can't reproduce). \`missing\` (un-baked) and \`unsupported\` (unparseable) steps are non-blocking — re-bake with \`scripts/prebake_semantic_graphs.py <scene> --write\`.</sub>"
-
+          BODY=$(cat /tmp/comment.md 2>/dev/null || echo "_prebaked-graph check produced no output_")
           gh pr comment "${{ github.event.pull_request.number }}" --body "$BODY" --edit-last 2>/dev/null || \
           gh pr comment "${{ github.event.pull_request.number }}" --body "$BODY"
 
@@ -109,6 +91,6 @@ jobs:
           fi
           echo "✅ All baked graphs in sync."
 
-      - name: No baked scenes changed
+      - name: No relevant scenes changed
         if: steps.scenes.outputs.list == ''
-        run: echo "No changed scenes contain baked graphs — nothing to validate."
+        run: echo "No changed scenes have proof steps — nothing to validate."

--- a/scenes/atmospheric-entry-physics.json
+++ b/scenes/atmospheric-entry-physics.json
@@ -42,7 +42,7 @@
         "name": "Earth",
         "radius_m": 6371000.0,
         "mu_m3_s2": 398600441800000.0,
-        "rotation_rate_rad_s": 0.00007292115,
+        "rotation_rate_rad_s": 7.292115e-05,
         "atmosphere_model_recommended": "US Standard Atmosphere 1976",
         "entry_interface_altitude_m_model_default": 121920.0
       },
@@ -66,7 +66,10 @@
             "entry_speed_mps": 11176.0,
             "entry_type": "skip_entry",
             "lift_to_drag_ratio": {
-              "value_range": [0.25, 0.27],
+              "value_range": [
+                0.25,
+                0.27
+              ],
               "source_type": "NASA technical paper"
             },
             "flight_path_angle_deg_estimated_or_model_default": -6.5
@@ -78,26 +81,47 @@
           "parachutes": {
             "total_parachutes": 11,
             "forward_bay_cover": {
-              "count": 3, "diameter_ft": 7.0, "diameter_m": 2.1336,
-              "deploy_altitude_ft": 26500.0, "deploy_altitude_m": 8077.2,
-              "deploy_speed_fps": 475.0, "deploy_speed_mps": 144.78, "deploy_speed_mph": 324.0
+              "count": 3,
+              "diameter_ft": 7.0,
+              "diameter_m": 2.1336,
+              "deploy_altitude_ft": 26500.0,
+              "deploy_altitude_m": 8077.2,
+              "deploy_speed_fps": 475.0,
+              "deploy_speed_mps": 144.78,
+              "deploy_speed_mph": 324.0
             },
             "drogue": {
-              "count": 2, "diameter_ft": 23.0, "diameter_m": 7.0104,
-              "single_canopy_area_m2": 38.61, "combined_area_m2": 77.22,
-              "deploy_altitude_ft": 25000.0, "deploy_altitude_m": 7620.0,
-              "deploy_speed_fps": 450.0, "deploy_speed_mps": 137.16, "deploy_speed_mph": 307.0
+              "count": 2,
+              "diameter_ft": 23.0,
+              "diameter_m": 7.0104,
+              "single_canopy_area_m2": 38.61,
+              "combined_area_m2": 77.22,
+              "deploy_altitude_ft": 25000.0,
+              "deploy_altitude_m": 7620.0,
+              "deploy_speed_fps": 450.0,
+              "deploy_speed_mps": 137.16,
+              "deploy_speed_mph": 307.0
             },
             "pilot": {
-              "count": 3, "diameter_ft": 11.0, "diameter_m": 3.3528,
-              "single_canopy_area_m2": 8.83, "combined_area_m2": 26.48,
-              "deploy_altitude_ft": 9500.0, "deploy_altitude_m": 2895.6,
-              "deploy_speed_fps": 190.0, "deploy_speed_mps": 57.91, "deploy_speed_mph": 130.0
+              "count": 3,
+              "diameter_ft": 11.0,
+              "diameter_m": 3.3528,
+              "single_canopy_area_m2": 8.83,
+              "combined_area_m2": 26.48,
+              "deploy_altitude_ft": 9500.0,
+              "deploy_altitude_m": 2895.6,
+              "deploy_speed_fps": 190.0,
+              "deploy_speed_mps": 57.91,
+              "deploy_speed_mph": 130.0
             },
             "main": {
-              "count": 3, "diameter_ft": 116.0, "diameter_m": 35.3568,
-              "single_canopy_area_m2": 981.97, "combined_area_m2": 2945.91,
-              "full_deploy_altitude_ft": 9000.0, "full_deploy_altitude_m": 2743.2,
+              "count": 3,
+              "diameter_ft": 116.0,
+              "diameter_m": 35.3568,
+              "single_canopy_area_m2": 981.97,
+              "combined_area_m2": 2945.91,
+              "full_deploy_altitude_ft": 9000.0,
+              "full_deploy_altitude_m": 2743.2,
               "deploy_speed_mph": 130.0
             }
           },
@@ -111,8 +135,10 @@
           "program": "Commercial Crew",
           "mission_class": "LEO_return",
           "geometry": {
-            "height_m": 8.1382, "diameter_m": 3.7,
-            "reference_area_m2": 10.752, "shape": "blunt lifting capsule"
+            "height_m": 8.1382,
+            "diameter_m": 3.7,
+            "reference_area_m2": 10.752,
+            "shape": "blunt lifting capsule"
           },
           "mass": {
             "vehicle_weight_lb_approx": 21000.0,
@@ -120,24 +146,43 @@
             "mass_quality": "approximate"
           },
           "entry": {
-            "entry_speed_mph": 17500.0, "entry_speed_mps": 7823.2,
+            "entry_speed_mph": 17500.0,
+            "entry_speed_mps": 7823.2,
             "entry_type": "direct_LEO_return",
-            "lift_to_drag_ratio": { "value": null, "note": "Not found in the source set used here" },
+            "lift_to_drag_ratio": {
+              "value": null,
+              "note": "Not found in the source set used here"
+            },
             "flight_path_angle_deg_estimated_or_model_default": -6.0
           },
-          "thermal_protection": { "type": "PICA-X" },
+          "thermal_protection": {
+            "type": "PICA-X"
+          },
           "parachutes": {
             "drogue": {
-              "count": 2, "deploy_altitude_ft": 18000.0, "deploy_altitude_m": 5486.4,
-              "deploy_speed_mph": 350.0, "deploy_speed_mps": 156.46
+              "count": 2,
+              "deploy_altitude_ft": 18000.0,
+              "deploy_altitude_m": 5486.4,
+              "deploy_speed_mph": 350.0,
+              "deploy_speed_mps": 156.46
             },
             "main": {
-              "count": 4, "diameter_m": 35.0, "diameter_ft": 114.83,
-              "single_canopy_area_m2": 962.11, "combined_area_m2": 3848.45,
-              "deploy_altitude_ft": 6000.0, "deploy_altitude_m": 1828.8,
-              "deploy_speed_mph": 119.0, "deploy_speed_mps": 53.2
+              "count": 4,
+              "diameter_m": 35.0,
+              "diameter_ft": 114.83,
+              "single_canopy_area_m2": 962.11,
+              "combined_area_m2": 3848.45,
+              "deploy_altitude_ft": 6000.0,
+              "deploy_altitude_m": 1828.8,
+              "deploy_speed_mph": 119.0,
+              "deploy_speed_mps": 53.2
             },
-            "touchdown_speed": { "min_mps": 4.8, "max_mps": 5.4, "min_fps": 16.0, "max_fps": 18.0 }
+            "touchdown_speed": {
+              "min_mps": 4.8,
+              "max_mps": 5.4,
+              "min_fps": 16.0,
+              "max_fps": 18.0
+            }
           },
           "modeling_status": {
             "good_for_pre_chute_3dof": true,
@@ -149,9 +194,12 @@
           "program": "Project Gemini",
           "mission_class": "LEO_return",
           "geometry": {
-            "spacecraft_total_height_m": 5.6134, "spacecraft_total_base_diameter_m": 3.048,
-            "reentry_module_height_m": 3.3528, "reentry_module_base_diameter_m": 2.22504,
-            "reference_area_m2": 3.888, "shape": "blunt lifting capsule"
+            "spacecraft_total_height_m": 5.6134,
+            "spacecraft_total_base_diameter_m": 3.048,
+            "reentry_module_height_m": 3.3528,
+            "reentry_module_base_diameter_m": 2.22504,
+            "reference_area_m2": 3.888,
+            "shape": "blunt lifting capsule"
           },
           "mass": {
             "launch_weight_lb_approx": 7000.0,
@@ -159,28 +207,45 @@
             "entry_mass_kg_approx": 2132.0
           },
           "entry": {
-            "reentry_velocity_fps": 24000.0, "entry_speed_mph": 16450.0, "entry_speed_mps": 7353.96,
+            "reentry_velocity_fps": 24000.0,
+            "entry_speed_mph": 16450.0,
+            "entry_speed_mps": 7353.96,
             "entry_type": "direct_LEO_return",
-            "lift_to_drag_ratio": { "value_approx": 0.26, "source_type": "NASA history source" },
+            "lift_to_drag_ratio": {
+              "value_approx": 0.26,
+              "source_type": "NASA history source"
+            },
             "flight_path_angle_deg_estimated_or_model_default": -6.0
           },
-          "thermal_protection": { "type": "ablative heat shield" },
+          "thermal_protection": {
+            "type": "ablative heat shield"
+          },
           "parachutes": {
             "drogue": {
-              "count": 1, "diameter_ft": 8.3, "diameter_m": 2.52984,
+              "count": 1,
+              "diameter_ft": 8.3,
+              "diameter_m": 2.52984,
               "single_canopy_area_m2": 5.03,
-              "deploy_altitude_ft": 50000.0, "deploy_altitude_m": 15240.0
+              "deploy_altitude_ft": 50000.0,
+              "deploy_altitude_m": 15240.0
             },
             "pilot": {
-              "count": 1, "diameter_ft": 18.2, "diameter_m": 5.54736,
+              "count": 1,
+              "diameter_ft": 18.2,
+              "diameter_m": 5.54736,
               "single_canopy_area_m2": 24.17,
-              "deploy_altitude_ft": 10600.0, "deploy_altitude_m": 3230.88
+              "deploy_altitude_ft": 10600.0,
+              "deploy_altitude_m": 3230.88
             },
             "main": {
-              "count": 1, "diameter_ft": 84.2, "diameter_m": 25.66416,
+              "count": 1,
+              "diameter_ft": 84.2,
+              "diameter_m": 25.66416,
               "single_canopy_area_m2": 517.24,
-              "deploy_altitude_ft": 10600.0, "deploy_altitude_m": 3230.88,
-              "descent_rate_fps_at_1000_ft": 29.8, "descent_rate_mps_at_1000_ft": 9.08
+              "deploy_altitude_ft": 10600.0,
+              "deploy_altitude_m": 3230.88,
+              "descent_rate_fps_at_1000_ft": 29.8,
+              "descent_rate_mps_at_1000_ft": 9.08
             }
           },
           "modeling_status": {
@@ -193,26 +258,51 @@
           "program": "Apollo",
           "mission_class": "lunar_return",
           "geometry": {
-            "height_m": 3.23, "diameter_m": 3.91,
-            "reference_area_m2": 12.0, "shape": "blunt lifting capsule"
+            "height_m": 3.23,
+            "diameter_m": 3.91,
+            "reference_area_m2": 12.0,
+            "shape": "blunt lifting capsule"
           },
-          "mass": { "entry_mass_kg": 5500 },
+          "mass": {
+            "entry_mass_kg": 5500
+          },
           "entry": {
-            "entry_speed_mps": 11000, "entry_speed_mph": 25000,
+            "entry_speed_mps": 11000,
+            "entry_speed_mph": 25000,
             "entry_type": "skip_entry_capable",
-            "lift_to_drag_ratio": { "value_range": [0.3, 0.35] },
+            "lift_to_drag_ratio": {
+              "value_range": [
+                0.3,
+                0.35
+              ]
+            },
             "flight_path_angle_deg_estimated_or_model_default": -6.5
           },
           "thermal_protection": {
             "type": "Avcoat ablative heat shield",
             "heat_shield_diameter_m": 3.91
           },
-          "aero": { "drag_coefficient_cd_estimated": 1.0, "lift_coefficient_cl_estimated": 0.3 },
-          "parachutes": {
-            "drogue": { "count": 2, "diameter_m": 5.2, "deploy_altitude_m": 7600 },
-            "main": { "count": 3, "diameter_m": 25.4, "combined_area_m2": 1520, "deploy_altitude_m": 3000 }
+          "aero": {
+            "drag_coefficient_cd_estimated": 1.0,
+            "lift_coefficient_cl_estimated": 0.3
           },
-          "landing": { "type": "ocean", "touchdown_velocity_mps": 9 },
+          "parachutes": {
+            "drogue": {
+              "count": 2,
+              "diameter_m": 5.2,
+              "deploy_altitude_m": 7600
+            },
+            "main": {
+              "count": 3,
+              "diameter_m": 25.4,
+              "combined_area_m2": 1520,
+              "deploy_altitude_m": 3000
+            }
+          },
+          "landing": {
+            "type": "ocean",
+            "touchdown_velocity_mps": 9
+          },
           "modeling_notes": {
             "good_for_pre_chute_3dof": true,
             "skip_entry_behavior": "requires lift + guidance modeling",
@@ -226,8 +316,11 @@
         "ballistic_coefficient": "beta = m / (Cd * A)"
       },
       "missing_for_high_fidelity": [
-        "Cd(Mach, alpha)", "Cl(Mach, alpha)", "bank-angle guidance law",
-        "mission-specific entry interface state vector", "winds",
+        "Cd(Mach, alpha)",
+        "Cl(Mach, alpha)",
+        "bank-angle guidance law",
+        "mission-specific entry interface state vector",
+        "winds",
         "Earth rotation treatment if landing footprint matters",
         "trim angle of attack and center-of-mass offset details"
       ]
@@ -491,8 +584,8 @@
     },
     {
       "title": "The Exponential Atmosphere",
-      "description": "Explore the exponential atmosphere model \u03c1(h) = \u03c1\u2080 e^{-h/H} and understand scale height \u2014 the single number that controls how quickly air thins with altitude.",
-      "markdown": "# The Exponential Atmosphere\n\nThe density of air falls off exponentially with altitude:\n\n$$ \\rho(h) = \\rho_0\\, e^{-h/H} $$\n\nwhere $\\rho_0 = 1.225\\,\\text{kg/m}^3$ is sea-level density and $H \\approx 7.2\\,\\text{km}$ is the **scale height** \u2014 the altitude gain that reduces density by a factor of $e \\approx 2.718$.\n\nThis simple model captures the essential physics: the atmosphere is a thin shell that gets exponentially thinner with altitude. By the entry interface at $122\\,\\text{km}$, density is roughly $10^{-7}$ of sea level \u2014 effectively vacuum.\n\n---\n**Key insight:** Every $H$ km of altitude costs a factor of $e$ in density. After $n$ scale heights, density is $e^{-n}$ of the surface value.",
+      "description": "Explore the exponential atmosphere model ρ(h) = ρ₀ e^{-h/H} and understand scale height — the single number that controls how quickly air thins with altitude.",
+      "markdown": "# The Exponential Atmosphere\n\nThe density of air falls off exponentially with altitude:\n\n$$ \\rho(h) = \\rho_0\\, e^{-h/H} $$\n\nwhere $\\rho_0 = 1.225\\,\\text{kg/m}^3$ is sea-level density and $H \\approx 7.2\\,\\text{km}$ is the **scale height** — the altitude gain that reduces density by a factor of $e \\approx 2.718$.\n\nThis simple model captures the essential physics: the atmosphere is a thin shell that gets exponentially thinner with altitude. By the entry interface at $122\\,\\text{km}$, density is roughly $10^{-7}$ of sea level — effectively vacuum.\n\n---\n**Key insight:** Every $H$ km of altitude costs a factor of $e$ in density. After $n$ scale heights, density is $e^{-n}$ of the surface value.",
       "prompt": "Help the student build intuition for exponential decay in the atmosphere. Emphasize the scale height concept and connect it to why entry dynamics are so sensitive to altitude.",
       "range": [
         [
@@ -570,8 +663,8 @@
       "steps": [
         {
           "title": "Sea-Level Density",
-          "description": "At sea level (h = 0), the atmosphere has its maximum density \u03c1\u2080 = 1.225 kg/m\u00b3. This is the starting point of our exponential model.",
-          "prompt": "Introduce \u03c1\u2080 as the anchor point. Ask: how does density change as we go up? Most students guess linear \u2014 set up the surprise that it's exponential.",
+          "description": "At sea level (h = 0), the atmosphere has its maximum density ρ₀ = 1.225 kg/m³. This is the starting point of our exponential model.",
+          "prompt": "Introduce ρ₀ as the anchor point. Ask: how does density change as we go up? Most students guess linear — set up the surprise that it's exponential.",
           "add": [
             {
               "type": "point",
@@ -583,7 +676,7 @@
               ],
               "color": "#2ecc71",
               "size": 12,
-              "label": "$\\rho_0 = 1.225$ kg/m\u00b3 (100%)"
+              "label": "$\\rho_0 = 1.225$ kg/m³ (100%)"
             },
             {
               "type": "line",
@@ -608,8 +701,8 @@
         },
         {
           "title": "The Exponential Profile",
-          "description": "Density drops exponentially: \u03c1(h) = \u03c1\u2080 e^{-h/H}. The curve hugs the altitude axis \u2014 almost all the atmosphere is packed into the lowest few tens of kilometers.",
-          "prompt": "Point out how the curve is steep near the ground and nearly flat high up. Ask: at what altitude has the density dropped to half? (Answer: h = H\u00b7ln2 \u2248 5 km.)",
+          "description": "Density drops exponentially: ρ(h) = ρ₀ e^{-h/H}. The curve hugs the altitude axis — almost all the atmosphere is packed into the lowest few tens of kilometers.",
+          "prompt": "Point out how the curve is steep near the ground and nearly flat high up. Ask: at what altitude has the density dropped to half? (Answer: h = H·ln2 ≈ 5 km.)",
           "add": [
             {
               "type": "parametric_curve",
@@ -640,8 +733,8 @@
         },
         {
           "title": "Scale Height",
-          "description": "The scale height H = 7.2 km is the altitude at which density drops by a factor of e \u2248 2.718. It's the characteristic 'thickness' of the atmosphere.",
-          "prompt": "Draw attention to the horizontal markers showing density at each scale height. Ask: after 3 scale heights (~22 km), what fraction of sea-level density remains? Answer: e^{-3} \u2248 5%.",
+          "description": "The scale height H = 7.2 km is the altitude at which density drops by a factor of e ≈ 2.718. It's the characteristic 'thickness' of the atmosphere.",
+          "prompt": "Draw attention to the horizontal markers showing density at each scale height. Ask: after 3 scale heights (~22 km), what fraction of sea-level density remains? Answer: e^{-3} ≈ 5%.",
           "add": [
             {
               "type": "animated_line",
@@ -707,7 +800,7 @@
         },
         {
           "title": "The Entry Interface",
-          "description": "At 122 km \u2014 about 17 scale heights \u2014 the density is roughly 10\u207b\u2077 of sea level. This is the altitude where atmospheric drag first becomes non-negligible for an entering spacecraft.",
+          "description": "At 122 km — about 17 scale heights — the density is roughly 10⁻⁷ of sea level. This is the altitude where atmospheric drag first becomes non-negligible for an entering spacecraft.",
           "prompt": "Emphasize the enormous contrast: at the entry interface, density is essentially zero on this plot. Yet that tiny sliver of air is enough to generate thousands of degrees of heating and many G's of deceleration at orbital speeds.",
           "add": [
             {
@@ -769,7 +862,7 @@
         "title": "Deriving the Exponential Atmosphere",
         "technique": "derivation",
         "goal": "$$\\rho(h) = \\rho_0\\, e^{-h/H}, \\quad H = \\frac{k_B T}{m g}$$",
-        "prompt": "Derive the exponential atmosphere from first principles \u2014 hydrostatic equilibrium and the ideal gas law. Show that the scale height has a beautiful physical meaning: the height at which thermal energy equals gravitational potential energy per molecule.",
+        "prompt": "Derive the exponential atmosphere from first principles — hydrostatic equilibrium and the ideal gas law. Show that the scale height has a beautiful physical meaning: the height at which thermal energy equals gravitational potential energy per molecule.",
         "steps": [
           {
             "type": "given",
@@ -778,7 +871,90 @@
             "justification": "The pressure decrease across a thin slab of air equals the weight of that slab per unit area.",
             "explanation": "Consider a thin horizontal layer of air at altitude $h$ with thickness $dh$. The pressure at the bottom must support the weight of the air above. This gives a differential relationship between pressure and altitude.",
             "prompt": "Ask: why is there a negative sign? Because pressure decreases as altitude increases.",
-            "sceneStep": 0
+            "sceneStep": 0,
+            "semanticGraph": {
+              "graph": {
+                "nodes": [
+                  {
+                    "id": "__equals_1",
+                    "type": "relation",
+                    "op": "equals",
+                    "subexpr": "dP = -\\rho\\, g\\, dh"
+                  },
+                  {
+                    "id": "dP",
+                    "type": "scalar",
+                    "latex": "dP",
+                    "subexpr": "dP"
+                  },
+                  {
+                    "id": "__negation_2",
+                    "type": "operator",
+                    "op": "negation",
+                    "subexpr": "-\\rho g dh"
+                  },
+                  {
+                    "id": "__multiply_3",
+                    "type": "operator",
+                    "op": "multiply",
+                    "subexpr": "\\rho g dh"
+                  },
+                  {
+                    "id": "dh",
+                    "type": "scalar",
+                    "latex": "dh",
+                    "subexpr": "dh"
+                  },
+                  {
+                    "id": "g",
+                    "type": "scalar",
+                    "latex": "g",
+                    "subexpr": "g"
+                  },
+                  {
+                    "id": "rho",
+                    "type": "scalar",
+                    "latex": "\\rho",
+                    "subexpr": "\\rho"
+                  }
+                ],
+                "edges": [
+                  {
+                    "from": "dP",
+                    "to": "__equals_1"
+                  },
+                  {
+                    "from": "dh",
+                    "to": "__multiply_3",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "g",
+                    "to": "__multiply_3",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "rho",
+                    "to": "__multiply_3",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "__multiply_3",
+                    "to": "__negation_2"
+                  },
+                  {
+                    "from": "__negation_2",
+                    "to": "__equals_1"
+                  }
+                ],
+                "classification": {
+                  "kind": "algebraic"
+                }
+              }
+            }
           },
           {
             "type": "given",
@@ -786,8 +962,127 @@
             "math": "P = \\frac{\\rho\\, k_B T}{m}",
             "justification": "The ideal gas equation of state, written in terms of mass density $\\rho$ and molecular mass $m$.",
             "explanation": "Air behaves as an ideal gas to a good approximation. Here $k_B$ is Boltzmann's constant, $T$ is temperature, and $m$ is the mean molecular mass of air ($\\approx 4.8 \\times 10^{-26}$ kg).",
-            "prompt": "If the student asks about the molecular mass, explain that air is ~78% N\u2082 and ~21% O\u2082, giving a mean molecular weight of about 29 g/mol.",
-            "sceneStep": 0
+            "prompt": "If the student asks about the molecular mass, explain that air is ~78% N₂ and ~21% O₂, giving a mean molecular weight of about 29 g/mol.",
+            "sceneStep": 0,
+            "semanticGraph": {
+              "graph": {
+                "nodes": [
+                  {
+                    "id": "__equals_1",
+                    "type": "relation",
+                    "op": "equals",
+                    "subexpr": "P = \\frac{\\rho\\, k_B T}{m}"
+                  },
+                  {
+                    "id": "P",
+                    "type": "scalar",
+                    "latex": "P",
+                    "subexpr": "P"
+                  },
+                  {
+                    "id": "__multiply_2",
+                    "type": "operator",
+                    "op": "multiply",
+                    "subexpr": "\\frac{1}{m} \\rho T k_{B}"
+                  },
+                  {
+                    "id": "__multiply_3",
+                    "type": "operator",
+                    "op": "multiply",
+                    "subexpr": "\\rho T k_{B}"
+                  },
+                  {
+                    "id": "rho",
+                    "type": "scalar",
+                    "latex": "\\rho",
+                    "subexpr": "\\rho"
+                  },
+                  {
+                    "id": "__multiply_4",
+                    "type": "operator",
+                    "op": "multiply",
+                    "subexpr": "T k_{B}"
+                  },
+                  {
+                    "id": "k_{B}",
+                    "type": "scalar",
+                    "latex": "k_{B}",
+                    "subexpr": "k_{B}"
+                  },
+                  {
+                    "id": "T",
+                    "type": "scalar",
+                    "latex": "T",
+                    "subexpr": "T"
+                  },
+                  {
+                    "id": "__power_5",
+                    "type": "operator",
+                    "latex": "\\dfrac{1}{(\\cdot)}",
+                    "op": "power",
+                    "exponent": "-1",
+                    "subexpr": "\\frac{1}{m}"
+                  },
+                  {
+                    "id": "m",
+                    "type": "scalar",
+                    "latex": "m",
+                    "subexpr": "m"
+                  }
+                ],
+                "edges": [
+                  {
+                    "from": "P",
+                    "to": "__equals_1"
+                  },
+                  {
+                    "from": "rho",
+                    "to": "__multiply_3",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "k_{B}",
+                    "to": "__multiply_4",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "T",
+                    "to": "__multiply_4",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "__multiply_4",
+                    "to": "__multiply_3",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "__multiply_3",
+                    "to": "__multiply_2",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "m",
+                    "to": "__power_5"
+                  },
+                  {
+                    "from": "__power_5",
+                    "to": "__multiply_2"
+                  },
+                  {
+                    "from": "__multiply_2",
+                    "to": "__equals_1"
+                  }
+                ],
+                "classification": {
+                  "kind": "algebraic"
+                }
+              }
+            }
           },
           {
             "type": "step",
@@ -796,16 +1091,347 @@
             "justification": "Isothermal approximation: temperature doesn't vary much over the relevant altitude range.",
             "explanation": "This is the key simplification. Real atmosphere temperature varies, but the isothermal model captures the essential exponential behavior. Differentiating the ideal gas law at constant $T$ gives $dP$ in terms of $d\\rho$.",
             "prompt": "Acknowledge this is an approximation. The real atmosphere has a lapse rate, but the exponential model is surprisingly good for entry dynamics because the density variation dominates over temperature variation.",
-            "sceneStep": 1
+            "sceneStep": 1,
+            "semanticGraph": {
+              "graph": {
+                "nodes": [
+                  {
+                    "id": "__equals_1",
+                    "type": "relation",
+                    "op": "equals",
+                    "subexpr": "T = \\text{const}"
+                  },
+                  {
+                    "id": "T",
+                    "type": "scalar",
+                    "latex": "T",
+                    "subexpr": "T"
+                  },
+                  {
+                    "id": "const",
+                    "type": "text",
+                    "label": "const",
+                    "latex": "\\text{const}",
+                    "subexpr": "\\text{const}"
+                  },
+                  {
+                    "id": "__equals_2",
+                    "type": "relation",
+                    "op": "equals",
+                    "subexpr": "dP = \\frac{k_{B} T}{m} d\\rho"
+                  },
+                  {
+                    "id": "dP",
+                    "type": "scalar",
+                    "latex": "dP",
+                    "subexpr": "dP"
+                  },
+                  {
+                    "id": "__multiply_3",
+                    "type": "operator",
+                    "op": "multiply",
+                    "subexpr": "\\frac{1}{m} T k_{B} \\mathrm{d}\\rho"
+                  },
+                  {
+                    "id": "__multiply_4",
+                    "type": "operator",
+                    "op": "multiply",
+                    "subexpr": "\\frac{1}{m} T k_{B}"
+                  },
+                  {
+                    "id": "__multiply_5",
+                    "type": "operator",
+                    "op": "multiply",
+                    "subexpr": "T k_{B}"
+                  },
+                  {
+                    "id": "k_{B}",
+                    "type": "scalar",
+                    "latex": "k_{B}",
+                    "subexpr": "k_{B}"
+                  },
+                  {
+                    "id": "__power_6",
+                    "type": "operator",
+                    "latex": "\\dfrac{1}{(\\cdot)}",
+                    "op": "power",
+                    "exponent": "-1",
+                    "subexpr": "\\frac{1}{m}"
+                  },
+                  {
+                    "id": "m",
+                    "type": "scalar",
+                    "latex": "m",
+                    "subexpr": "m"
+                  },
+                  {
+                    "id": "drho",
+                    "type": "scalar",
+                    "latex": "\\mathrm{d}\\rho",
+                    "subexpr": "\\mathrm{d}\\rho"
+                  },
+                  {
+                    "id": "__implies_7",
+                    "type": "operator",
+                    "label": "implies",
+                    "emoji": "⇒",
+                    "op": "implies",
+                    "subexpr": "T = \\text{const} \\implies dP = \\frac{k_B T}{m}\\, d\\rho"
+                  }
+                ],
+                "edges": [
+                  {
+                    "from": "T",
+                    "to": "__equals_1"
+                  },
+                  {
+                    "from": "const",
+                    "to": "__equals_1"
+                  },
+                  {
+                    "from": "dP",
+                    "to": "__equals_2"
+                  },
+                  {
+                    "from": "k_{B}",
+                    "to": "__multiply_5",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "T",
+                    "to": "__multiply_5",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "__multiply_5",
+                    "to": "__multiply_4",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "m",
+                    "to": "__power_6"
+                  },
+                  {
+                    "from": "__power_6",
+                    "to": "__multiply_4"
+                  },
+                  {
+                    "from": "__multiply_4",
+                    "to": "__multiply_3",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "drho",
+                    "to": "__multiply_3",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "__multiply_3",
+                    "to": "__equals_2"
+                  },
+                  {
+                    "from": "__equals_1",
+                    "to": "__implies_7",
+                    "role": "lhs"
+                  },
+                  {
+                    "from": "__equals_2",
+                    "to": "__implies_7",
+                    "role": "rhs"
+                  }
+                ],
+                "classification": {
+                  "kind": "algebraic"
+                }
+              }
+            }
           },
           {
             "type": "step",
             "label": "Combine into a Separable ODE",
             "math": "\\frac{d\\rho}{\\rho} = -\\frac{m g}{k_B T}\\, dh",
             "justification": "Substitute $dP = (k_B T / m)\\, d\\rho$ into the hydrostatic equation and divide by $\\rho$.",
-            "explanation": "This is now a separable first-order ODE \u2014 the same form as radioactive decay, population decline, or RC circuit discharge. The ratio $mg / (k_B T)$ is a constant with units of inverse length.",
+            "explanation": "This is now a separable first-order ODE — the same form as radioactive decay, population decline, or RC circuit discharge. The ratio $mg / (k_B T)$ is a constant with units of inverse length.",
             "prompt": "Point out the universality: this is the same math as radioactive decay. Exponential processes appear everywhere in physics when the rate of change is proportional to the current value.",
-            "sceneStep": 1
+            "sceneStep": 1,
+            "semanticGraph": {
+              "graph": {
+                "nodes": [
+                  {
+                    "id": "__equals_1",
+                    "type": "relation",
+                    "op": "equals",
+                    "subexpr": "\\frac{d\\rho}{\\rho} = -\\frac{m g}{k_B T}\\, dh"
+                  },
+                  {
+                    "id": "__multiply_2",
+                    "type": "operator",
+                    "op": "multiply",
+                    "subexpr": "\\frac{1}{\\rho} \\mathrm{d}\\rho"
+                  },
+                  {
+                    "id": "drho",
+                    "type": "scalar",
+                    "latex": "\\mathrm{d}\\rho",
+                    "subexpr": "\\mathrm{d}\\rho"
+                  },
+                  {
+                    "id": "__power_3",
+                    "type": "operator",
+                    "latex": "\\dfrac{1}{(\\cdot)}",
+                    "op": "power",
+                    "exponent": "-1",
+                    "subexpr": "\\frac{1}{\\rho}"
+                  },
+                  {
+                    "id": "rho",
+                    "type": "scalar",
+                    "latex": "\\rho",
+                    "subexpr": "\\rho"
+                  },
+                  {
+                    "id": "__negation_4",
+                    "type": "operator",
+                    "op": "negation",
+                    "subexpr": "-m g dh \\frac{1}{T} \\frac{1}{k_{B}}"
+                  },
+                  {
+                    "id": "__multiply_5",
+                    "type": "operator",
+                    "op": "multiply",
+                    "subexpr": "m g dh \\frac{1}{T} \\frac{1}{k_{B}}"
+                  },
+                  {
+                    "id": "dh",
+                    "type": "scalar",
+                    "latex": "dh",
+                    "subexpr": "dh"
+                  },
+                  {
+                    "id": "g",
+                    "type": "scalar",
+                    "latex": "g",
+                    "subexpr": "g"
+                  },
+                  {
+                    "id": "m",
+                    "type": "scalar",
+                    "latex": "m",
+                    "subexpr": "m"
+                  },
+                  {
+                    "id": "__multiply_6",
+                    "type": "operator",
+                    "op": "multiply",
+                    "subexpr": "\\frac{1}{T} \\frac{1}{k_{B}}"
+                  },
+                  {
+                    "id": "__power_7",
+                    "type": "operator",
+                    "latex": "\\dfrac{1}{(\\cdot)}",
+                    "op": "power",
+                    "exponent": "-1",
+                    "subexpr": "\\frac{1}{T}"
+                  },
+                  {
+                    "id": "T",
+                    "type": "scalar",
+                    "latex": "T",
+                    "subexpr": "T"
+                  },
+                  {
+                    "id": "__power_8",
+                    "type": "operator",
+                    "latex": "\\dfrac{1}{(\\cdot)}",
+                    "op": "power",
+                    "exponent": "-1",
+                    "subexpr": "\\frac{1}{k_{B}}"
+                  },
+                  {
+                    "id": "k_{B}",
+                    "type": "scalar",
+                    "latex": "k_{B}",
+                    "subexpr": "k_{B}"
+                  }
+                ],
+                "edges": [
+                  {
+                    "from": "drho",
+                    "to": "__multiply_2",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "rho",
+                    "to": "__power_3"
+                  },
+                  {
+                    "from": "__power_3",
+                    "to": "__multiply_2"
+                  },
+                  {
+                    "from": "__multiply_2",
+                    "to": "__equals_1"
+                  },
+                  {
+                    "from": "dh",
+                    "to": "__multiply_5",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "g",
+                    "to": "__multiply_5",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "m",
+                    "to": "__multiply_5",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "T",
+                    "to": "__power_7"
+                  },
+                  {
+                    "from": "__power_7",
+                    "to": "__multiply_6"
+                  },
+                  {
+                    "from": "k_{B}",
+                    "to": "__power_8"
+                  },
+                  {
+                    "from": "__power_8",
+                    "to": "__multiply_6"
+                  },
+                  {
+                    "from": "__multiply_6",
+                    "to": "__multiply_5",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "__multiply_5",
+                    "to": "__negation_4"
+                  },
+                  {
+                    "from": "__negation_4",
+                    "to": "__equals_1"
+                  }
+                ],
+                "classification": {
+                  "kind": "algebraic"
+                }
+              }
+            }
           },
           {
             "type": "step",
@@ -818,7 +1444,131 @@
             "highlights": {
               "H": {
                 "color": "yellow",
-                "label": "scale height \u2014 where thermal energy balances gravity"
+                "label": "scale height — where thermal energy balances gravity"
+              }
+            },
+            "semanticGraph": {
+              "graph": {
+                "nodes": [
+                  {
+                    "id": "H",
+                    "type": "scalar",
+                    "latex": "H",
+                    "subexpr": "H"
+                  },
+                  {
+                    "id": "__multiply_1",
+                    "type": "operator",
+                    "op": "multiply",
+                    "subexpr": "\\frac{k_{B} T}{m g}"
+                  },
+                  {
+                    "id": "__multiply_2",
+                    "type": "operator",
+                    "op": "multiply",
+                    "subexpr": "T k_{B}"
+                  },
+                  {
+                    "id": "k_{B}",
+                    "type": "scalar",
+                    "latex": "k_{B}",
+                    "subexpr": "k_{B}"
+                  },
+                  {
+                    "id": "T",
+                    "type": "scalar",
+                    "latex": "T",
+                    "subexpr": "T"
+                  },
+                  {
+                    "id": "__power_3",
+                    "type": "operator",
+                    "latex": "\\dfrac{1}{(\\cdot)}",
+                    "op": "power",
+                    "exponent": "-1",
+                    "subexpr": "\\frac{1}{g m}"
+                  },
+                  {
+                    "id": "__multiply_4",
+                    "type": "operator",
+                    "op": "multiply",
+                    "subexpr": "m g"
+                  },
+                  {
+                    "id": "m",
+                    "type": "scalar",
+                    "latex": "m",
+                    "subexpr": "m"
+                  },
+                  {
+                    "id": "g",
+                    "type": "scalar",
+                    "latex": "g",
+                    "subexpr": "g"
+                  },
+                  {
+                    "id": "__congruent_5",
+                    "type": "relation",
+                    "label": "congruent to",
+                    "emoji": "≡",
+                    "op": "congruent",
+                    "subexpr": "H \\equiv \\frac{k_B T}{m g}",
+                    "description": "scale height — where thermal energy balances gravity",
+                    "color": "yellow",
+                    "highlight": "H"
+                  }
+                ],
+                "edges": [
+                  {
+                    "from": "k_{B}",
+                    "to": "__multiply_2",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "T",
+                    "to": "__multiply_2",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "__multiply_2",
+                    "to": "__multiply_1",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "m",
+                    "to": "__multiply_4",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "g",
+                    "to": "__multiply_4",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "__multiply_4",
+                    "to": "__power_3"
+                  },
+                  {
+                    "from": "__power_3",
+                    "to": "__multiply_1"
+                  },
+                  {
+                    "from": "H",
+                    "to": "__congruent_5"
+                  },
+                  {
+                    "from": "__multiply_1",
+                    "to": "__congruent_5"
+                  }
+                ],
+                "classification": {
+                  "kind": "algebraic"
+                }
               }
             }
           },
@@ -836,13 +1586,147 @@
             "label": "Exponential Atmosphere",
             "math": "\\htmlClass{hl-result}{\\rho(h) = \\rho_0\\, e^{-h/H}}",
             "justification": "Exponentiate both sides.",
-            "explanation": "This is the result used throughout atmospheric entry analysis. The entire structure of the atmosphere \u2014 and all of entry dynamics \u2014 flows from this single exponential. Every $H \\approx 7.2\\,\\text{km}$ of altitude costs a factor of $e \\approx 2.718$ in density.",
+            "explanation": "This is the result used throughout atmospheric entry analysis. The entire structure of the atmosphere — and all of entry dynamics — flows from this single exponential. Every $H \\approx 7.2\\,\\text{km}$ of altitude costs a factor of $e \\approx 2.718$ in density.",
             "prompt": "Connect to the visualization: the curve you see is exactly this equation. Drag the scale height slider to see how $H$ controls the rate of thinning.",
             "sceneStep": 1,
             "highlights": {
               "result": {
                 "color": "green",
                 "label": "the exponential atmosphere model"
+              }
+            },
+            "semanticGraph": {
+              "graph": {
+                "nodes": [
+                  {
+                    "id": "__equals_1",
+                    "type": "relation",
+                    "op": "equals",
+                    "subexpr": "\\rho(h) = \\rho_0\\, e^{-h/H}",
+                    "description": "the exponential atmosphere model",
+                    "color": "green",
+                    "highlight": "result"
+                  },
+                  {
+                    "id": "__rho_2",
+                    "type": "function",
+                    "latex": "\\rho",
+                    "op": "rho",
+                    "subexpr": "\\rho{\\left(h \\right)}"
+                  },
+                  {
+                    "id": "h",
+                    "type": "scalar",
+                    "latex": "h",
+                    "subexpr": "h"
+                  },
+                  {
+                    "id": "__multiply_3",
+                    "type": "operator",
+                    "op": "multiply",
+                    "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0}"
+                  },
+                  {
+                    "id": "rho_{0}",
+                    "type": "scalar",
+                    "latex": "\\rho_{0}",
+                    "subexpr": "\\rho_{0}"
+                  },
+                  {
+                    "id": "__power_4",
+                    "type": "operator",
+                    "op": "power",
+                    "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"
+                  },
+                  {
+                    "id": "e",
+                    "type": "scalar",
+                    "latex": "e",
+                    "subexpr": "e"
+                  },
+                  {
+                    "id": "__multiply_5",
+                    "type": "operator",
+                    "op": "multiply",
+                    "subexpr": "\\frac{1}{H} -h"
+                  },
+                  {
+                    "id": "__negation_6",
+                    "type": "operator",
+                    "op": "negation",
+                    "subexpr": "-h"
+                  },
+                  {
+                    "id": "__power_7",
+                    "type": "operator",
+                    "latex": "\\dfrac{1}{(\\cdot)}",
+                    "op": "power",
+                    "exponent": "-1",
+                    "subexpr": "\\frac{1}{H}"
+                  },
+                  {
+                    "id": "H",
+                    "type": "scalar",
+                    "latex": "H",
+                    "subexpr": "H"
+                  }
+                ],
+                "edges": [
+                  {
+                    "from": "h",
+                    "to": "__rho_2"
+                  },
+                  {
+                    "from": "__rho_2",
+                    "to": "__equals_1"
+                  },
+                  {
+                    "from": "rho_{0}",
+                    "to": "__multiply_3",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "e",
+                    "to": "__power_4"
+                  },
+                  {
+                    "from": "h",
+                    "to": "__negation_6"
+                  },
+                  {
+                    "from": "__negation_6",
+                    "to": "__multiply_5",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "H",
+                    "to": "__power_7"
+                  },
+                  {
+                    "from": "__power_7",
+                    "to": "__multiply_5"
+                  },
+                  {
+                    "from": "__multiply_5",
+                    "to": "__power_4",
+                    "role": "exp"
+                  },
+                  {
+                    "from": "__power_4",
+                    "to": "__multiply_3",
+                    "semantic": "direct",
+                    "weight": 1.0
+                  },
+                  {
+                    "from": "__multiply_3",
+                    "to": "__equals_1"
+                  }
+                ],
+                "classification": {
+                  "kind": "algebraic"
+                }
               }
             }
           }
@@ -1255,7 +2139,7 @@
             {
               "id": "entry_info",
               "position": "top-right",
-              "content": "### Simulated Entry State\n**Vehicle:** {{entryVehicleName()}}  \n**Mission:** {{entryVehicleMission()}}  \n**Entry speed:** {{toFixed(entryVehicleSpeed(), 2)}} km/s  \n**Estimated $\\beta$:** {{toFixed(entryVehicleBeta(), 1)}} kg/m$^2$  \n**Reference $L/D$:** {{toFixed(entryVehicleLD(), 2)}}\n\n**Computed corridor:** {{toFixed(entryCorridorLo(), 2)}}\u00b0 to {{toFixed(entryCorridorHi(), 2)}}\u00b0  \n**Selected $\\gamma$:** {{toFixed(s2_gamma, 2)}}\u00b0  \n**Effective bank:** {{toFixed(s2_bank, 0)}}\u00b0  \n**Time:** {{toFixed(min(s2_t, entryEndTime()), 0)}} s\n\n**Altitude:** {{toFixed(entryAlt(s2_t), 1)}} km  \n**Speed:** {{toFixed(entrySpeed(s2_t), 2)}} km/s  \n**Current aero decel:** {{toFixed(entryG(s2_t), 2)}} g\n\n{{entryOutcome()}}"
+              "content": "### Simulated Entry State\n**Vehicle:** {{entryVehicleName()}}  \n**Mission:** {{entryVehicleMission()}}  \n**Entry speed:** {{toFixed(entryVehicleSpeed(), 2)}} km/s  \n**Estimated $\\beta$:** {{toFixed(entryVehicleBeta(), 1)}} kg/m$^2$  \n**Reference $L/D$:** {{toFixed(entryVehicleLD(), 2)}}\n\n**Computed corridor:** {{toFixed(entryCorridorLo(), 2)}}° to {{toFixed(entryCorridorHi(), 2)}}°  \n**Selected $\\gamma$:** {{toFixed(s2_gamma, 2)}}°  \n**Effective bank:** {{toFixed(s2_bank, 0)}}°  \n**Time:** {{toFixed(min(s2_t, entryEndTime()), 0)}} s\n\n**Altitude:** {{toFixed(entryAlt(s2_t), 1)}} km  \n**Speed:** {{toFixed(entrySpeed(s2_t), 2)}} km/s  \n**Current aero decel:** {{toFixed(entryG(s2_t), 2)}} g\n\n{{entryOutcome()}}"
             }
           ]
         },
@@ -1544,7 +2428,93 @@
               "justification": "Newton's law of gravitation. $\\mu = GM$ is the gravitational parameter.",
               "explanation": "Gravity pulls the capsule toward the planet center. The inverse-square law is written in vector form: the $r^3$ in the denominator (not $r^2$) comes from the unit vector $\\hat{r} = \\mathbf{r}/r$.",
               "prompt": "Ask the student why the denominator is $r^3$ rather than $r^2$. Answer: we're multiplying the $1/r^2$ magnitude by the direction vector $\\mathbf{r}/r$.",
-              "sceneStep": 0
+              "sceneStep": 0,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "a_g = -\\frac{\\mu}{r^3}r"
+                    },
+                    {
+                      "id": "a_{g}",
+                      "type": "scalar",
+                      "latex": "a_{g}",
+                      "subexpr": "a_{g}"
+                    },
+                    {
+                      "id": "__negation_2",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-r \\frac{1}{r^{3}} \\mu"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "r \\frac{1}{r^{3}} \\mu"
+                    },
+                    {
+                      "id": "mu",
+                      "type": "scalar",
+                      "latex": "\\mu",
+                      "subexpr": "\\mu"
+                    },
+                    {
+                      "id": "r",
+                      "type": "scalar",
+                      "latex": "r",
+                      "subexpr": "r"
+                    },
+                    {
+                      "id": "__power_4",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "-3",
+                      "subexpr": "\\frac{1}{r^{3}}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "a_{g}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "mu",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "r",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "r",
+                      "to": "__power_4"
+                    },
+                    {
+                      "from": "__power_4",
+                      "to": "__multiply_3"
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__negation_2"
+                    },
+                    {
+                      "from": "__negation_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "given",
@@ -1553,7 +2523,141 @@
               "justification": "Standard scale-height atmosphere: density drops by a factor of $e$ every $H \\approx 7.2\\,\\text{km}$.",
               "explanation": "This is the simplest useful atmosphere model. $\\rho_0 = 1.225\\,\\text{kg/m}^3$ is sea-level density and $H$ is the scale height. At the entry interface ($h = 122\\,\\text{km}$), density is roughly $10^{-7}$ of sea level.",
               "prompt": "Have the student estimate: at $h = 50\\,\\text{km}$, what fraction of sea-level density is the air? Answer: $e^{-50/7.2} \\approx 10^{-3}$.",
-              "sceneStep": 0
+              "sceneStep": 0,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\rho(h) = \\rho_0\\, e^{-h/H}",
+                      "description": "the exponential atmosphere model",
+                      "color": "green",
+                      "highlight": "result"
+                    },
+                    {
+                      "id": "__rho_2",
+                      "type": "function",
+                      "latex": "\\rho",
+                      "op": "rho",
+                      "subexpr": "\\rho{\\left(h \\right)}"
+                    },
+                    {
+                      "id": "h",
+                      "type": "scalar",
+                      "latex": "h",
+                      "subexpr": "h"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0}"
+                    },
+                    {
+                      "id": "rho_{0}",
+                      "type": "scalar",
+                      "latex": "\\rho_{0}",
+                      "subexpr": "\\rho_{0}"
+                    },
+                    {
+                      "id": "__power_4",
+                      "type": "operator",
+                      "op": "power",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"
+                    },
+                    {
+                      "id": "e",
+                      "type": "scalar",
+                      "latex": "e",
+                      "subexpr": "e"
+                    },
+                    {
+                      "id": "__multiply_5",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{H} -h"
+                    },
+                    {
+                      "id": "__negation_6",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-h"
+                    },
+                    {
+                      "id": "__power_7",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{H}"
+                    },
+                    {
+                      "id": "H",
+                      "type": "scalar",
+                      "latex": "H",
+                      "subexpr": "H"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "h",
+                      "to": "__rho_2"
+                    },
+                    {
+                      "from": "__rho_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "rho_{0}",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "e",
+                      "to": "__power_4"
+                    },
+                    {
+                      "from": "h",
+                      "to": "__negation_6"
+                    },
+                    {
+                      "from": "__negation_6",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__power_7"
+                    },
+                    {
+                      "from": "__power_7",
+                      "to": "__multiply_5"
+                    },
+                    {
+                      "from": "__multiply_5",
+                      "to": "__power_4",
+                      "role": "exp"
+                    },
+                    {
+                      "from": "__power_4",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "given",
@@ -1562,22 +2666,397 @@
               "justification": "Standard drag equation with ballistic coefficient $\\beta = m/(C_d A)$.",
               "explanation": "Drag opposes the velocity direction ($-\\hat{V}$). We write $V^2 \\hat{V} = V\\mathbf{V}$ to get the compact form. The ballistic coefficient $\\beta$ bundles all vehicle properties into a single number.",
               "prompt": "Ask: why does drag go as $V^2$? Because the capsule sweeps out volume $\\propto V$, and the momentum of each intercepted air molecule is also $\\propto V$.",
-              "sceneStep": 0
+              "sceneStep": 0,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "a_{D}",
+                      "type": "scalar",
+                      "latex": "a_{D}",
+                      "subexpr": "a_D"
+                    },
+                    {
+                      "id": "s1___negation_1",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-\\frac{1}{2m}\\rho \\hat{V}^2 C_d A\\,\\hat{V}"
+                    },
+                    {
+                      "id": "s1___multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho \\hat{V}^{3} A C_{d} \\frac{1}{m} \\frac{1}{2}"
+                    },
+                    {
+                      "id": "A",
+                      "type": "scalar",
+                      "latex": "A",
+                      "subexpr": "A"
+                    },
+                    {
+                      "id": "C_{d}",
+                      "type": "scalar",
+                      "latex": "C_{d}",
+                      "subexpr": "C_{d}"
+                    },
+                    {
+                      "id": "rho",
+                      "type": "scalar",
+                      "latex": "\\rho",
+                      "subexpr": "\\rho"
+                    },
+                    {
+                      "id": "s1___power_3",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "3",
+                      "subexpr": "\\hat{V}^{3}"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "\\hat{V}",
+                      "subexpr": "\\hat{V}"
+                    },
+                    {
+                      "id": "s1___multiply_4",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{m} \\frac{1}{2}"
+                    },
+                    {
+                      "id": "s1___num_5",
+                      "type": "number",
+                      "label": "1/2",
+                      "subexpr": "\\frac{1}{2}"
+                    },
+                    {
+                      "id": "s1___power_6",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{m}"
+                    },
+                    {
+                      "id": "m",
+                      "type": "scalar",
+                      "latex": "m",
+                      "subexpr": "m"
+                    },
+                    {
+                      "id": "s2___negation_1",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-\\frac{\\rho V}{2\\beta}V"
+                    },
+                    {
+                      "id": "s2___multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho V^{2} \\frac{1}{\\beta} \\frac{1}{2}"
+                    },
+                    {
+                      "id": "s2___power_3",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V^{2}"
+                    },
+                    {
+                      "id": "s2___multiply_4",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{\\beta} \\frac{1}{2}"
+                    },
+                    {
+                      "id": "s2___num_5",
+                      "type": "number",
+                      "label": "1/2",
+                      "subexpr": "\\frac{1}{2}"
+                    },
+                    {
+                      "id": "s2___power_6",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\beta}"
+                    },
+                    {
+                      "id": "beta",
+                      "type": "scalar",
+                      "latex": "\\beta",
+                      "subexpr": "\\beta"
+                    },
+                    {
+                      "id": "__equals_1",
+                      "type": "operator",
+                      "op": "equals",
+                      "subexpr": "\\mathbf{a}_D = -\\frac{1}{2m}\\rho V^2 C_d A\\,\\hat{V} = -\\frac{\\rho V}{2\\beta}\\mathbf{V}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "A",
+                      "to": "s1___multiply_2"
+                    },
+                    {
+                      "from": "C_{d}",
+                      "to": "s1___multiply_2"
+                    },
+                    {
+                      "from": "rho",
+                      "to": "s1___multiply_2"
+                    },
+                    {
+                      "from": "V",
+                      "to": "s1___power_3"
+                    },
+                    {
+                      "from": "s1___power_3",
+                      "to": "s1___multiply_2"
+                    },
+                    {
+                      "from": "s1___num_5",
+                      "to": "s1___multiply_4"
+                    },
+                    {
+                      "from": "m",
+                      "to": "s1___power_6"
+                    },
+                    {
+                      "from": "s1___power_6",
+                      "to": "s1___multiply_4"
+                    },
+                    {
+                      "from": "s1___multiply_4",
+                      "to": "s1___multiply_2"
+                    },
+                    {
+                      "from": "s1___multiply_2",
+                      "to": "s1___negation_1"
+                    },
+                    {
+                      "from": "rho",
+                      "to": "s2___multiply_2"
+                    },
+                    {
+                      "from": "V",
+                      "to": "s2___power_3"
+                    },
+                    {
+                      "from": "s2___power_3",
+                      "to": "s2___multiply_2"
+                    },
+                    {
+                      "from": "s2___num_5",
+                      "to": "s2___multiply_4"
+                    },
+                    {
+                      "from": "beta",
+                      "to": "s2___power_6"
+                    },
+                    {
+                      "from": "s2___power_6",
+                      "to": "s2___multiply_4"
+                    },
+                    {
+                      "from": "s2___multiply_4",
+                      "to": "s2___multiply_2"
+                    },
+                    {
+                      "from": "s2___multiply_2",
+                      "to": "s2___negation_1"
+                    },
+                    {
+                      "from": "a_{D}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "s1___negation_1",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "s2___negation_1",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
               "label": "Lift Force (In-Plane Component)",
               "math": "\\mathbf{a}_L = \\frac{L}{D}\\cos\\phi \\cdot a_D \\cdot \\hat{n}",
               "justification": "Lift is perpendicular to the velocity, scaled by the lift-to-drag ratio $L/D$ and bank angle $\\phi$.",
-              "explanation": "The unit vector $\\hat{n}$ is perpendicular to $\\mathbf{V}$ and points away from the planet (the \"upward\" normal). The bank angle $\\phi$ controls how much of the total lift acts in the entry plane: $\\cos 0\u00b0 = 1$ (full lift up), $\\cos 90\u00b0 = 0$ (all lift goes sideways, out of plane).",
-              "prompt": "Connect to the bank-angle slider: rolling the capsule redirects lift. Full bank ($90\u00b0$) gives zero in-plane lift, behaving like a ballistic entry.",
-              "sceneStep": 0
+              "explanation": "The unit vector $\\hat{n}$ is perpendicular to $\\mathbf{V}$ and points away from the planet (the \"upward\" normal). The bank angle $\\phi$ controls how much of the total lift acts in the entry plane: $\\cos 0° = 1$ (full lift up), $\\cos 90° = 0$ (all lift goes sideways, out of plane).",
+              "prompt": "Connect to the bank-angle slider: rolling the capsule redirects lift. Full bank ($90°$) gives zero in-plane lift, behaving like a ballistic entry.",
+              "sceneStep": 0,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "a_L = \\frac{L}{D}\\cos\\phi \\cdot a_D \\cdot \\hat{n}"
+                    },
+                    {
+                      "id": "a_{L}",
+                      "type": "scalar",
+                      "latex": "a_{L}",
+                      "subexpr": "a_{L}"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "L \\frac{1}{D} \\cos{\\left(\\hat{n} a_{D} \\phi \\right)}"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "L \\frac{1}{D}"
+                    },
+                    {
+                      "id": "L",
+                      "type": "scalar",
+                      "latex": "L",
+                      "subexpr": "L"
+                    },
+                    {
+                      "id": "__power_4",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{D}"
+                    },
+                    {
+                      "id": "D",
+                      "type": "scalar",
+                      "latex": "D",
+                      "subexpr": "D"
+                    },
+                    {
+                      "id": "__cos_5",
+                      "type": "function",
+                      "latex": "\\cos",
+                      "op": "cos",
+                      "subexpr": "\\cos{\\left(\\hat{n} a_{D} \\phi \\right)}"
+                    },
+                    {
+                      "id": "__multiply_6",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\hat{n} \\phi a_{D}"
+                    },
+                    {
+                      "id": "__multiply_7",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\phi a_{D}"
+                    },
+                    {
+                      "id": "phi",
+                      "type": "scalar",
+                      "latex": "\\phi",
+                      "subexpr": "\\phi"
+                    },
+                    {
+                      "id": "a_{D}",
+                      "type": "scalar",
+                      "latex": "a_{D}",
+                      "subexpr": "a_{D}"
+                    },
+                    {
+                      "id": "n",
+                      "type": "scalar",
+                      "latex": "\\hat{n}",
+                      "subexpr": "\\hat{n}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "a_{L}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "L",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "D",
+                      "to": "__power_4"
+                    },
+                    {
+                      "from": "__power_4",
+                      "to": "__multiply_3"
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "phi",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "a_{D}",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_7",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "n",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_6",
+                      "to": "__cos_5"
+                    },
+                    {
+                      "from": "__cos_5",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
               "label": "Upward Normal Vector",
               "math": "\\hat{n} = \\frac{1}{V}\\begin{pmatrix} -v_y \\\\ v_x \\end{pmatrix}, \\quad \\text{chosen so } \\hat{n} \\cdot \\hat{r} > 0",
-              "justification": "Rotate the velocity vector $90\u00b0$ and pick the direction pointing away from the planet.",
+              "justification": "Rotate the velocity vector $90°$ and pick the direction pointing away from the planet.",
               "explanation": "There are two perpendicular directions to any velocity vector. We choose the one that has a positive component along the radial (outward) direction, so that positive lift pushes the capsule away from the planet.",
               "prompt": "Explain the sign choice: if we picked the wrong perpendicular, 'lift' would push the capsule toward the ground.",
               "sceneStep": 0
@@ -1587,13 +3066,470 @@
               "label": "Full Equation of Motion",
               "math": "\\htmlClass{hl-eom}{\\ddot{\\mathbf{r}} = -\\frac{\\mu}{r^3}\\mathbf{r} - \\frac{\\rho V}{2\\beta}\\mathbf{V} + \\frac{L}{D}\\cos\\phi\\cdot\\frac{\\rho V^2}{2\\beta}\\hat{n}}",
               "justification": "Sum all forces: gravity + drag + lift.",
-              "explanation": "This is the vector ODE that the simulation integrates numerically using Euler steps. It has no closed-form solution in general \u2014 the exponential atmosphere couples altitude and velocity in a nonlinear way. But under simplifying assumptions (straight-line path, drag-dominant), Allen and Eggers found elegant approximate solutions.",
+              "explanation": "This is the vector ODE that the simulation integrates numerically using Euler steps. It has no closed-form solution in general — the exponential atmosphere couples altitude and velocity in a nonlinear way. But under simplifying assumptions (straight-line path, drag-dominant), Allen and Eggers found elegant approximate solutions.",
               "prompt": "Emphasize: this one equation generates every trajectory you see in the visualization. Changing the vehicle changes $\\beta$ and $L/D$. Changing $\\gamma$ changes the initial velocity direction. Changing bank angle changes $\\cos\\phi$.",
               "sceneStep": 0,
               "highlights": {
                 "eom": {
                   "color": "cyan",
                   "label": "Complete entry dynamics equation"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\frac{d}{d t} \\frac{d}{d t} r = -\\frac{\\mu}{r^3}r - \\frac{\\rho V}{2\\beta}V + \\frac{L}{D}\\cos\\phi\\cdot\\frac{\\rho V^2}{2\\beta}\\hat{n}"
+                    },
+                    {
+                      "id": "r",
+                      "type": "scalar",
+                      "latex": "r",
+                      "subexpr": "r"
+                    },
+                    {
+                      "id": "t",
+                      "type": "scalar",
+                      "latex": "t",
+                      "subexpr": "t"
+                    },
+                    {
+                      "id": "__deriv_2",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t",
+                      "subexpr": "\\frac{d^{2}}{d t^{2}} r"
+                    },
+                    {
+                      "id": "__add_3",
+                      "type": "operator",
+                      "op": "add",
+                      "subexpr": "L \\frac{1}{D} \\cos{\\left(\\phi \\hat{n} \\frac{V^{2} \\rho}{2 \\beta} \\right)} - V \\rho V \\frac{1}{2 \\beta} - r \\frac{1}{r^{3}} \\mu"
+                    },
+                    {
+                      "id": "__add_4",
+                      "type": "operator",
+                      "op": "add",
+                      "subexpr": "-V \\rho V \\frac{1}{2 \\beta} - r \\frac{1}{r^{3}} \\mu"
+                    },
+                    {
+                      "id": "__negation_5",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-r \\frac{1}{r^{3}} \\mu"
+                    },
+                    {
+                      "id": "__multiply_6",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "r \\frac{1}{r^{3}} \\mu"
+                    },
+                    {
+                      "id": "mu",
+                      "type": "scalar",
+                      "latex": "\\mu",
+                      "subexpr": "\\mu"
+                    },
+                    {
+                      "id": "__power_7",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "-3",
+                      "subexpr": "\\frac{1}{r^{3}}"
+                    },
+                    {
+                      "id": "__negation_8",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-V \\rho V \\frac{1}{2 \\beta}"
+                    },
+                    {
+                      "id": "__multiply_9",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V \\rho V \\frac{1}{2 \\beta}"
+                    },
+                    {
+                      "id": "__multiply_10",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho V \\frac{1}{2 \\beta}"
+                    },
+                    {
+                      "id": "__multiply_11",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho V"
+                    },
+                    {
+                      "id": "rho",
+                      "type": "scalar",
+                      "latex": "\\rho",
+                      "subexpr": "\\rho"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    },
+                    {
+                      "id": "__power_12",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2 \\beta}"
+                    },
+                    {
+                      "id": "__multiply_13",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\beta 2"
+                    },
+                    {
+                      "id": "__num_14",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "beta",
+                      "type": "scalar",
+                      "latex": "\\beta",
+                      "subexpr": "\\beta"
+                    },
+                    {
+                      "id": "__multiply_15",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "L \\frac{1}{D} \\cos{\\left(\\phi \\hat{n} \\frac{V^{2} \\rho}{2 \\beta} \\right)}"
+                    },
+                    {
+                      "id": "__multiply_16",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "L \\frac{1}{D}"
+                    },
+                    {
+                      "id": "L",
+                      "type": "scalar",
+                      "latex": "L",
+                      "subexpr": "L"
+                    },
+                    {
+                      "id": "__power_17",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{D}"
+                    },
+                    {
+                      "id": "D",
+                      "type": "scalar",
+                      "latex": "D",
+                      "subexpr": "D"
+                    },
+                    {
+                      "id": "__cos_18",
+                      "type": "function",
+                      "latex": "\\cos",
+                      "op": "cos",
+                      "subexpr": "\\cos{\\left(\\phi \\hat{n} \\frac{V^{2} \\rho}{2 \\beta} \\right)}"
+                    },
+                    {
+                      "id": "__multiply_19",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\phi \\hat{n} \\rho V^{2} \\frac{1}{2 \\beta}"
+                    },
+                    {
+                      "id": "phi",
+                      "type": "scalar",
+                      "latex": "\\phi",
+                      "subexpr": "\\phi"
+                    },
+                    {
+                      "id": "__multiply_20",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\hat{n} \\rho V^{2} \\frac{1}{2 \\beta}"
+                    },
+                    {
+                      "id": "__multiply_21",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho V^{2} \\frac{1}{2 \\beta}"
+                    },
+                    {
+                      "id": "__multiply_22",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho V^{2}"
+                    },
+                    {
+                      "id": "__power_23",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V^{2}"
+                    },
+                    {
+                      "id": "__power_24",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2 \\beta}"
+                    },
+                    {
+                      "id": "__multiply_25",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\beta 2"
+                    },
+                    {
+                      "id": "__num_26",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "n",
+                      "type": "scalar",
+                      "latex": "\\hat{n}",
+                      "subexpr": "\\hat{n}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "r",
+                      "to": "__deriv_2"
+                    },
+                    {
+                      "from": "t",
+                      "to": "__deriv_2",
+                      "role": "wrt"
+                    },
+                    {
+                      "from": "__deriv_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "mu",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "r",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "r",
+                      "to": "__power_7"
+                    },
+                    {
+                      "from": "__power_7",
+                      "to": "__multiply_6"
+                    },
+                    {
+                      "from": "__multiply_6",
+                      "to": "__negation_5"
+                    },
+                    {
+                      "from": "__negation_5",
+                      "to": "__add_4"
+                    },
+                    {
+                      "from": "rho",
+                      "to": "__multiply_11",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V",
+                      "to": "__multiply_11",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_11",
+                      "to": "__multiply_10",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_14",
+                      "to": "__multiply_13",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "beta",
+                      "to": "__multiply_13",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_13",
+                      "to": "__power_12"
+                    },
+                    {
+                      "from": "__power_12",
+                      "to": "__multiply_10"
+                    },
+                    {
+                      "from": "__multiply_10",
+                      "to": "__multiply_9",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V",
+                      "to": "__multiply_9",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_9",
+                      "to": "__negation_8"
+                    },
+                    {
+                      "from": "__negation_8",
+                      "to": "__add_4"
+                    },
+                    {
+                      "from": "__add_4",
+                      "to": "__add_3"
+                    },
+                    {
+                      "from": "L",
+                      "to": "__multiply_16",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "D",
+                      "to": "__power_17"
+                    },
+                    {
+                      "from": "__power_17",
+                      "to": "__multiply_16"
+                    },
+                    {
+                      "from": "__multiply_16",
+                      "to": "__multiply_15",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "phi",
+                      "to": "__multiply_19",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "rho",
+                      "to": "__multiply_22",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V",
+                      "to": "__power_23"
+                    },
+                    {
+                      "from": "__power_23",
+                      "to": "__multiply_22",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_22",
+                      "to": "__multiply_21",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_26",
+                      "to": "__multiply_25",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "beta",
+                      "to": "__multiply_25",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_25",
+                      "to": "__power_24"
+                    },
+                    {
+                      "from": "__power_24",
+                      "to": "__multiply_21"
+                    },
+                    {
+                      "from": "__multiply_21",
+                      "to": "__multiply_20",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "n",
+                      "to": "__multiply_20",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_20",
+                      "to": "__multiply_19",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_19",
+                      "to": "__cos_18"
+                    },
+                    {
+                      "from": "__cos_18",
+                      "to": "__multiply_15",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_15",
+                      "to": "__add_3"
+                    },
+                    {
+                      "from": "__add_3",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "ODE",
+                    "order": 2,
+                    "dependent_variables": [
+                      "r"
+                    ],
+                    "independent_variables": [
+                      "t"
+                    ],
+                    "sympy_hints": [
+                      "2nd_nonlinear_autonomous_conserved"
+                    ],
+                    "linear": true,
+                    "homogeneous": false,
+                    "constant_coefficients": false
+                  }
                 }
               }
             }
@@ -1614,7 +3550,184 @@
               "justification": "During peak deceleration, drag overwhelms gravity by an order of magnitude.",
               "explanation": "We drop gravity and lift to isolate the dominant drag force. This is the Allen-Eggers approximation: valid when the deceleration is many G's.",
               "prompt": "Ask the student: at 10 G's of deceleration, gravity (1 G) is only a 10% correction. Why is ignoring it still useful?",
-              "sceneStep": 0
+              "sceneStep": 0,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "m\\frac{d}{d t} V = -\\frac{1}{2}\\rho V^2 C_d A"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "m \\frac{d}{d t} V"
+                    },
+                    {
+                      "id": "m",
+                      "type": "scalar",
+                      "latex": "m",
+                      "subexpr": "m"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    },
+                    {
+                      "id": "t",
+                      "type": "scalar",
+                      "latex": "t",
+                      "subexpr": "t"
+                    },
+                    {
+                      "id": "__deriv_3",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t",
+                      "subexpr": "\\frac{d}{d t} V"
+                    },
+                    {
+                      "id": "__negation_4",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-V^{2} \\rho A \\frac{1}{2} C_{d}"
+                    },
+                    {
+                      "id": "__multiply_5",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V^{2} \\rho A \\frac{1}{2} C_{d}"
+                    },
+                    {
+                      "id": "__num_6",
+                      "type": "number",
+                      "label": "1/2",
+                      "subexpr": "\\frac{1}{2}"
+                    },
+                    {
+                      "id": "A",
+                      "type": "scalar",
+                      "latex": "A",
+                      "subexpr": "A"
+                    },
+                    {
+                      "id": "C_{d}",
+                      "type": "scalar",
+                      "latex": "C_{d}",
+                      "subexpr": "C_{d}"
+                    },
+                    {
+                      "id": "rho",
+                      "type": "scalar",
+                      "latex": "\\rho",
+                      "subexpr": "\\rho"
+                    },
+                    {
+                      "id": "__power_7",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V^{2}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "m",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V",
+                      "to": "__deriv_3"
+                    },
+                    {
+                      "from": "t",
+                      "to": "__deriv_3",
+                      "role": "wrt"
+                    },
+                    {
+                      "from": "__deriv_3",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "__num_6",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "A",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "C_{d}",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "rho",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V",
+                      "to": "__power_7"
+                    },
+                    {
+                      "from": "__power_7",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_5",
+                      "to": "__negation_4"
+                    },
+                    {
+                      "from": "__negation_4",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "ODE",
+                    "order": 1,
+                    "dependent_variables": [
+                      "V"
+                    ],
+                    "independent_variables": [
+                      "t"
+                    ],
+                    "sympy_hints": [
+                      "factorable",
+                      "separable",
+                      "1st_exact",
+                      "Bernoulli",
+                      "Riccati_special_minus2",
+                      "1st_power_series",
+                      "lie_group"
+                    ],
+                    "linear": false,
+                    "homogeneous": false,
+                    "constant_coefficients": false
+                  }
+                }
+              }
             },
             {
               "type": "step",
@@ -1623,7 +3736,164 @@
               "justification": "Assume the flight-path angle $\\gamma$ stays approximately constant during the intense deceleration phase.",
               "explanation": "The rate of altitude loss is the vertical component of velocity. For a steep, fast entry, the path curves very little before most of the energy is dissipated. This lets us treat $\\gamma$ as a constant.",
               "prompt": "This is the key simplification. In reality $\\gamma$ changes, but for ballistic or near-ballistic entries the path is nearly straight through the region of peak heating and deceleration.",
-              "sceneStep": 0
+              "sceneStep": 0,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "c0___equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\frac{d}{d t} h = -V\\sin\\gamma"
+                    },
+                    {
+                      "id": "h",
+                      "type": "scalar",
+                      "latex": "h",
+                      "subexpr": "h"
+                    },
+                    {
+                      "id": "t",
+                      "type": "scalar",
+                      "latex": "t",
+                      "subexpr": "t"
+                    },
+                    {
+                      "id": "c0___deriv_2",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t",
+                      "subexpr": "\\frac{d}{d t} h"
+                    },
+                    {
+                      "id": "c0___negation_3",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-V \\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "c0___multiply_4",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V \\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    },
+                    {
+                      "id": "c0___sin_5",
+                      "type": "function",
+                      "latex": "\\sin",
+                      "op": "sin",
+                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "gamma",
+                      "type": "scalar",
+                      "latex": "\\gamma",
+                      "subexpr": "\\gamma"
+                    },
+                    {
+                      "id": "c1___equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\gamma = \\text{const}"
+                    },
+                    {
+                      "id": "const",
+                      "type": "text",
+                      "label": "const",
+                      "latex": "\\text{const}",
+                      "subexpr": "\\text{const}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "h",
+                      "to": "c0___deriv_2"
+                    },
+                    {
+                      "from": "t",
+                      "to": "c0___deriv_2",
+                      "role": "wrt"
+                    },
+                    {
+                      "from": "c0___deriv_2",
+                      "to": "c0___equals_1"
+                    },
+                    {
+                      "from": "V",
+                      "to": "c0___multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "gamma",
+                      "to": "c0___sin_5"
+                    },
+                    {
+                      "from": "c0___sin_5",
+                      "to": "c0___multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "c0___multiply_4",
+                      "to": "c0___negation_3"
+                    },
+                    {
+                      "from": "c0___negation_3",
+                      "to": "c0___equals_1"
+                    },
+                    {
+                      "from": "gamma",
+                      "to": "c1___equals_1"
+                    },
+                    {
+                      "from": "const",
+                      "to": "c1___equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "statements",
+                    "count": 2,
+                    "clauses": [
+                      {
+                        "kind": "ODE",
+                        "order": 1,
+                        "dependent_variables": [
+                          "h"
+                        ],
+                        "independent_variables": [
+                          "t"
+                        ],
+                        "sympy_hints": [
+                          "nth_algebraic",
+                          "separable",
+                          "1st_exact",
+                          "1st_linear",
+                          "Bernoulli",
+                          "1st_power_series",
+                          "lie_group",
+                          "nth_linear_constant_coeff_undetermined_coefficients",
+                          "nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients",
+                          "nth_linear_constant_coeff_variation_of_parameters",
+                          "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters"
+                        ],
+                        "linear": true,
+                        "homogeneous": true,
+                        "constant_coefficients": true
+                      },
+                      {
+                        "kind": "algebraic"
+                      }
+                    ]
+                  }
+                }
+              }
             },
             {
               "type": "step",
@@ -1632,7 +3902,183 @@
               "justification": "Chain rule: replace time with altitude as the independent variable.",
               "explanation": "The atmosphere varies with altitude, not time, so altitude is the natural variable. The chain rule lets us swap.",
               "prompt": "Explain simply: 'We want to know how speed changes with height, not with time, because the air density is a function of height.'",
-              "sceneStep": 0
+              "sceneStep": 0,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    },
+                    {
+                      "id": "t",
+                      "type": "scalar",
+                      "latex": "t",
+                      "subexpr": "t"
+                    },
+                    {
+                      "id": "s0___deriv_1",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t",
+                      "subexpr": "\\frac{d}{d t} V"
+                    },
+                    {
+                      "id": "s1___multiply_1",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{dV}{dh}\\cdot\\frac{d}{d t} h"
+                    },
+                    {
+                      "id": "h",
+                      "type": "scalar",
+                      "latex": "h",
+                      "subexpr": "h"
+                    },
+                    {
+                      "id": "s1___deriv_2",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "h",
+                      "subexpr": "\\frac{d}{d h} V"
+                    },
+                    {
+                      "id": "s1___deriv_3",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t",
+                      "subexpr": "\\frac{d}{d t} h"
+                    },
+                    {
+                      "id": "s2___negation_1",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-V\\sin\\gamma\\,\\frac{dV}{dh}"
+                    },
+                    {
+                      "id": "s2___multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V \\sin{\\left(\\gamma \\frac{d}{d h} V \\right)}"
+                    },
+                    {
+                      "id": "s2___sin_3",
+                      "type": "function",
+                      "latex": "\\sin",
+                      "op": "sin",
+                      "subexpr": "\\sin{\\left(\\gamma \\frac{d}{d h} V \\right)}"
+                    },
+                    {
+                      "id": "s2___multiply_4",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\gamma \\frac{d}{d h} V"
+                    },
+                    {
+                      "id": "gamma",
+                      "type": "scalar",
+                      "latex": "\\gamma",
+                      "subexpr": "\\gamma"
+                    },
+                    {
+                      "id": "s2___deriv_5",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "h",
+                      "subexpr": "\\frac{d}{d h} V"
+                    },
+                    {
+                      "id": "__equals_1",
+                      "type": "operator",
+                      "op": "equals",
+                      "subexpr": "\\frac{dV}{dt} = \\frac{dV}{dh}\\cdot\\frac{dh}{dt} = -V\\sin\\gamma\\,\\frac{dV}{dh}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "V",
+                      "to": "s0___deriv_1"
+                    },
+                    {
+                      "from": "t",
+                      "to": "s0___deriv_1"
+                    },
+                    {
+                      "from": "V",
+                      "to": "s1___deriv_2"
+                    },
+                    {
+                      "from": "h",
+                      "to": "s1___deriv_2"
+                    },
+                    {
+                      "from": "s1___deriv_2",
+                      "to": "s1___multiply_1"
+                    },
+                    {
+                      "from": "h",
+                      "to": "s1___deriv_3"
+                    },
+                    {
+                      "from": "t",
+                      "to": "s1___deriv_3"
+                    },
+                    {
+                      "from": "s1___deriv_3",
+                      "to": "s1___multiply_1"
+                    },
+                    {
+                      "from": "V",
+                      "to": "s2___multiply_2"
+                    },
+                    {
+                      "from": "gamma",
+                      "to": "s2___multiply_4"
+                    },
+                    {
+                      "from": "V",
+                      "to": "s2___deriv_5"
+                    },
+                    {
+                      "from": "h",
+                      "to": "s2___deriv_5"
+                    },
+                    {
+                      "from": "s2___deriv_5",
+                      "to": "s2___multiply_4"
+                    },
+                    {
+                      "from": "s2___multiply_4",
+                      "to": "s2___sin_3"
+                    },
+                    {
+                      "from": "s2___sin_3",
+                      "to": "s2___multiply_2"
+                    },
+                    {
+                      "from": "s2___multiply_2",
+                      "to": "s2___negation_1"
+                    },
+                    {
+                      "from": "s0___deriv_1",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "s1___multiply_1",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "s2___negation_1",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
@@ -1641,7 +4087,284 @@
               "justification": "Substitute $\\rho = \\rho_0 e^{-h/H}$, cancel one $V$, and separate variables.",
               "explanation": "Substituting the chain rule result into the equation of motion and dividing both sides by $V$: $-V\\sin\\gamma\\frac{dV}{dh} = -\\frac{\\rho V^2}{2\\beta}$, which simplifies to $\\frac{dV}{V} = \\frac{\\rho}{2\\beta\\sin\\gamma}dh$.",
               "prompt": "Walk through the algebra step by step. One $V$ cancels, and $\\sin\\gamma$ moves to the denominator.",
-              "sceneStep": 0
+              "sceneStep": 0,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\frac{dV}{V} = \\frac{\\rho_0\\, e^{-h/H}}{2\\beta\\sin\\gamma}\\,dh"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{V} dV"
+                    },
+                    {
+                      "id": "dV",
+                      "type": "scalar",
+                      "latex": "dV",
+                      "subexpr": "dV"
+                    },
+                    {
+                      "id": "__power_3",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{V}"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    },
+                    {
+                      "id": "__multiply_4",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0} \\frac{1}{2 \\beta \\sin{\\left(\\gamma \\right)}} dh"
+                    },
+                    {
+                      "id": "__multiply_5",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0} \\frac{1}{2 \\beta \\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__multiply_6",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0}"
+                    },
+                    {
+                      "id": "rho_{0}",
+                      "type": "scalar",
+                      "latex": "\\rho_{0}",
+                      "subexpr": "\\rho_{0}"
+                    },
+                    {
+                      "id": "__power_7",
+                      "type": "operator",
+                      "op": "power",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"
+                    },
+                    {
+                      "id": "e",
+                      "type": "scalar",
+                      "latex": "e",
+                      "subexpr": "e"
+                    },
+                    {
+                      "id": "__multiply_8",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{H} -h"
+                    },
+                    {
+                      "id": "__negation_9",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-h"
+                    },
+                    {
+                      "id": "h",
+                      "type": "scalar",
+                      "latex": "h",
+                      "subexpr": "h"
+                    },
+                    {
+                      "id": "__power_10",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{H}"
+                    },
+                    {
+                      "id": "H",
+                      "type": "scalar",
+                      "latex": "H",
+                      "subexpr": "H"
+                    },
+                    {
+                      "id": "__power_11",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2 \\beta \\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__multiply_12",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "2 \\beta \\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "__num_13",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "__multiply_14",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\beta \\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "beta",
+                      "type": "scalar",
+                      "latex": "\\beta",
+                      "subexpr": "\\beta"
+                    },
+                    {
+                      "id": "__sin_15",
+                      "type": "function",
+                      "latex": "\\sin",
+                      "op": "sin",
+                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "gamma",
+                      "type": "scalar",
+                      "latex": "\\gamma",
+                      "subexpr": "\\gamma"
+                    },
+                    {
+                      "id": "dh",
+                      "type": "scalar",
+                      "latex": "dh",
+                      "subexpr": "dh"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "dV",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V",
+                      "to": "__power_3"
+                    },
+                    {
+                      "from": "__power_3",
+                      "to": "__multiply_2"
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "rho_{0}",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "e",
+                      "to": "__power_7"
+                    },
+                    {
+                      "from": "h",
+                      "to": "__negation_9"
+                    },
+                    {
+                      "from": "__negation_9",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__power_10"
+                    },
+                    {
+                      "from": "__power_10",
+                      "to": "__multiply_8"
+                    },
+                    {
+                      "from": "__multiply_8",
+                      "to": "__power_7",
+                      "role": "exp"
+                    },
+                    {
+                      "from": "__power_7",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_6",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_13",
+                      "to": "__multiply_12",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "beta",
+                      "to": "__multiply_14",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "gamma",
+                      "to": "__sin_15"
+                    },
+                    {
+                      "from": "__sin_15",
+                      "to": "__multiply_14",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_14",
+                      "to": "__multiply_12",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_12",
+                      "to": "__power_11"
+                    },
+                    {
+                      "from": "__power_11",
+                      "to": "__multiply_5"
+                    },
+                    {
+                      "from": "__multiply_5",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "dh",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_4",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
@@ -1663,11 +4386,387 @@
               "highlights": {
                 "exit": {
                   "color": "green",
-                  "label": "\u2248 0 because entry altitude is very high"
+                  "label": "≈ 0 because entry altitude is very high"
                 },
                 "curr": {
                   "color": "yellow",
                   "label": "grows as the capsule descends"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\ln\\frac{V}{V_E} = \\frac{\\rho_0 H}{2\\beta\\sin\\gamma}\\left(e^{-h_E/H} - e^{-h/H}\\right)"
+                    },
+                    {
+                      "id": "__log_2",
+                      "type": "function",
+                      "op": "log",
+                      "subexpr": "\\ln{\\left(\\frac{V}{V_{E}} \\right)}"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V \\frac{1}{V_{E}}"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    },
+                    {
+                      "id": "__power_4",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{V_{E}}"
+                    },
+                    {
+                      "id": "V_{E}",
+                      "type": "scalar",
+                      "latex": "V_{E}",
+                      "subexpr": "V_{E}"
+                    },
+                    {
+                      "id": "__const_5",
+                      "type": "constant",
+                      "label": "e (Euler's number)",
+                      "latex": "e",
+                      "subexpr": "e"
+                    },
+                    {
+                      "id": "__multiply_6",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "H \\rho_{0} \\frac{1}{2 \\beta \\sin{\\left(\\gamma \\right)}} \\left(e^{\\frac{\\left(-1\\right) h_{E}}{H}} - e^{\\frac{\\left(-1\\right) h}{H}}\\right)"
+                    },
+                    {
+                      "id": "__multiply_7",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "H \\rho_{0} \\frac{1}{2 \\beta \\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__multiply_8",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "H \\rho_{0}"
+                    },
+                    {
+                      "id": "rho_{0}",
+                      "type": "scalar",
+                      "latex": "\\rho_{0}",
+                      "subexpr": "\\rho_{0}"
+                    },
+                    {
+                      "id": "H",
+                      "type": "scalar",
+                      "latex": "H",
+                      "subexpr": "H"
+                    },
+                    {
+                      "id": "__power_9",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2 \\beta \\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__multiply_10",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "2 \\beta \\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "__num_11",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "__multiply_12",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\beta \\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "beta",
+                      "type": "scalar",
+                      "latex": "\\beta",
+                      "subexpr": "\\beta"
+                    },
+                    {
+                      "id": "__sin_13",
+                      "type": "function",
+                      "latex": "\\sin",
+                      "op": "sin",
+                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "gamma",
+                      "type": "scalar",
+                      "latex": "\\gamma",
+                      "subexpr": "\\gamma"
+                    },
+                    {
+                      "id": "__add_14",
+                      "type": "operator",
+                      "op": "add",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}} - e^{\\frac{\\left(-1\\right) h}{H}}"
+                    },
+                    {
+                      "id": "__power_15",
+                      "type": "operator",
+                      "op": "power",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}}"
+                    },
+                    {
+                      "id": "e",
+                      "type": "scalar",
+                      "latex": "e",
+                      "subexpr": "e"
+                    },
+                    {
+                      "id": "__multiply_16",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{H} -h_{E}"
+                    },
+                    {
+                      "id": "__negation_17",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-h_{E}"
+                    },
+                    {
+                      "id": "h_{E}",
+                      "type": "scalar",
+                      "latex": "h_{E}",
+                      "subexpr": "h_{E}"
+                    },
+                    {
+                      "id": "__power_18",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{H}"
+                    },
+                    {
+                      "id": "__negation_19",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-e^{\\frac{\\left(-1\\right) h}{H}}"
+                    },
+                    {
+                      "id": "__power_20",
+                      "type": "operator",
+                      "op": "power",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"
+                    },
+                    {
+                      "id": "__multiply_21",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{H} -h"
+                    },
+                    {
+                      "id": "__negation_22",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-h"
+                    },
+                    {
+                      "id": "h",
+                      "type": "scalar",
+                      "latex": "h",
+                      "subexpr": "h"
+                    },
+                    {
+                      "id": "__power_23",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{H}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "V",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V_{E}",
+                      "to": "__power_4"
+                    },
+                    {
+                      "from": "__power_4",
+                      "to": "__multiply_3"
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__log_2"
+                    },
+                    {
+                      "from": "__const_5",
+                      "to": "__log_2",
+                      "role": "base"
+                    },
+                    {
+                      "from": "__log_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "rho_{0}",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_8",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_11",
+                      "to": "__multiply_10",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "beta",
+                      "to": "__multiply_12",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "gamma",
+                      "to": "__sin_13"
+                    },
+                    {
+                      "from": "__sin_13",
+                      "to": "__multiply_12",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_12",
+                      "to": "__multiply_10",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_10",
+                      "to": "__power_9"
+                    },
+                    {
+                      "from": "__power_9",
+                      "to": "__multiply_7"
+                    },
+                    {
+                      "from": "__multiply_7",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "e",
+                      "to": "__power_15"
+                    },
+                    {
+                      "from": "h_{E}",
+                      "to": "__negation_17"
+                    },
+                    {
+                      "from": "__negation_17",
+                      "to": "__multiply_16",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__power_18"
+                    },
+                    {
+                      "from": "__power_18",
+                      "to": "__multiply_16"
+                    },
+                    {
+                      "from": "__multiply_16",
+                      "to": "__power_15",
+                      "role": "exp"
+                    },
+                    {
+                      "from": "__power_15",
+                      "to": "__add_14"
+                    },
+                    {
+                      "from": "e",
+                      "to": "__power_20"
+                    },
+                    {
+                      "from": "h",
+                      "to": "__negation_22"
+                    },
+                    {
+                      "from": "__negation_22",
+                      "to": "__multiply_21",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__power_23"
+                    },
+                    {
+                      "from": "__power_23",
+                      "to": "__multiply_21"
+                    },
+                    {
+                      "from": "__multiply_21",
+                      "to": "__power_20",
+                      "role": "exp"
+                    },
+                    {
+                      "from": "__power_20",
+                      "to": "__negation_19"
+                    },
+                    {
+                      "from": "__negation_19",
+                      "to": "__add_14"
+                    },
+                    {
+                      "from": "__add_14",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_6",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
                 }
               }
             },
@@ -1678,7 +4777,203 @@
               "justification": "At $h_E = 122\\,\\text{km}$ with $H = 7.2\\,\\text{km}$, the density is negligible.",
               "explanation": "The atmosphere at the entry interface is essentially vacuum. The exponential term there is so tiny we can set it to zero without meaningful error.",
               "prompt": "Have the student compute: $122/7.2 \\approx 17$ scale heights, so $e^{-17} \\approx 4 \\times 10^{-8}$.",
-              "sceneStep": 0
+              "sceneStep": 0,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "s0___power_1",
+                      "type": "operator",
+                      "op": "power",
+                      "subexpr": "e^{-h_E/H}"
+                    },
+                    {
+                      "id": "e",
+                      "type": "scalar",
+                      "latex": "e",
+                      "subexpr": "e"
+                    },
+                    {
+                      "id": "s0___multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{H} -h_{E}"
+                    },
+                    {
+                      "id": "s0___negation_3",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-h_{E}"
+                    },
+                    {
+                      "id": "h_{E}",
+                      "type": "scalar",
+                      "latex": "h_{E}",
+                      "subexpr": "h_{E}"
+                    },
+                    {
+                      "id": "s0___power_4",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{H}"
+                    },
+                    {
+                      "id": "H",
+                      "type": "scalar",
+                      "latex": "H",
+                      "subexpr": "H"
+                    },
+                    {
+                      "id": "s1___power_1",
+                      "type": "operator",
+                      "op": "power",
+                      "subexpr": "e^{-122/7.2}"
+                    },
+                    {
+                      "id": "s1___multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "-122 \\frac{1}{7.2}"
+                    },
+                    {
+                      "id": "s1___num_3",
+                      "type": "number",
+                      "label": "-122",
+                      "subexpr": "-122"
+                    },
+                    {
+                      "id": "s1___power_4",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{7.2}"
+                    },
+                    {
+                      "id": "s1___num_5",
+                      "type": "number",
+                      "label": "7.2",
+                      "subexpr": "7.2"
+                    },
+                    {
+                      "id": "s2___multiply_1",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "4 \\times 10^{-8}"
+                    },
+                    {
+                      "id": "s2___num_2",
+                      "type": "number",
+                      "label": "4",
+                      "subexpr": "4"
+                    },
+                    {
+                      "id": "s2___power_3",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "-8",
+                      "subexpr": "\\frac{1}{100000000}"
+                    },
+                    {
+                      "id": "s2___num_4",
+                      "type": "number",
+                      "label": "10",
+                      "subexpr": "10"
+                    },
+                    {
+                      "id": "s3___num_1",
+                      "type": "number",
+                      "label": "0",
+                      "subexpr": "0"
+                    },
+                    {
+                      "id": "__equals_1",
+                      "type": "operator",
+                      "op": "equals",
+                      "subexpr": "e^{-h_E/H} = e^{-122/7.2} = 4 \\times 10^{-8} = 0"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "e",
+                      "to": "s0___power_1"
+                    },
+                    {
+                      "from": "h_{E}",
+                      "to": "s0___negation_3"
+                    },
+                    {
+                      "from": "s0___negation_3",
+                      "to": "s0___multiply_2"
+                    },
+                    {
+                      "from": "H",
+                      "to": "s0___power_4"
+                    },
+                    {
+                      "from": "s0___power_4",
+                      "to": "s0___multiply_2"
+                    },
+                    {
+                      "from": "s0___multiply_2",
+                      "to": "s0___power_1"
+                    },
+                    {
+                      "from": "e",
+                      "to": "s1___power_1"
+                    },
+                    {
+                      "from": "s1___num_3",
+                      "to": "s1___multiply_2"
+                    },
+                    {
+                      "from": "s1___num_5",
+                      "to": "s1___power_4"
+                    },
+                    {
+                      "from": "s1___power_4",
+                      "to": "s1___multiply_2"
+                    },
+                    {
+                      "from": "s1___multiply_2",
+                      "to": "s1___power_1"
+                    },
+                    {
+                      "from": "s2___num_2",
+                      "to": "s2___multiply_1"
+                    },
+                    {
+                      "from": "s2___num_4",
+                      "to": "s2___power_3"
+                    },
+                    {
+                      "from": "s2___power_3",
+                      "to": "s2___multiply_1"
+                    },
+                    {
+                      "from": "s0___power_1",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "s1___power_1",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "s2___multiply_1",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "s3___num_1",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "conclusion",
@@ -1686,12 +4981,275 @@
               "math": "\\htmlClass{hl-result}{V(h) = V_E \\exp\\!\\left(-\\frac{\\rho_0 H}{2\\beta\\sin\\gamma}\\,e^{-h/H}\\right)}",
               "justification": "Exponentiate both sides: $V/V_E = \\exp(\\text{negative quantity})$, so $V < V_E$ always.",
               "explanation": "This is the Allen-Eggers velocity solution. As the capsule descends, $e^{-h/H}$ grows, making the exponent more negative, and $V$ drops. The rate of deceleration depends on $\\beta$ (how heavy and blunt the vehicle is) and $\\sin\\gamma$ (how steeply it enters). Remarkably, this closed-form solution captures the essential physics of atmospheric braking.",
-              "prompt": "Key insight: a heavier vehicle ($\\beta$ large) loses speed more slowly \u2014 it 'punches through' the atmosphere. A steep entry ($\\gamma$ large) means less path length through thin upper air, so deceleration is concentrated lower down.",
+              "prompt": "Key insight: a heavier vehicle ($\\beta$ large) loses speed more slowly — it 'punches through' the atmosphere. A steep entry ($\\gamma$ large) means less path length through thin upper air, so deceleration is concentrated lower down.",
               "sceneStep": 0,
               "highlights": {
                 "result": {
                   "color": "green",
                   "label": "Allen-Eggers velocity solution"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "V(h) = V_E \\exp\\!\\left(-\\frac{\\rho_0 H}{2\\beta\\sin\\gamma}\\,e^{-h/H}\\right)",
+                      "description": "Allen-Eggers velocity solution",
+                      "color": "green",
+                      "highlight": "result"
+                    },
+                    {
+                      "id": "__V_2",
+                      "type": "function",
+                      "op": "V",
+                      "subexpr": "V{\\left(h \\right)}"
+                    },
+                    {
+                      "id": "h",
+                      "type": "scalar",
+                      "latex": "h",
+                      "subexpr": "h"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{E} e^{- e^{\\frac{\\left(-1\\right) h}{H}} \\frac{H \\rho_{0}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"
+                    },
+                    {
+                      "id": "V_{E}",
+                      "type": "scalar",
+                      "latex": "V_{E}",
+                      "subexpr": "V_{E}"
+                    },
+                    {
+                      "id": "__exp_4",
+                      "type": "function",
+                      "latex": "\\exp",
+                      "op": "exp",
+                      "subexpr": "e^{- e^{\\frac{\\left(-1\\right) h}{H}} \\frac{H \\rho_{0}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"
+                    },
+                    {
+                      "id": "__negation_5",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-e^{\\frac{\\left(-1\\right) h}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__multiply_6",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "H",
+                      "type": "scalar",
+                      "latex": "H",
+                      "subexpr": "H"
+                    },
+                    {
+                      "id": "rho_{0}",
+                      "type": "scalar",
+                      "latex": "\\rho_{0}",
+                      "subexpr": "\\rho_{0}"
+                    },
+                    {
+                      "id": "__power_7",
+                      "type": "operator",
+                      "op": "power",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"
+                    },
+                    {
+                      "id": "e",
+                      "type": "scalar",
+                      "latex": "e",
+                      "subexpr": "e"
+                    },
+                    {
+                      "id": "__multiply_8",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{H} -h"
+                    },
+                    {
+                      "id": "__negation_9",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-h"
+                    },
+                    {
+                      "id": "__power_10",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{H}"
+                    },
+                    {
+                      "id": "__multiply_11",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__num_12",
+                      "type": "number",
+                      "label": "1/2",
+                      "subexpr": "\\frac{1}{2}"
+                    },
+                    {
+                      "id": "__power_13",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\beta}"
+                    },
+                    {
+                      "id": "beta",
+                      "type": "scalar",
+                      "latex": "\\beta",
+                      "subexpr": "\\beta"
+                    },
+                    {
+                      "id": "__power_14",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__sin_15",
+                      "type": "function",
+                      "latex": "\\sin",
+                      "op": "sin",
+                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "gamma",
+                      "type": "scalar",
+                      "latex": "\\gamma",
+                      "subexpr": "\\gamma"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "h",
+                      "to": "__V_2"
+                    },
+                    {
+                      "from": "__V_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "V_{E}",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "rho_{0}",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "e",
+                      "to": "__power_7"
+                    },
+                    {
+                      "from": "h",
+                      "to": "__negation_9"
+                    },
+                    {
+                      "from": "__negation_9",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__power_10"
+                    },
+                    {
+                      "from": "__power_10",
+                      "to": "__multiply_8"
+                    },
+                    {
+                      "from": "__multiply_8",
+                      "to": "__power_7",
+                      "role": "exp"
+                    },
+                    {
+                      "from": "__power_7",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_12",
+                      "to": "__multiply_11",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "beta",
+                      "to": "__power_13"
+                    },
+                    {
+                      "from": "__power_13",
+                      "to": "__multiply_11"
+                    },
+                    {
+                      "from": "gamma",
+                      "to": "__sin_15"
+                    },
+                    {
+                      "from": "__sin_15",
+                      "to": "__power_14"
+                    },
+                    {
+                      "from": "__power_14",
+                      "to": "__multiply_11"
+                    },
+                    {
+                      "from": "__multiply_11",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_6",
+                      "to": "__negation_5"
+                    },
+                    {
+                      "from": "__negation_5",
+                      "to": "__exp_4"
+                    },
+                    {
+                      "from": "__exp_4",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
                 }
               }
             }
@@ -1712,7 +5270,68 @@
               "explanation": "Acceleration $a$ is the rate of change of velocity, so we can write this as $F_{\\text{net}} = m \\frac{dV}{dt}$.",
               "prompt": "Remind the student of Newton's Second Law and ask what acceleration means in terms of velocity.",
               "sceneStep": 1,
-              "highlights": {}
+              "highlights": {},
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "F_{\\text{net}} = m a"
+                    },
+                    {
+                      "id": "F_{\\text{net}}",
+                      "type": "scalar",
+                      "latex": "F_{\\text{net}}",
+                      "subexpr": "F_{\\text{net}}"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "a m"
+                    },
+                    {
+                      "id": "m",
+                      "type": "scalar",
+                      "latex": "m",
+                      "subexpr": "m"
+                    },
+                    {
+                      "id": "a",
+                      "type": "scalar",
+                      "latex": "a",
+                      "subexpr": "a"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "F_{\\text{net}}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "m",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "a",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "given",
@@ -1722,7 +5341,161 @@
               "explanation": "Drag depends on the air density $\\rho$, the square of the velocity $V^2$, the capsule's drag coefficient $C_d$, and its cross-sectional area $A$.",
               "prompt": "Have the user identify the components of the drag equation.",
               "sceneStep": 1,
-              "highlights": {}
+              "highlights": {},
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "F_D = \\frac{1}{2}\\rho V^2 C_d A"
+                    },
+                    {
+                      "id": "F_{D}",
+                      "type": "scalar",
+                      "latex": "F_{D}",
+                      "subexpr": "F_{D}"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{2} \\rho V^{2} A C_{d}"
+                    },
+                    {
+                      "id": "__power_3",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2}"
+                    },
+                    {
+                      "id": "__num_4",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "__multiply_5",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho V^{2} A C_{d}"
+                    },
+                    {
+                      "id": "rho",
+                      "type": "scalar",
+                      "latex": "\\rho",
+                      "subexpr": "\\rho"
+                    },
+                    {
+                      "id": "__multiply_6",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V^{2} A C_{d}"
+                    },
+                    {
+                      "id": "__power_7",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V^{2}"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    },
+                    {
+                      "id": "__multiply_8",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "A C_{d}"
+                    },
+                    {
+                      "id": "C_{d}",
+                      "type": "scalar",
+                      "latex": "C_{d}",
+                      "subexpr": "C_{d}"
+                    },
+                    {
+                      "id": "A",
+                      "type": "scalar",
+                      "latex": "A",
+                      "subexpr": "A"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "F_{D}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "__num_4",
+                      "to": "__power_3"
+                    },
+                    {
+                      "from": "__power_3",
+                      "to": "__multiply_2"
+                    },
+                    {
+                      "from": "rho",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V",
+                      "to": "__power_7"
+                    },
+                    {
+                      "from": "__power_7",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "C_{d}",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "A",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_8",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_6",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_5",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
@@ -1732,7 +5505,54 @@
               "explanation": "We ignore gravity because the deceleration from drag reaches many G's. The negative sign shows that drag opposes the direction of motion.",
               "prompt": "Ask the student why we can ignore gravity when the spacecraft is experiencing 10 G's of deceleration.",
               "sceneStep": 1,
-              "highlights": {}
+              "highlights": {},
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "F_{\\text{net}} = -F_D"
+                    },
+                    {
+                      "id": "F_{\\text{net}}",
+                      "type": "scalar",
+                      "latex": "F_{\\text{net}}",
+                      "subexpr": "F_{\\text{net}}"
+                    },
+                    {
+                      "id": "__negation_2",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-F_{D}"
+                    },
+                    {
+                      "id": "F_{D}",
+                      "type": "scalar",
+                      "latex": "F_{D}",
+                      "subexpr": "F_{D}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "F_{\\text{net}}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "F_{D}",
+                      "to": "__negation_2"
+                    },
+                    {
+                      "from": "__negation_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
@@ -1742,7 +5562,184 @@
               "explanation": "This gives us our starting differential equation for the spacecraft's motion. It tells us exactly how fast the velocity is dropping at any given moment.",
               "prompt": "Ask the student to put the pieces together to form the full equation of motion.",
               "sceneStep": 1,
-              "highlights": {}
+              "highlights": {},
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "m \\frac{d}{d t} V = -\\frac{1}{2}\\rho V^2 C_d A"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "m \\frac{d}{d t} V"
+                    },
+                    {
+                      "id": "m",
+                      "type": "scalar",
+                      "latex": "m",
+                      "subexpr": "m"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    },
+                    {
+                      "id": "t",
+                      "type": "scalar",
+                      "latex": "t",
+                      "subexpr": "t"
+                    },
+                    {
+                      "id": "__deriv_3",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t",
+                      "subexpr": "\\frac{d}{d t} V"
+                    },
+                    {
+                      "id": "__negation_4",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-V^{2} \\rho A \\frac{1}{2} C_{d}"
+                    },
+                    {
+                      "id": "__multiply_5",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V^{2} \\rho A \\frac{1}{2} C_{d}"
+                    },
+                    {
+                      "id": "__num_6",
+                      "type": "number",
+                      "label": "1/2",
+                      "subexpr": "\\frac{1}{2}"
+                    },
+                    {
+                      "id": "A",
+                      "type": "scalar",
+                      "latex": "A",
+                      "subexpr": "A"
+                    },
+                    {
+                      "id": "C_{d}",
+                      "type": "scalar",
+                      "latex": "C_{d}",
+                      "subexpr": "C_{d}"
+                    },
+                    {
+                      "id": "rho",
+                      "type": "scalar",
+                      "latex": "\\rho",
+                      "subexpr": "\\rho"
+                    },
+                    {
+                      "id": "__power_7",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V^{2}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "m",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V",
+                      "to": "__deriv_3"
+                    },
+                    {
+                      "from": "t",
+                      "to": "__deriv_3",
+                      "role": "wrt"
+                    },
+                    {
+                      "from": "__deriv_3",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "__num_6",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "A",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "C_{d}",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "rho",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V",
+                      "to": "__power_7"
+                    },
+                    {
+                      "from": "__power_7",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_5",
+                      "to": "__negation_4"
+                    },
+                    {
+                      "from": "__negation_4",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "ODE",
+                    "order": 1,
+                    "dependent_variables": [
+                      "V"
+                    ],
+                    "independent_variables": [
+                      "t"
+                    ],
+                    "sympy_hints": [
+                      "factorable",
+                      "separable",
+                      "1st_exact",
+                      "Bernoulli",
+                      "Riccati_special_minus2",
+                      "1st_power_series",
+                      "lie_group"
+                    ],
+                    "linear": false,
+                    "homogeneous": false,
+                    "constant_coefficients": false
+                  }
+                }
+              }
             },
             {
               "type": "step",
@@ -1752,7 +5749,183 @@
               "explanation": "Instead of tracking time, we track how fast we are falling. The vertical speed is just the total speed $V$ times the sine of the entry angle $\\gamma$.",
               "prompt": "Explain the chain rule simply: 'We want to know how speed changes with height, not time.'",
               "sceneStep": 1,
-              "highlights": {}
+              "highlights": {},
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    },
+                    {
+                      "id": "t",
+                      "type": "scalar",
+                      "latex": "t",
+                      "subexpr": "t"
+                    },
+                    {
+                      "id": "s0___deriv_1",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t",
+                      "subexpr": "\\frac{d}{d t} V"
+                    },
+                    {
+                      "id": "s1___multiply_1",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{dV}{dh} \\frac{d}{d t} h"
+                    },
+                    {
+                      "id": "h",
+                      "type": "scalar",
+                      "latex": "h",
+                      "subexpr": "h"
+                    },
+                    {
+                      "id": "s1___deriv_2",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "h",
+                      "subexpr": "\\frac{d}{d h} V"
+                    },
+                    {
+                      "id": "s1___deriv_3",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t",
+                      "subexpr": "\\frac{d}{d t} h"
+                    },
+                    {
+                      "id": "s2___negation_1",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-V \\sin \\gamma \\frac{dV}{dh}"
+                    },
+                    {
+                      "id": "s2___multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V \\sin{\\left(\\gamma \\frac{d}{d h} V \\right)}"
+                    },
+                    {
+                      "id": "s2___sin_3",
+                      "type": "function",
+                      "latex": "\\sin",
+                      "op": "sin",
+                      "subexpr": "\\sin{\\left(\\gamma \\frac{d}{d h} V \\right)}"
+                    },
+                    {
+                      "id": "s2___multiply_4",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\gamma \\frac{d}{d h} V"
+                    },
+                    {
+                      "id": "gamma",
+                      "type": "scalar",
+                      "latex": "\\gamma",
+                      "subexpr": "\\gamma"
+                    },
+                    {
+                      "id": "s2___deriv_5",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "h",
+                      "subexpr": "\\frac{d}{d h} V"
+                    },
+                    {
+                      "id": "__equals_1",
+                      "type": "operator",
+                      "op": "equals",
+                      "subexpr": "\\frac{dV}{dt} = \\frac{dV}{dh} \\frac{dh}{dt} = -V \\sin \\gamma \\frac{dV}{dh}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "V",
+                      "to": "s0___deriv_1"
+                    },
+                    {
+                      "from": "t",
+                      "to": "s0___deriv_1"
+                    },
+                    {
+                      "from": "V",
+                      "to": "s1___deriv_2"
+                    },
+                    {
+                      "from": "h",
+                      "to": "s1___deriv_2"
+                    },
+                    {
+                      "from": "s1___deriv_2",
+                      "to": "s1___multiply_1"
+                    },
+                    {
+                      "from": "h",
+                      "to": "s1___deriv_3"
+                    },
+                    {
+                      "from": "t",
+                      "to": "s1___deriv_3"
+                    },
+                    {
+                      "from": "s1___deriv_3",
+                      "to": "s1___multiply_1"
+                    },
+                    {
+                      "from": "V",
+                      "to": "s2___multiply_2"
+                    },
+                    {
+                      "from": "gamma",
+                      "to": "s2___multiply_4"
+                    },
+                    {
+                      "from": "V",
+                      "to": "s2___deriv_5"
+                    },
+                    {
+                      "from": "h",
+                      "to": "s2___deriv_5"
+                    },
+                    {
+                      "from": "s2___deriv_5",
+                      "to": "s2___multiply_4"
+                    },
+                    {
+                      "from": "s2___multiply_4",
+                      "to": "s2___sin_3"
+                    },
+                    {
+                      "from": "s2___sin_3",
+                      "to": "s2___multiply_2"
+                    },
+                    {
+                      "from": "s2___multiply_2",
+                      "to": "s2___negation_1"
+                    },
+                    {
+                      "from": "s0___deriv_1",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "s1___multiply_1",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "s2___negation_1",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
@@ -1762,7 +5935,267 @@
               "explanation": "Skipping the messy calculus, if we add up all the drag as we fall, we get a formula showing how our speed $V$ drops from our initial entry speed $V_E$.",
               "prompt": "Tell the student not to worry about the calculus integration. The key takeaway is: speed drops exponentially as the air gets thicker.",
               "sceneStep": 1,
-              "highlights": {}
+              "highlights": {},
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "V(h) = V_E \\exp\\left(-\\frac{\\rho_0 H}{2\\beta \\sin\\gamma}\\,e^{-h/H}\\right)"
+                    },
+                    {
+                      "id": "__V_2",
+                      "type": "function",
+                      "op": "V",
+                      "subexpr": "V{\\left(h \\right)}"
+                    },
+                    {
+                      "id": "h",
+                      "type": "scalar",
+                      "latex": "h",
+                      "subexpr": "h"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{E} e^{- e^{\\frac{\\left(-1\\right) h}{H}} \\frac{H \\rho_{0}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"
+                    },
+                    {
+                      "id": "V_{E}",
+                      "type": "scalar",
+                      "latex": "V_{E}",
+                      "subexpr": "V_{E}"
+                    },
+                    {
+                      "id": "__exp_4",
+                      "type": "function",
+                      "latex": "\\exp",
+                      "op": "exp",
+                      "subexpr": "e^{- e^{\\frac{\\left(-1\\right) h}{H}} \\frac{H \\rho_{0}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"
+                    },
+                    {
+                      "id": "__negation_5",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-e^{\\frac{\\left(-1\\right) h}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__multiply_6",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "H",
+                      "type": "scalar",
+                      "latex": "H",
+                      "subexpr": "H"
+                    },
+                    {
+                      "id": "rho_{0}",
+                      "type": "scalar",
+                      "latex": "\\rho_{0}",
+                      "subexpr": "\\rho_{0}"
+                    },
+                    {
+                      "id": "__power_7",
+                      "type": "operator",
+                      "op": "power",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"
+                    },
+                    {
+                      "id": "e",
+                      "type": "scalar",
+                      "latex": "e",
+                      "subexpr": "e"
+                    },
+                    {
+                      "id": "__multiply_8",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{H} -h"
+                    },
+                    {
+                      "id": "__negation_9",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-h"
+                    },
+                    {
+                      "id": "__power_10",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{H}"
+                    },
+                    {
+                      "id": "__multiply_11",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__num_12",
+                      "type": "number",
+                      "label": "1/2",
+                      "subexpr": "\\frac{1}{2}"
+                    },
+                    {
+                      "id": "__power_13",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\beta}"
+                    },
+                    {
+                      "id": "beta",
+                      "type": "scalar",
+                      "latex": "\\beta",
+                      "subexpr": "\\beta"
+                    },
+                    {
+                      "id": "__power_14",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__sin_15",
+                      "type": "function",
+                      "latex": "\\sin",
+                      "op": "sin",
+                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "gamma",
+                      "type": "scalar",
+                      "latex": "\\gamma",
+                      "subexpr": "\\gamma"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "h",
+                      "to": "__V_2"
+                    },
+                    {
+                      "from": "__V_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "V_{E}",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "rho_{0}",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "e",
+                      "to": "__power_7"
+                    },
+                    {
+                      "from": "h",
+                      "to": "__negation_9"
+                    },
+                    {
+                      "from": "__negation_9",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__power_10"
+                    },
+                    {
+                      "from": "__power_10",
+                      "to": "__multiply_8"
+                    },
+                    {
+                      "from": "__multiply_8",
+                      "to": "__power_7",
+                      "role": "exp"
+                    },
+                    {
+                      "from": "__power_7",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_12",
+                      "to": "__multiply_11",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "beta",
+                      "to": "__power_13"
+                    },
+                    {
+                      "from": "__power_13",
+                      "to": "__multiply_11"
+                    },
+                    {
+                      "from": "gamma",
+                      "to": "__sin_15"
+                    },
+                    {
+                      "from": "__sin_15",
+                      "to": "__power_14"
+                    },
+                    {
+                      "from": "__power_14",
+                      "to": "__multiply_11"
+                    },
+                    {
+                      "from": "__multiply_11",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_6",
+                      "to": "__negation_5"
+                    },
+                    {
+                      "from": "__negation_5",
+                      "to": "__exp_4"
+                    },
+                    {
+                      "from": "__exp_4",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
@@ -1770,9 +6203,87 @@
               "math": "\\frac{d}{dh} \\left( \\frac{dV}{dt} \\right) = 0",
               "justification": "To find the peak (maximum) deceleration, we find where the derivative of deceleration is zero.",
               "explanation": "In calculus, you find the highest point of a curve by looking for where it goes flat (slope is zero). The maximum drag happens exactly when the spacecraft has lost a specific fraction of its speed.",
-              "prompt": "Relate finding a maximum to the peak of a roller coaster\u2014the very top is flat for a split second.",
+              "prompt": "Relate finding a maximum to the peak of a roller coaster—the very top is flat for a split second.",
               "sceneStep": 1,
-              "highlights": {}
+              "highlights": {},
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\frac{d}{dh} \\left( \\frac{d}{d t} V \\right) = 0"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    },
+                    {
+                      "id": "t",
+                      "type": "scalar",
+                      "latex": "t",
+                      "subexpr": "t"
+                    },
+                    {
+                      "id": "h",
+                      "type": "scalar",
+                      "latex": "h",
+                      "subexpr": "h"
+                    },
+                    {
+                      "id": "__deriv_2",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t, h",
+                      "subexpr": "\\frac{d^{2}}{d hd t} V"
+                    },
+                    {
+                      "id": "__num_3",
+                      "type": "number",
+                      "label": "0",
+                      "subexpr": "0"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "V",
+                      "to": "__deriv_2"
+                    },
+                    {
+                      "from": "t",
+                      "to": "__deriv_2",
+                      "role": "wrt"
+                    },
+                    {
+                      "from": "h",
+                      "to": "__deriv_2",
+                      "role": "wrt"
+                    },
+                    {
+                      "from": "__deriv_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "__num_3",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "PDE",
+                    "order": 2,
+                    "dependent_variables": [
+                      "V"
+                    ],
+                    "independent_variables": [
+                      "h",
+                      "t"
+                    ]
+                  }
+                }
+              }
             },
             {
               "type": "conclusion",
@@ -1790,6 +6301,177 @@
                 "gamma": {
                   "color": "yellow",
                   "label": "Flight Path Angle"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "a_{\\text{max}} = \\frac{V_E^2 \\sin \\gamma}{2e H}"
+                    },
+                    {
+                      "id": "a_{\\text{max}}",
+                      "type": "scalar",
+                      "latex": "a_{\\text{max}}",
+                      "subexpr": "a_{\\text{max}}"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma \\right)} \\frac{1}{2 H e}"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "__power_4",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V_{E}^{2}",
+                      "description": "Entry Velocity",
+                      "color": "cyan",
+                      "highlight": "ve"
+                    },
+                    {
+                      "id": "V_{E}",
+                      "type": "scalar",
+                      "latex": "V_{E}",
+                      "subexpr": "V_{E}"
+                    },
+                    {
+                      "id": "__sin_5",
+                      "type": "function",
+                      "latex": "\\sin",
+                      "op": "sin",
+                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "gamma",
+                      "type": "scalar",
+                      "latex": "\\gamma",
+                      "subexpr": "\\gamma",
+                      "description": "Flight Path Angle",
+                      "color": "yellow",
+                      "highlight": "gamma"
+                    },
+                    {
+                      "id": "__power_6",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2 H e}"
+                    },
+                    {
+                      "id": "__multiply_7",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "2 e H"
+                    },
+                    {
+                      "id": "__num_8",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "__multiply_9",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "e H"
+                    },
+                    {
+                      "id": "e",
+                      "type": "scalar",
+                      "latex": "e",
+                      "subexpr": "e"
+                    },
+                    {
+                      "id": "H",
+                      "type": "scalar",
+                      "latex": "H",
+                      "subexpr": "H"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "a_{\\text{max}}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "V_{E}",
+                      "to": "__power_4"
+                    },
+                    {
+                      "from": "__power_4",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "gamma",
+                      "to": "__sin_5"
+                    },
+                    {
+                      "from": "__sin_5",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_8",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "e",
+                      "to": "__multiply_9",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__multiply_9",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_9",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_7",
+                      "to": "__power_6"
+                    },
+                    {
+                      "from": "__power_6",
+                      "to": "__multiply_2"
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
                 }
               }
             }
@@ -1810,7 +6492,137 @@
               "justification": "Drag acceleration magnitude from the equation of motion.",
               "explanation": "The g-load felt by the crew is proportional to this deceleration: $n = a_D / g_0$. We want to find how $a_D$ varies with altitude.",
               "prompt": "Remind the student that the g-load chart in the visualization is showing exactly this quantity divided by $g_0 = 9.81\\,\\text{m/s}^2$.",
-              "sceneStep": 1
+              "sceneStep": 1,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "a_D = \\frac{\\rho V^2}{2\\beta}"
+                    },
+                    {
+                      "id": "a_{D}",
+                      "type": "scalar",
+                      "latex": "a_{D}",
+                      "subexpr": "a_{D}"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho V^{2} \\frac{1}{2 \\beta}"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho V^{2}"
+                    },
+                    {
+                      "id": "rho",
+                      "type": "scalar",
+                      "latex": "\\rho",
+                      "subexpr": "\\rho"
+                    },
+                    {
+                      "id": "__power_4",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V^{2}"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    },
+                    {
+                      "id": "__power_5",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2 \\beta}"
+                    },
+                    {
+                      "id": "__multiply_6",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\beta 2"
+                    },
+                    {
+                      "id": "__num_7",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "beta",
+                      "type": "scalar",
+                      "latex": "\\beta",
+                      "subexpr": "\\beta"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "a_{D}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "rho",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V",
+                      "to": "__power_4"
+                    },
+                    {
+                      "from": "__power_4",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_7",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "beta",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_6",
+                      "to": "__power_5"
+                    },
+                    {
+                      "from": "__power_5",
+                      "to": "__multiply_2"
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
@@ -1818,8 +6630,408 @@
               "math": "a_D(h) = \\frac{\\rho_0\\,e^{-h/H}\\cdot V_E^2}{2\\beta}\\exp\\!\\left(-\\frac{\\rho_0 H}{\\beta\\sin\\gamma}\\,e^{-h/H}\\right)",
               "justification": "Plug $\\rho = \\rho_0 e^{-h/H}$ and $V(h)^2 = V_E^2 \\exp\\left(-\\frac{\\rho_0 H}{\\beta\\sin\\gamma}e^{-h/H}\\right)$ into the drag formula.",
               "explanation": "Note: $V^2$ brings a factor of $\\exp(-2\\cdot\\ldots)$, but one factor of $\\rho_0 H/(2\\beta\\sin\\gamma)$ was already in the $V$ exponent. Combined with the $\\rho$ in front, the $e^{-h/H}$ terms group into a product of $u$ and $e^{-ku}$.",
-              "prompt": "The algebra is a bit involved. Focus on the structure: it's density \u00d7 speed\u00b2, and both change with altitude in opposing ways.",
-              "sceneStep": 1
+              "prompt": "The algebra is a bit involved. Focus on the structure: it's density × speed², and both change with altitude in opposing ways.",
+              "sceneStep": 1,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "a_D(h) = \\frac{\\rho_0\\,e^{-h/H}\\cdot V_E^2}{2\\beta}\\exp\\!\\left(-\\frac{\\rho_0 H}{\\beta\\sin\\gamma}\\,e^{-h/H}\\right)"
+                    },
+                    {
+                      "id": "__a_{D}_2",
+                      "type": "function",
+                      "op": "a_{D}",
+                      "subexpr": "a_{D}{\\left(h \\right)}"
+                    },
+                    {
+                      "id": "h",
+                      "type": "scalar",
+                      "latex": "h",
+                      "subexpr": "h"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0} V_{E}^{2} \\frac{1}{2 \\beta} e^{- e^{\\frac{\\left(-1\\right) h}{H}} \\frac{H \\rho_{0}}{\\beta \\sin{\\left(\\gamma \\right)}}}"
+                    },
+                    {
+                      "id": "__multiply_4",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0} V_{E}^{2} \\frac{1}{2 \\beta}"
+                    },
+                    {
+                      "id": "__multiply_5",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0} V_{E}^{2}"
+                    },
+                    {
+                      "id": "__multiply_6",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0}"
+                    },
+                    {
+                      "id": "rho_{0}",
+                      "type": "scalar",
+                      "latex": "\\rho_{0}",
+                      "subexpr": "\\rho_{0}"
+                    },
+                    {
+                      "id": "__power_7",
+                      "type": "operator",
+                      "op": "power",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"
+                    },
+                    {
+                      "id": "e",
+                      "type": "scalar",
+                      "latex": "e",
+                      "subexpr": "e"
+                    },
+                    {
+                      "id": "__multiply_8",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{H} -h"
+                    },
+                    {
+                      "id": "__negation_9",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-h"
+                    },
+                    {
+                      "id": "__power_10",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{H}"
+                    },
+                    {
+                      "id": "H",
+                      "type": "scalar",
+                      "latex": "H",
+                      "subexpr": "H"
+                    },
+                    {
+                      "id": "__power_11",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V_{E}^{2}"
+                    },
+                    {
+                      "id": "V_{E}",
+                      "type": "scalar",
+                      "latex": "V_{E}",
+                      "subexpr": "V_{E}"
+                    },
+                    {
+                      "id": "__power_12",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2 \\beta}"
+                    },
+                    {
+                      "id": "__multiply_13",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\beta 2"
+                    },
+                    {
+                      "id": "__num_14",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "beta",
+                      "type": "scalar",
+                      "latex": "\\beta",
+                      "subexpr": "\\beta"
+                    },
+                    {
+                      "id": "__exp_15",
+                      "type": "function",
+                      "latex": "\\exp",
+                      "op": "exp",
+                      "subexpr": "e^{- e^{\\frac{\\left(-1\\right) h}{H}} \\frac{H \\rho_{0}}{\\beta \\sin{\\left(\\gamma \\right)}}}"
+                    },
+                    {
+                      "id": "__negation_16",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-e^{\\frac{\\left(-1\\right) h}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__multiply_17",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__power_18",
+                      "type": "operator",
+                      "op": "power",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"
+                    },
+                    {
+                      "id": "__multiply_19",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{H} -h"
+                    },
+                    {
+                      "id": "__negation_20",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-h"
+                    },
+                    {
+                      "id": "__power_21",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{H}"
+                    },
+                    {
+                      "id": "__multiply_22",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{\\beta} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__power_23",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\beta}"
+                    },
+                    {
+                      "id": "__power_24",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__sin_25",
+                      "type": "function",
+                      "latex": "\\sin",
+                      "op": "sin",
+                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "gamma",
+                      "type": "scalar",
+                      "latex": "\\gamma",
+                      "subexpr": "\\gamma"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "h",
+                      "to": "__a_{D}_2"
+                    },
+                    {
+                      "from": "__a_{D}_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "rho_{0}",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "e",
+                      "to": "__power_7"
+                    },
+                    {
+                      "from": "h",
+                      "to": "__negation_9"
+                    },
+                    {
+                      "from": "__negation_9",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__power_10"
+                    },
+                    {
+                      "from": "__power_10",
+                      "to": "__multiply_8"
+                    },
+                    {
+                      "from": "__multiply_8",
+                      "to": "__power_7",
+                      "role": "exp"
+                    },
+                    {
+                      "from": "__power_7",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_6",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V_{E}",
+                      "to": "__power_11"
+                    },
+                    {
+                      "from": "__power_11",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_5",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_14",
+                      "to": "__multiply_13",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "beta",
+                      "to": "__multiply_13",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_13",
+                      "to": "__power_12"
+                    },
+                    {
+                      "from": "__power_12",
+                      "to": "__multiply_4"
+                    },
+                    {
+                      "from": "__multiply_4",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__multiply_17",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "rho_{0}",
+                      "to": "__multiply_17",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "e",
+                      "to": "__power_18"
+                    },
+                    {
+                      "from": "h",
+                      "to": "__negation_20"
+                    },
+                    {
+                      "from": "__negation_20",
+                      "to": "__multiply_19",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__power_21"
+                    },
+                    {
+                      "from": "__power_21",
+                      "to": "__multiply_19"
+                    },
+                    {
+                      "from": "__multiply_19",
+                      "to": "__power_18",
+                      "role": "exp"
+                    },
+                    {
+                      "from": "__power_18",
+                      "to": "__multiply_17",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "beta",
+                      "to": "__power_23"
+                    },
+                    {
+                      "from": "__power_23",
+                      "to": "__multiply_22"
+                    },
+                    {
+                      "from": "gamma",
+                      "to": "__sin_25"
+                    },
+                    {
+                      "from": "__sin_25",
+                      "to": "__power_24"
+                    },
+                    {
+                      "from": "__power_24",
+                      "to": "__multiply_22"
+                    },
+                    {
+                      "from": "__multiply_22",
+                      "to": "__multiply_17",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_17",
+                      "to": "__negation_16"
+                    },
+                    {
+                      "from": "__negation_16",
+                      "to": "__exp_15"
+                    },
+                    {
+                      "from": "__exp_15",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
@@ -1837,6 +7049,345 @@
                 "k": {
                   "color": "cyan",
                   "label": "dimensionless drag parameter"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "c0___equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "a_D = \\frac{\\rho_0 V_E^2}{2\\beta}\\;u\\;\\exp\\!\\left(-k\\,u\\right)"
+                    },
+                    {
+                      "id": "a_{D}",
+                      "type": "scalar",
+                      "latex": "a_{D}",
+                      "subexpr": "a_{D}"
+                    },
+                    {
+                      "id": "c0___multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho_{0} V_{E}^{2} \\frac{1}{2 \\beta} u e^{- k u}"
+                    },
+                    {
+                      "id": "c0___multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho_{0} V_{E}^{2} \\frac{1}{2 \\beta}"
+                    },
+                    {
+                      "id": "c0___multiply_4",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho_{0} V_{E}^{2}"
+                    },
+                    {
+                      "id": "c0_rho_{0}",
+                      "type": "scalar",
+                      "latex": "\\rho_{0}",
+                      "subexpr": "\\rho_{0}"
+                    },
+                    {
+                      "id": "c0___power_5",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V_{E}^{2}"
+                    },
+                    {
+                      "id": "V_{E}",
+                      "type": "scalar",
+                      "latex": "V_{E}",
+                      "subexpr": "V_{E}"
+                    },
+                    {
+                      "id": "c0___power_6",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2 \\beta}"
+                    },
+                    {
+                      "id": "c0___multiply_7",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\beta 2"
+                    },
+                    {
+                      "id": "c0___num_8",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "beta",
+                      "type": "scalar",
+                      "latex": "\\beta",
+                      "subexpr": "\\beta"
+                    },
+                    {
+                      "id": "c0___multiply_9",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "u e^{- k u}"
+                    },
+                    {
+                      "id": "u",
+                      "type": "scalar",
+                      "latex": "u",
+                      "subexpr": "u",
+                      "description": "density factor (grows during descent)",
+                      "color": "yellow",
+                      "highlight": "u"
+                    },
+                    {
+                      "id": "c0___exp_10",
+                      "type": "function",
+                      "latex": "\\exp",
+                      "op": "exp",
+                      "subexpr": "e^{- k u}"
+                    },
+                    {
+                      "id": "c0___negation_11",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-u k"
+                    },
+                    {
+                      "id": "c0___multiply_12",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "u k"
+                    },
+                    {
+                      "id": "k",
+                      "type": "scalar",
+                      "latex": "k",
+                      "subexpr": "k",
+                      "description": "dimensionless drag parameter",
+                      "color": "cyan",
+                      "highlight": "k"
+                    },
+                    {
+                      "id": "c1___equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "k = \\frac{\\rho_0 H}{\\beta\\sin\\gamma}"
+                    },
+                    {
+                      "id": "c1___multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "H \\rho_{0} \\frac{1}{\\beta \\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "c1___multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "H \\rho_{0}"
+                    },
+                    {
+                      "id": "c1_rho_{0}",
+                      "type": "scalar",
+                      "latex": "\\rho_{0}",
+                      "subexpr": "\\rho_{0}"
+                    },
+                    {
+                      "id": "H",
+                      "type": "scalar",
+                      "latex": "H",
+                      "subexpr": "H"
+                    },
+                    {
+                      "id": "c1___power_4",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\beta \\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "c1___multiply_5",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\beta \\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "c1___sin_6",
+                      "type": "function",
+                      "latex": "\\sin",
+                      "op": "sin",
+                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "gamma",
+                      "type": "scalar",
+                      "latex": "\\gamma",
+                      "subexpr": "\\gamma"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "a_{D}",
+                      "to": "c0___equals_1"
+                    },
+                    {
+                      "from": "c0_rho_{0}",
+                      "to": "c0___multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V_{E}",
+                      "to": "c0___power_5"
+                    },
+                    {
+                      "from": "c0___power_5",
+                      "to": "c0___multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "c0___multiply_4",
+                      "to": "c0___multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "c0___num_8",
+                      "to": "c0___multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "beta",
+                      "to": "c0___multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "c0___multiply_7",
+                      "to": "c0___power_6"
+                    },
+                    {
+                      "from": "c0___power_6",
+                      "to": "c0___multiply_3"
+                    },
+                    {
+                      "from": "c0___multiply_3",
+                      "to": "c0___multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "u",
+                      "to": "c0___multiply_9",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "k",
+                      "to": "c0___multiply_12",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "u",
+                      "to": "c0___multiply_12",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "c0___multiply_12",
+                      "to": "c0___negation_11"
+                    },
+                    {
+                      "from": "c0___negation_11",
+                      "to": "c0___exp_10"
+                    },
+                    {
+                      "from": "c0___exp_10",
+                      "to": "c0___multiply_9",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "c0___multiply_9",
+                      "to": "c0___multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "c0___multiply_2",
+                      "to": "c0___equals_1"
+                    },
+                    {
+                      "from": "k",
+                      "to": "c1___equals_1"
+                    },
+                    {
+                      "from": "c1_rho_{0}",
+                      "to": "c1___multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "c1___multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "c1___multiply_3",
+                      "to": "c1___multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "beta",
+                      "to": "c1___multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "gamma",
+                      "to": "c1___sin_6"
+                    },
+                    {
+                      "from": "c1___sin_6",
+                      "to": "c1___multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "c1___multiply_5",
+                      "to": "c1___power_4"
+                    },
+                    {
+                      "from": "c1___power_4",
+                      "to": "c1___multiply_2"
+                    },
+                    {
+                      "from": "c1___multiply_2",
+                      "to": "c1___equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "statements",
+                    "count": 2,
+                    "clauses": [
+                      {
+                        "kind": "algebraic"
+                      },
+                      {
+                        "kind": "algebraic"
+                      }
+                    ]
+                  }
                 }
               }
             },
@@ -1856,20 +7407,181 @@
               "justification": "Solve $ku^* = 1$ for $u^*$.",
               "explanation": "At peak deceleration, the density parameter $u^*$ depends on the vehicle ($\\beta$) and entry angle ($\\gamma$). A heavier or steeper-entering vehicle reaches peak-g at a lower altitude (larger $u^*$, meaning denser air).",
               "prompt": "Connect to the visualization: heavier capsules (higher $\\beta$) punch deeper into the atmosphere before reaching peak g.",
-              "sceneStep": 1
+              "sceneStep": 1,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "u",
+                      "type": "scalar",
+                      "latex": "u",
+                      "subexpr": "u^*"
+                    },
+                    {
+                      "id": "s1___power_1",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{k}"
+                    },
+                    {
+                      "id": "k",
+                      "type": "scalar",
+                      "latex": "k",
+                      "subexpr": "k"
+                    },
+                    {
+                      "id": "s2___multiply_1",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{\\beta\\sin\\gamma}{\\rho_0 H}"
+                    },
+                    {
+                      "id": "s2___multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\beta \\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "beta",
+                      "type": "scalar",
+                      "latex": "\\beta",
+                      "subexpr": "\\beta"
+                    },
+                    {
+                      "id": "s2___sin_3",
+                      "type": "function",
+                      "latex": "\\sin",
+                      "op": "sin",
+                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "gamma",
+                      "type": "scalar",
+                      "latex": "\\gamma",
+                      "subexpr": "\\gamma"
+                    },
+                    {
+                      "id": "s2___power_4",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{H \\rho_{0}}"
+                    },
+                    {
+                      "id": "s2___multiply_5",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "H \\rho_{0}"
+                    },
+                    {
+                      "id": "rho_{0}",
+                      "type": "scalar",
+                      "latex": "\\rho_{0}",
+                      "subexpr": "\\rho_{0}"
+                    },
+                    {
+                      "id": "H",
+                      "type": "scalar",
+                      "latex": "H",
+                      "subexpr": "H"
+                    },
+                    {
+                      "id": "__equals_1",
+                      "type": "operator",
+                      "op": "equals",
+                      "subexpr": "u^* = \\frac{1}{k} = \\frac{\\beta\\sin\\gamma}{\\rho_0 H}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "k",
+                      "to": "s1___power_1"
+                    },
+                    {
+                      "from": "beta",
+                      "to": "s2___multiply_2"
+                    },
+                    {
+                      "from": "gamma",
+                      "to": "s2___sin_3"
+                    },
+                    {
+                      "from": "s2___sin_3",
+                      "to": "s2___multiply_2"
+                    },
+                    {
+                      "from": "s2___multiply_2",
+                      "to": "s2___multiply_1"
+                    },
+                    {
+                      "from": "rho_{0}",
+                      "to": "s2___multiply_5"
+                    },
+                    {
+                      "from": "H",
+                      "to": "s2___multiply_5"
+                    },
+                    {
+                      "from": "s2___multiply_5",
+                      "to": "s2___power_4"
+                    },
+                    {
+                      "from": "s2___power_4",
+                      "to": "s2___multiply_1"
+                    },
+                    {
+                      "from": "u",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "s1___power_1",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "s2___multiply_1",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
               "label": "Peak Deceleration Altitude",
               "math": "\\htmlClass{hl-hstar}{h^* = H\\ln\\frac{\\rho_0 H}{\\beta\\sin\\gamma}}",
               "justification": "From $u^* = e^{-h^*/H}$, solve for $h^*$: $h^* = -H\\ln u^* = H\\ln(1/u^*) = H\\ln(k)$.",
-              "explanation": "This gives the exact altitude of maximum g-load. For Apollo at $\\gamma = 6.5\u00b0$: $\\beta \\approx 458$, so $h^* \\approx 7.2 \\times \\ln(1.225 \\times 7200 / (458 \\times 0.113)) \\approx 7.2 \\times \\ln(170) \\approx 37\\,\\text{km}$.",
+              "explanation": "This gives the exact altitude of maximum g-load. For Apollo at $\\gamma = 6.5°$: $\\beta \\approx 458$, so $h^* \\approx 7.2 \\times \\ln(1.225 \\times 7200 / (458 \\times 0.113)) \\approx 7.2 \\times \\ln(170) \\approx 37\\,\\text{km}$.",
               "prompt": "Have the student estimate $h^*$ for the current vehicle and compare with where the peak appears on the g-load chart.",
               "sceneStep": 1,
               "highlights": {
                 "hstar": {
                   "color": "magenta",
                   "label": "altitude of peak g-load"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "h",
+                      "type": "scalar",
+                      "latex": "h",
+                      "subexpr": "h^* = H\\ln\\frac{\\rho_0 H}{\\beta\\sin\\gamma}",
+                      "description": "altitude of peak g-load",
+                      "color": "magenta",
+                      "highlight": "hstar"
+                    }
+                  ],
+                  "edges": [],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
                 }
               }
             },
@@ -1878,13 +7590,215 @@
               "label": "Complete G-Load Profile",
               "math": "\\htmlClass{hl-profile}{n(h) = \\frac{V_E^2\\sin\\gamma}{2eHg_0}\\;\\left(\\frac{u}{u^*}\\right)\\exp\\!\\left(1 - \\frac{u}{u^*}\\right)}",
               "justification": "Divide $a_D(h)$ by the peak value $a_{\\max} = V_E^2\\sin\\gamma/(2eH)$ and multiply by that peak to get the normalized profile scaled to physical units.",
-              "explanation": "The g-load profile is a universal bell-shaped curve when plotted against $u/u^*$ (normalized density). The shape is always the same \u2014 only the peak value and peak altitude change with vehicle and entry angle. This is the curve you see in the g-load chart.",
+              "explanation": "The g-load profile is a universal bell-shaped curve when plotted against $u/u^*$ (normalized density). The shape is always the same — only the peak value and peak altitude change with vehicle and entry angle. This is the curve you see in the g-load chart.",
               "prompt": "Key insight: the SHAPE of the g-load curve is universal for all ballistic entries. Only the peak value and the altitude shift change.",
               "sceneStep": 1,
               "highlights": {
                 "profile": {
                   "color": "green",
                   "label": "universal g-load profile"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "n(h) = \\frac{V_E^2\\sin\\gamma}{2eHg_0}\\;\\left(\\frac{u}{u^*}\\right)\\exp\\!\\left(1 - \\frac{u}{u^*}\\right)",
+                      "description": "universal g-load profile",
+                      "color": "green",
+                      "highlight": "profile"
+                    },
+                    {
+                      "id": "__n_2",
+                      "type": "function",
+                      "op": "n",
+                      "subexpr": "n{\\left(h \\right)}"
+                    },
+                    {
+                      "id": "h",
+                      "type": "scalar",
+                      "latex": "h",
+                      "subexpr": "h"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma \\right)} \\frac{1}{2 e H g_{0}}"
+                    },
+                    {
+                      "id": "__multiply_4",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "__power_5",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V_{E}^{2}"
+                    },
+                    {
+                      "id": "V_{E}",
+                      "type": "scalar",
+                      "latex": "V_{E}",
+                      "subexpr": "V_{E}"
+                    },
+                    {
+                      "id": "__sin_6",
+                      "type": "function",
+                      "latex": "\\sin",
+                      "op": "sin",
+                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "gamma",
+                      "type": "scalar",
+                      "latex": "\\gamma",
+                      "subexpr": "\\gamma"
+                    },
+                    {
+                      "id": "__power_7",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2 e H g_{0}}"
+                    },
+                    {
+                      "id": "__multiply_8",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "2 e H g_{0}"
+                    },
+                    {
+                      "id": "__num_9",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "__multiply_10",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "e H g_{0}"
+                    },
+                    {
+                      "id": "e",
+                      "type": "scalar",
+                      "latex": "e",
+                      "subexpr": "e"
+                    },
+                    {
+                      "id": "__multiply_11",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "H g_{0}"
+                    },
+                    {
+                      "id": "H",
+                      "type": "scalar",
+                      "latex": "H",
+                      "subexpr": "H"
+                    },
+                    {
+                      "id": "g_{0}",
+                      "type": "scalar",
+                      "latex": "g_{0}",
+                      "subexpr": "g_{0}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "h",
+                      "to": "__n_2"
+                    },
+                    {
+                      "from": "__n_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "V_{E}",
+                      "to": "__power_5"
+                    },
+                    {
+                      "from": "__power_5",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "gamma",
+                      "to": "__sin_6"
+                    },
+                    {
+                      "from": "__sin_6",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_4",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_9",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "e",
+                      "to": "__multiply_10",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__multiply_11",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "g_{0}",
+                      "to": "__multiply_11",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_11",
+                      "to": "__multiply_10",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_10",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_8",
+                      "to": "__power_7"
+                    },
+                    {
+                      "from": "__power_7",
+                      "to": "__multiply_3"
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
                 }
               }
             }
@@ -1905,7 +7819,70 @@
               "justification": "The entry corridor is the range of flight-path angles that produce a survivable entry.",
               "explanation": "Too steep ($\\gamma > \\gamma_{\\text{steep}}$) and the g-loads exceed crew tolerance. Too shallow ($\\gamma < \\gamma_{\\text{shallow}}$) and the vehicle skips off the atmosphere back into space. The corridor is the safe window between these extremes.",
               "prompt": "Relate to the green wedge in the visualization: the two edges correspond to these two limits. Ask the student what happens at each edge.",
-              "sceneStep": 0
+              "sceneStep": 0,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "gamma_{\\text{steep}}",
+                      "type": "scalar",
+                      "latex": "\\gamma_{\\text{steep}}",
+                      "subexpr": "\\gamma_{\\text{steep}}"
+                    },
+                    {
+                      "id": "__less_equal_1",
+                      "type": "relation",
+                      "op": "less_equal",
+                      "subexpr": "\\gamma \\leq \\gamma_{\\text{shallow}}"
+                    },
+                    {
+                      "id": "gamma",
+                      "type": "scalar",
+                      "latex": "\\gamma",
+                      "subexpr": "\\gamma"
+                    },
+                    {
+                      "id": "gamma_{\\text{shallow}}",
+                      "type": "scalar",
+                      "latex": "\\gamma_{\\text{shallow}}",
+                      "subexpr": "\\gamma_{\\text{shallow}}"
+                    },
+                    {
+                      "id": "__less_equal_2",
+                      "type": "relation",
+                      "label": "less than or equal to",
+                      "emoji": "≤",
+                      "op": "less_equal",
+                      "subexpr": "\\gamma_{\\text{steep}} \\leq \\gamma \\leq \\gamma_{\\text{shallow}}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "gamma",
+                      "to": "__less_equal_1",
+                      "role": "lhs"
+                    },
+                    {
+                      "from": "gamma_{\\text{shallow}}",
+                      "to": "__less_equal_1",
+                      "role": "rhs"
+                    },
+                    {
+                      "from": "gamma_{\\text{steep}}",
+                      "to": "__less_equal_2",
+                      "role": "lhs"
+                    },
+                    {
+                      "from": "__less_equal_1",
+                      "to": "__less_equal_2",
+                      "role": "rhs"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "given",
@@ -1914,20 +7891,374 @@
               "justification": "Previously derived: the maximum deceleration depends only on entry speed and angle.",
               "explanation": "This result (from the Allen-Eggers proof) is the key to the steep boundary. The vehicle parameters $m$, $C_d$, $A$ have cancelled out completely.",
               "prompt": "Reference the earlier proof. The student should already know this result.",
-              "sceneStep": 0
+              "sceneStep": 0,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "a_{\\max} = \\frac{V_E^2\\sin\\gamma}{2eH}"
+                    },
+                    {
+                      "id": "a_{max}",
+                      "type": "scalar",
+                      "latex": "a_{max}",
+                      "subexpr": "a_{max}"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma \\right)} \\frac{1}{2 H e}"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "__power_4",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V_{E}^{2}"
+                    },
+                    {
+                      "id": "V_{E}",
+                      "type": "scalar",
+                      "latex": "V_{E}",
+                      "subexpr": "V_{E}"
+                    },
+                    {
+                      "id": "__sin_5",
+                      "type": "function",
+                      "latex": "\\sin",
+                      "op": "sin",
+                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "gamma",
+                      "type": "scalar",
+                      "latex": "\\gamma",
+                      "subexpr": "\\gamma"
+                    },
+                    {
+                      "id": "__power_6",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2 H e}"
+                    },
+                    {
+                      "id": "__multiply_7",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "2 e H"
+                    },
+                    {
+                      "id": "__num_8",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "__multiply_9",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "e H"
+                    },
+                    {
+                      "id": "e",
+                      "type": "scalar",
+                      "latex": "e",
+                      "subexpr": "e"
+                    },
+                    {
+                      "id": "H",
+                      "type": "scalar",
+                      "latex": "H",
+                      "subexpr": "H"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "a_{max}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "V_{E}",
+                      "to": "__power_4"
+                    },
+                    {
+                      "from": "__power_4",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "gamma",
+                      "to": "__sin_5"
+                    },
+                    {
+                      "from": "__sin_5",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_8",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "e",
+                      "to": "__multiply_9",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__multiply_9",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_9",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_7",
+                      "to": "__power_6"
+                    },
+                    {
+                      "from": "__power_6",
+                      "to": "__multiply_2"
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
               "label": "Steep Boundary (G-Limit)",
               "math": "\\frac{V_E^2\\sin\\gamma_{\\text{steep}}}{2eH} = \\htmlClass{hl-glimit}{n_{\\max}\\cdot g_0}",
               "justification": "Set the peak deceleration equal to the maximum tolerable g-load.",
-              "explanation": "The crew can survive up to $n_{\\max}$ G's (typically 8\u201312 G for short-duration entry). Setting the Allen-Eggers peak equal to this limit defines the steepest allowable angle.",
-              "prompt": "Have the student adjust the g-limit slider and watch how the steep boundary moves. Lower g-tolerance \u2192 shallower steep limit \u2192 narrower corridor.",
+              "explanation": "The crew can survive up to $n_{\\max}$ G's (typically 8–12 G for short-duration entry). Setting the Allen-Eggers peak equal to this limit defines the steepest allowable angle.",
+              "prompt": "Have the student adjust the g-limit slider and watch how the steep boundary moves. Lower g-tolerance → shallower steep limit → narrower corridor.",
               "sceneStep": 0,
               "highlights": {
                 "glimit": {
                   "color": "red",
                   "label": "crew survivability limit"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\frac{V_E^2\\sin\\gamma_{\\text{steep}}}{2eH} = n_{\\max}\\cdot g_0"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma_{\\text{steep}} \\right)} \\frac{1}{2 H e}"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma_{\\text{steep}} \\right)}"
+                    },
+                    {
+                      "id": "__power_4",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V_{E}^{2}"
+                    },
+                    {
+                      "id": "V_{E}",
+                      "type": "scalar",
+                      "latex": "V_{E}",
+                      "subexpr": "V_{E}"
+                    },
+                    {
+                      "id": "__sin_5",
+                      "type": "function",
+                      "latex": "\\sin",
+                      "op": "sin",
+                      "subexpr": "\\sin{\\left(\\gamma_{\\text{steep}} \\right)}"
+                    },
+                    {
+                      "id": "gamma_{\\text{steep}}",
+                      "type": "scalar",
+                      "latex": "\\gamma_{\\text{steep}}",
+                      "subexpr": "\\gamma_{\\text{steep}}"
+                    },
+                    {
+                      "id": "__power_6",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2 H e}"
+                    },
+                    {
+                      "id": "__multiply_7",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "2 e H"
+                    },
+                    {
+                      "id": "__num_8",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "__multiply_9",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "e H"
+                    },
+                    {
+                      "id": "e",
+                      "type": "scalar",
+                      "latex": "e",
+                      "subexpr": "e"
+                    },
+                    {
+                      "id": "H",
+                      "type": "scalar",
+                      "latex": "H",
+                      "subexpr": "H"
+                    },
+                    {
+                      "id": "__multiply_10",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "n_{max} g_{0}"
+                    },
+                    {
+                      "id": "n_{max}",
+                      "type": "scalar",
+                      "latex": "n_{max}",
+                      "subexpr": "n_{max}"
+                    },
+                    {
+                      "id": "g_{0}",
+                      "type": "scalar",
+                      "latex": "g_{0}",
+                      "subexpr": "g_{0}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "V_{E}",
+                      "to": "__power_4"
+                    },
+                    {
+                      "from": "__power_4",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "gamma_{\\text{steep}}",
+                      "to": "__sin_5"
+                    },
+                    {
+                      "from": "__sin_5",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_8",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "e",
+                      "to": "__multiply_9",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__multiply_9",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_9",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_7",
+                      "to": "__power_6"
+                    },
+                    {
+                      "from": "__power_6",
+                      "to": "__multiply_2"
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "n_{max}",
+                      "to": "__multiply_10",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "g_{0}",
+                      "to": "__multiply_10",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_10",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
                 }
               }
             },
@@ -1936,13 +8267,204 @@
               "label": "Steep Bound Solution",
               "math": "\\htmlClass{hl-steep}{\\gamma_{\\text{steep}} = \\arcsin\\!\\left(\\frac{2eHg_0\\,n_{\\max}}{V_E^2}\\right)}",
               "justification": "Solve for $\\gamma$: $\\sin\\gamma = 2eHg_0 n_{\\max}/V_E^2$.",
-              "explanation": "For Apollo ($V_E = 11\\,\\text{km/s}$, $n_{\\max} = 10\\,\\text{G}$): $\\sin\\gamma = 2 \\times 2.718 \\times 7200 \\times 9.81 \\times 10 / (11000)^2 \\approx 0.0318$, giving $\\gamma_{\\text{steep}} \\approx 1.8\u00b0$. Faster entry speeds dramatically narrow the corridor \u2014 the denominator grows as $V_E^2$.",
-              "prompt": "Key insight: the steep boundary depends only on the entry speed and the g-tolerance, NOT on the vehicle's mass or shape. A heavier capsule hits the same peak g at the same angle \u2014 it just happens deeper in the atmosphere.",
+              "explanation": "For Apollo ($V_E = 11\\,\\text{km/s}$, $n_{\\max} = 10\\,\\text{G}$): $\\sin\\gamma = 2 \\times 2.718 \\times 7200 \\times 9.81 \\times 10 / (11000)^2 \\approx 0.0318$, giving $\\gamma_{\\text{steep}} \\approx 1.8°$. Faster entry speeds dramatically narrow the corridor — the denominator grows as $V_E^2$.",
+              "prompt": "Key insight: the steep boundary depends only on the entry speed and the g-tolerance, NOT on the vehicle's mass or shape. A heavier capsule hits the same peak g at the same angle — it just happens deeper in the atmosphere.",
               "sceneStep": 0,
               "highlights": {
                 "steep": {
                   "color": "red",
                   "label": "maximum entry angle for crew survival"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\gamma_{\\text{steep}} = \\arcsin\\!\\left(\\frac{2eHg_0\\,n_{\\max}}{V_E^2}\\right)",
+                      "description": "maximum entry angle for crew survival",
+                      "color": "red",
+                      "highlight": "steep"
+                    },
+                    {
+                      "id": "gamma_{\\text{steep}}",
+                      "type": "scalar",
+                      "latex": "\\gamma_{\\text{steep}}",
+                      "subexpr": "\\gamma_{\\text{steep}}"
+                    },
+                    {
+                      "id": "__asin_2",
+                      "type": "function",
+                      "op": "asin",
+                      "subexpr": "\\operatorname{asin}{\\left(\\frac{2 e H g_{0} n_{max}}{V_{E}^{2}} \\right)}"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "2 e H g_{0} n_{max} \\frac{1}{V_{E}^{2}}"
+                    },
+                    {
+                      "id": "__multiply_4",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "2 e H g_{0} n_{max}"
+                    },
+                    {
+                      "id": "__num_5",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "__multiply_6",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "e H g_{0} n_{max}"
+                    },
+                    {
+                      "id": "e",
+                      "type": "scalar",
+                      "latex": "e",
+                      "subexpr": "e"
+                    },
+                    {
+                      "id": "__multiply_7",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "H g_{0} n_{max}"
+                    },
+                    {
+                      "id": "H",
+                      "type": "scalar",
+                      "latex": "H",
+                      "subexpr": "H"
+                    },
+                    {
+                      "id": "__multiply_8",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "g_{0} n_{max}"
+                    },
+                    {
+                      "id": "g_{0}",
+                      "type": "scalar",
+                      "latex": "g_{0}",
+                      "subexpr": "g_{0}"
+                    },
+                    {
+                      "id": "n_{max}",
+                      "type": "scalar",
+                      "latex": "n_{max}",
+                      "subexpr": "n_{max}"
+                    },
+                    {
+                      "id": "__power_9",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{V_{E}^{2}}"
+                    },
+                    {
+                      "id": "__power_10",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V_{E}^{2}"
+                    },
+                    {
+                      "id": "V_{E}",
+                      "type": "scalar",
+                      "latex": "V_{E}",
+                      "subexpr": "V_{E}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "gamma_{\\text{steep}}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "__num_5",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "e",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "g_{0}",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "n_{max}",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_8",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_7",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_6",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_4",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V_{E}",
+                      "to": "__power_10"
+                    },
+                    {
+                      "from": "__power_10",
+                      "to": "__power_9"
+                    },
+                    {
+                      "from": "__power_9",
+                      "to": "__multiply_3"
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__asin_2"
+                    },
+                    {
+                      "from": "__asin_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
                 }
               }
             },
@@ -1951,22 +8473,629 @@
               "label": "Skip-Out Physics",
               "math": "V_{\\text{exit}} = V_E\\exp\\!\\left(-\\frac{\\rho_0 H}{2\\beta\\sin\\gamma}\\,e^{-h_E/H}\\right)",
               "justification": "Apply the Allen-Eggers velocity solution at the exit altitude $h \\approx h_E$.",
-              "explanation": "For a symmetric atmospheric pass (valid at shallow angles), the vehicle exits near the same altitude it entered. If the exit speed is still close to orbital velocity, the resulting orbit will carry the vehicle back above the atmosphere \u2014 a skip-out.",
-              "prompt": "Ask: why is the pass approximately symmetric for shallow angles? Because $\\gamma$ is small, so the path barely curves \u2014 the vehicle enters and exits at nearly the same altitude.",
-              "sceneStep": 0
+              "explanation": "For a symmetric atmospheric pass (valid at shallow angles), the vehicle exits near the same altitude it entered. If the exit speed is still close to orbital velocity, the resulting orbit will carry the vehicle back above the atmosphere — a skip-out.",
+              "prompt": "Ask: why is the pass approximately symmetric for shallow angles? Because $\\gamma$ is small, so the path barely curves — the vehicle enters and exits at nearly the same altitude.",
+              "sceneStep": 0,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "V_{\\text{exit}} = V_E\\exp\\!\\left(-\\frac{\\rho_0 H}{2\\beta\\sin\\gamma}\\,e^{-h_E/H}\\right)"
+                    },
+                    {
+                      "id": "V_{\\text{exit}}",
+                      "type": "scalar",
+                      "latex": "V_{\\text{exit}}",
+                      "subexpr": "V_{\\text{exit}}"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{E} e^{- e^{\\frac{\\left(-1\\right) h_{E}}{H}} \\frac{H \\rho_{0}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"
+                    },
+                    {
+                      "id": "V_{E}",
+                      "type": "scalar",
+                      "latex": "V_{E}",
+                      "subexpr": "V_{E}"
+                    },
+                    {
+                      "id": "__exp_3",
+                      "type": "function",
+                      "latex": "\\exp",
+                      "op": "exp",
+                      "subexpr": "e^{- e^{\\frac{\\left(-1\\right) h_{E}}{H}} \\frac{H \\rho_{0}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"
+                    },
+                    {
+                      "id": "__negation_4",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-e^{\\frac{\\left(-1\\right) h_{E}}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__multiply_5",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "H",
+                      "type": "scalar",
+                      "latex": "H",
+                      "subexpr": "H"
+                    },
+                    {
+                      "id": "rho_{0}",
+                      "type": "scalar",
+                      "latex": "\\rho_{0}",
+                      "subexpr": "\\rho_{0}"
+                    },
+                    {
+                      "id": "__power_6",
+                      "type": "operator",
+                      "op": "power",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}}"
+                    },
+                    {
+                      "id": "e",
+                      "type": "scalar",
+                      "latex": "e",
+                      "subexpr": "e"
+                    },
+                    {
+                      "id": "__multiply_7",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{H} -h_{E}"
+                    },
+                    {
+                      "id": "__negation_8",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-h_{E}"
+                    },
+                    {
+                      "id": "h_{E}",
+                      "type": "scalar",
+                      "latex": "h_{E}",
+                      "subexpr": "h_{E}"
+                    },
+                    {
+                      "id": "__power_9",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{H}"
+                    },
+                    {
+                      "id": "__multiply_10",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__num_11",
+                      "type": "number",
+                      "label": "1/2",
+                      "subexpr": "\\frac{1}{2}"
+                    },
+                    {
+                      "id": "__power_12",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\beta}"
+                    },
+                    {
+                      "id": "beta",
+                      "type": "scalar",
+                      "latex": "\\beta",
+                      "subexpr": "\\beta"
+                    },
+                    {
+                      "id": "__power_13",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__sin_14",
+                      "type": "function",
+                      "latex": "\\sin",
+                      "op": "sin",
+                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "gamma",
+                      "type": "scalar",
+                      "latex": "\\gamma",
+                      "subexpr": "\\gamma"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "V_{\\text{exit}}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "V_{E}",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "rho_{0}",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "e",
+                      "to": "__power_6"
+                    },
+                    {
+                      "from": "h_{E}",
+                      "to": "__negation_8"
+                    },
+                    {
+                      "from": "__negation_8",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__power_9"
+                    },
+                    {
+                      "from": "__power_9",
+                      "to": "__multiply_7"
+                    },
+                    {
+                      "from": "__multiply_7",
+                      "to": "__power_6",
+                      "role": "exp"
+                    },
+                    {
+                      "from": "__power_6",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_11",
+                      "to": "__multiply_10",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "beta",
+                      "to": "__power_12"
+                    },
+                    {
+                      "from": "__power_12",
+                      "to": "__multiply_10"
+                    },
+                    {
+                      "from": "gamma",
+                      "to": "__sin_14"
+                    },
+                    {
+                      "from": "__sin_14",
+                      "to": "__power_13"
+                    },
+                    {
+                      "from": "__power_13",
+                      "to": "__multiply_10"
+                    },
+                    {
+                      "from": "__multiply_10",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_5",
+                      "to": "__negation_4"
+                    },
+                    {
+                      "from": "__negation_4",
+                      "to": "__exp_3"
+                    },
+                    {
+                      "from": "__exp_3",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
               "label": "Fractional Velocity Loss",
               "math": "\\htmlClass{hl-delta}{\\delta} \\equiv 1 - \\frac{V_{\\text{exit}}}{V_E} = 1 - \\exp\\!\\left(-\\frac{\\rho_0 H\\,e^{-h_E/H}}{2\\beta\\sin\\gamma}\\right)",
               "justification": "Define $\\delta$ as the fraction of entry speed lost during the atmospheric pass.",
-              "explanation": "For very shallow angles ($\\gamma \\to 0$), $\\sin\\gamma \\to 0$, the exponent's denominator grows, making the exponential approach 1, so $\\delta \\to 0$ \u2014 negligible deceleration, guaranteed skip-out. For steeper angles, more speed is lost.",
-              "prompt": "This is the critical quantity: $\\delta$ measures how effective the atmosphere is at capturing the vehicle. Too little $\\delta$ \u2192 skip-out.",
+              "explanation": "For very shallow angles ($\\gamma \\to 0$), $\\sin\\gamma \\to 0$, the exponent's denominator grows, making the exponential approach 1, so $\\delta \\to 0$ — negligible deceleration, guaranteed skip-out. For steeper angles, more speed is lost.",
+              "prompt": "This is the critical quantity: $\\delta$ measures how effective the atmosphere is at capturing the vehicle. Too little $\\delta$ → skip-out.",
               "sceneStep": 0,
               "highlights": {
                 "delta": {
                   "color": "orange",
                   "label": "fractional speed loss during atmospheric pass"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "delta",
+                      "type": "scalar",
+                      "latex": "\\delta",
+                      "subexpr": "\\delta",
+                      "description": "fractional speed loss during atmospheric pass",
+                      "color": "orange",
+                      "highlight": "delta"
+                    },
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "1 - \\frac{V_{\\text{exit}}}{V_{E}} = 1 - \\exp \\left(-\\frac{\\rho_{0} H e^{-h_{E}/H}}{2\\beta\\sin\\gamma}\\right)"
+                    },
+                    {
+                      "id": "__add_2",
+                      "type": "operator",
+                      "op": "add",
+                      "subexpr": "1 - V_{\\text{exit}} \\frac{1}{V_{E}}"
+                    },
+                    {
+                      "id": "__num_3",
+                      "type": "number",
+                      "label": "1",
+                      "subexpr": "1"
+                    },
+                    {
+                      "id": "__negation_4",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-V_{\\text{exit}} \\frac{1}{V_{E}}"
+                    },
+                    {
+                      "id": "__multiply_5",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{\\text{exit}} \\frac{1}{V_{E}}"
+                    },
+                    {
+                      "id": "V_{\\text{exit}}",
+                      "type": "scalar",
+                      "latex": "V_{\\text{exit}}",
+                      "subexpr": "V_{\\text{exit}}"
+                    },
+                    {
+                      "id": "__power_6",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{V_{E}}"
+                    },
+                    {
+                      "id": "V_{E}",
+                      "type": "scalar",
+                      "latex": "V_{E}",
+                      "subexpr": "V_{E}"
+                    },
+                    {
+                      "id": "__add_7",
+                      "type": "operator",
+                      "op": "add",
+                      "subexpr": "1 - e^{- \\frac{\\rho_{0} H e^{\\frac{\\left(-1\\right) h_{E}}{H}}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"
+                    },
+                    {
+                      "id": "__num_8",
+                      "type": "number",
+                      "label": "1",
+                      "subexpr": "1"
+                    },
+                    {
+                      "id": "__negation_9",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-e^{- \\frac{\\rho_{0} H e^{\\frac{\\left(-1\\right) h_{E}}{H}}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"
+                    },
+                    {
+                      "id": "__exp_10",
+                      "type": "function",
+                      "latex": "\\exp",
+                      "op": "exp",
+                      "subexpr": "e^{- \\frac{\\rho_{0} H e^{\\frac{\\left(-1\\right) h_{E}}{H}}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"
+                    },
+                    {
+                      "id": "__negation_11",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-e^{\\frac{\\left(-1\\right) h_{E}}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__multiply_12",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "H",
+                      "type": "scalar",
+                      "latex": "H",
+                      "subexpr": "H"
+                    },
+                    {
+                      "id": "rho_{0}",
+                      "type": "scalar",
+                      "latex": "\\rho_{0}",
+                      "subexpr": "\\rho_{0}"
+                    },
+                    {
+                      "id": "__power_13",
+                      "type": "operator",
+                      "op": "power",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}}"
+                    },
+                    {
+                      "id": "e",
+                      "type": "scalar",
+                      "latex": "e",
+                      "subexpr": "e"
+                    },
+                    {
+                      "id": "__multiply_14",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{H} -h_{E}"
+                    },
+                    {
+                      "id": "__negation_15",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-h_{E}"
+                    },
+                    {
+                      "id": "h_{E}",
+                      "type": "scalar",
+                      "latex": "h_{E}",
+                      "subexpr": "h_{E}"
+                    },
+                    {
+                      "id": "__power_16",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{H}"
+                    },
+                    {
+                      "id": "__multiply_17",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__num_18",
+                      "type": "number",
+                      "label": "1/2",
+                      "subexpr": "\\frac{1}{2}"
+                    },
+                    {
+                      "id": "__power_19",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\beta}"
+                    },
+                    {
+                      "id": "beta",
+                      "type": "scalar",
+                      "latex": "\\beta",
+                      "subexpr": "\\beta"
+                    },
+                    {
+                      "id": "__power_20",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\sin{\\left(\\gamma \\right)}}"
+                    },
+                    {
+                      "id": "__sin_21",
+                      "type": "function",
+                      "latex": "\\sin",
+                      "op": "sin",
+                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
+                    },
+                    {
+                      "id": "gamma",
+                      "type": "scalar",
+                      "latex": "\\gamma",
+                      "subexpr": "\\gamma"
+                    },
+                    {
+                      "id": "__congruent_22",
+                      "type": "relation",
+                      "label": "congruent to",
+                      "emoji": "≡",
+                      "op": "congruent",
+                      "subexpr": "\\delta \\equiv 1 - \\frac{V_{\\text{exit}}}{V_E} = 1 - \\exp\\!\\left(-\\frac{\\rho_0 H\\,e^{-h_E/H}}{2\\beta\\sin\\gamma}\\right)"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "__num_3",
+                      "to": "__add_2"
+                    },
+                    {
+                      "from": "V_{\\text{exit}}",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V_{E}",
+                      "to": "__power_6"
+                    },
+                    {
+                      "from": "__power_6",
+                      "to": "__multiply_5"
+                    },
+                    {
+                      "from": "__multiply_5",
+                      "to": "__negation_4"
+                    },
+                    {
+                      "from": "__negation_4",
+                      "to": "__add_2"
+                    },
+                    {
+                      "from": "__add_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "__num_8",
+                      "to": "__add_7"
+                    },
+                    {
+                      "from": "H",
+                      "to": "__multiply_12",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "rho_{0}",
+                      "to": "__multiply_12",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "e",
+                      "to": "__power_13"
+                    },
+                    {
+                      "from": "h_{E}",
+                      "to": "__negation_15"
+                    },
+                    {
+                      "from": "__negation_15",
+                      "to": "__multiply_14",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__power_16"
+                    },
+                    {
+                      "from": "__power_16",
+                      "to": "__multiply_14"
+                    },
+                    {
+                      "from": "__multiply_14",
+                      "to": "__power_13",
+                      "role": "exp"
+                    },
+                    {
+                      "from": "__power_13",
+                      "to": "__multiply_12",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_18",
+                      "to": "__multiply_17",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "beta",
+                      "to": "__power_19"
+                    },
+                    {
+                      "from": "__power_19",
+                      "to": "__multiply_17"
+                    },
+                    {
+                      "from": "gamma",
+                      "to": "__sin_21"
+                    },
+                    {
+                      "from": "__sin_21",
+                      "to": "__power_20"
+                    },
+                    {
+                      "from": "__power_20",
+                      "to": "__multiply_17"
+                    },
+                    {
+                      "from": "__multiply_17",
+                      "to": "__multiply_12",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_12",
+                      "to": "__negation_11"
+                    },
+                    {
+                      "from": "__negation_11",
+                      "to": "__exp_10"
+                    },
+                    {
+                      "from": "__exp_10",
+                      "to": "__negation_9"
+                    },
+                    {
+                      "from": "__negation_9",
+                      "to": "__add_7"
+                    },
+                    {
+                      "from": "__add_7",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "delta",
+                      "to": "__congruent_22"
+                    },
+                    {
+                      "from": "__equals_1",
+                      "to": "__congruent_22"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
                 }
               }
             },
@@ -1975,13 +9104,254 @@
               "label": "Minimum Deceleration for Capture",
               "math": "\\delta \\geq \\htmlClass{hl-dmin}{\\delta_{\\min}} = 1 - \\frac{V_{\\text{circ}}}{V_E}\\sqrt{1 + \\frac{2h_E}{R_p}}",
               "justification": "The post-pass orbit must have perigee below the entry interface. For an orbit at radius $r_E = R_p + h_E$ with speed $V_{\\text{exit}}$, the apoapsis condition gives this threshold.",
-              "explanation": "If the vehicle exits with speed above this threshold, its orbit takes it back above the atmosphere and it escapes. For lunar return ($V_E \\approx 11\\,\\text{km/s}$, $V_{\\text{circ}} \\approx 7.8\\,\\text{km/s}$), $\\delta_{\\min}$ is only about $2\\%$ \u2014 the corridor is more forgiving than for LEO return. For LEO return ($V_E \\approx V_{\\text{circ}}$), the vehicle barely needs any deceleration.",
+              "explanation": "If the vehicle exits with speed above this threshold, its orbit takes it back above the atmosphere and it escapes. For lunar return ($V_E \\approx 11\\,\\text{km/s}$, $V_{\\text{circ}} \\approx 7.8\\,\\text{km/s}$), $\\delta_{\\min}$ is only about $2\\%$ — the corridor is more forgiving than for LEO return. For LEO return ($V_E \\approx V_{\\text{circ}}$), the vehicle barely needs any deceleration.",
               "prompt": "For super-orbital entries (like lunar or Mars return), the vehicle comes in much faster than orbital speed, so even a small fractional loss matters enormously.",
               "sceneStep": 0,
               "highlights": {
                 "dmin": {
                   "color": "magenta",
                   "label": "minimum fractional speed loss for atmospheric capture"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "delta",
+                      "type": "scalar",
+                      "latex": "\\delta",
+                      "subexpr": "\\delta"
+                    },
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\delta_{\\min} = 1 - \\frac{V_{\\text{circ}}}{V_{E}}\\sqrt{1 + \\frac{2h_{E}}{R_{p}}}"
+                    },
+                    {
+                      "id": "delta_{\\min}",
+                      "type": "scalar",
+                      "latex": "\\delta_{\\min}",
+                      "subexpr": "\\delta_{\\min}",
+                      "description": "minimum fractional speed loss for atmospheric capture",
+                      "color": "magenta",
+                      "highlight": "dmin"
+                    },
+                    {
+                      "id": "__add_2",
+                      "type": "operator",
+                      "op": "add",
+                      "subexpr": "1 - V_{\\text{circ}} \\frac{1}{V_{E}} \\sqrt{1 + \\frac{2 h_{E}}{R_{p}}}"
+                    },
+                    {
+                      "id": "__num_3",
+                      "type": "number",
+                      "label": "1",
+                      "subexpr": "1"
+                    },
+                    {
+                      "id": "__negation_4",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-V_{\\text{circ}} \\frac{1}{V_{E}} \\sqrt{1 + \\frac{2 h_{E}}{R_{p}}}"
+                    },
+                    {
+                      "id": "__multiply_5",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{\\text{circ}} \\frac{1}{V_{E}} \\sqrt{1 + \\frac{2 h_{E}}{R_{p}}}"
+                    },
+                    {
+                      "id": "__multiply_6",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{\\text{circ}} \\frac{1}{V_{E}}"
+                    },
+                    {
+                      "id": "V_{\\text{circ}}",
+                      "type": "scalar",
+                      "latex": "V_{\\text{circ}}",
+                      "subexpr": "V_{\\text{circ}}"
+                    },
+                    {
+                      "id": "__power_7",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{V_{E}}"
+                    },
+                    {
+                      "id": "V_{E}",
+                      "type": "scalar",
+                      "latex": "V_{E}",
+                      "subexpr": "V_{E}"
+                    },
+                    {
+                      "id": "__power_8",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "1/2",
+                      "subexpr": "\\sqrt{1 + \\frac{2 h_{E}}{R_{p}}}"
+                    },
+                    {
+                      "id": "__add_9",
+                      "type": "operator",
+                      "op": "add",
+                      "subexpr": "1 + 2 h_{E} \\frac{1}{R_{p}}"
+                    },
+                    {
+                      "id": "__num_10",
+                      "type": "number",
+                      "label": "1",
+                      "subexpr": "1"
+                    },
+                    {
+                      "id": "__multiply_11",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "2 h_{E} \\frac{1}{R_{p}}"
+                    },
+                    {
+                      "id": "__multiply_12",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "2 h_{E}"
+                    },
+                    {
+                      "id": "__num_13",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "h_{E}",
+                      "type": "scalar",
+                      "latex": "h_{E}",
+                      "subexpr": "h_{E}"
+                    },
+                    {
+                      "id": "__power_14",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{R_{p}}"
+                    },
+                    {
+                      "id": "R_{p}",
+                      "type": "scalar",
+                      "latex": "R_{p}",
+                      "subexpr": "R_{p}"
+                    },
+                    {
+                      "id": "__greater_equal_15",
+                      "type": "relation",
+                      "label": "greater than or equal to",
+                      "emoji": "≥",
+                      "op": "greater_equal",
+                      "subexpr": "\\delta \\geq \\delta_{\\min} = 1 - \\frac{V_{\\text{circ}}}{V_E}\\sqrt{1 + \\frac{2h_E}{R_p}}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "delta_{\\min}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "__num_3",
+                      "to": "__add_2"
+                    },
+                    {
+                      "from": "V_{\\text{circ}}",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V_{E}",
+                      "to": "__power_7"
+                    },
+                    {
+                      "from": "__power_7",
+                      "to": "__multiply_6"
+                    },
+                    {
+                      "from": "__multiply_6",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_10",
+                      "to": "__add_9"
+                    },
+                    {
+                      "from": "__num_13",
+                      "to": "__multiply_12",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "h_{E}",
+                      "to": "__multiply_12",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_12",
+                      "to": "__multiply_11",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "R_{p}",
+                      "to": "__power_14"
+                    },
+                    {
+                      "from": "__power_14",
+                      "to": "__multiply_11"
+                    },
+                    {
+                      "from": "__multiply_11",
+                      "to": "__add_9"
+                    },
+                    {
+                      "from": "__add_9",
+                      "to": "__power_8"
+                    },
+                    {
+                      "from": "__power_8",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_5",
+                      "to": "__negation_4"
+                    },
+                    {
+                      "from": "__negation_4",
+                      "to": "__add_2"
+                    },
+                    {
+                      "from": "__add_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "delta",
+                      "to": "__greater_equal_15",
+                      "role": "lhs"
+                    },
+                    {
+                      "from": "__equals_1",
+                      "to": "__greater_equal_15",
+                      "role": "rhs"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
                 }
               }
             },
@@ -1992,7 +9362,308 @@
               "justification": "Set $\\delta = \\delta_{\\min}$ in the velocity-loss equation and solve for $\\sin\\gamma$.",
               "explanation": "From $1 - \\delta_{\\min} = \\exp(-\\xi)$ where $\\xi = \\rho_0 H e^{-h_E/H}/(2\\beta\\sin\\gamma)$, we get $\\xi = \\ln(1/(1-\\delta_{\\min}))$, then solve for $\\sin\\gamma$.",
               "prompt": "Walk through the algebra: take the log of both sides, then isolate $\\sin\\gamma$.",
-              "sceneStep": 0
+              "sceneStep": 0,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\sin\\gamma_{\\text{shallow}} = \\frac{\\rho_0 H\\,e^{-h_E/H}}{2\\beta\\,\\ln\\!\\left(\\frac{1}{1 - \\delta_{\\min}}\\right)}"
+                    },
+                    {
+                      "id": "__sin_2",
+                      "type": "function",
+                      "latex": "\\sin",
+                      "op": "sin",
+                      "subexpr": "\\sin{\\left(\\gamma_{\\text{shallow}} \\right)}"
+                    },
+                    {
+                      "id": "gamma_{\\text{shallow}}",
+                      "type": "scalar",
+                      "latex": "\\gamma_{\\text{shallow}}",
+                      "subexpr": "\\gamma_{\\text{shallow}}"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho_{0} H e^{\\frac{\\left(-1\\right) h_{E}}{H}} \\frac{1}{2 \\beta \\ln{\\left(\\frac{1}{1 - \\delta_{\\min}} \\right)}}"
+                    },
+                    {
+                      "id": "__multiply_4",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho_{0} H e^{\\frac{\\left(-1\\right) h_{E}}{H}}"
+                    },
+                    {
+                      "id": "rho_{0}",
+                      "type": "scalar",
+                      "latex": "\\rho_{0}",
+                      "subexpr": "\\rho_{0}"
+                    },
+                    {
+                      "id": "__multiply_5",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "H e^{\\frac{\\left(-1\\right) h_{E}}{H}}"
+                    },
+                    {
+                      "id": "H",
+                      "type": "scalar",
+                      "latex": "H",
+                      "subexpr": "H"
+                    },
+                    {
+                      "id": "__power_6",
+                      "type": "operator",
+                      "op": "power",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}}"
+                    },
+                    {
+                      "id": "e",
+                      "type": "scalar",
+                      "latex": "e",
+                      "subexpr": "e"
+                    },
+                    {
+                      "id": "__multiply_7",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{H} -h_{E}"
+                    },
+                    {
+                      "id": "__negation_8",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-h_{E}"
+                    },
+                    {
+                      "id": "h_{E}",
+                      "type": "scalar",
+                      "latex": "h_{E}",
+                      "subexpr": "h_{E}"
+                    },
+                    {
+                      "id": "__power_9",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{H}"
+                    },
+                    {
+                      "id": "__power_10",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2 \\beta \\ln{\\left(\\frac{1}{1 - \\delta_{\\min}} \\right)}}"
+                    },
+                    {
+                      "id": "__multiply_11",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "2 \\beta \\ln{\\left(\\frac{1}{1 - \\delta_{\\min}} \\right)}"
+                    },
+                    {
+                      "id": "__num_12",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "__multiply_13",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\beta \\ln{\\left(\\frac{1}{1 - \\delta_{\\min}} \\right)}"
+                    },
+                    {
+                      "id": "beta",
+                      "type": "scalar",
+                      "latex": "\\beta",
+                      "subexpr": "\\beta"
+                    },
+                    {
+                      "id": "__log_14",
+                      "type": "function",
+                      "op": "log",
+                      "subexpr": "\\ln{\\left(\\frac{1}{1 - \\delta_{\\min}} \\right)}"
+                    },
+                    {
+                      "id": "__power_15",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{1 - \\delta_{\\min}}"
+                    },
+                    {
+                      "id": "__add_16",
+                      "type": "operator",
+                      "op": "add",
+                      "subexpr": "1 - \\delta_{\\min}"
+                    },
+                    {
+                      "id": "__num_17",
+                      "type": "number",
+                      "label": "1",
+                      "subexpr": "1"
+                    },
+                    {
+                      "id": "__negation_18",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-\\delta_{\\min}"
+                    },
+                    {
+                      "id": "delta_{\\min}",
+                      "type": "scalar",
+                      "latex": "\\delta_{\\min}",
+                      "subexpr": "\\delta_{\\min}"
+                    },
+                    {
+                      "id": "__const_19",
+                      "type": "constant",
+                      "label": "e (Euler's number)",
+                      "latex": "e",
+                      "subexpr": "e"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "gamma_{\\text{shallow}}",
+                      "to": "__sin_2"
+                    },
+                    {
+                      "from": "__sin_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "rho_{0}",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "e",
+                      "to": "__power_6"
+                    },
+                    {
+                      "from": "h_{E}",
+                      "to": "__negation_8"
+                    },
+                    {
+                      "from": "__negation_8",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__power_9"
+                    },
+                    {
+                      "from": "__power_9",
+                      "to": "__multiply_7"
+                    },
+                    {
+                      "from": "__multiply_7",
+                      "to": "__power_6",
+                      "role": "exp"
+                    },
+                    {
+                      "from": "__power_6",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_5",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_4",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_12",
+                      "to": "__multiply_11",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "beta",
+                      "to": "__multiply_13",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_17",
+                      "to": "__add_16"
+                    },
+                    {
+                      "from": "delta_{\\min}",
+                      "to": "__negation_18"
+                    },
+                    {
+                      "from": "__negation_18",
+                      "to": "__add_16"
+                    },
+                    {
+                      "from": "__add_16",
+                      "to": "__power_15"
+                    },
+                    {
+                      "from": "__power_15",
+                      "to": "__log_14"
+                    },
+                    {
+                      "from": "__const_19",
+                      "to": "__log_14",
+                      "role": "base"
+                    },
+                    {
+                      "from": "__log_14",
+                      "to": "__multiply_13",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_13",
+                      "to": "__multiply_11",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_11",
+                      "to": "__power_10"
+                    },
+                    {
+                      "from": "__power_10",
+                      "to": "__multiply_3"
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
@@ -2007,6 +9678,242 @@
                   "color": "orange",
                   "label": "minimum entry angle to avoid skip-out"
                 }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\gamma_{\\text{shallow}} = \\arcsin\\!\\left(\\frac{\\rho_0 H\\,e^{-h_E/H}}{2\\beta\\,\\delta_{\\min}}\\right)"
+                    },
+                    {
+                      "id": "gamma_{\\text{shallow}}",
+                      "type": "scalar",
+                      "latex": "\\gamma_{\\text{shallow}}",
+                      "subexpr": "\\gamma_{\\text{shallow}}"
+                    },
+                    {
+                      "id": "__asin_2",
+                      "type": "function",
+                      "op": "asin",
+                      "subexpr": "\\operatorname{asin}{\\left(\\frac{\\rho_{0} H e^{\\frac{\\left(-1\\right) h_{E}}{H}}}{2 \\delta_{\\min} \\beta} \\right)}"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho_{0} e^{\\frac{\\left(-1\\right) h_{E}}{H}} H \\frac{1}{2 \\delta_{\\min} \\beta}"
+                    },
+                    {
+                      "id": "__multiply_4",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho_{0} e^{\\frac{\\left(-1\\right) h_{E}}{H}} H"
+                    },
+                    {
+                      "id": "rho_{0}",
+                      "type": "scalar",
+                      "latex": "\\rho_{0}",
+                      "subexpr": "\\rho_{0}"
+                    },
+                    {
+                      "id": "__multiply_5",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}} H"
+                    },
+                    {
+                      "id": "H",
+                      "type": "scalar",
+                      "latex": "H",
+                      "subexpr": "H"
+                    },
+                    {
+                      "id": "__power_6",
+                      "type": "operator",
+                      "op": "power",
+                      "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}}"
+                    },
+                    {
+                      "id": "e",
+                      "type": "scalar",
+                      "latex": "e",
+                      "subexpr": "e"
+                    },
+                    {
+                      "id": "__multiply_7",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{H} -h_{E}"
+                    },
+                    {
+                      "id": "__negation_8",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-h_{E}"
+                    },
+                    {
+                      "id": "h_{E}",
+                      "type": "scalar",
+                      "latex": "h_{E}",
+                      "subexpr": "h_{E}"
+                    },
+                    {
+                      "id": "__power_9",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{H}"
+                    },
+                    {
+                      "id": "__power_10",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2 \\delta_{\\min} \\beta}"
+                    },
+                    {
+                      "id": "__multiply_11",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "2 \\beta \\delta_{\\min}"
+                    },
+                    {
+                      "id": "__num_12",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "__multiply_13",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\beta \\delta_{\\min}"
+                    },
+                    {
+                      "id": "beta",
+                      "type": "scalar",
+                      "latex": "\\beta",
+                      "subexpr": "\\beta"
+                    },
+                    {
+                      "id": "delta_{\\min}",
+                      "type": "scalar",
+                      "latex": "\\delta_{\\min}",
+                      "subexpr": "\\delta_{\\min}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "gamma_{\\text{shallow}}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "rho_{0}",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "e",
+                      "to": "__power_6"
+                    },
+                    {
+                      "from": "h_{E}",
+                      "to": "__negation_8"
+                    },
+                    {
+                      "from": "__negation_8",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "H",
+                      "to": "__power_9"
+                    },
+                    {
+                      "from": "__power_9",
+                      "to": "__multiply_7"
+                    },
+                    {
+                      "from": "__multiply_7",
+                      "to": "__power_6",
+                      "role": "exp"
+                    },
+                    {
+                      "from": "__power_6",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_5",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_4",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_12",
+                      "to": "__multiply_11",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "beta",
+                      "to": "__multiply_13",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "delta_{\\min}",
+                      "to": "__multiply_13",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_13",
+                      "to": "__multiply_11",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_11",
+                      "to": "__power_10"
+                    },
+                    {
+                      "from": "__power_10",
+                      "to": "__multiply_3"
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__asin_2"
+                    },
+                    {
+                      "from": "__asin_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
               }
             },
             {
@@ -2014,22 +9921,252 @@
               "label": "Effect of Lift on the Corridor",
               "math": "\\beta_{\\text{eff}} = \\frac{\\beta}{1 + (L/D)\\cos\\phi}",
               "justification": "Lift acts perpendicular to the velocity but its upward component reduces the net 'sinking' rate, effectively increasing the path length through the atmosphere.",
-              "explanation": "A lifting vehicle with $L/D > 0$ can fly shallower without skipping out \u2014 the lift force keeps it in the atmosphere longer, giving drag more time to work. This widens the corridor. Setting $\\phi = 0\u00b0$ (full lift up) gives maximum corridor width; $\\phi = 90\u00b0$ (full bank) gives the ballistic corridor.",
-              "prompt": "Have the student adjust the bank angle slider: at $0\u00b0$ bank, the corridor is widest. At $90\u00b0$ bank, it collapses to the ballistic corridor. This is why Apollo rolled during entry \u2014 to modulate the corridor width.",
-              "sceneStep": 0
+              "explanation": "A lifting vehicle with $L/D > 0$ can fly shallower without skipping out — the lift force keeps it in the atmosphere longer, giving drag more time to work. This widens the corridor. Setting $\\phi = 0°$ (full lift up) gives maximum corridor width; $\\phi = 90°$ (full bank) gives the ballistic corridor.",
+              "prompt": "Have the student adjust the bank angle slider: at $0°$ bank, the corridor is widest. At $90°$ bank, it collapses to the ballistic corridor. This is why Apollo rolled during entry — to modulate the corridor width.",
+              "sceneStep": 0,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\beta_{\\text{eff}} = \\frac{\\beta}{1 + (L/D)\\cos\\phi}"
+                    },
+                    {
+                      "id": "beta_{\\text{eff}}",
+                      "type": "scalar",
+                      "latex": "\\beta_{\\text{eff}}",
+                      "subexpr": "\\beta_{\\text{eff}}"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\beta \\frac{1}{\\frac{L}{D} \\cos{\\left(\\phi \\right)} + 1}"
+                    },
+                    {
+                      "id": "beta",
+                      "type": "scalar",
+                      "latex": "\\beta",
+                      "subexpr": "\\beta"
+                    },
+                    {
+                      "id": "__power_3",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\frac{L}{D} \\cos{\\left(\\phi \\right)} + 1}"
+                    },
+                    {
+                      "id": "__add_4",
+                      "type": "operator",
+                      "op": "add",
+                      "subexpr": "L \\frac{1}{D} \\cos{\\left(\\phi \\right)} + 1"
+                    },
+                    {
+                      "id": "__num_5",
+                      "type": "number",
+                      "label": "1",
+                      "subexpr": "1"
+                    },
+                    {
+                      "id": "__multiply_6",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "L \\frac{1}{D} \\cos{\\left(\\phi \\right)}"
+                    },
+                    {
+                      "id": "__multiply_7",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "L \\frac{1}{D}"
+                    },
+                    {
+                      "id": "L",
+                      "type": "scalar",
+                      "latex": "L",
+                      "subexpr": "L"
+                    },
+                    {
+                      "id": "__power_8",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{D}"
+                    },
+                    {
+                      "id": "D",
+                      "type": "scalar",
+                      "latex": "D",
+                      "subexpr": "D"
+                    },
+                    {
+                      "id": "__cos_9",
+                      "type": "function",
+                      "latex": "\\cos",
+                      "op": "cos",
+                      "subexpr": "\\cos{\\left(\\phi \\right)}"
+                    },
+                    {
+                      "id": "phi",
+                      "type": "scalar",
+                      "latex": "\\phi",
+                      "subexpr": "\\phi"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "beta_{\\text{eff}}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "beta",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_5",
+                      "to": "__add_4"
+                    },
+                    {
+                      "from": "L",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "D",
+                      "to": "__power_8"
+                    },
+                    {
+                      "from": "__power_8",
+                      "to": "__multiply_7"
+                    },
+                    {
+                      "from": "__multiply_7",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "phi",
+                      "to": "__cos_9"
+                    },
+                    {
+                      "from": "__cos_9",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_6",
+                      "to": "__add_4"
+                    },
+                    {
+                      "from": "__add_4",
+                      "to": "__power_3"
+                    },
+                    {
+                      "from": "__power_3",
+                      "to": "__multiply_2"
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "conclusion",
               "label": "Corridor Width",
               "math": "\\htmlClass{hl-width}{\\Delta\\gamma = \\gamma_{\\text{steep}} - \\gamma_{\\text{shallow}}}",
               "justification": "The corridor width is the difference between the two bounds.",
-              "explanation": "For Apollo lunar return: $\\gamma_{\\text{steep}} \\approx 7.5\u00b0$ and $\\gamma_{\\text{shallow}} \\approx 5.3\u00b0$, giving a corridor of only $\\sim 2\u00b0$. This razor-thin window is why guidance, navigation, and control (GNC) is so critical for crewed entry. Faster entries and lower g-tolerances narrow the corridor further. Lifting bodies widen it \u2014 this is a key design driver for crewed capsules.",
-              "prompt": "Final takeaway: the entry corridor is a consequence of two competing constraints \u2014 not burning up vs. not bouncing off. The numbers show why atmospheric entry is one of the hardest problems in spaceflight.",
+              "explanation": "For Apollo lunar return: $\\gamma_{\\text{steep}} \\approx 7.5°$ and $\\gamma_{\\text{shallow}} \\approx 5.3°$, giving a corridor of only $\\sim 2°$. This razor-thin window is why guidance, navigation, and control (GNC) is so critical for crewed entry. Faster entries and lower g-tolerances narrow the corridor further. Lifting bodies widen it — this is a key design driver for crewed capsules.",
+              "prompt": "Final takeaway: the entry corridor is a consequence of two competing constraints — not burning up vs. not bouncing off. The numbers show why atmospheric entry is one of the hardest problems in spaceflight.",
               "sceneStep": 0,
               "highlights": {
                 "width": {
                   "color": "green",
                   "label": "the survivable entry window"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\Delta\\gamma = \\gamma_{\\text{steep}} - \\gamma_{\\text{shallow}}",
+                      "description": "the survivable entry window",
+                      "color": "green",
+                      "highlight": "width"
+                    },
+                    {
+                      "id": "Delta \\gamma",
+                      "type": "scalar",
+                      "latex": "\\Delta \\gamma",
+                      "subexpr": "\\Delta \\gamma"
+                    },
+                    {
+                      "id": "__add_2",
+                      "type": "operator",
+                      "op": "add",
+                      "subexpr": "\\gamma_{\\text{steep}} - \\gamma_{\\text{shallow}}"
+                    },
+                    {
+                      "id": "gamma_{\\text{steep}}",
+                      "type": "scalar",
+                      "latex": "\\gamma_{\\text{steep}}",
+                      "subexpr": "\\gamma_{\\text{steep}}"
+                    },
+                    {
+                      "id": "__negation_3",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-\\gamma_{\\text{shallow}}"
+                    },
+                    {
+                      "id": "gamma_{\\text{shallow}}",
+                      "type": "scalar",
+                      "latex": "\\gamma_{\\text{shallow}}",
+                      "subexpr": "\\gamma_{\\text{shallow}}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "Delta \\gamma",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "gamma_{\\text{steep}}",
+                      "to": "__add_2"
+                    },
+                    {
+                      "from": "gamma_{\\text{shallow}}",
+                      "to": "__negation_3"
+                    },
+                    {
+                      "from": "__negation_3",
+                      "to": "__add_2"
+                    },
+                    {
+                      "from": "__add_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
                 }
               }
             }
@@ -2040,7 +10177,7 @@
     {
       "title": "Aerodynamic Heating and the Bow Shock",
       "description": "Understand why blunt bodies are used for reentry to create a detached bow shock.",
-      "markdown": "# Aerodynamic Heating and the Bow Shock\n\nA common misconception is that spacecraft heat up during re-entry because of friction with the air. In reality, the vast majority of the heating is caused by **adiabatic compression**.\n\n## The Blunt Body Solution\nIn 1958, H. Julian Allen and Alfred J. Eggers demonstrated that a blunt shape is far superior to a sharp, aerodynamic shape for re-entry. A blunt capsule plows through the atmosphere, creating a **detached bow shock**. The air squeezed between this shockwave and the capsule is violently compressed, heating up immensely. This super-heated cushion of air keeps the worst of the heat off the spacecraft's skin.\n\nIf a sharp-nosed vehicle were used, the shockwave would attach directly to the tip, concentrating all the thermal energy there and quickly melting the structure.\n\n## Stagnation Point Heating Rate\nThe heating is most intense at the **stagnation point**\u2014the point on the heat shield where the airflow is brought to a complete stop. The convective heating rate $\\dot{q}_s$ at this point is given by:\n\n$$ \\dot{q}_s \\approx \\frac{K}{\\sqrt{R_N}} \\sqrt{\\rho} \\, V^3 $$\n\nWhere:\n- $\\rho$ is the atmospheric density\n- $V$ is the spacecraft's velocity\n- $R_N$ is the nose radius (larger for blunter bodies)\n\nBecause heating scales with the *cube* of velocity ($V^3$), a lunar-return speed of $11\\,\\text{km/s}$ produces about $2.81\\times$ the convective heating of a $7.8\\,\\text{km/s}$ LEO return from speed alone.",
+      "markdown": "# Aerodynamic Heating and the Bow Shock\n\nA common misconception is that spacecraft heat up during re-entry because of friction with the air. In reality, the vast majority of the heating is caused by **adiabatic compression**.\n\n## The Blunt Body Solution\nIn 1958, H. Julian Allen and Alfred J. Eggers demonstrated that a blunt shape is far superior to a sharp, aerodynamic shape for re-entry. A blunt capsule plows through the atmosphere, creating a **detached bow shock**. The air squeezed between this shockwave and the capsule is violently compressed, heating up immensely. This super-heated cushion of air keeps the worst of the heat off the spacecraft's skin.\n\nIf a sharp-nosed vehicle were used, the shockwave would attach directly to the tip, concentrating all the thermal energy there and quickly melting the structure.\n\n## Stagnation Point Heating Rate\nThe heating is most intense at the **stagnation point**—the point on the heat shield where the airflow is brought to a complete stop. The convective heating rate $\\dot{q}_s$ at this point is given by:\n\n$$ \\dot{q}_s \\approx \\frac{K}{\\sqrt{R_N}} \\sqrt{\\rho} \\, V^3 $$\n\nWhere:\n- $\\rho$ is the atmospheric density\n- $V$ is the spacecraft's velocity\n- $R_N$ is the nose radius (larger for blunter bodies)\n\nBecause heating scales with the *cube* of velocity ($V^3$), a lunar-return speed of $11\\,\\text{km/s}$ produces about $2.81\\times$ the convective heating of a $7.8\\,\\text{km/s}$ LEO return from speed alone.",
       "prompt": "You are a tutor explaining the physics of atmospheric entry. Emphasize that heating is due to adiabatic compression, not friction. Guide the student to experiment with the bluntness slider to see how the bow shock detaches. Ask follow up questions like: 'If velocity doubles, how much does the heating rate increase according to the V^3 law?'",
       "range": [
         [
@@ -2300,7 +10437,7 @@
             {
               "id": "heating_info",
               "position": "top-right",
-              "content": "### Stagnation Heating\n\n$$\\dot{q}_s \\approx \\frac{K}{\\sqrt{R_N}} \\sqrt{\\rho} \\, V^3$$\n\n$R_N$ (Nose Radius): **{{toFixed(noseRadius(s3_bluntness), 2)}} m**\n\n$V$ (Velocity): **{{s3_velocity}} km/s**\n\nRelative Heating: **{{toFixed(heatingRate(s3_velocity, noseRadius(s3_bluntness)) / heatingRate(7.8, noseRadius(1)), 2)}}\u00d7** vs blunt LEO"
+              "content": "### Stagnation Heating\n\n$$\\dot{q}_s \\approx \\frac{K}{\\sqrt{R_N}} \\sqrt{\\rho} \\, V^3$$\n\n$R_N$ (Nose Radius): **{{toFixed(noseRadius(s3_bluntness), 2)}} m**\n\n$V$ (Velocity): **{{s3_velocity}} km/s**\n\nRelative Heating: **{{toFixed(heatingRate(s3_velocity, noseRadius(s3_bluntness)) / heatingRate(7.8, noseRadius(1)), 2)}}×** vs blunt LEO"
             }
           ]
         }
@@ -2335,11 +10472,120 @@
               "type": "given",
               "label": "Kinetic energy of oncoming air",
               "math": "E_k = \\frac{1}{2} m \\htmlClass{hl-vel}{V}^2",
-              "explanation": "From the spacecraft frame, air rushes toward it at velocity V. Each parcel of air carries kinetic energy proportional to V\u00b2.",
+              "explanation": "From the spacecraft frame, air rushes toward it at velocity V. Each parcel of air carries kinetic energy proportional to V².",
               "highlights": {
                 "vel": {
                   "color": "cyan",
                   "label": "Freestream velocity"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "E_k = \\frac{1}{2} m V^2"
+                    },
+                    {
+                      "id": "E_{k}",
+                      "type": "scalar",
+                      "latex": "E_{k}",
+                      "subexpr": "E_{k}"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{2} m V^{2}"
+                    },
+                    {
+                      "id": "__power_3",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2}"
+                    },
+                    {
+                      "id": "__num_4",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "__multiply_5",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "m V^{2}"
+                    },
+                    {
+                      "id": "m",
+                      "type": "scalar",
+                      "latex": "m",
+                      "subexpr": "m"
+                    },
+                    {
+                      "id": "__power_6",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V^{2}"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V",
+                      "description": "Freestream velocity",
+                      "color": "cyan",
+                      "highlight": "vel"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "E_{k}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "__num_4",
+                      "to": "__power_3"
+                    },
+                    {
+                      "from": "__power_3",
+                      "to": "__multiply_2"
+                    },
+                    {
+                      "from": "m",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V",
+                      "to": "__power_6"
+                    },
+                    {
+                      "from": "__power_6",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_5",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
                 }
               }
             },
@@ -2349,7 +10595,7 @@
               "label": "Air brought to rest at stagnation point",
               "math": "\\frac{1}{2} V^2 = \\htmlClass{hl-cp}{c_p} (\\htmlClass{hl-T0}{T_0} - \\htmlClass{hl-Tinf}{T_\\infty})",
               "justification": "Energy conservation (adiabatic): kinetic energy converts entirely to enthalpy",
-              "explanation": "At the stagnation point the flow velocity is zero. All kinetic energy converts to thermal energy via adiabatic compression \u2014 not friction. Here $T_0$ is the stagnation temperature (at the surface), $T_\\infty$ is the freestream temperature of the undisturbed air, and $c_p$ is the specific heat at constant pressure.",
+              "explanation": "At the stagnation point the flow velocity is zero. All kinetic energy converts to thermal energy via adiabatic compression — not friction. Here $T_0$ is the stagnation temperature (at the surface), $T_\\infty$ is the freestream temperature of the undisturbed air, and $c_p$ is the specific heat at constant pressure.",
               "highlights": {
                 "T0": {
                   "color": "orange",
@@ -2363,6 +10609,131 @@
                   "color": "green",
                   "label": "Specific heat at constant pressure"
                 }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\frac{1}{2} V^2 = c_p (T_0 - T_\\infty)"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V^{2} \\frac{1}{2}"
+                    },
+                    {
+                      "id": "__power_3",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2}"
+                    },
+                    {
+                      "id": "__num_4",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "__power_5",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V^{2}"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    },
+                    {
+                      "id": "__c_{p}_6",
+                      "type": "function",
+                      "op": "c_{p}",
+                      "subexpr": "c_{p}{\\left(T_{0} - T_{oo} \\right)}"
+                    },
+                    {
+                      "id": "__add_7",
+                      "type": "operator",
+                      "op": "add",
+                      "subexpr": "T_{0} - T_{oo}"
+                    },
+                    {
+                      "id": "T_{0}",
+                      "type": "scalar",
+                      "latex": "T_{0}",
+                      "subexpr": "T_{0}",
+                      "description": "Stagnation temperature (at surface)",
+                      "color": "orange",
+                      "highlight": "T0"
+                    },
+                    {
+                      "id": "__negation_8",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-T_{oo}"
+                    },
+                    {
+                      "id": "T_{oo}",
+                      "type": "scalar",
+                      "latex": "T_{oo}",
+                      "subexpr": "T_{oo}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "__num_4",
+                      "to": "__power_3"
+                    },
+                    {
+                      "from": "__power_3",
+                      "to": "__multiply_2"
+                    },
+                    {
+                      "from": "V",
+                      "to": "__power_5"
+                    },
+                    {
+                      "from": "__power_5",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "T_{0}",
+                      "to": "__add_7"
+                    },
+                    {
+                      "from": "T_{oo}",
+                      "to": "__negation_8"
+                    },
+                    {
+                      "from": "__negation_8",
+                      "to": "__add_7"
+                    },
+                    {
+                      "from": "__add_7",
+                      "to": "__c_{p}_6"
+                    },
+                    {
+                      "from": "__c_{p}_6",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
               }
             },
             {
@@ -2370,7 +10741,7 @@
               "type": "step",
               "label": "Solve for stagnation temperature",
               "math": "\\htmlClass{hl-T0}{T_0} = \\htmlClass{hl-Tinf}{T_\\infty} + \\htmlClass{hl-dom}{\\frac{V^2}{2 c_p}}",
-              "justification": "Rearrange for T\u2080",
+              "justification": "Rearrange for T₀",
               "explanation": "At high altitude $T_\\infty \\approx 200\\,\\text{K}$, so the stagnation temperature is dominated by the $V^2$ term.",
               "highlights": {
                 "T0": {
@@ -2379,11 +10750,140 @@
                 },
                 "Tinf": {
                   "color": "blue",
-                  "label": "~200 K at altitude \u2014 small"
+                  "label": "~200 K at altitude — small"
                 },
                 "dom": {
                   "color": "yellow",
                   "label": "Dominant term at entry speeds"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "T_0 = T_\\infty + \\frac{V^2}{2 c_p}"
+                    },
+                    {
+                      "id": "T_{0}",
+                      "type": "scalar",
+                      "latex": "T_{0}",
+                      "subexpr": "T_{0}",
+                      "description": "Stagnation temperature",
+                      "color": "orange",
+                      "highlight": "T0"
+                    },
+                    {
+                      "id": "__add_2",
+                      "type": "operator",
+                      "op": "add",
+                      "subexpr": "T_{oo} + V^{2} \\frac{1}{2 c_{p}}"
+                    },
+                    {
+                      "id": "T_{oo}",
+                      "type": "scalar",
+                      "latex": "T_{oo}",
+                      "subexpr": "T_{oo}"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V^{2} \\frac{1}{2 c_{p}}"
+                    },
+                    {
+                      "id": "__power_4",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V^{2}"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    },
+                    {
+                      "id": "__power_5",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2 c_{p}}"
+                    },
+                    {
+                      "id": "__multiply_6",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "2 c_{p}"
+                    },
+                    {
+                      "id": "__num_7",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "c_{p}",
+                      "type": "scalar",
+                      "latex": "c_{p}",
+                      "subexpr": "c_{p}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "T_{0}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "T_{oo}",
+                      "to": "__add_2"
+                    },
+                    {
+                      "from": "V",
+                      "to": "__power_4"
+                    },
+                    {
+                      "from": "__power_4",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_7",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "c_{p}",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_6",
+                      "to": "__power_5"
+                    },
+                    {
+                      "from": "__power_5",
+                      "to": "__multiply_3"
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__add_2"
+                    },
+                    {
+                      "from": "__add_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
                 }
               }
             },
@@ -2393,15 +10893,201 @@
               "label": "Express in terms of Mach number",
               "math": "\\frac{T_0}{T_\\infty} = 1 + \\frac{\\htmlClass{hl-gamma}{\\gamma} - 1}{2} \\htmlClass{hl-mach}{M}^2",
               "justification": "Substitute $V = M a$ and $c_p = \\frac{\\gamma R}{(\\gamma-1) M_w}$, where $M$ is the Mach number, $a$ is the speed of sound, and $\\gamma \\approx 1.4$ is the ratio of specific heats for air",
-              "explanation": "For a Mach 25 reentry (\u22487.8 km/s), this gives T\u2080/T\u221e \u2248 1 + 0.2 \u00d7 625 = 126. Even with T\u221e = 200 K, that is over 25,000 K.",
+              "explanation": "For a Mach 25 reentry (≈7.8 km/s), this gives T₀/T∞ ≈ 1 + 0.2 × 625 = 126. Even with T∞ = 200 K, that is over 25,000 K.",
               "highlights": {
                 "gamma": {
                   "color": "green",
-                  "label": "Ratio of specific heats (\u03b3 \u2248 1.4 for air)"
+                  "label": "Ratio of specific heats (γ ≈ 1.4 for air)"
                 },
                 "mach": {
                   "color": "cyan",
-                  "label": "Mach number (M \u2248 25 for LEO entry)"
+                  "label": "Mach number (M ≈ 25 for LEO entry)"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\frac{T_0}{T_\\infty} = 1 + \\frac{\\gamma - 1}{2} M^2"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "T_{0} \\frac{1}{T_{oo}}"
+                    },
+                    {
+                      "id": "T_{0}",
+                      "type": "scalar",
+                      "latex": "T_{0}",
+                      "subexpr": "T_{0}"
+                    },
+                    {
+                      "id": "__power_3",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{T_{oo}}"
+                    },
+                    {
+                      "id": "T_{oo}",
+                      "type": "scalar",
+                      "latex": "T_{oo}",
+                      "subexpr": "T_{oo}"
+                    },
+                    {
+                      "id": "__add_4",
+                      "type": "operator",
+                      "op": "add",
+                      "subexpr": "M^{2} \\left(\\gamma - 1\\right) \\frac{1}{2} + 1"
+                    },
+                    {
+                      "id": "__num_5",
+                      "type": "number",
+                      "label": "1",
+                      "subexpr": "1"
+                    },
+                    {
+                      "id": "__multiply_6",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "M^{2} \\left(\\gamma - 1\\right) \\frac{1}{2}"
+                    },
+                    {
+                      "id": "__multiply_7",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\left(\\gamma - 1\\right) \\frac{1}{2}"
+                    },
+                    {
+                      "id": "__add_8",
+                      "type": "operator",
+                      "op": "add",
+                      "subexpr": "\\gamma - 1"
+                    },
+                    {
+                      "id": "gamma",
+                      "type": "scalar",
+                      "latex": "\\gamma",
+                      "subexpr": "\\gamma",
+                      "description": "Ratio of specific heats (γ ≈ 1.4 for air)",
+                      "color": "green",
+                      "highlight": "gamma"
+                    },
+                    {
+                      "id": "__num_9",
+                      "type": "number",
+                      "label": "-1",
+                      "subexpr": "-1"
+                    },
+                    {
+                      "id": "__power_10",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2}"
+                    },
+                    {
+                      "id": "__num_11",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "__power_12",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "M^{2}"
+                    },
+                    {
+                      "id": "M",
+                      "type": "scalar",
+                      "latex": "M",
+                      "subexpr": "M",
+                      "description": "Mach number (M ≈ 25 for LEO entry)",
+                      "color": "cyan",
+                      "highlight": "mach"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "T_{0}",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "T_{oo}",
+                      "to": "__power_3"
+                    },
+                    {
+                      "from": "__power_3",
+                      "to": "__multiply_2"
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "__num_5",
+                      "to": "__add_4"
+                    },
+                    {
+                      "from": "gamma",
+                      "to": "__add_8"
+                    },
+                    {
+                      "from": "__num_9",
+                      "to": "__add_8"
+                    },
+                    {
+                      "from": "__add_8",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_11",
+                      "to": "__power_10"
+                    },
+                    {
+                      "from": "__power_10",
+                      "to": "__multiply_7"
+                    },
+                    {
+                      "from": "__multiply_7",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "M",
+                      "to": "__power_12"
+                    },
+                    {
+                      "from": "__power_12",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_6",
+                      "to": "__add_4"
+                    },
+                    {
+                      "from": "__add_4",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
                 }
               }
             },
@@ -2410,12 +11096,65 @@
               "type": "conclusion",
               "label": "Heating is adiabatic compression, not friction",
               "math": "\\htmlClass{hl-result}{T_0 \\propto V^2}",
-              "justification": "The V\u00b2 dependence comes from kinetic energy conversion",
-              "explanation": "The enormous temperatures at the stagnation point arise from adiabatic compression of the air \u2014 the same process that heats air in a bicycle pump. Friction plays a negligible role.",
+              "justification": "The V² dependence comes from kinetic energy conversion",
+              "explanation": "The enormous temperatures at the stagnation point arise from adiabatic compression of the air — the same process that heats air in a bicycle pump. Friction plays a negligible role.",
               "highlights": {
                 "result": {
                   "color": "yellow",
                   "label": "Adiabatic compression, not friction"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "T_{0}",
+                      "type": "scalar",
+                      "latex": "T_{0}",
+                      "subexpr": "T_{0}"
+                    },
+                    {
+                      "id": "__power_1",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V^2"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    },
+                    {
+                      "id": "__proportional_2",
+                      "type": "relation",
+                      "label": "proportional to",
+                      "emoji": "∝",
+                      "op": "proportional",
+                      "subexpr": "T_0 \\propto V^2",
+                      "description": "Adiabatic compression, not friction",
+                      "color": "yellow",
+                      "highlight": "result"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "V",
+                      "to": "__power_1"
+                    },
+                    {
+                      "from": "T_{0}",
+                      "to": "__proportional_2"
+                    },
+                    {
+                      "from": "__power_1",
+                      "to": "__proportional_2"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
                 }
               }
             }
@@ -2423,7 +11162,7 @@
         },
         {
           "id": "blunt-body-heating",
-          "title": "Why Blunt Bodies Survive: The 1/\u221aR_N Law",
+          "title": "Why Blunt Bodies Survive: The 1/√R_N Law",
           "sceneStep": 2,
           "goal": "Derive $\\dot{q}_s \\approx \\frac{K}{\\sqrt{R_N}} \\sqrt{\\rho} V^3$ and show why larger nose radius reduces heating",
           "prompt": "Walk through the Fay-Riddell result showing how nose radius affects stagnation point heating. Connect to the bluntness slider.",
@@ -2443,6 +11182,120 @@
                   "color": "cyan",
                   "label": "Nose radius"
                 }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "delta",
+                      "type": "scalar",
+                      "latex": "\\delta",
+                      "subexpr": "\\delta",
+                      "description": "Boundary layer thickness",
+                      "color": "orange",
+                      "highlight": "delta"
+                    },
+                    {
+                      "id": "__power_1",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "1/2",
+                      "subexpr": "\\sqrt{\\frac{R_{N}}{\\rho V}}"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "R_{N} \\frac{1}{V \\rho}"
+                    },
+                    {
+                      "id": "R_{N}",
+                      "type": "scalar",
+                      "latex": "R_{N}",
+                      "subexpr": "R_{N}",
+                      "description": "Nose radius",
+                      "color": "cyan",
+                      "highlight": "rn"
+                    },
+                    {
+                      "id": "__power_3",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{V \\rho}"
+                    },
+                    {
+                      "id": "__multiply_4",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho V"
+                    },
+                    {
+                      "id": "rho",
+                      "type": "scalar",
+                      "latex": "\\rho",
+                      "subexpr": "\\rho"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    },
+                    {
+                      "id": "__proportional_5",
+                      "type": "relation",
+                      "label": "proportional to",
+                      "emoji": "∝",
+                      "op": "proportional",
+                      "subexpr": "\\delta \\propto \\sqrt{\\frac{R_N}{\\rho V}}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "R_{N}",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "rho",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_4",
+                      "to": "__power_3"
+                    },
+                    {
+                      "from": "__power_3",
+                      "to": "__multiply_2"
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__power_1"
+                    },
+                    {
+                      "from": "delta",
+                      "to": "__proportional_5"
+                    },
+                    {
+                      "from": "__power_1",
+                      "to": "__proportional_5"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
               }
             },
             {
@@ -2450,7 +11303,7 @@
               "type": "step",
               "label": "Heat flux through the boundary layer",
               "math": "\\htmlClass{hl-qdot}{\\dot{q}_s} \\propto \\frac{\\Delta T}{\\htmlClass{hl-delta}{\\delta}}",
-              "justification": "Fourier's law: heat flux = thermal conductivity \u00d7 temperature gradient",
+              "justification": "Fourier's law: heat flux = thermal conductivity × temperature gradient",
               "explanation": "The heat conducted to the surface is proportional to the temperature difference across the boundary layer divided by its thickness.",
               "highlights": {
                 "qdot": {
@@ -2459,21 +11312,248 @@
                 },
                 "delta": {
                   "color": "orange",
-                  "label": "Thicker boundary layer \u2192 less heating"
+                  "label": "Thicker boundary layer → less heating"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "q_{s}",
+                      "type": "scalar",
+                      "latex": "q_{s}",
+                      "subexpr": "q_{s}",
+                      "description": "Stagnation point heat flux",
+                      "color": "red",
+                      "highlight": "qdot"
+                    },
+                    {
+                      "id": "t",
+                      "type": "scalar",
+                      "latex": "t",
+                      "subexpr": "t"
+                    },
+                    {
+                      "id": "__deriv_1",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t",
+                      "subexpr": "\\frac{d}{d t} q_{s}"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{{\\Delta T}}{\\delta}"
+                    },
+                    {
+                      "id": "Delta T",
+                      "type": "scalar",
+                      "latex": "\\Delta T",
+                      "subexpr": "\\Delta T"
+                    },
+                    {
+                      "id": "__power_3",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\delta}"
+                    },
+                    {
+                      "id": "delta",
+                      "type": "scalar",
+                      "latex": "\\delta",
+                      "subexpr": "\\delta",
+                      "description": "Thicker boundary layer → less heating",
+                      "color": "orange",
+                      "highlight": "delta"
+                    },
+                    {
+                      "id": "__proportional_4",
+                      "type": "relation",
+                      "label": "proportional to",
+                      "emoji": "∝",
+                      "op": "proportional",
+                      "subexpr": "\\dot{q_s} \\propto \\frac{\\Delta T}{\\delta}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "q_{s}",
+                      "to": "__deriv_1"
+                    },
+                    {
+                      "from": "t",
+                      "to": "__deriv_1",
+                      "role": "wrt"
+                    },
+                    {
+                      "from": "Delta T",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "delta",
+                      "to": "__power_3"
+                    },
+                    {
+                      "from": "__power_3",
+                      "to": "__multiply_2"
+                    },
+                    {
+                      "from": "__deriv_1",
+                      "to": "__proportional_4"
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__proportional_4"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "ODE",
+                    "order": 1,
+                    "dependent_variables": [
+                      "q_{s}"
+                    ],
+                    "independent_variables": [
+                      "t"
+                    ],
+                    "sympy_hints": [
+                      "nth_algebraic",
+                      "separable",
+                      "1st_exact",
+                      "1st_linear",
+                      "Bernoulli",
+                      "1st_power_series",
+                      "lie_group",
+                      "nth_linear_constant_coeff_undetermined_coefficients",
+                      "nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients",
+                      "nth_linear_constant_coeff_variation_of_parameters",
+                      "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters"
+                    ],
+                    "linear": true,
+                    "homogeneous": true,
+                    "constant_coefficients": true
+                  }
                 }
               }
             },
             {
               "id": "delta-T",
               "type": "step",
-              "label": "Temperature difference scales with V\u00b2",
+              "label": "Temperature difference scales with V²",
               "math": "\\Delta T = T_0 - T_w \\propto \\htmlClass{hl-v2}{V^2}",
-              "justification": "From the stagnation temperature result: T\u2080 \u221d V\u00b2",
-              "explanation": "The wall temperature T_w is kept relatively low by the heat shield, so \u0394T is dominated by the stagnation temperature.",
+              "justification": "From the stagnation temperature result: T₀ ∝ V²",
+              "explanation": "The wall temperature T_w is kept relatively low by the heat shield, so ΔT is dominated by the stagnation temperature.",
               "highlights": {
                 "v2": {
                   "color": "yellow",
                   "label": "From stagnation temperature proof"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "{\\Delta T} = T_{0} - T_{w}"
+                    },
+                    {
+                      "id": "Delta T",
+                      "type": "scalar",
+                      "latex": "\\Delta T",
+                      "subexpr": "\\Delta T"
+                    },
+                    {
+                      "id": "__add_2",
+                      "type": "operator",
+                      "op": "add",
+                      "subexpr": "T_{0} - T_{w}"
+                    },
+                    {
+                      "id": "T_{0}",
+                      "type": "scalar",
+                      "latex": "T_{0}",
+                      "subexpr": "T_{0}"
+                    },
+                    {
+                      "id": "__negation_3",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-T_{w}"
+                    },
+                    {
+                      "id": "T_{w}",
+                      "type": "scalar",
+                      "latex": "T_{w}",
+                      "subexpr": "T_{w}"
+                    },
+                    {
+                      "id": "__power_4",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V^2",
+                      "description": "From stagnation temperature proof",
+                      "color": "yellow",
+                      "highlight": "v2"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    },
+                    {
+                      "id": "__proportional_5",
+                      "type": "relation",
+                      "label": "proportional to",
+                      "emoji": "∝",
+                      "op": "proportional",
+                      "subexpr": "\\Delta T = T_0 - T_w \\propto V^2"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "Delta T",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "T_{0}",
+                      "to": "__add_2"
+                    },
+                    {
+                      "from": "T_{w}",
+                      "to": "__negation_3"
+                    },
+                    {
+                      "from": "__negation_3",
+                      "to": "__add_2"
+                    },
+                    {
+                      "from": "__add_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "V",
+                      "to": "__power_4"
+                    },
+                    {
+                      "from": "__equals_1",
+                      "to": "__proportional_5"
+                    },
+                    {
+                      "from": "__power_4",
+                      "to": "__proportional_5"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
                 }
               }
             },
@@ -2482,12 +11562,342 @@
               "type": "step",
               "label": "Combine to get heating rate",
               "math": "\\dot{q}_s \\propto \\frac{V^2}{\\sqrt{R_N / (\\rho V)}} = \\htmlClass{hl-result}{\\frac{\\sqrt{\\rho} \\cdot V^{5/2}}{\\sqrt{R_N}}}",
-              "justification": "Substitute \u03b4 and \u0394T into the heat flux expression",
-              "explanation": "This simplified analysis gives V^(5/2). The full Fay-Riddell analysis, accounting for dissociation and ionization effects at high temperatures, modifies this to V\u00b3.",
+              "justification": "Substitute δ and ΔT into the heat flux expression",
+              "explanation": "This simplified analysis gives V^(5/2). The full Fay-Riddell analysis, accounting for dissociation and ionization effects at high temperatures, modifies this to V³.",
               "highlights": {
                 "result": {
                   "color": "yellow",
-                  "label": "Simplified analysis \u2014 real-gas effects modify this"
+                  "label": "Simplified analysis — real-gas effects modify this"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "q_{s}",
+                      "type": "scalar",
+                      "latex": "q_{s}",
+                      "subexpr": "q_{s}"
+                    },
+                    {
+                      "id": "t",
+                      "type": "scalar",
+                      "latex": "t",
+                      "subexpr": "t"
+                    },
+                    {
+                      "id": "__deriv_1",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t",
+                      "subexpr": "\\frac{d}{d t} q_{s}"
+                    },
+                    {
+                      "id": "__equals_2",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\frac{V^2}{\\sqrt{R_{N} / (\\rho V)}} = \\frac{\\sqrt{\\rho} \\cdot V^{5/2}}{\\sqrt{R_{N}}}"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V^{2} \\frac{1}{\\sqrt{\\frac{R_{N}}{V \\rho}}}"
+                    },
+                    {
+                      "id": "__power_4",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V^{2}"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    },
+                    {
+                      "id": "__power_5",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\sqrt{\\frac{R_{N}}{V \\rho}}}"
+                    },
+                    {
+                      "id": "__power_6",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "1/2",
+                      "subexpr": "\\sqrt{\\frac{R_{N}}{V \\rho}}"
+                    },
+                    {
+                      "id": "__multiply_7",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "R_{N} \\frac{1}{V \\rho}"
+                    },
+                    {
+                      "id": "R_{N}",
+                      "type": "scalar",
+                      "latex": "R_{N}",
+                      "subexpr": "R_{N}"
+                    },
+                    {
+                      "id": "__power_8",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{V \\rho}"
+                    },
+                    {
+                      "id": "__multiply_9",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V \\rho"
+                    },
+                    {
+                      "id": "rho",
+                      "type": "scalar",
+                      "latex": "\\rho",
+                      "subexpr": "\\rho"
+                    },
+                    {
+                      "id": "__multiply_10",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V^{\\frac{5}{2}} \\sqrt{\\rho} \\frac{1}{\\sqrt{R_{N}}}"
+                    },
+                    {
+                      "id": "__multiply_11",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V^{\\frac{5}{2}} \\sqrt{\\rho}"
+                    },
+                    {
+                      "id": "__power_12",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "1/2",
+                      "subexpr": "\\sqrt{\\rho}"
+                    },
+                    {
+                      "id": "__power_13",
+                      "type": "operator",
+                      "op": "power",
+                      "subexpr": "V^{\\frac{5}{2}}"
+                    },
+                    {
+                      "id": "__multiply_14",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "5 \\frac{1}{2}"
+                    },
+                    {
+                      "id": "__num_15",
+                      "type": "number",
+                      "label": "5",
+                      "subexpr": "5"
+                    },
+                    {
+                      "id": "__power_16",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2}"
+                    },
+                    {
+                      "id": "__num_17",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "__power_18",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\sqrt{R_{N}}}"
+                    },
+                    {
+                      "id": "__power_19",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "1/2",
+                      "subexpr": "\\sqrt{R_{N}}"
+                    },
+                    {
+                      "id": "__proportional_20",
+                      "type": "relation",
+                      "label": "proportional to",
+                      "emoji": "∝",
+                      "op": "proportional",
+                      "subexpr": "\\dot{q_s} \\propto \\frac{V^2}{\\sqrt{R_N / (\\rho V)}} = \\frac{\\sqrt{\\rho} \\cdot V^{5/2}}{\\sqrt{R_N}}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "q_{s}",
+                      "to": "__deriv_1"
+                    },
+                    {
+                      "from": "t",
+                      "to": "__deriv_1",
+                      "role": "wrt"
+                    },
+                    {
+                      "from": "V",
+                      "to": "__power_4"
+                    },
+                    {
+                      "from": "__power_4",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "R_{N}",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "rho",
+                      "to": "__multiply_9",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V",
+                      "to": "__multiply_9",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_9",
+                      "to": "__power_8"
+                    },
+                    {
+                      "from": "__power_8",
+                      "to": "__multiply_7"
+                    },
+                    {
+                      "from": "__multiply_7",
+                      "to": "__power_6"
+                    },
+                    {
+                      "from": "__power_6",
+                      "to": "__power_5"
+                    },
+                    {
+                      "from": "__power_5",
+                      "to": "__multiply_3"
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__equals_2"
+                    },
+                    {
+                      "from": "rho",
+                      "to": "__power_12"
+                    },
+                    {
+                      "from": "__power_12",
+                      "to": "__multiply_11",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V",
+                      "to": "__power_13"
+                    },
+                    {
+                      "from": "__num_15",
+                      "to": "__multiply_14",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__num_17",
+                      "to": "__power_16"
+                    },
+                    {
+                      "from": "__power_16",
+                      "to": "__multiply_14"
+                    },
+                    {
+                      "from": "__multiply_14",
+                      "to": "__power_13",
+                      "role": "exp"
+                    },
+                    {
+                      "from": "__power_13",
+                      "to": "__multiply_11",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_11",
+                      "to": "__multiply_10",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "R_{N}",
+                      "to": "__power_19"
+                    },
+                    {
+                      "from": "__power_19",
+                      "to": "__power_18"
+                    },
+                    {
+                      "from": "__power_18",
+                      "to": "__multiply_10"
+                    },
+                    {
+                      "from": "__multiply_10",
+                      "to": "__equals_2"
+                    },
+                    {
+                      "from": "__deriv_1",
+                      "to": "__proportional_20"
+                    },
+                    {
+                      "from": "__equals_2",
+                      "to": "__proportional_20"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "ODE",
+                    "order": 1,
+                    "dependent_variables": [
+                      "q_{s}"
+                    ],
+                    "independent_variables": [
+                      "t"
+                    ],
+                    "sympy_hints": [
+                      "nth_algebraic",
+                      "separable",
+                      "1st_exact",
+                      "1st_linear",
+                      "Bernoulli",
+                      "1st_homogeneous_coeff_best",
+                      "1st_homogeneous_coeff_subs_indep_div_dep",
+                      "1st_homogeneous_coeff_subs_dep_div_indep",
+                      "1st_power_series",
+                      "lie_group",
+                      "nth_linear_constant_coeff_homogeneous",
+                      "nth_linear_euler_eq_homogeneous"
+                    ],
+                    "linear": true,
+                    "homogeneous": true,
+                    "constant_coefficients": true
+                  }
                 }
               }
             },
@@ -2496,12 +11906,210 @@
               "type": "step",
               "label": "Fay-Riddell stagnation heating (1958)",
               "math": "\\htmlClass{hl-fr}{\\dot{q}_s \\approx \\frac{K}{\\sqrt{R_N}} \\sqrt{\\rho} \\, V^3}",
-              "justification": "Full analysis includes real-gas effects (dissociation, ionization) which steepen the velocity dependence from V^(5/2) to V\u00b3",
+              "justification": "Full analysis includes real-gas effects (dissociation, ionization) which steepen the velocity dependence from V^(5/2) to V³",
               "explanation": "This is the key result used in spacecraft design. K depends on gas properties but is roughly constant for Earth entry.",
               "highlights": {
                 "fr": {
                   "color": "cyan",
-                  "label": "Fay-Riddell (1958) \u2014 the spacecraft design formula"
+                  "label": "Fay-Riddell (1958) — the spacecraft design formula"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\dot{q_s} = \\frac{K}{\\sqrt{R_N}} \\sqrt{\\rho} \\, V^3"
+                    },
+                    {
+                      "id": "q_{s}",
+                      "type": "scalar",
+                      "latex": "q_{s}",
+                      "subexpr": "q_{s}"
+                    },
+                    {
+                      "id": "t",
+                      "type": "scalar",
+                      "latex": "t",
+                      "subexpr": "t"
+                    },
+                    {
+                      "id": "__deriv_2",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t",
+                      "subexpr": "\\frac{d}{d t} q_{s}"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "K \\frac{1}{\\sqrt{R_{N}}} \\sqrt{\\rho} V^{3}"
+                    },
+                    {
+                      "id": "__multiply_4",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "K \\frac{1}{\\sqrt{R_{N}}}"
+                    },
+                    {
+                      "id": "K",
+                      "type": "scalar",
+                      "latex": "K",
+                      "subexpr": "K"
+                    },
+                    {
+                      "id": "__power_5",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\sqrt{R_{N}}}"
+                    },
+                    {
+                      "id": "__power_6",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "1/2",
+                      "subexpr": "\\sqrt{R_{N}}"
+                    },
+                    {
+                      "id": "R_{N}",
+                      "type": "scalar",
+                      "latex": "R_{N}",
+                      "subexpr": "R_{N}"
+                    },
+                    {
+                      "id": "__multiply_7",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\sqrt{\\rho} V^{3}"
+                    },
+                    {
+                      "id": "__power_8",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "1/2",
+                      "subexpr": "\\sqrt{\\rho}"
+                    },
+                    {
+                      "id": "rho",
+                      "type": "scalar",
+                      "latex": "\\rho",
+                      "subexpr": "\\rho"
+                    },
+                    {
+                      "id": "__power_9",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "3",
+                      "subexpr": "V^{3}"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "q_{s}",
+                      "to": "__deriv_2"
+                    },
+                    {
+                      "from": "t",
+                      "to": "__deriv_2",
+                      "role": "wrt"
+                    },
+                    {
+                      "from": "__deriv_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "K",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "R_{N}",
+                      "to": "__power_6"
+                    },
+                    {
+                      "from": "__power_6",
+                      "to": "__power_5"
+                    },
+                    {
+                      "from": "__power_5",
+                      "to": "__multiply_4"
+                    },
+                    {
+                      "from": "__multiply_4",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "rho",
+                      "to": "__power_8"
+                    },
+                    {
+                      "from": "__power_8",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V",
+                      "to": "__power_9"
+                    },
+                    {
+                      "from": "__power_9",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_7",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "ODE",
+                    "order": 1,
+                    "dependent_variables": [
+                      "q_{s}"
+                    ],
+                    "independent_variables": [
+                      "t"
+                    ],
+                    "sympy_hints": [
+                      "factorable",
+                      "nth_algebraic",
+                      "separable",
+                      "1st_exact",
+                      "1st_linear",
+                      "Bernoulli",
+                      "1st_power_series",
+                      "lie_group",
+                      "nth_linear_constant_coeff_undetermined_coefficients",
+                      "nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients",
+                      "nth_linear_constant_coeff_variation_of_parameters",
+                      "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters"
+                    ],
+                    "linear": true,
+                    "homogeneous": true,
+                    "constant_coefficients": true
+                  }
                 }
               }
             },
@@ -2510,12 +12118,170 @@
               "type": "conclusion",
               "label": "The blunt body principle",
               "math": "\\dot{q}_s \\propto \\htmlClass{hl-inv}{\\frac{1}{\\sqrt{R_N}}} \\implies \\text{larger nose} \\rightarrow \\text{less heating}",
-              "justification": "Doubling the nose radius reduces heating by \u221a2 \u2248 29%",
+              "justification": "Doubling the nose radius reduces heating by √2 ≈ 29%",
               "explanation": "This is Allen and Eggers' key insight (1958): a blunt shape is counterintuitively better for reentry. The thicker boundary layer acts as an insulating cushion, and the detached bow shock diverts most of the heated air around the vehicle.",
               "highlights": {
                 "inv": {
                   "color": "green",
-                  "label": "Double R_N \u2192 29% less heating"
+                  "label": "Double R_N → 29% less heating"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "q_{s}",
+                      "type": "scalar",
+                      "latex": "q_{s}",
+                      "subexpr": "q_{s}"
+                    },
+                    {
+                      "id": "t",
+                      "type": "scalar",
+                      "latex": "t",
+                      "subexpr": "t"
+                    },
+                    {
+                      "id": "__deriv_1",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t",
+                      "subexpr": "\\frac{d}{d t} q_{s}"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{\\sqrt{R_{N}}} \\implies \\text{larger nose} \\rightarrow \\text{less heating}"
+                    },
+                    {
+                      "id": "__power_3",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\sqrt{R_{N}}}",
+                      "description": "Double R_N → 29% less heating",
+                      "color": "green",
+                      "highlight": "inv"
+                    },
+                    {
+                      "id": "__power_4",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "1/2",
+                      "subexpr": "\\sqrt{R_{N}}"
+                    },
+                    {
+                      "id": "R_{N}",
+                      "type": "scalar",
+                      "latex": "R_{N}",
+                      "subexpr": "R_{N}"
+                    },
+                    {
+                      "id": "__multiply_5",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\implies \\text{larger nose}"
+                    },
+                    {
+                      "id": "implies",
+                      "type": "scalar",
+                      "latex": "\\implies",
+                      "subexpr": "\\implies"
+                    },
+                    {
+                      "id": "larger nose",
+                      "type": "text",
+                      "label": "larger nose",
+                      "latex": "\\text{larger nose}",
+                      "subexpr": "\\text{larger nose}"
+                    },
+                    {
+                      "id": "__proportional_6",
+                      "type": "relation",
+                      "label": "proportional to",
+                      "emoji": "∝",
+                      "op": "proportional",
+                      "subexpr": "\\dot{q_s} \\propto \\frac{1}{\\sqrt{R_N}} \\implies \\text{larger nose} \\rightarrow \\text{less heating}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "q_{s}",
+                      "to": "__deriv_1"
+                    },
+                    {
+                      "from": "t",
+                      "to": "__deriv_1",
+                      "role": "wrt"
+                    },
+                    {
+                      "from": "R_{N}",
+                      "to": "__power_4"
+                    },
+                    {
+                      "from": "__power_4",
+                      "to": "__power_3"
+                    },
+                    {
+                      "from": "__power_3",
+                      "to": "__multiply_2"
+                    },
+                    {
+                      "from": "implies",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "larger nose",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_5",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__deriv_1",
+                      "to": "__proportional_6"
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__proportional_6"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "ODE",
+                    "order": 1,
+                    "dependent_variables": [
+                      "q_{s}"
+                    ],
+                    "independent_variables": [
+                      "t"
+                    ],
+                    "sympy_hints": [
+                      "factorable",
+                      "nth_algebraic",
+                      "separable",
+                      "1st_exact",
+                      "1st_linear",
+                      "Bernoulli",
+                      "1st_power_series",
+                      "lie_group",
+                      "nth_linear_constant_coeff_undetermined_coefficients",
+                      "nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients",
+                      "nth_linear_constant_coeff_variation_of_parameters",
+                      "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters"
+                    ],
+                    "linear": true,
+                    "homogeneous": true,
+                    "constant_coefficients": true
+                  }
                 }
               }
             }
@@ -2523,21 +12289,186 @@
         },
         {
           "id": "lunar-vs-leo-heating",
-          "title": "Lunar Return vs LEO: The V\u00b3 Penalty",
+          "title": "Lunar Return vs LEO: The V³ Penalty",
           "sceneStep": 2,
           "goal": "Calculate the heating ratio between lunar return (11 km/s) and LEO return (7.8 km/s)",
-          "prompt": "Use the V\u00b3 law to show why lunar return is so much more demanding thermally.",
+          "prompt": "Use the V³ law to show why lunar return is so much more demanding thermally.",
           "steps": [
             {
               "id": "ratio-setup",
               "type": "given",
               "label": "Heating ratio at same altitude",
               "math": "\\frac{\\dot{q}_{\\text{lunar}}}{\\dot{q}_{\\text{LEO}}} = \\htmlClass{hl-cube}{\\left(\\frac{V_{\\text{lunar}}}{V_{\\text{LEO}}}\\right)^3}",
-              "explanation": "At the same altitude (same \u03c1) and same vehicle (same R_N), only velocity differs between the two returns.",
+              "explanation": "At the same altitude (same ρ) and same vehicle (same R_N), only velocity differs between the two returns.",
               "highlights": {
                 "cube": {
                   "color": "yellow",
                   "label": "Cubic velocity dependence"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\frac{\\dot{q_{\\text{lunar}}}}{\\dot{q_{\\text{LEO}}}} = \\left(\\frac{V_{\\text{lunar}}}{V_{\\text{LEO}}}\\right)^3"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\dot{q_{\\text{lunar}}} \\frac{1}{\\dot{q_{\\text{LEO}}}}"
+                    },
+                    {
+                      "id": "q_{\\text{lunar}}",
+                      "type": "scalar",
+                      "latex": "q_{\\text{lunar}}",
+                      "subexpr": "q_{\\text{lunar}}"
+                    },
+                    {
+                      "id": "t",
+                      "type": "scalar",
+                      "latex": "t",
+                      "subexpr": "t"
+                    },
+                    {
+                      "id": "__deriv_3",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t",
+                      "subexpr": "\\dot{q_{\\text{lunar}}}"
+                    },
+                    {
+                      "id": "__power_4",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\dot{q_{\\text{LEO}}}}"
+                    },
+                    {
+                      "id": "q_{\\text{LEO}}",
+                      "type": "scalar",
+                      "latex": "q_{\\text{LEO}}",
+                      "subexpr": "q_{\\text{LEO}}"
+                    },
+                    {
+                      "id": "__deriv_5",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t",
+                      "subexpr": "\\dot{q_{\\text{LEO}}}"
+                    },
+                    {
+                      "id": "__power_6",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "3",
+                      "subexpr": "\\left(\\frac{V_{\\text{lunar}}}{V_{\\text{LEO}}}\\right)^{3}",
+                      "description": "Cubic velocity dependence",
+                      "color": "yellow",
+                      "highlight": "cube"
+                    },
+                    {
+                      "id": "__multiply_7",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{\\text{lunar}} \\frac{1}{V_{\\text{LEO}}}"
+                    },
+                    {
+                      "id": "V_{\\text{lunar}}",
+                      "type": "scalar",
+                      "latex": "V_{\\text{lunar}}",
+                      "subexpr": "V_{\\text{lunar}}"
+                    },
+                    {
+                      "id": "__power_8",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{V_{\\text{LEO}}}"
+                    },
+                    {
+                      "id": "V_{\\text{LEO}}",
+                      "type": "scalar",
+                      "latex": "V_{\\text{LEO}}",
+                      "subexpr": "V_{\\text{LEO}}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "q_{\\text{lunar}}",
+                      "to": "__deriv_3"
+                    },
+                    {
+                      "from": "t",
+                      "to": "__deriv_3",
+                      "role": "wrt"
+                    },
+                    {
+                      "from": "__deriv_3",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "q_{\\text{LEO}}",
+                      "to": "__deriv_5"
+                    },
+                    {
+                      "from": "t",
+                      "to": "__deriv_5",
+                      "role": "wrt"
+                    },
+                    {
+                      "from": "__deriv_5",
+                      "to": "__power_4"
+                    },
+                    {
+                      "from": "__power_4",
+                      "to": "__multiply_2"
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "V_{\\text{lunar}}",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V_{\\text{LEO}}",
+                      "to": "__power_8"
+                    },
+                    {
+                      "from": "__power_8",
+                      "to": "__multiply_7"
+                    },
+                    {
+                      "from": "__multiply_7",
+                      "to": "__power_6"
+                    },
+                    {
+                      "from": "__power_6",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "ODE",
+                    "order": 1,
+                    "dependent_variables": [
+                      "Xi_{0}",
+                      "Xi_{1}"
+                    ],
+                    "independent_variables": [
+                      "t"
+                    ]
+                  }
                 }
               }
             },
@@ -2546,12 +12477,12 @@
               "type": "step",
               "label": "Substitute return velocities",
               "math": "\\frac{\\dot{q}_{\\text{lunar}}}{\\dot{q}_{\\text{LEO}}} = \\left(\\frac{\\htmlClass{hl-vl}{11.0}}{\\htmlClass{hl-vleo}{7.8}}\\right)^3 = (\\htmlClass{hl-ratio}{1.410})^3",
-              "justification": "V_lunar \u2248 11.0 km/s (Earth escape), V_LEO \u2248 7.8 km/s (circular orbit)",
+              "justification": "V_lunar ≈ 11.0 km/s (Earth escape), V_LEO ≈ 7.8 km/s (circular orbit)",
               "explanation": "Lunar return velocity is only 41% higher than LEO, but the cubic relationship amplifies this dramatically.",
               "highlights": {
                 "vl": {
                   "color": "orange",
-                  "label": "Lunar return \u2248 Earth escape velocity"
+                  "label": "Lunar return ≈ Earth escape velocity"
                 },
                 "vleo": {
                   "color": "cyan",
@@ -2561,19 +12492,314 @@
                   "color": "yellow",
                   "label": "Only 41% faster, but cubed..."
                 }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "s0___multiply_1",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{\\dot{q_{\\text{lunar}}}}{\\dot{q_{\\text{LEO}}}}"
+                    },
+                    {
+                      "id": "q_{\\text{lunar}}",
+                      "type": "scalar",
+                      "latex": "q_{\\text{lunar}}",
+                      "subexpr": "q_{\\text{lunar}}"
+                    },
+                    {
+                      "id": "t",
+                      "type": "scalar",
+                      "latex": "t",
+                      "subexpr": "t"
+                    },
+                    {
+                      "id": "s0___deriv_2",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t",
+                      "subexpr": "\\dot{q_{\\text{lunar}}}"
+                    },
+                    {
+                      "id": "s0___power_3",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\dot{q_{\\text{LEO}}}}"
+                    },
+                    {
+                      "id": "q_{\\text{LEO}}",
+                      "type": "scalar",
+                      "latex": "q_{\\text{LEO}}",
+                      "subexpr": "q_{\\text{LEO}}"
+                    },
+                    {
+                      "id": "s0___deriv_4",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t",
+                      "subexpr": "\\dot{q_{\\text{LEO}}}"
+                    },
+                    {
+                      "id": "s1___power_1",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "3",
+                      "subexpr": "\\left(\\frac{11.0}{7.8}\\right)^3"
+                    },
+                    {
+                      "id": "s1___multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "11.0 \\frac{1}{7.8}"
+                    },
+                    {
+                      "id": "s1___num_3",
+                      "type": "number",
+                      "label": "11.0",
+                      "subexpr": "11.0",
+                      "description": "Lunar return ≈ Earth escape velocity",
+                      "color": "orange",
+                      "highlight": "vl"
+                    },
+                    {
+                      "id": "s1___power_4",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{7.8}"
+                    },
+                    {
+                      "id": "s1___num_5",
+                      "type": "number",
+                      "label": "7.8",
+                      "subexpr": "7.8",
+                      "description": "LEO circular orbit velocity",
+                      "color": "cyan",
+                      "highlight": "vleo"
+                    },
+                    {
+                      "id": "s2___power_1",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "3",
+                      "subexpr": "(1.410)^3"
+                    },
+                    {
+                      "id": "s2___num_2",
+                      "type": "number",
+                      "label": "1.41",
+                      "subexpr": "1.41"
+                    },
+                    {
+                      "id": "__equals_1",
+                      "type": "operator",
+                      "op": "equals",
+                      "subexpr": "\\frac{\\dot{q}_{\\text{lunar}}}{\\dot{q}_{\\text{LEO}}} = \\left(\\frac{11.0}{7.8}\\right)^3 = (1.410)^3"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "q_{\\text{lunar}}",
+                      "to": "s0___deriv_2"
+                    },
+                    {
+                      "from": "t",
+                      "to": "s0___deriv_2"
+                    },
+                    {
+                      "from": "s0___deriv_2",
+                      "to": "s0___multiply_1"
+                    },
+                    {
+                      "from": "q_{\\text{LEO}}",
+                      "to": "s0___deriv_4"
+                    },
+                    {
+                      "from": "t",
+                      "to": "s0___deriv_4"
+                    },
+                    {
+                      "from": "s0___deriv_4",
+                      "to": "s0___power_3"
+                    },
+                    {
+                      "from": "s0___power_3",
+                      "to": "s0___multiply_1"
+                    },
+                    {
+                      "from": "s1___num_3",
+                      "to": "s1___multiply_2"
+                    },
+                    {
+                      "from": "s1___num_5",
+                      "to": "s1___power_4"
+                    },
+                    {
+                      "from": "s1___power_4",
+                      "to": "s1___multiply_2"
+                    },
+                    {
+                      "from": "s1___multiply_2",
+                      "to": "s1___power_1"
+                    },
+                    {
+                      "from": "s2___num_2",
+                      "to": "s2___power_1"
+                    },
+                    {
+                      "from": "s0___multiply_1",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "s1___power_1",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "s2___power_1",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
               }
             },
             {
               "id": "result",
               "type": "conclusion",
-              "label": "The V\u00b3 penalty",
+              "label": "The V³ penalty",
               "math": "\\frac{\\dot{q}_{\\text{lunar}}}{\\dot{q}_{\\text{LEO}}} \\approx \\htmlClass{hl-result}{2.81}",
-              "justification": "1.410\u00b3 \u2248 2.81",
-              "explanation": "Lunar return produces 2.81\u00d7 the peak heating of LEO return \u2014 from speed alone. This is why Apollo needed a massive ablative heat shield, and why Artemis uses a skip entry to spread the heat load over two atmospheric passes.",
+              "justification": "1.410³ ≈ 2.81",
+              "explanation": "Lunar return produces 2.81× the peak heating of LEO return — from speed alone. This is why Apollo needed a massive ablative heat shield, and why Artemis uses a skip entry to spread the heat load over two atmospheric passes.",
               "highlights": {
                 "result": {
                   "color": "red",
-                  "label": "2.81\u00d7 more heating from speed alone"
+                  "label": "2.81× more heating from speed alone"
+                }
+              },
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "\\frac{\\dot{q_{\\text{lunar}}}}{\\dot{q_{\\text{LEO}}}} = 2.81"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\dot{q_{\\text{lunar}}} \\frac{1}{\\dot{q_{\\text{LEO}}}}"
+                    },
+                    {
+                      "id": "q_{\\text{lunar}}",
+                      "type": "scalar",
+                      "latex": "q_{\\text{lunar}}",
+                      "subexpr": "q_{\\text{lunar}}"
+                    },
+                    {
+                      "id": "t",
+                      "type": "scalar",
+                      "latex": "t",
+                      "subexpr": "t"
+                    },
+                    {
+                      "id": "__deriv_3",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t",
+                      "subexpr": "\\dot{q_{\\text{lunar}}}"
+                    },
+                    {
+                      "id": "__power_4",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\dot{q_{\\text{LEO}}}}"
+                    },
+                    {
+                      "id": "q_{\\text{LEO}}",
+                      "type": "scalar",
+                      "latex": "q_{\\text{LEO}}",
+                      "subexpr": "q_{\\text{LEO}}"
+                    },
+                    {
+                      "id": "__deriv_5",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t",
+                      "subexpr": "\\dot{q_{\\text{LEO}}}"
+                    },
+                    {
+                      "id": "__num_6",
+                      "type": "number",
+                      "label": "2.81",
+                      "subexpr": "2.81",
+                      "description": "2.81× more heating from speed alone",
+                      "color": "red",
+                      "highlight": "result"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "q_{\\text{lunar}}",
+                      "to": "__deriv_3"
+                    },
+                    {
+                      "from": "t",
+                      "to": "__deriv_3",
+                      "role": "wrt"
+                    },
+                    {
+                      "from": "__deriv_3",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "q_{\\text{LEO}}",
+                      "to": "__deriv_5"
+                    },
+                    {
+                      "from": "t",
+                      "to": "__deriv_5",
+                      "role": "wrt"
+                    },
+                    {
+                      "from": "__deriv_5",
+                      "to": "__power_4"
+                    },
+                    {
+                      "from": "__power_4",
+                      "to": "__multiply_2"
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "__num_6",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "ODE",
+                    "order": 1,
+                    "dependent_variables": [
+                      "Xi_{0}",
+                      "Xi_{1}"
+                    ],
+                    "independent_variables": [
+                      "t"
+                    ]
+                  }
                 }
               }
             }
@@ -2861,7 +13087,7 @@
         },
         {
           "title": "Bank Angle Steering",
-          "description": "The bank angle \u03c6 is the roll angle around the velocity vector. Rolling doesn't change the total lift \u2014 it redirects it. At \u03c6 = 0\u00b0 all lift fights gravity (maximum corridor width). As the capsule banks, lift trades altitude control for lateral steering, curving the ground track left or right. More bank means more crossrange but a narrower entry corridor.",
+          "description": "The bank angle φ is the roll angle around the velocity vector. Rolling doesn't change the total lift — it redirects it. At φ = 0° all lift fights gravity (maximum corridor width). As the capsule banks, lift trades altitude control for lateral steering, curving the ground track left or right. More bank means more crossrange but a narrower entry corridor.",
           "prompt": "Guide the user to play with the Bank Angle slider and watch both the lift vector and the projected flight-path bend rotate together.",
           "add": [
             {
@@ -2953,7 +13179,7 @@
               ],
               "color": "#e74c3c",
               "size": 0,
-              "labelExpr": "concat('\u03c6 = ', toFixed(abs(s4_bank_angle), 0), '\u00b0')"
+              "labelExpr": "concat('φ = ', toFixed(abs(s4_bank_angle), 0), '°')"
             }
           ],
           "remove": [],
@@ -2970,7 +13196,7 @@
           "info": [
             {
               "id": "bank_info",
-              "content": "### Lift Steering\nBank Angle: ${{s4_bank_angle}}^\\circ$\n\nVertical lift $\\propto \\cos \\phi = {{toFixed(cos(s4_bank_angle * pi / 180), 2)}}$\nLateral lift $\\propto \\sin \\phi = {{toFixed(sin(s4_bank_angle * pi / 180), 2)}}$\n\nTotal lift is fixed by aerodynamics. Banking doesn't create more lift \u2014 it **redirects** it. Vertical lift controls descent rate and corridor width. Lateral lift steers the ground track left or right (crossrange). More bank = more crossrange steering but narrower corridor.",
+              "content": "### Lift Steering\nBank Angle: ${{s4_bank_angle}}^\\circ$\n\nVertical lift $\\propto \\cos \\phi = {{toFixed(cos(s4_bank_angle * pi / 180), 2)}}$\nLateral lift $\\propto \\sin \\phi = {{toFixed(sin(s4_bank_angle * pi / 180), 2)}}$\n\nTotal lift is fixed by aerodynamics. Banking doesn't create more lift — it **redirects** it. Vertical lift controls descent rate and corridor width. Lateral lift steers the ground track left or right (crossrange). More bank = more crossrange steering but narrower corridor.",
               "position": "top-right"
             }
           ]
@@ -2980,7 +13206,7 @@
     {
       "title": "Splashdown Dynamics",
       "description": "Understand terminal velocity under parachutes and how stopping time in water sets the final splashdown loads.",
-      "markdown": "# Splashdown Dynamics\n\nAfter surviving the intense heat of reentry, a spacecraft must decelerate to a safe landing speed. In the lower, thicker atmosphere, capsules like Apollo, Crew Dragon, and Orion deploy a series of parachutes to increase their drag area and reduce their **terminal velocity** before splashdown.\n\n### The Force Balance\nTwo forces act on the falling capsule:\n\n* **Gravity** pulls it downward: $F_g = mg$\n* **Aerodynamic drag** pushes upward: $F_d = \\frac{1}{2}\\rho V^2 C_d A$\n\nDrag depends on the square of speed \u2014 the faster the capsule falls, the harder the air pushes back.\n\n### Why $F_d = F_g$ Means Constant Speed\nFor the capsule to fall at **constant speed** (zero acceleration), Newton's second law requires the net force to be zero:\n\n$$F_{\\text{net}} = F_d - F_g = 0 \\quad \\Longrightarrow \\quad F_d = F_g$$\n\nThe unique speed at which this balance occurs is the **terminal velocity**. Once the capsule reaches it, there is no more acceleration \u2014 the crew feels only **1g** (their own weight), just like sitting in a chair.\n\n### Solving for Terminal Velocity\nSetting $F_g = F_d$:\n\n$$mg = \\frac{1}{2}\\rho V_t^2 C_d A \\quad \\Longrightarrow \\quad V_t = \\sqrt{\\frac{2mg}{\\rho C_d A}}$$\n\n### The Role of Parachutes\nBy deploying parachutes, the spacecraft massively increases its cross-sectional area $A$ and drag coefficient $C_d$. Increasing $A$ in the denominator dramatically reduces $V_t$, allowing the crew to approach a safe splashdown speed.\n\n**Right after deployment**, the capsule is still falling fast from freefall, so $F_d > F_g$ and the crew feels a brief high-g deceleration spike. As the capsule slows, drag decreases until $F_d = F_g$ and the ride becomes a gentle 1g descent.\n\n### Water Impact Loads\nEven after the parachutes do their job, the capsule still reaches the ocean with nonzero speed. If the vertical speed just before contact is $V_t$ and the water brings the capsule to rest over a stopping time $\\Delta t$, then the average deceleration is roughly\n\n$$a_{\\text{impact}} \\approx \\frac{V_t}{\\Delta t}$$\n\nand the corresponding load factor is\n\n$$n \\approx \\frac{a_{\\text{impact}}}{g}$$\n\nA softer, longer splashdown reduces the deceleration the crew feels.",
+      "markdown": "# Splashdown Dynamics\n\nAfter surviving the intense heat of reentry, a spacecraft must decelerate to a safe landing speed. In the lower, thicker atmosphere, capsules like Apollo, Crew Dragon, and Orion deploy a series of parachutes to increase their drag area and reduce their **terminal velocity** before splashdown.\n\n### The Force Balance\nTwo forces act on the falling capsule:\n\n* **Gravity** pulls it downward: $F_g = mg$\n* **Aerodynamic drag** pushes upward: $F_d = \\frac{1}{2}\\rho V^2 C_d A$\n\nDrag depends on the square of speed — the faster the capsule falls, the harder the air pushes back.\n\n### Why $F_d = F_g$ Means Constant Speed\nFor the capsule to fall at **constant speed** (zero acceleration), Newton's second law requires the net force to be zero:\n\n$$F_{\\text{net}} = F_d - F_g = 0 \\quad \\Longrightarrow \\quad F_d = F_g$$\n\nThe unique speed at which this balance occurs is the **terminal velocity**. Once the capsule reaches it, there is no more acceleration — the crew feels only **1g** (their own weight), just like sitting in a chair.\n\n### Solving for Terminal Velocity\nSetting $F_g = F_d$:\n\n$$mg = \\frac{1}{2}\\rho V_t^2 C_d A \\quad \\Longrightarrow \\quad V_t = \\sqrt{\\frac{2mg}{\\rho C_d A}}$$\n\n### The Role of Parachutes\nBy deploying parachutes, the spacecraft massively increases its cross-sectional area $A$ and drag coefficient $C_d$. Increasing $A$ in the denominator dramatically reduces $V_t$, allowing the crew to approach a safe splashdown speed.\n\n**Right after deployment**, the capsule is still falling fast from freefall, so $F_d > F_g$ and the crew feels a brief high-g deceleration spike. As the capsule slows, drag decreases until $F_d = F_g$ and the ride becomes a gentle 1g descent.\n\n### Water Impact Loads\nEven after the parachutes do their job, the capsule still reaches the ocean with nonzero speed. If the vertical speed just before contact is $V_t$ and the water brings the capsule to rest over a stopping time $\\Delta t$, then the average deceleration is roughly\n\n$$a_{\\text{impact}} \\approx \\frac{V_t}{\\Delta t}$$\n\nand the corresponding load factor is\n\n$$n \\approx \\frac{a_{\\text{impact}}}{g}$$\n\nA softer, longer splashdown reduces the deceleration the crew feels.",
       "prompt": "Emphasize how terminal velocity is reached when drag equals gravity. Guide the student to see how parachute area inversely affects the final velocity. Suggest asking 'What would happen if the atmosphere were thinner (like on Mars)?'",
       "range": [
         [
@@ -3177,8 +13403,8 @@
         },
         {
           "title": "Parachute Deployment",
-          "description": "The chute opens and drag jumps. The capsule is still fast from freefall, so $F_d > F_g$ \u2014 causing rapid deceleration. Select a capsule to see its parachute area.",
-          "prompt": "Highlight the capsule selector slider. Explain how each capsule has a different parachute area. Crew Dragon has the largest chute at 440 m\u00b2, Gemini the smallest at 84 m\u00b2.",
+          "description": "The chute opens and drag jumps. The capsule is still fast from freefall, so $F_d > F_g$ — causing rapid deceleration. Select a capsule to see its parachute area.",
+          "prompt": "Highlight the capsule selector slider. Explain how each capsule has a different parachute area. Crew Dragon has the largest chute at 440 m², Gemini the smallest at 84 m².",
           "add": [
             {
               "id": "parachute",
@@ -3206,7 +13432,7 @@
               ],
               "color": "#ffffff",
               "size": 0,
-              "labelExpr": "concat(dataTable('capsules', s5_capsule, 'name'), ': A = ', toFixed(dataTable('capsules', s5_capsule, 'chuteArea'), 0), ' m\u00b2')"
+              "labelExpr": "concat(dataTable('capsules', s5_capsule, 'name'), ': A = ', toFixed(dataTable('capsules', s5_capsule, 'chuteArea'), 0), ' m²')"
             },
             {
               "id": "cords1",
@@ -3278,7 +13504,7 @@
         },
         {
           "title": "Terminal Velocity",
-          "description": "For constant speed (zero acceleration), we need $F_d = F_g$ exactly. The speed where this balance occurs is the terminal velocity \u2014 the crew feels only 1g from here to splashdown.",
+          "description": "For constant speed (zero acceleration), we need $F_d = F_g$ exactly. The speed where this balance occurs is the terminal velocity — the crew feels only 1g from here to splashdown.",
           "prompt": "Point out that the drag and gravity vectors are now equal in length but opposite in direction. This means net force is zero.",
           "add": [
             {
@@ -3312,7 +13538,7 @@
           "info": [
             {
               "id": "info_terminal",
-              "content": "### Terminal Velocity \u2014 {{dataTable('capsules', s5_capsule, 'name')}}\n$m = {{dataTable('capsules', s5_capsule, 'mass')}}\\ \\text{kg}$, $\\rho = 1.225\\ \\text{kg/m}^3$, $C_d = {{dataTable('capsules', s5_capsule, 'chuteCd')}}$\n\n$F_g = F_d$\n\n$V_t = \\sqrt{ \\frac{2mg}{\\rho C_d A} } = {{toFixed(sqrt(2 * dataTable('capsules', s5_capsule, 'mass') * 9.81 / (1.225 * dataTable('capsules', s5_capsule, 'chuteCd') * dataTable('capsules', s5_capsule, 'chuteArea'))), 1)}}\\ \\text{m/s}$",
+              "content": "### Terminal Velocity — {{dataTable('capsules', s5_capsule, 'name')}}\n$m = {{dataTable('capsules', s5_capsule, 'mass')}}\\ \\text{kg}$, $\\rho = 1.225\\ \\text{kg/m}^3$, $C_d = {{dataTable('capsules', s5_capsule, 'chuteCd')}}$\n\n$F_g = F_d$\n\n$V_t = \\sqrt{ \\frac{2mg}{\\rho C_d A} } = {{toFixed(sqrt(2 * dataTable('capsules', s5_capsule, 'mass') * 9.81 / (1.225 * dataTable('capsules', s5_capsule, 'chuteCd') * dataTable('capsules', s5_capsule, 'chuteArea'))), 1)}}\\ \\text{m/s}$",
               "position": "top-right"
             }
           ]
@@ -3420,7 +13646,7 @@
           "info": [
             {
               "id": "info_impact",
-              "content": "### Water Impact \u2014 {{dataTable('capsules', s5_capsule, 'name')}}\n$V_t = {{toFixed(sqrt(2 * dataTable('capsules', s5_capsule, 'mass') * 9.81 / (1.225 * dataTable('capsules', s5_capsule, 'chuteCd') * dataTable('capsules', s5_capsule, 'chuteArea'))), 1)}}\\ \\text{m/s}$\n\n$a_{\\text{impact}} \\approx \\frac{V_t}{\\Delta t} = {{toFixed(sqrt(2 * dataTable('capsules', s5_capsule, 'mass') * 9.81 / (1.225 * dataTable('capsules', s5_capsule, 'chuteCd') * dataTable('capsules', s5_capsule, 'chuteArea'))) / s5_stop_time, 1)}}\\ \\text{m/s}^2$\n\n$n \\approx \\frac{a}{g} = {{toFixed(sqrt(2 * dataTable('capsules', s5_capsule, 'mass') * 9.81 / (1.225 * dataTable('capsules', s5_capsule, 'chuteCd') * dataTable('capsules', s5_capsule, 'chuteArea'))) / (9.81 * s5_stop_time), 1)}}\\ g$",
+              "content": "### Water Impact — {{dataTable('capsules', s5_capsule, 'name')}}\n$V_t = {{toFixed(sqrt(2 * dataTable('capsules', s5_capsule, 'mass') * 9.81 / (1.225 * dataTable('capsules', s5_capsule, 'chuteCd') * dataTable('capsules', s5_capsule, 'chuteArea'))), 1)}}\\ \\text{m/s}$\n\n$a_{\\text{impact}} \\approx \\frac{V_t}{\\Delta t} = {{toFixed(sqrt(2 * dataTable('capsules', s5_capsule, 'mass') * 9.81 / (1.225 * dataTable('capsules', s5_capsule, 'chuteCd') * dataTable('capsules', s5_capsule, 'chuteArea'))) / s5_stop_time, 1)}}\\ \\text{m/s}^2$\n\n$n \\approx \\frac{a}{g} = {{toFixed(sqrt(2 * dataTable('capsules', s5_capsule, 'mass') * 9.81 / (1.225 * dataTable('capsules', s5_capsule, 'chuteCd') * dataTable('capsules', s5_capsule, 'chuteArea'))) / (9.81 * s5_stop_time), 1)}}\\ g$",
               "position": "top-right"
             }
           ],
@@ -3455,7 +13681,90 @@
               "explanation": "Terminal velocity is the special moment when this change becomes zero.",
               "sceneStep": 2,
               "highlights": {},
-              "prompt": "Ask what it means physically when the velocity stops changing."
+              "prompt": "Ask what it means physically when the velocity stops changing.",
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "a = \\frac{d}{d t} V"
+                    },
+                    {
+                      "id": "a",
+                      "type": "scalar",
+                      "latex": "a",
+                      "subexpr": "a"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    },
+                    {
+                      "id": "t",
+                      "type": "scalar",
+                      "latex": "t",
+                      "subexpr": "t"
+                    },
+                    {
+                      "id": "__deriv_2",
+                      "type": "operator",
+                      "op": "derivative",
+                      "with_respect_to": "t",
+                      "subexpr": "\\frac{d}{d t} V"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "a",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "V",
+                      "to": "__deriv_2"
+                    },
+                    {
+                      "from": "t",
+                      "to": "__deriv_2",
+                      "role": "wrt"
+                    },
+                    {
+                      "from": "__deriv_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "ODE",
+                    "order": 1,
+                    "dependent_variables": [
+                      "V"
+                    ],
+                    "independent_variables": [
+                      "t"
+                    ],
+                    "sympy_hints": [
+                      "factorable",
+                      "nth_algebraic",
+                      "separable",
+                      "1st_exact",
+                      "1st_linear",
+                      "Bernoulli",
+                      "1st_power_series",
+                      "lie_group",
+                      "nth_linear_constant_coeff_undetermined_coefficients",
+                      "nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients",
+                      "nth_linear_constant_coeff_variation_of_parameters",
+                      "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters"
+                    ],
+                    "linear": true,
+                    "homogeneous": true,
+                    "constant_coefficients": true
+                  }
+                }
+              }
             },
             {
               "type": "given",
@@ -3465,7 +13774,68 @@
               "explanation": "This lets us translate a force balance into a statement about constant speed.",
               "sceneStep": 2,
               "highlights": {},
-              "prompt": "Tell the student this is the starting rule behind the whole derivation."
+              "prompt": "Tell the student this is the starting rule behind the whole derivation.",
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "F_{\\text{net}} = ma"
+                    },
+                    {
+                      "id": "F_{\\text{net}}",
+                      "type": "scalar",
+                      "latex": "F_{\\text{net}}",
+                      "subexpr": "F_{\\text{net}}"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "a m"
+                    },
+                    {
+                      "id": "m",
+                      "type": "scalar",
+                      "latex": "m",
+                      "subexpr": "m"
+                    },
+                    {
+                      "id": "a",
+                      "type": "scalar",
+                      "latex": "a",
+                      "subexpr": "a"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "F_{\\text{net}}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "m",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "a",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "given",
@@ -3475,7 +13845,68 @@
               "explanation": "This is the downward force trying to make the capsule fall faster.",
               "sceneStep": 2,
               "highlights": {},
-              "prompt": "Ask the student to identify which force points downward in the scene."
+              "prompt": "Ask the student to identify which force points downward in the scene.",
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "F_g = mg"
+                    },
+                    {
+                      "id": "F_{g}",
+                      "type": "scalar",
+                      "latex": "F_{g}",
+                      "subexpr": "F_{g}"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "g m"
+                    },
+                    {
+                      "id": "m",
+                      "type": "scalar",
+                      "latex": "m",
+                      "subexpr": "m"
+                    },
+                    {
+                      "id": "g",
+                      "type": "scalar",
+                      "latex": "g",
+                      "subexpr": "g"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "F_{g}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "m",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "g",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "given",
@@ -3490,7 +13921,164 @@
                   "label": "Parachute Area"
                 }
               },
-              "prompt": "Have the student locate the term that gets larger when the parachute opens."
+              "prompt": "Have the student locate the term that gets larger when the parachute opens.",
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "F_d = \\frac{1}{2}\\rho V^2 C_d A"
+                    },
+                    {
+                      "id": "F_{d}",
+                      "type": "scalar",
+                      "latex": "F_{d}",
+                      "subexpr": "F_{d}"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{2} \\rho V^{2} A C_{d}"
+                    },
+                    {
+                      "id": "__power_3",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2}"
+                    },
+                    {
+                      "id": "__num_4",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "__multiply_5",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho V^{2} A C_{d}"
+                    },
+                    {
+                      "id": "rho",
+                      "type": "scalar",
+                      "latex": "\\rho",
+                      "subexpr": "\\rho"
+                    },
+                    {
+                      "id": "__multiply_6",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V^{2} A C_{d}"
+                    },
+                    {
+                      "id": "__power_7",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V^{2}"
+                    },
+                    {
+                      "id": "V",
+                      "type": "scalar",
+                      "latex": "V",
+                      "subexpr": "V"
+                    },
+                    {
+                      "id": "__multiply_8",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "A C_{d}"
+                    },
+                    {
+                      "id": "C_{d}",
+                      "type": "scalar",
+                      "latex": "C_{d}",
+                      "subexpr": "C_{d}"
+                    },
+                    {
+                      "id": "A",
+                      "type": "scalar",
+                      "latex": "A",
+                      "subexpr": "A",
+                      "description": "Parachute Area",
+                      "color": "cyan",
+                      "highlight": "area"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "F_{d}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "__num_4",
+                      "to": "__power_3"
+                    },
+                    {
+                      "from": "__power_3",
+                      "to": "__multiply_2"
+                    },
+                    {
+                      "from": "rho",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V",
+                      "to": "__power_7"
+                    },
+                    {
+                      "from": "__power_7",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "C_{d}",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "A",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_8",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_6",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_5",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
@@ -3500,7 +14088,76 @@
               "explanation": "The capsule is still moving downward, but it is no longer changing its speed.",
               "sceneStep": 2,
               "highlights": {},
-              "prompt": "Use the phrase 'steady falling speed' before naming it terminal velocity."
+              "prompt": "Use the phrase 'steady falling speed' before naming it terminal velocity.",
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "a",
+                      "type": "scalar",
+                      "latex": "a",
+                      "subexpr": "a"
+                    },
+                    {
+                      "id": "s1___num_1",
+                      "type": "number",
+                      "label": "0",
+                      "subexpr": "0"
+                    },
+                    {
+                      "id": "F_{\\text{net}}",
+                      "type": "scalar",
+                      "latex": "F_{\\text{net}}",
+                      "subexpr": "F_{\\text{net}}"
+                    },
+                    {
+                      "id": "s1___implies_2",
+                      "type": "operator",
+                      "label": "implies",
+                      "emoji": "⟹",
+                      "op": "implies",
+                      "subexpr": "0 \\quad \\Longrightarrow \\quad F_{\\text{net}}"
+                    },
+                    {
+                      "id": "s2___num_1",
+                      "type": "number",
+                      "label": "0",
+                      "subexpr": "0"
+                    },
+                    {
+                      "id": "__equals_1",
+                      "type": "operator",
+                      "op": "equals",
+                      "subexpr": "a = 0 \\quad \\Longrightarrow \\quad F_{\\text{net}} = 0"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "s1___num_1",
+                      "to": "s1___implies_2"
+                    },
+                    {
+                      "from": "F_{\\text{net}}",
+                      "to": "s1___implies_2"
+                    },
+                    {
+                      "from": "a",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "s1___implies_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "s2___num_1",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
@@ -3510,7 +14167,44 @@
               "explanation": "This balance is the definition of terminal velocity in this setting.",
               "sceneStep": 2,
               "highlights": {},
-              "prompt": "Compare it to a tug-of-war ending in a tie."
+              "prompt": "Compare it to a tug-of-war ending in a tie.",
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "F_g = F_d"
+                    },
+                    {
+                      "id": "F_{g}",
+                      "type": "scalar",
+                      "latex": "F_{g}",
+                      "subexpr": "F_{g}"
+                    },
+                    {
+                      "id": "F_{d}",
+                      "type": "scalar",
+                      "latex": "F_{d}",
+                      "subexpr": "F_{d}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "F_{g}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "F_{d}",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
@@ -3525,7 +14219,188 @@
                   "label": "Parachute Area"
                 }
               },
-              "prompt": "Tell the student this is the key equation for the whole derivation."
+              "prompt": "Tell the student this is the key equation for the whole derivation.",
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "mg = \\frac{1}{2}\\rho V_t^2 C_d A"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "m g"
+                    },
+                    {
+                      "id": "m",
+                      "type": "scalar",
+                      "latex": "m",
+                      "subexpr": "m"
+                    },
+                    {
+                      "id": "g",
+                      "type": "scalar",
+                      "latex": "g",
+                      "subexpr": "g"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{2} \\rho V_{t}^{2} A C_{d}"
+                    },
+                    {
+                      "id": "__power_4",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{2}"
+                    },
+                    {
+                      "id": "__num_5",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "__multiply_6",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho V_{t}^{2} A C_{d}"
+                    },
+                    {
+                      "id": "rho",
+                      "type": "scalar",
+                      "latex": "\\rho",
+                      "subexpr": "\\rho"
+                    },
+                    {
+                      "id": "__multiply_7",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{t}^{2} A C_{d}"
+                    },
+                    {
+                      "id": "__power_8",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V_{t}^{2}"
+                    },
+                    {
+                      "id": "V_{t}",
+                      "type": "scalar",
+                      "latex": "V_{t}",
+                      "subexpr": "V_{t}"
+                    },
+                    {
+                      "id": "__multiply_9",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "A C_{d}"
+                    },
+                    {
+                      "id": "C_{d}",
+                      "type": "scalar",
+                      "latex": "C_{d}",
+                      "subexpr": "C_{d}"
+                    },
+                    {
+                      "id": "A",
+                      "type": "scalar",
+                      "latex": "A",
+                      "subexpr": "A",
+                      "description": "Parachute Area",
+                      "color": "cyan",
+                      "highlight": "area"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "m",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "g",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "__num_5",
+                      "to": "__power_4"
+                    },
+                    {
+                      "from": "__power_4",
+                      "to": "__multiply_3"
+                    },
+                    {
+                      "from": "rho",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V_{t}",
+                      "to": "__power_8"
+                    },
+                    {
+                      "from": "__power_8",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "C_{d}",
+                      "to": "__multiply_9",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "A",
+                      "to": "__multiply_9",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_9",
+                      "to": "__multiply_7",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_7",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_6",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
@@ -3540,7 +14415,178 @@
                   "label": "Parachute Area"
                 }
               },
-              "prompt": "Explain that we are simplifying the equation one small move at a time."
+              "prompt": "Explain that we are simplifying the equation one small move at a time.",
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "2mg = \\rho V_t^2 C_d A"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "2 m g"
+                    },
+                    {
+                      "id": "__num_3",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "__multiply_4",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "m g"
+                    },
+                    {
+                      "id": "m",
+                      "type": "scalar",
+                      "latex": "m",
+                      "subexpr": "m"
+                    },
+                    {
+                      "id": "g",
+                      "type": "scalar",
+                      "latex": "g",
+                      "subexpr": "g"
+                    },
+                    {
+                      "id": "__multiply_5",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho V_{t}^{2} A C_{d}"
+                    },
+                    {
+                      "id": "rho",
+                      "type": "scalar",
+                      "latex": "\\rho",
+                      "subexpr": "\\rho"
+                    },
+                    {
+                      "id": "__multiply_6",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{t}^{2} A C_{d}"
+                    },
+                    {
+                      "id": "__power_7",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V_{t}^{2}"
+                    },
+                    {
+                      "id": "V_{t}",
+                      "type": "scalar",
+                      "latex": "V_{t}",
+                      "subexpr": "V_{t}"
+                    },
+                    {
+                      "id": "__multiply_8",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "A C_{d}"
+                    },
+                    {
+                      "id": "C_{d}",
+                      "type": "scalar",
+                      "latex": "C_{d}",
+                      "subexpr": "C_{d}"
+                    },
+                    {
+                      "id": "A",
+                      "type": "scalar",
+                      "latex": "A",
+                      "subexpr": "A",
+                      "description": "Parachute Area",
+                      "color": "cyan",
+                      "highlight": "area"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "__num_3",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "m",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "g",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_4",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "rho",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "V_{t}",
+                      "to": "__power_7"
+                    },
+                    {
+                      "from": "__power_7",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "C_{d}",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "A",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_8",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_6",
+                      "to": "__multiply_5",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_5",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
@@ -3555,7 +14601,188 @@
                   "label": "Parachute Area"
                 }
               },
-              "prompt": "Use the phrase 'get $V_t^2$ alone' so the algebra feels mechanical and safe."
+              "prompt": "Use the phrase 'get $V_t^2$ alone' so the algebra feels mechanical and safe.",
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "V_t^2 = \\frac{2mg}{\\rho C_d A}"
+                    },
+                    {
+                      "id": "__power_2",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "2",
+                      "subexpr": "V_{t}^{2}"
+                    },
+                    {
+                      "id": "V_{t}",
+                      "type": "scalar",
+                      "latex": "V_{t}",
+                      "subexpr": "V_{t}"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "2 m g \\frac{1}{\\rho A C_{d}}"
+                    },
+                    {
+                      "id": "__multiply_4",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "2 m g"
+                    },
+                    {
+                      "id": "__num_5",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "__multiply_6",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "m g"
+                    },
+                    {
+                      "id": "m",
+                      "type": "scalar",
+                      "latex": "m",
+                      "subexpr": "m"
+                    },
+                    {
+                      "id": "g",
+                      "type": "scalar",
+                      "latex": "g",
+                      "subexpr": "g"
+                    },
+                    {
+                      "id": "__power_7",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\rho A C_{d}}"
+                    },
+                    {
+                      "id": "__multiply_8",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho A C_{d}"
+                    },
+                    {
+                      "id": "rho",
+                      "type": "scalar",
+                      "latex": "\\rho",
+                      "subexpr": "\\rho"
+                    },
+                    {
+                      "id": "__multiply_9",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "A C_{d}"
+                    },
+                    {
+                      "id": "C_{d}",
+                      "type": "scalar",
+                      "latex": "C_{d}",
+                      "subexpr": "C_{d}"
+                    },
+                    {
+                      "id": "A",
+                      "type": "scalar",
+                      "latex": "A",
+                      "subexpr": "A",
+                      "description": "Parachute Area",
+                      "color": "cyan",
+                      "highlight": "area"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "V_{t}",
+                      "to": "__power_2"
+                    },
+                    {
+                      "from": "__power_2",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "__num_5",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "m",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "g",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_6",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_4",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "rho",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "C_{d}",
+                      "to": "__multiply_9",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "A",
+                      "to": "__multiply_9",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_9",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_8",
+                      "to": "__power_7"
+                    },
+                    {
+                      "from": "__power_7",
+                      "to": "__multiply_3"
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "conclusion",
@@ -3574,7 +14801,191 @@
                   "label": "Parachute Area"
                 }
               },
-              "prompt": "End by connecting back to splashdown: reducing $V_t$ makes the water impact gentler."
+              "prompt": "End by connecting back to splashdown: reducing $V_t$ makes the water impact gentler.",
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "V_t = \\sqrt{\\frac{2mg}{\\rho C_d A}}"
+                    },
+                    {
+                      "id": "V_{t}",
+                      "type": "scalar",
+                      "latex": "V_{t}",
+                      "subexpr": "V_{t}",
+                      "description": "Terminal Velocity",
+                      "color": "green",
+                      "highlight": "vt"
+                    },
+                    {
+                      "id": "__power_2",
+                      "type": "operator",
+                      "op": "power",
+                      "exponent": "1/2",
+                      "subexpr": "\\sqrt{\\frac{2 g m}{\\rho A C_{d}}}"
+                    },
+                    {
+                      "id": "__multiply_3",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "2 m g \\frac{1}{\\rho A C_{d}}"
+                    },
+                    {
+                      "id": "__multiply_4",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "2 m g"
+                    },
+                    {
+                      "id": "__num_5",
+                      "type": "number",
+                      "label": "2",
+                      "subexpr": "2"
+                    },
+                    {
+                      "id": "__multiply_6",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "m g"
+                    },
+                    {
+                      "id": "m",
+                      "type": "scalar",
+                      "latex": "m",
+                      "subexpr": "m"
+                    },
+                    {
+                      "id": "g",
+                      "type": "scalar",
+                      "latex": "g",
+                      "subexpr": "g"
+                    },
+                    {
+                      "id": "__power_7",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{\\rho A C_{d}}"
+                    },
+                    {
+                      "id": "__multiply_8",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\rho A C_{d}"
+                    },
+                    {
+                      "id": "rho",
+                      "type": "scalar",
+                      "latex": "\\rho",
+                      "subexpr": "\\rho"
+                    },
+                    {
+                      "id": "__multiply_9",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "A C_{d}"
+                    },
+                    {
+                      "id": "C_{d}",
+                      "type": "scalar",
+                      "latex": "C_{d}",
+                      "subexpr": "C_{d}"
+                    },
+                    {
+                      "id": "A",
+                      "type": "scalar",
+                      "latex": "A",
+                      "subexpr": "A",
+                      "description": "Parachute Area",
+                      "color": "cyan",
+                      "highlight": "area"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "V_{t}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "__num_5",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "m",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "g",
+                      "to": "__multiply_6",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_6",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_4",
+                      "to": "__multiply_3",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "rho",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "C_{d}",
+                      "to": "__multiply_9",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "A",
+                      "to": "__multiply_9",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_9",
+                      "to": "__multiply_8",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_8",
+                      "to": "__power_7"
+                    },
+                    {
+                      "from": "__power_7",
+                      "to": "__multiply_3"
+                    },
+                    {
+                      "from": "__multiply_3",
+                      "to": "__power_2"
+                    },
+                    {
+                      "from": "__power_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             }
           ]
         },
@@ -3591,7 +15002,7 @@
               "label": "Capsule arrives at terminal velocity",
               "math": "V_i = \\htmlClass{hl-vt}{V_t}",
               "justification": "The parachute has slowed the capsule to its terminal speed before hitting the water.",
-              "explanation": "This is the speed we derived in the terminal velocity proof \u2014 the starting condition for the water impact.",
+              "explanation": "This is the speed we derived in the terminal velocity proof — the starting condition for the water impact.",
               "sceneStep": 3,
               "highlights": {
                 "vt": {
@@ -3599,7 +15010,47 @@
                   "label": "Terminal Velocity"
                 }
               },
-              "prompt": "Remind the student that V_t depends on mass, chute area, and drag coefficient."
+              "prompt": "Remind the student that V_t depends on mass, chute area, and drag coefficient.",
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "V_i = V_t"
+                    },
+                    {
+                      "id": "V_{i}",
+                      "type": "scalar",
+                      "latex": "V_{i}",
+                      "subexpr": "V_{i}"
+                    },
+                    {
+                      "id": "V_{t}",
+                      "type": "scalar",
+                      "latex": "V_{t}",
+                      "subexpr": "V_{t}",
+                      "description": "Terminal Velocity",
+                      "color": "green",
+                      "highlight": "vt"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "V_{i}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "V_{t}",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "given",
@@ -3609,14 +15060,51 @@
               "explanation": "The question is: how quickly does this happen?",
               "sceneStep": 3,
               "highlights": {},
-              "prompt": "Ask what determines how harsh this stop feels to the crew."
+              "prompt": "Ask what determines how harsh this stop feels to the crew.",
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "V_f = 0"
+                    },
+                    {
+                      "id": "V_{f}",
+                      "type": "scalar",
+                      "latex": "V_{f}",
+                      "subexpr": "V_{f}"
+                    },
+                    {
+                      "id": "__num_2",
+                      "type": "number",
+                      "label": "0",
+                      "subexpr": "0"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "V_{f}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "__num_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "given",
               "label": "Average acceleration",
               "math": "\\bar{a} = \\frac{\\Delta V}{\\htmlClass{hl-dt}{\\Delta t}} = \\frac{V_f - V_i}{\\htmlClass{hl-dt}{\\Delta t}}",
               "justification": "Average acceleration is the change in velocity divided by the time interval.",
-              "explanation": "This is the kinematic definition \u2014 it tells us the average deceleration the crew experiences.",
+              "explanation": "This is the kinematic definition — it tells us the average deceleration the crew experiences.",
               "sceneStep": 3,
               "highlights": {
                 "dt": {
@@ -3624,7 +15112,145 @@
                   "label": "Stop Time"
                 }
               },
-              "prompt": "Point out that a shorter time interval means a larger acceleration."
+              "prompt": "Point out that a shorter time interval means a larger acceleration.",
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "a",
+                      "type": "scalar",
+                      "latex": "\\bar{a}",
+                      "subexpr": "\\bar{a}"
+                    },
+                    {
+                      "id": "s1___multiply_1",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{\\Delta V}{\\Delta t}"
+                    },
+                    {
+                      "id": "Delta V",
+                      "type": "scalar",
+                      "latex": "\\Delta V",
+                      "subexpr": "\\Delta V"
+                    },
+                    {
+                      "id": "s1___power_2",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{{\\Delta t}}"
+                    },
+                    {
+                      "id": "Delta t",
+                      "type": "scalar",
+                      "latex": "\\Delta t",
+                      "subexpr": "\\Delta t",
+                      "description": "Stop Time",
+                      "color": "orange",
+                      "highlight": "dt"
+                    },
+                    {
+                      "id": "s2___multiply_1",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{V_f - V_i}{\\Delta t}"
+                    },
+                    {
+                      "id": "s2___add_2",
+                      "type": "operator",
+                      "op": "add",
+                      "subexpr": "V_{f} - V_{i}"
+                    },
+                    {
+                      "id": "V_{f}",
+                      "type": "scalar",
+                      "latex": "V_{f}",
+                      "subexpr": "V_{f}"
+                    },
+                    {
+                      "id": "s2___negation_3",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-V_{i}"
+                    },
+                    {
+                      "id": "V_{i}",
+                      "type": "scalar",
+                      "latex": "V_{i}",
+                      "subexpr": "V_{i}"
+                    },
+                    {
+                      "id": "s2___power_4",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{{\\Delta t}}"
+                    },
+                    {
+                      "id": "__equals_1",
+                      "type": "operator",
+                      "op": "equals",
+                      "subexpr": "\\bar{a} = \\frac{\\Delta V}{\\Delta t} = \\frac{V_f - V_i}{\\Delta t}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "Delta V",
+                      "to": "s1___multiply_1"
+                    },
+                    {
+                      "from": "Delta t",
+                      "to": "s1___power_2"
+                    },
+                    {
+                      "from": "s1___power_2",
+                      "to": "s1___multiply_1"
+                    },
+                    {
+                      "from": "V_{f}",
+                      "to": "s2___add_2"
+                    },
+                    {
+                      "from": "V_{i}",
+                      "to": "s2___negation_3"
+                    },
+                    {
+                      "from": "s2___negation_3",
+                      "to": "s2___add_2"
+                    },
+                    {
+                      "from": "s2___add_2",
+                      "to": "s2___multiply_1"
+                    },
+                    {
+                      "from": "Delta t",
+                      "to": "s2___power_4"
+                    },
+                    {
+                      "from": "s2___power_4",
+                      "to": "s2___multiply_1"
+                    },
+                    {
+                      "from": "a",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "s1___multiply_1",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "s2___multiply_1",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
@@ -3643,13 +15269,158 @@
                   "label": "Stop Time"
                 }
               },
-              "prompt": "Explain that the minus sign just means slowing down, and we take the absolute value."
+              "prompt": "Explain that the minus sign just means slowing down, and we take the absolute value.",
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "a",
+                      "type": "scalar",
+                      "latex": "\\bar{a}",
+                      "subexpr": "\\bar{a}"
+                    },
+                    {
+                      "id": "s1___multiply_1",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{0 - V_t}{\\Delta t}"
+                    },
+                    {
+                      "id": "s1___add_2",
+                      "type": "operator",
+                      "op": "add",
+                      "subexpr": "-V_{t} + 0"
+                    },
+                    {
+                      "id": "s1___num_3",
+                      "type": "number",
+                      "label": "0",
+                      "subexpr": "0"
+                    },
+                    {
+                      "id": "s1___negation_4",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-V_{t}"
+                    },
+                    {
+                      "id": "V_{t}",
+                      "type": "scalar",
+                      "latex": "V_{t}",
+                      "subexpr": "V_{t}",
+                      "description": "Terminal Velocity",
+                      "color": "green",
+                      "highlight": "vt"
+                    },
+                    {
+                      "id": "s1___power_5",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{{\\Delta t}}"
+                    },
+                    {
+                      "id": "Delta t",
+                      "type": "scalar",
+                      "latex": "\\Delta t",
+                      "subexpr": "\\Delta t",
+                      "description": "Stop Time",
+                      "color": "orange",
+                      "highlight": "dt"
+                    },
+                    {
+                      "id": "s2___negation_1",
+                      "type": "operator",
+                      "op": "negation",
+                      "subexpr": "-\\frac{V_t}{\\Delta t}"
+                    },
+                    {
+                      "id": "s2___multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{t} \\frac{1}{{\\Delta t}}"
+                    },
+                    {
+                      "id": "s2___power_3",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{{\\Delta t}}"
+                    },
+                    {
+                      "id": "__equals_1",
+                      "type": "operator",
+                      "op": "equals",
+                      "subexpr": "\\bar{a} = \\frac{0 - V_t}{\\Delta t} = -\\frac{V_t}{\\Delta t}"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "s1___num_3",
+                      "to": "s1___add_2"
+                    },
+                    {
+                      "from": "V_{t}",
+                      "to": "s1___negation_4"
+                    },
+                    {
+                      "from": "s1___negation_4",
+                      "to": "s1___add_2"
+                    },
+                    {
+                      "from": "s1___add_2",
+                      "to": "s1___multiply_1"
+                    },
+                    {
+                      "from": "Delta t",
+                      "to": "s1___power_5"
+                    },
+                    {
+                      "from": "s1___power_5",
+                      "to": "s1___multiply_1"
+                    },
+                    {
+                      "from": "V_{t}",
+                      "to": "s2___multiply_2"
+                    },
+                    {
+                      "from": "Delta t",
+                      "to": "s2___power_3"
+                    },
+                    {
+                      "from": "s2___power_3",
+                      "to": "s2___multiply_2"
+                    },
+                    {
+                      "from": "s2___multiply_2",
+                      "to": "s2___negation_1"
+                    },
+                    {
+                      "from": "a",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "s1___multiply_1",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "s2___negation_1",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
               "label": "Impact deceleration magnitude",
               "math": "a_{\\text{impact}} = \\frac{\\htmlClass{hl-vt}{V_t}}{\\htmlClass{hl-dt}{\\Delta t}}",
-              "justification": "Take the absolute value \u2014 we want the magnitude of deceleration felt by the crew.",
+              "justification": "Take the absolute value — we want the magnitude of deceleration felt by the crew.",
               "explanation": "Faster arrival speed or shorter stopping time means harsher impact.",
               "sceneStep": 3,
               "highlights": {
@@ -3662,14 +15433,91 @@
                   "label": "Stop Time"
                 }
               },
-              "prompt": "Use concrete numbers: if V_t = 8 m/s and stop time is 0.5 s, that is 16 m/s\u00b2."
+              "prompt": "Use concrete numbers: if V_t = 8 m/s and stop time is 0.5 s, that is 16 m/s².",
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "a_{\\text{impact}} = \\frac{V_t}{\\Delta t}"
+                    },
+                    {
+                      "id": "a_{\\text{impact}}",
+                      "type": "scalar",
+                      "latex": "a_{\\text{impact}}",
+                      "subexpr": "a_{\\text{impact}}"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{t} \\frac{1}{{\\Delta t}}"
+                    },
+                    {
+                      "id": "V_{t}",
+                      "type": "scalar",
+                      "latex": "V_{t}",
+                      "subexpr": "V_{t}",
+                      "description": "Terminal Velocity",
+                      "color": "green",
+                      "highlight": "vt"
+                    },
+                    {
+                      "id": "__power_3",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{{\\Delta t}}"
+                    },
+                    {
+                      "id": "Delta t",
+                      "type": "scalar",
+                      "latex": "\\Delta t",
+                      "subexpr": "\\Delta t",
+                      "description": "Stop Time",
+                      "color": "orange",
+                      "highlight": "dt"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "a_{\\text{impact}}",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "V_{t}",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "Delta t",
+                      "to": "__power_3"
+                    },
+                    {
+                      "from": "__power_3",
+                      "to": "__multiply_2"
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "step",
               "label": "Convert to g-loads",
               "math": "\\htmlClass{hl-n}{n} = \\frac{a_{\\text{impact}}}{g}",
               "justification": "Dividing by $g = 9.81\\ \\text{m/s}^2$ expresses the deceleration as a multiple of Earth's gravity.",
-              "explanation": "Astronauts and engineers think in g-loads \u2014 1g is normal gravity, 3g is uncomfortable, 10g+ is dangerous.",
+              "explanation": "Astronauts and engineers think in g-loads — 1g is normal gravity, 3g is uncomfortable, 10g+ is dangerous.",
               "sceneStep": 3,
               "highlights": {
                 "n": {
@@ -3677,7 +15525,81 @@
                   "label": "Load Factor"
                 }
               },
-              "prompt": "Compare to everyday examples: a roller coaster is about 3-4g, fighter pilots experience up to 9g."
+              "prompt": "Compare to everyday examples: a roller coaster is about 3-4g, fighter pilots experience up to 9g.",
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "n = \\frac{a_{\\text{impact}}}{g}"
+                    },
+                    {
+                      "id": "n",
+                      "type": "scalar",
+                      "latex": "n",
+                      "subexpr": "n",
+                      "description": "Load Factor",
+                      "color": "yellow",
+                      "highlight": "n"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "\\frac{1}{g} a_{\\text{impact}}"
+                    },
+                    {
+                      "id": "a_{\\text{impact}}",
+                      "type": "scalar",
+                      "latex": "a_{\\text{impact}}",
+                      "subexpr": "a_{\\text{impact}}"
+                    },
+                    {
+                      "id": "__power_3",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{g}"
+                    },
+                    {
+                      "id": "g",
+                      "type": "scalar",
+                      "latex": "g",
+                      "subexpr": "g"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "n",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "a_{\\text{impact}}",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "g",
+                      "to": "__power_3"
+                    },
+                    {
+                      "from": "__power_3",
+                      "to": "__multiply_2"
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             },
             {
               "type": "conclusion",
@@ -3700,7 +15622,111 @@
                   "label": "Stop Time"
                 }
               },
-              "prompt": "Connect back to design: this is why capsules have crushable structures and why landing in water is gentler than land."
+              "prompt": "Connect back to design: this is why capsules have crushable structures and why landing in water is gentler than land.",
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {
+                      "id": "__equals_1",
+                      "type": "relation",
+                      "op": "equals",
+                      "subexpr": "n = \\frac{V_t}{g\\,\\Delta t}"
+                    },
+                    {
+                      "id": "n",
+                      "type": "scalar",
+                      "latex": "n",
+                      "subexpr": "n",
+                      "description": "Load Factor",
+                      "color": "yellow",
+                      "highlight": "n"
+                    },
+                    {
+                      "id": "__multiply_2",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "V_{t} \\frac{1}{{\\Delta t} g}"
+                    },
+                    {
+                      "id": "V_{t}",
+                      "type": "scalar",
+                      "latex": "V_{t}",
+                      "subexpr": "V_{t}",
+                      "description": "Terminal Velocity",
+                      "color": "green",
+                      "highlight": "vt"
+                    },
+                    {
+                      "id": "__power_3",
+                      "type": "operator",
+                      "latex": "\\dfrac{1}{(\\cdot)}",
+                      "op": "power",
+                      "exponent": "-1",
+                      "subexpr": "\\frac{1}{{\\Delta t} g}"
+                    },
+                    {
+                      "id": "__multiply_4",
+                      "type": "operator",
+                      "op": "multiply",
+                      "subexpr": "g \\Delta t"
+                    },
+                    {
+                      "id": "g",
+                      "type": "scalar",
+                      "latex": "g",
+                      "subexpr": "g"
+                    },
+                    {
+                      "id": "Delta t",
+                      "type": "scalar",
+                      "latex": "\\Delta t",
+                      "subexpr": "\\Delta t",
+                      "description": "Stop Time",
+                      "color": "orange",
+                      "highlight": "dt"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "from": "n",
+                      "to": "__equals_1"
+                    },
+                    {
+                      "from": "V_{t}",
+                      "to": "__multiply_2",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "g",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "Delta t",
+                      "to": "__multiply_4",
+                      "semantic": "direct",
+                      "weight": 1.0
+                    },
+                    {
+                      "from": "__multiply_4",
+                      "to": "__power_3"
+                    },
+                    {
+                      "from": "__power_3",
+                      "to": "__multiply_2"
+                    },
+                    {
+                      "from": "__multiply_2",
+                      "to": "__equals_1"
+                    }
+                  ],
+                  "classification": {
+                    "kind": "algebraic"
+                  }
+                }
+              }
             }
           ]
         }

--- a/scenes/atmospheric-entry-physics.json
+++ b/scenes/atmospheric-entry-physics.json
@@ -1,329 +1,115 @@
 {
   "title": "Atmospheric Entry and Splashdown Physics",
-  "import": [
-    "atmospheric-entry"
-  ],
+  "import": ["atmospheric-entry"],
   "data": {
     "capsules": [
-      {
-        "name": "Crew Dragon",
-        "mass": 9525,
-        "chuteArea": 440,
-        "chuteCd": 1.6
-      },
-      {
-        "name": "Gemini",
-        "mass": 2132,
-        "chuteArea": 84,
-        "chuteCd": 1.4
-      },
-      {
-        "name": "Apollo CM",
-        "mass": 5500,
-        "chuteArea": 333,
-        "chuteCd": 1.5
-      },
-      {
-        "name": "Orion",
-        "mass": 9299,
-        "chuteArea": 348,
-        "chuteCd": 1.5
-      }
+      {"name": "Crew Dragon", "mass": 9525, "chuteArea": 440, "chuteCd": 1.6},
+      {"name": "Gemini", "mass": 2132, "chuteArea": 84, "chuteCd": 1.4},
+      {"name": "Apollo CM", "mass": 5500, "chuteArea": 333, "chuteCd": 1.5},
+      {"name": "Orion", "mass": 9299, "chuteArea": 348, "chuteCd": 1.5}
     ],
     "research": {
       "schema_version": "1.0",
       "purpose": "Pre-parachute Earth entry trajectory modeling inputs",
-      "notes": [
-        "This package is suitable for a simplified 3-DOF point-mass simulation up to parachute deployment.",
-        "Fields marked as estimated_or_model_default are not directly specified in the cited source set and should be refined for higher-fidelity work.",
-        "Reference area is the projected frontal area computed from the cited base/heat-shield diameter."
-      ],
-      "planet": {
-        "name": "Earth",
-        "radius_m": 6371000.0,
-        "mu_m3_s2": 398600441800000.0,
-        "rotation_rate_rad_s": 7.292115e-05,
-        "atmosphere_model_recommended": "US Standard Atmosphere 1976",
-        "entry_interface_altitude_m_model_default": 121920.0
-      },
+      "notes": ["This package is suitable for a simplified 3-DOF point-mass simulation up to parachute deployment.", "Fields marked as estimated_or_model_default are not directly specified in the cited source set and should be refined for higher-fidelity work.", "Reference area is the projected frontal area computed from the cited base/heat-shield diameter."],
+      "planet": {"name": "Earth", "radius_m": 6371000.0, "mu_m3_s2": 398600441800000.0, "rotation_rate_rad_s": 7.292115e-05, "atmosphere_model_recommended": "US Standard Atmosphere 1976", "entry_interface_altitude_m_model_default": 121920.0},
       "vehicles": {
         "orion": {
           "name": "Orion Crew Module",
           "program": "Artemis",
           "mission_class": "lunar_return",
-          "geometry": {
-            "height_m": 3.3528,
-            "diameter_m": 5.0292,
-            "reference_area_m2": 19.866,
-            "shape": "blunt lifting capsule"
-          },
-          "mass": {
-            "landing_weight_lb_artemis_ii": 20500.0,
-            "entry_mass_kg_approx": 9299.0
-          },
+          "geometry": {"height_m": 3.3528, "diameter_m": 5.0292, "reference_area_m2": 19.866, "shape": "blunt lifting capsule"},
+          "mass": {"landing_weight_lb_artemis_ii": 20500.0, "entry_mass_kg_approx": 9299.0},
           "entry": {
             "entry_speed_mph": 25000.0,
             "entry_speed_mps": 11176.0,
             "entry_type": "skip_entry",
             "lift_to_drag_ratio": {
-              "value_range": [
-                0.25,
-                0.27
-              ],
+              "value_range": [0.25, 0.27],
               "source_type": "NASA technical paper"
             },
             "flight_path_angle_deg_estimated_or_model_default": -6.5
           },
-          "thermal_protection": {
-            "type": "Avcoat ablative heat shield",
-            "heat_shield_diameter_m": 5.0292
-          },
+          "thermal_protection": {"type": "Avcoat ablative heat shield", "heat_shield_diameter_m": 5.0292},
           "parachutes": {
             "total_parachutes": 11,
-            "forward_bay_cover": {
-              "count": 3,
-              "diameter_ft": 7.0,
-              "diameter_m": 2.1336,
-              "deploy_altitude_ft": 26500.0,
-              "deploy_altitude_m": 8077.2,
-              "deploy_speed_fps": 475.0,
-              "deploy_speed_mps": 144.78,
-              "deploy_speed_mph": 324.0
-            },
-            "drogue": {
-              "count": 2,
-              "diameter_ft": 23.0,
-              "diameter_m": 7.0104,
-              "single_canopy_area_m2": 38.61,
-              "combined_area_m2": 77.22,
-              "deploy_altitude_ft": 25000.0,
-              "deploy_altitude_m": 7620.0,
-              "deploy_speed_fps": 450.0,
-              "deploy_speed_mps": 137.16,
-              "deploy_speed_mph": 307.0
-            },
-            "pilot": {
-              "count": 3,
-              "diameter_ft": 11.0,
-              "diameter_m": 3.3528,
-              "single_canopy_area_m2": 8.83,
-              "combined_area_m2": 26.48,
-              "deploy_altitude_ft": 9500.0,
-              "deploy_altitude_m": 2895.6,
-              "deploy_speed_fps": 190.0,
-              "deploy_speed_mps": 57.91,
-              "deploy_speed_mph": 130.0
-            },
-            "main": {
-              "count": 3,
-              "diameter_ft": 116.0,
-              "diameter_m": 35.3568,
-              "single_canopy_area_m2": 981.97,
-              "combined_area_m2": 2945.91,
-              "full_deploy_altitude_ft": 9000.0,
-              "full_deploy_altitude_m": 2743.2,
-              "deploy_speed_mph": 130.0
-            }
+            "forward_bay_cover": {"count": 3, "diameter_ft": 7.0, "diameter_m": 2.1336, "deploy_altitude_ft": 26500.0, "deploy_altitude_m": 8077.2, "deploy_speed_fps": 475.0, "deploy_speed_mps": 144.78, "deploy_speed_mph": 324.0},
+            "drogue": {"count": 2, "diameter_ft": 23.0, "diameter_m": 7.0104, "single_canopy_area_m2": 38.61, "combined_area_m2": 77.22, "deploy_altitude_ft": 25000.0, "deploy_altitude_m": 7620.0, "deploy_speed_fps": 450.0, "deploy_speed_mps": 137.16, "deploy_speed_mph": 307.0},
+            "pilot": {"count": 3, "diameter_ft": 11.0, "diameter_m": 3.3528, "single_canopy_area_m2": 8.83, "combined_area_m2": 26.48, "deploy_altitude_ft": 9500.0, "deploy_altitude_m": 2895.6, "deploy_speed_fps": 190.0, "deploy_speed_mps": 57.91, "deploy_speed_mph": 130.0},
+            "main": {"count": 3, "diameter_ft": 116.0, "diameter_m": 35.3568, "single_canopy_area_m2": 981.97, "combined_area_m2": 2945.91, "full_deploy_altitude_ft": 9000.0, "full_deploy_altitude_m": 2743.2, "deploy_speed_mph": 130.0}
           },
-          "modeling_status": {
-            "good_for_pre_chute_3dof": true,
-            "needs_full_aero_tables_for_high_fidelity": true
-          }
+          "modeling_status": {"good_for_pre_chute_3dof": true, "needs_full_aero_tables_for_high_fidelity": true}
         },
         "crew_dragon": {
           "name": "SpaceX Crew Dragon",
           "program": "Commercial Crew",
           "mission_class": "LEO_return",
-          "geometry": {
-            "height_m": 8.1382,
-            "diameter_m": 3.7,
-            "reference_area_m2": 10.752,
-            "shape": "blunt lifting capsule"
-          },
-          "mass": {
-            "vehicle_weight_lb_approx": 21000.0,
-            "entry_mass_kg_approx": 9525.0,
-            "mass_quality": "approximate"
-          },
+          "geometry": {"height_m": 8.1382, "diameter_m": 3.7, "reference_area_m2": 10.752, "shape": "blunt lifting capsule"},
+          "mass": {"vehicle_weight_lb_approx": 21000.0, "entry_mass_kg_approx": 9525.0, "mass_quality": "approximate"},
           "entry": {
             "entry_speed_mph": 17500.0,
             "entry_speed_mps": 7823.2,
             "entry_type": "direct_LEO_return",
-            "lift_to_drag_ratio": {
-              "value": null,
-              "note": "Not found in the source set used here"
-            },
+            "lift_to_drag_ratio": {"value": null, "note": "Not found in the source set used here"},
             "flight_path_angle_deg_estimated_or_model_default": -6.0
           },
-          "thermal_protection": {
-            "type": "PICA-X"
-          },
+          "thermal_protection": {"type": "PICA-X"},
           "parachutes": {
-            "drogue": {
-              "count": 2,
-              "deploy_altitude_ft": 18000.0,
-              "deploy_altitude_m": 5486.4,
-              "deploy_speed_mph": 350.0,
-              "deploy_speed_mps": 156.46
-            },
-            "main": {
-              "count": 4,
-              "diameter_m": 35.0,
-              "diameter_ft": 114.83,
-              "single_canopy_area_m2": 962.11,
-              "combined_area_m2": 3848.45,
-              "deploy_altitude_ft": 6000.0,
-              "deploy_altitude_m": 1828.8,
-              "deploy_speed_mph": 119.0,
-              "deploy_speed_mps": 53.2
-            },
-            "touchdown_speed": {
-              "min_mps": 4.8,
-              "max_mps": 5.4,
-              "min_fps": 16.0,
-              "max_fps": 18.0
-            }
+            "drogue": {"count": 2, "deploy_altitude_ft": 18000.0, "deploy_altitude_m": 5486.4, "deploy_speed_mph": 350.0, "deploy_speed_mps": 156.46},
+            "main": {"count": 4, "diameter_m": 35.0, "diameter_ft": 114.83, "single_canopy_area_m2": 962.11, "combined_area_m2": 3848.45, "deploy_altitude_ft": 6000.0, "deploy_altitude_m": 1828.8, "deploy_speed_mph": 119.0, "deploy_speed_mps": 53.2},
+            "touchdown_speed": {"min_mps": 4.8, "max_mps": 5.4, "min_fps": 16.0, "max_fps": 18.0}
           },
-          "modeling_status": {
-            "good_for_pre_chute_3dof": true,
-            "needs_better_mass_and_aero_data_for_higher_fidelity": true
-          }
+          "modeling_status": {"good_for_pre_chute_3dof": true, "needs_better_mass_and_aero_data_for_higher_fidelity": true}
         },
         "gemini": {
           "name": "Gemini Reentry Module",
           "program": "Project Gemini",
           "mission_class": "LEO_return",
-          "geometry": {
-            "spacecraft_total_height_m": 5.6134,
-            "spacecraft_total_base_diameter_m": 3.048,
-            "reentry_module_height_m": 3.3528,
-            "reentry_module_base_diameter_m": 2.22504,
-            "reference_area_m2": 3.888,
-            "shape": "blunt lifting capsule"
-          },
-          "mass": {
-            "launch_weight_lb_approx": 7000.0,
-            "reentry_module_landing_weight_lb_approx": 4700.0,
-            "entry_mass_kg_approx": 2132.0
-          },
+          "geometry": {"spacecraft_total_height_m": 5.6134, "spacecraft_total_base_diameter_m": 3.048, "reentry_module_height_m": 3.3528, "reentry_module_base_diameter_m": 2.22504, "reference_area_m2": 3.888, "shape": "blunt lifting capsule"},
+          "mass": {"launch_weight_lb_approx": 7000.0, "reentry_module_landing_weight_lb_approx": 4700.0, "entry_mass_kg_approx": 2132.0},
           "entry": {
             "reentry_velocity_fps": 24000.0,
             "entry_speed_mph": 16450.0,
             "entry_speed_mps": 7353.96,
             "entry_type": "direct_LEO_return",
-            "lift_to_drag_ratio": {
-              "value_approx": 0.26,
-              "source_type": "NASA history source"
-            },
+            "lift_to_drag_ratio": {"value_approx": 0.26, "source_type": "NASA history source"},
             "flight_path_angle_deg_estimated_or_model_default": -6.0
           },
-          "thermal_protection": {
-            "type": "ablative heat shield"
-          },
+          "thermal_protection": {"type": "ablative heat shield"},
           "parachutes": {
-            "drogue": {
-              "count": 1,
-              "diameter_ft": 8.3,
-              "diameter_m": 2.52984,
-              "single_canopy_area_m2": 5.03,
-              "deploy_altitude_ft": 50000.0,
-              "deploy_altitude_m": 15240.0
-            },
-            "pilot": {
-              "count": 1,
-              "diameter_ft": 18.2,
-              "diameter_m": 5.54736,
-              "single_canopy_area_m2": 24.17,
-              "deploy_altitude_ft": 10600.0,
-              "deploy_altitude_m": 3230.88
-            },
-            "main": {
-              "count": 1,
-              "diameter_ft": 84.2,
-              "diameter_m": 25.66416,
-              "single_canopy_area_m2": 517.24,
-              "deploy_altitude_ft": 10600.0,
-              "deploy_altitude_m": 3230.88,
-              "descent_rate_fps_at_1000_ft": 29.8,
-              "descent_rate_mps_at_1000_ft": 9.08
-            }
+            "drogue": {"count": 1, "diameter_ft": 8.3, "diameter_m": 2.52984, "single_canopy_area_m2": 5.03, "deploy_altitude_ft": 50000.0, "deploy_altitude_m": 15240.0},
+            "pilot": {"count": 1, "diameter_ft": 18.2, "diameter_m": 5.54736, "single_canopy_area_m2": 24.17, "deploy_altitude_ft": 10600.0, "deploy_altitude_m": 3230.88},
+            "main": {"count": 1, "diameter_ft": 84.2, "diameter_m": 25.66416, "single_canopy_area_m2": 517.24, "deploy_altitude_ft": 10600.0, "deploy_altitude_m": 3230.88, "descent_rate_fps_at_1000_ft": 29.8, "descent_rate_mps_at_1000_ft": 9.08}
           },
-          "modeling_status": {
-            "good_for_pre_chute_3dof": true,
-            "needs_mission_specific_entry_state_for_best_results": true
-          }
+          "modeling_status": {"good_for_pre_chute_3dof": true, "needs_mission_specific_entry_state_for_best_results": true}
         },
         "apollo_command_module": {
           "name": "Apollo Command Module",
           "program": "Apollo",
           "mission_class": "lunar_return",
-          "geometry": {
-            "height_m": 3.23,
-            "diameter_m": 3.91,
-            "reference_area_m2": 12.0,
-            "shape": "blunt lifting capsule"
-          },
-          "mass": {
-            "entry_mass_kg": 5500
-          },
+          "geometry": {"height_m": 3.23, "diameter_m": 3.91, "reference_area_m2": 12.0, "shape": "blunt lifting capsule"},
+          "mass": {"entry_mass_kg": 5500},
           "entry": {
             "entry_speed_mps": 11000,
             "entry_speed_mph": 25000,
             "entry_type": "skip_entry_capable",
             "lift_to_drag_ratio": {
-              "value_range": [
-                0.3,
-                0.35
-              ]
+              "value_range": [0.3, 0.35]
             },
             "flight_path_angle_deg_estimated_or_model_default": -6.5
           },
-          "thermal_protection": {
-            "type": "Avcoat ablative heat shield",
-            "heat_shield_diameter_m": 3.91
-          },
-          "aero": {
-            "drag_coefficient_cd_estimated": 1.0,
-            "lift_coefficient_cl_estimated": 0.3
-          },
+          "thermal_protection": {"type": "Avcoat ablative heat shield", "heat_shield_diameter_m": 3.91},
+          "aero": {"drag_coefficient_cd_estimated": 1.0, "lift_coefficient_cl_estimated": 0.3},
           "parachutes": {
-            "drogue": {
-              "count": 2,
-              "diameter_m": 5.2,
-              "deploy_altitude_m": 7600
-            },
-            "main": {
-              "count": 3,
-              "diameter_m": 25.4,
-              "combined_area_m2": 1520,
-              "deploy_altitude_m": 3000
-            }
+            "drogue": {"count": 2, "diameter_m": 5.2, "deploy_altitude_m": 7600},
+            "main": {"count": 3, "diameter_m": 25.4, "combined_area_m2": 1520, "deploy_altitude_m": 3000}
           },
-          "landing": {
-            "type": "ocean",
-            "touchdown_velocity_mps": 9
-          },
-          "modeling_notes": {
-            "good_for_pre_chute_3dof": true,
-            "skip_entry_behavior": "requires lift + guidance modeling",
-            "similarity_to_orion": "high"
-          }
+          "landing": {"type": "ocean", "touchdown_velocity_mps": 9},
+          "modeling_notes": {"good_for_pre_chute_3dof": true, "skip_entry_behavior": "requires lift + guidance modeling", "similarity_to_orion": "high"}
         }
       },
-      "minimum_equations_needed": {
-        "drag": "D = 0.5 * rho * v^2 * Cd * A",
-        "lift": "L = 0.5 * rho * v^2 * Cl * A",
-        "ballistic_coefficient": "beta = m / (Cd * A)"
-      },
-      "missing_for_high_fidelity": [
-        "Cd(Mach, alpha)",
-        "Cl(Mach, alpha)",
-        "bank-angle guidance law",
-        "mission-specific entry interface state vector",
-        "winds",
-        "Earth rotation treatment if landing footprint matters",
-        "trim angle of attack and center-of-mass offset details"
-      ]
+      "minimum_equations_needed": {"drag": "D = 0.5 * rho * v^2 * Cd * A", "lift": "L = 0.5 * rho * v^2 * Cl * A", "ballistic_coefficient": "beta = m / (Cd * A)"},
+      "missing_for_high_fidelity": ["Cd(Mach, alpha)", "Cl(Mach, alpha)", "bank-angle guidance law", "mission-specific entry interface state vector", "winds", "Earth rotation treatment if landing footprint matters", "trim angle of attack and center-of-mass offset details"]
     }
   },
   "scenes": [
@@ -333,44 +119,19 @@
       "markdown": "# The Forces of Reentry\n\n## The Entry Interface\nThe **Entry Interface** is the altitude at which atmospheric drag becomes non-negligible, typically defined as $122\\text{ km}$ ($400,000\\text{ ft}$) for Earth. This is the invisible boundary where space ends and aerodynamic physics begins.\n\n## Ballistic Coefficient\nThe **Ballistic Coefficient** ($\\beta$) is a measure of a body's ability to overcome air resistance, defined as:\n\n$$ \\beta = \\frac{m}{C_d A} $$\n\nwhere:\n* $m$ is mass\n* $C_d$ is the drag coefficient\n* $A$ is the cross-sectional area\n\nA high value means a vehicle cuts through the air like a dart. A low value means it is slowed down easily high in the atmosphere, like a blunt capsule. This concept is foundational to atmospheric entry design, as established by Allen & Eggers [1].\n\n---\n**References:**\n[1] Allen, H. J., & Eggers Jr, A. J. (1958). A study of the motion and aerodynamic heating of ballistic missiles entering the earth's atmosphere at high supersonic speeds (NACA-TR-1381).",
       "prompt": "Ensure the drag vector scales properly with velocity squared and density.",
       "range": [
-        [
-          -10,
-          10
-        ],
-        [
-          0,
-          20
-        ],
-        [
-          -10,
-          10
-        ]
+        [-10, 10],
+        [0, 20],
+        [-10, 10]
       ],
       "camera": {
-        "position": [
-          0,
-          10,
-          20
-        ],
-        "target": [
-          0,
-          10,
-          0
-        ]
+        "position": [0, 10, 20],
+        "target": [0, 10, 0]
       },
       "views": [
         {
           "name": "Face On",
-          "position": [
-            0,
-            10,
-            20
-          ],
-          "target": [
-            0,
-            10,
-            0
-          ],
+          "position": [0, 10, 20],
+          "target": [0, 10, 0],
           "description": "Face-on 2D view"
         }
       ],
@@ -378,10 +139,7 @@
         {
           "type": "axis",
           "axis": "x",
-          "range": [
-            -10,
-            10
-          ],
+          "range": [-10, 10],
           "color": "#ff4444",
           "width": 1.5,
           "label": "x"
@@ -389,10 +147,7 @@
         {
           "type": "axis",
           "axis": "y",
-          "range": [
-            0,
-            20
-          ],
+          "range": [0, 20],
           "color": "#44cc44",
           "width": 1.5,
           "label": "y"
@@ -400,21 +155,12 @@
         {
           "type": "axis",
           "axis": "z",
-          "range": [
-            -10,
-            10
-          ],
+          "range": [-10, 10],
           "color": "#4488ff",
           "width": 1.5,
           "label": "z"
         },
-        {
-          "id": "_mathbox_init",
-          "type": "grid",
-          "plane": "xy",
-          "opacity": 0,
-          "divisions": 10
-        }
+        {"id": "_mathbox_init", "type": "grid", "plane": "xy", "opacity": 0, "divisions": 10}
       ],
       "steps": [
         {
@@ -426,16 +172,8 @@
               "id": "line_interface",
               "type": "line",
               "points": [
-                [
-                  -10,
-                  10,
-                  0
-                ],
-                [
-                  10,
-                  10,
-                  0
-                ]
+                [-10, 10, 0],
+                [10, 10, 0]
               ],
               "color": "#aaaaaa",
               "width": 2,
@@ -445,22 +183,14 @@
               "id": "text_interface",
               "type": "text",
               "text": "Entry Interface (122 km)",
-              "position": [
-                0,
-                10.5,
-                0
-              ],
+              "position": [0, 10.5, 0],
               "color": "#aaaaaa",
               "label": "Entry Interface"
             },
             {
               "id": "pt_capsule",
               "type": "point",
-              "position": [
-                0,
-                10,
-                0
-              ],
+              "position": [0, 10, 0],
               "color": "#ffffff",
               "size": 12,
               "label": "Capsule"
@@ -468,16 +198,8 @@
             {
               "id": "vec_velocity",
               "type": "animated_vector",
-              "from": [
-                0,
-                10,
-                0
-              ],
-              "expr": [
-                "0",
-                "10 - s1_velocity * 0.5",
-                "0"
-              ],
+              "from": [0, 10, 0],
+              "expr": ["0", "10 - s1_velocity * 0.5", "0"],
               "color": "#3498db",
               "width": 4,
               "label": "$\\vec{v}$"
@@ -485,14 +207,7 @@
           ],
           "remove": [],
           "sliders": [
-            {
-              "id": "s1_velocity",
-              "label": "Velocity (km/s)",
-              "min": 5,
-              "max": 12,
-              "default": 7.8,
-              "step": 0.1
-            }
+            {"id": "s1_velocity", "label": "Velocity (km/s)", "min": 5, "max": 12, "default": 7.8, "step": 0.1}
           ],
           "info": []
         },
@@ -504,16 +219,8 @@
             {
               "id": "vec_drag",
               "type": "animated_vector",
-              "from": [
-                0,
-                10,
-                0
-              ],
-              "expr": [
-                "0",
-                "10 + s1_density * (s1_velocity^2) / 20",
-                "0"
-              ],
+              "from": [0, 10, 0],
+              "expr": ["0", "10 + s1_density * (s1_velocity^2) / 20", "0"],
               "color": "#e74c3c",
               "width": 5,
               "label": "$\\vec{F}_D$"
@@ -522,25 +229,14 @@
               "id": "text_drag",
               "type": "text",
               "text": "$F_D \\propto \\rho v^2$",
-              "position": [
-                -5,
-                14,
-                0
-              ],
+              "position": [-5, 14, 0],
               "color": "#e74c3c",
               "label": "$\\vec{F}_D$"
             }
           ],
           "remove": [],
           "sliders": [
-            {
-              "id": "s1_density",
-              "label": "Atmospheric Density",
-              "min": 0,
-              "max": 1,
-              "default": 0.1,
-              "step": 0.01
-            }
+            {"id": "s1_density", "label": "Atmospheric Density", "min": 0, "max": 1, "default": 0.1, "step": 0.01}
           ],
           "info": []
         },
@@ -550,34 +246,14 @@
           "prompt": "Discuss the ballistic coefficient relationship with mass and area. Explain why a blunt shape is preferred for re-entry capsules.",
           "add": [],
           "remove": [
-            {
-              "id": "text_drag"
-            }
+            {"id": "text_drag"}
           ],
           "sliders": [
-            {
-              "id": "s1_mass",
-              "label": "Capsule Mass",
-              "min": 1000,
-              "max": 10000,
-              "default": 5000,
-              "step": 100
-            },
-            {
-              "id": "s1_area",
-              "label": "Cross-sectional Area",
-              "min": 5,
-              "max": 20,
-              "default": 10,
-              "step": 0.5
-            }
+            {"id": "s1_mass", "label": "Capsule Mass", "min": 1000, "max": 10000, "default": 5000, "step": 100},
+            {"id": "s1_area", "label": "Cross-sectional Area", "min": 5, "max": 20, "default": 10, "step": 0.5}
           ],
           "info": [
-            {
-              "id": "info_beta",
-              "content": "### Ballistic Coefficient\nAssume a blunt-capsule drag coefficient $C_d = 1.5$.\n\n$\\beta = \\frac{m}{C_d A} = \\frac{ {{s1_mass}} }{1.5 \\times {{s1_area}}} = {{toFixed(s1_mass / (1.5 * s1_area), 1)}}\\ \\text{kg/m}^2$\n\n$F_D = \\frac{1}{2} \\rho v^2 C_d A$",
-              "position": "top-right"
-            }
+            {"id": "info_beta", "content": "### Ballistic Coefficient\nAssume a blunt-capsule drag coefficient $C_d = 1.5$.\n\n$\\beta = \\frac{m}{C_d A} = \\frac{ {{s1_mass}} }{1.5 \\times {{s1_area}}} = {{toFixed(s1_mass / (1.5 * s1_area), 1)}}\\ \\text{kg/m}^2$\n\n$F_D = \\frac{1}{2} \\rho v^2 C_d A$", "position": "top-right"}
           ]
         }
       ]
@@ -588,62 +264,28 @@
       "markdown": "# The Exponential Atmosphere\n\nThe density of air falls off exponentially with altitude:\n\n$$ \\rho(h) = \\rho_0\\, e^{-h/H} $$\n\nwhere $\\rho_0 = 1.225\\,\\text{kg/m}^3$ is sea-level density and $H \\approx 7.2\\,\\text{km}$ is the **scale height** — the altitude gain that reduces density by a factor of $e \\approx 2.718$.\n\nThis simple model captures the essential physics: the atmosphere is a thin shell that gets exponentially thinner with altitude. By the entry interface at $122\\,\\text{km}$, density is roughly $10^{-7}$ of sea level — effectively vacuum.\n\n---\n**Key insight:** Every $H$ km of altitude costs a factor of $e$ in density. After $n$ scale heights, density is $e^{-n}$ of the surface value.",
       "prompt": "Help the student build intuition for exponential decay in the atmosphere. Emphasize the scale height concept and connect it to why entry dynamics are so sensitive to altitude.",
       "range": [
-        [
-          -10,
-          140
-        ],
-        [
-          0,
-          150
-        ],
-        [
-          -75,
-          75
-        ]
+        [-10, 140],
+        [0, 150],
+        [-75, 75]
       ],
       "camera": {
-        "position": [
-          65,
-          75,
-          200
-        ],
-        "target": [
-          65,
-          75,
-          0
-        ]
+        "position": [65, 75, 200],
+        "target": [65, 75, 0]
       },
       "views": [
         {
           "name": "Face On",
-          "position": [
-            65,
-            75,
-            200
-          ],
-          "target": [
-            65,
-            75,
-            0
-          ],
+          "position": [65, 75, 200],
+          "target": [65, 75, 0],
           "description": "2D view of density vs altitude"
         }
       ],
       "elements": [
-        {
-          "type": "grid",
-          "id": "_mathbox_init",
-          "plane": "xy",
-          "opacity": 0,
-          "divisions": 1
-        },
+        {"type": "grid", "id": "_mathbox_init", "plane": "xy", "opacity": 0, "divisions": 1},
         {
           "type": "axis",
           "axis": "x",
-          "range": [
-            0,
-            130
-          ],
+          "range": [0, 130],
           "color": "#aaaaaa",
           "width": 1.5,
           "label": "$\\rho$ (% of sea level)"
@@ -651,10 +293,7 @@
         {
           "type": "axis",
           "axis": "y",
-          "range": [
-            0,
-            150
-          ],
+          "range": [0, 150],
           "color": "#aaaaaa",
           "width": 1.5,
           "label": "$h$ (km)"
@@ -669,11 +308,7 @@
             {
               "type": "point",
               "id": "pt_sea_level",
-              "position": [
-                100,
-                5,
-                0
-              ],
+              "position": [100, 5, 0],
               "color": "#2ecc71",
               "size": 12,
               "label": "$\\rho_0 = 1.225$ kg/m³ (100%)"
@@ -682,16 +317,8 @@
               "type": "line",
               "id": "line_sea_level",
               "points": [
-                [
-                  0,
-                  0,
-                  0
-                ],
-                [
-                  130,
-                  0,
-                  0
-                ]
+                [0, 0, 0],
+                [130, 0, 0]
               ],
               "color": "#2ecc71",
               "width": 1,
@@ -710,10 +337,7 @@
               "x": "100 * exp(-t / s_atm_H)",
               "y": "t",
               "z": "0",
-              "range": [
-                0,
-                150
-              ],
+              "range": [0, 150],
               "samples": 300,
               "color": "#3498db",
               "width": 3,
@@ -721,14 +345,7 @@
             }
           ],
           "sliders": [
-            {
-              "id": "s_atm_H",
-              "label": "Scale Height H (km)",
-              "min": 3,
-              "max": 15,
-              "default": 7.2,
-              "step": 0.1
-            }
+            {"id": "s_atm_H", "label": "Scale Height H (km)", "min": 3, "max": 15, "default": 7.2, "step": 0.1}
           ]
         },
         {
@@ -740,16 +357,8 @@
               "type": "animated_line",
               "id": "line_1H",
               "points": [
-                [
-                  "0",
-                  "s_atm_H",
-                  "0"
-                ],
-                [
-                  "100 * exp(-1)",
-                  "s_atm_H",
-                  "0"
-                ]
+                ["0", "s_atm_H", "0"],
+                ["100 * exp(-1)", "s_atm_H", "0"]
               ],
               "color": "#f39c12",
               "width": 1.5,
@@ -760,16 +369,8 @@
               "type": "animated_line",
               "id": "line_2H",
               "points": [
-                [
-                  "0",
-                  "2 * s_atm_H",
-                  "0"
-                ],
-                [
-                  "100 * exp(-2)",
-                  "2 * s_atm_H",
-                  "0"
-                ]
+                ["0", "2 * s_atm_H", "0"],
+                ["100 * exp(-2)", "2 * s_atm_H", "0"]
               ],
               "color": "#e67e22",
               "width": 1.5,
@@ -780,16 +381,8 @@
               "type": "animated_line",
               "id": "line_3H",
               "points": [
-                [
-                  "0",
-                  "3 * s_atm_H",
-                  "0"
-                ],
-                [
-                  "100 * exp(-3)",
-                  "3 * s_atm_H",
-                  "0"
-                ]
+                ["0", "3 * s_atm_H", "0"],
+                ["100 * exp(-3)", "3 * s_atm_H", "0"]
               ],
               "color": "#e74c3c",
               "width": 1.5,
@@ -807,16 +400,8 @@
               "type": "line",
               "id": "line_entry",
               "points": [
-                [
-                  0,
-                  122,
-                  0
-                ],
-                [
-                  30,
-                  122,
-                  0
-                ]
+                [0, 122, 0],
+                [30, 122, 0]
               ],
               "color": "#e74c3c",
               "width": 2,
@@ -827,11 +412,7 @@
               "type": "text",
               "id": "text_entry",
               "text": "Entry Interface (122 km)",
-              "position": [
-                35,
-                122,
-                0
-              ],
+              "position": [35, 122, 0],
               "color": "#e74c3c",
               "label": "Entry Interface"
             },
@@ -839,21 +420,13 @@
               "type": "text",
               "id": "text_entry_rho",
               "text": "$\\rho \\approx 10^{-7}\\rho_0$",
-              "position": [
-                35,
-                116,
-                0
-              ],
+              "position": [35, 116, 0],
               "color": "#e74c3c",
               "label": "Entry Interface"
             }
           ],
           "info": [
-            {
-              "id": "atm_info",
-              "content": "### Density at Key Altitudes\n\n| Altitude | Scale Heights | Density |\n|----------|--------------|--------|\n| Sea level | 0 | 100% |\n| $1H$ = ${{toFixed(s_atm_H, 1)}}$ km | 1 | 36.8% |\n| $3H$ = ${{toFixed(3 * s_atm_H, 1)}}$ km | 3 | 5.0% |\n| 50 km | ${{toFixed(50 / s_atm_H, 1)}}$ | ${{toFixed(100 * exp(-50 / s_atm_H), 4)}}$% |\n| 122 km | ${{toFixed(122 / s_atm_H, 1)}}$ | $\\approx 0$ |",
-              "position": "top-right"
-            }
+            {"id": "atm_info", "content": "### Density at Key Altitudes\n\n| Altitude | Scale Heights | Density |\n|----------|--------------|--------|\n| Sea level | 0 | 100% |\n| $1H$ = ${{toFixed(s_atm_H, 1)}}$ km | 1 | 36.8% |\n| $3H$ = ${{toFixed(3 * s_atm_H, 1)}}$ km | 3 | 5.0% |\n| 50 km | ${{toFixed(50 / s_atm_H, 1)}}$ | ${{toFixed(100 * exp(-50 / s_atm_H), 4)}}$% |\n| 122 km | ${{toFixed(122 / s_atm_H, 1)}}$ | $\\approx 0$ |", "position": "top-right"}
           ]
         }
       ],
@@ -875,84 +448,23 @@
             "semanticGraph": {
               "graph": {
                 "nodes": [
-                  {
-                    "id": "__equals_1",
-                    "type": "relation",
-                    "op": "equals",
-                    "subexpr": "dP = -\\rho\\, g\\, dh"
-                  },
-                  {
-                    "id": "dP",
-                    "type": "scalar",
-                    "latex": "dP",
-                    "subexpr": "dP"
-                  },
-                  {
-                    "id": "__negation_2",
-                    "type": "operator",
-                    "op": "negation",
-                    "subexpr": "-\\rho g dh"
-                  },
-                  {
-                    "id": "__multiply_3",
-                    "type": "operator",
-                    "op": "multiply",
-                    "subexpr": "\\rho g dh"
-                  },
-                  {
-                    "id": "dh",
-                    "type": "scalar",
-                    "latex": "dh",
-                    "subexpr": "dh"
-                  },
-                  {
-                    "id": "g",
-                    "type": "scalar",
-                    "latex": "g",
-                    "subexpr": "g"
-                  },
-                  {
-                    "id": "rho",
-                    "type": "scalar",
-                    "latex": "\\rho",
-                    "subexpr": "\\rho"
-                  }
+                  {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "dP = -\\rho\\, g\\, dh"},
+                  {"id": "dP", "type": "scalar", "latex": "dP", "subexpr": "dP"},
+                  {"id": "__negation_2", "type": "operator", "op": "negation", "subexpr": "-\\rho g dh"},
+                  {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "\\rho g dh"},
+                  {"id": "dh", "type": "scalar", "latex": "dh", "subexpr": "dh"},
+                  {"id": "g", "type": "scalar", "latex": "g", "subexpr": "g"},
+                  {"id": "rho", "type": "scalar", "latex": "\\rho", "subexpr": "\\rho"}
                 ],
                 "edges": [
-                  {
-                    "from": "dP",
-                    "to": "__equals_1"
-                  },
-                  {
-                    "from": "dh",
-                    "to": "__multiply_3",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "g",
-                    "to": "__multiply_3",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "rho",
-                    "to": "__multiply_3",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "__multiply_3",
-                    "to": "__negation_2"
-                  },
-                  {
-                    "from": "__negation_2",
-                    "to": "__equals_1"
-                  }
+                  {"from": "dP", "to": "__equals_1"},
+                  {"from": "dh", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                  {"from": "g", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                  {"from": "rho", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                  {"from": "__multiply_3", "to": "__negation_2"},
+                  {"from": "__negation_2", "to": "__equals_1"}
                 ],
-                "classification": {
-                  "kind": "algebraic"
-                }
+                "classification": {"kind": "algebraic"}
               }
             }
           },
@@ -967,120 +479,29 @@
             "semanticGraph": {
               "graph": {
                 "nodes": [
-                  {
-                    "id": "__equals_1",
-                    "type": "relation",
-                    "op": "equals",
-                    "subexpr": "P = \\frac{\\rho\\, k_B T}{m}"
-                  },
-                  {
-                    "id": "P",
-                    "type": "scalar",
-                    "latex": "P",
-                    "subexpr": "P"
-                  },
-                  {
-                    "id": "__multiply_2",
-                    "type": "operator",
-                    "op": "multiply",
-                    "subexpr": "\\frac{1}{m} \\rho T k_{B}"
-                  },
-                  {
-                    "id": "__multiply_3",
-                    "type": "operator",
-                    "op": "multiply",
-                    "subexpr": "\\rho T k_{B}"
-                  },
-                  {
-                    "id": "rho",
-                    "type": "scalar",
-                    "latex": "\\rho",
-                    "subexpr": "\\rho"
-                  },
-                  {
-                    "id": "__multiply_4",
-                    "type": "operator",
-                    "op": "multiply",
-                    "subexpr": "T k_{B}"
-                  },
-                  {
-                    "id": "k_{B}",
-                    "type": "scalar",
-                    "latex": "k_{B}",
-                    "subexpr": "k_{B}"
-                  },
-                  {
-                    "id": "T",
-                    "type": "scalar",
-                    "latex": "T",
-                    "subexpr": "T"
-                  },
-                  {
-                    "id": "__power_5",
-                    "type": "operator",
-                    "latex": "\\dfrac{1}{(\\cdot)}",
-                    "op": "power",
-                    "exponent": "-1",
-                    "subexpr": "\\frac{1}{m}"
-                  },
-                  {
-                    "id": "m",
-                    "type": "scalar",
-                    "latex": "m",
-                    "subexpr": "m"
-                  }
+                  {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "P = \\frac{\\rho\\, k_B T}{m}"},
+                  {"id": "P", "type": "scalar", "latex": "P", "subexpr": "P"},
+                  {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{m} \\rho T k_{B}"},
+                  {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "\\rho T k_{B}"},
+                  {"id": "rho", "type": "scalar", "latex": "\\rho", "subexpr": "\\rho"},
+                  {"id": "__multiply_4", "type": "operator", "op": "multiply", "subexpr": "T k_{B}"},
+                  {"id": "k_{B}", "type": "scalar", "latex": "k_{B}", "subexpr": "k_{B}"},
+                  {"id": "T", "type": "scalar", "latex": "T", "subexpr": "T"},
+                  {"id": "__power_5", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{m}"},
+                  {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m"}
                 ],
                 "edges": [
-                  {
-                    "from": "P",
-                    "to": "__equals_1"
-                  },
-                  {
-                    "from": "rho",
-                    "to": "__multiply_3",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "k_{B}",
-                    "to": "__multiply_4",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "T",
-                    "to": "__multiply_4",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "__multiply_4",
-                    "to": "__multiply_3",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "__multiply_3",
-                    "to": "__multiply_2",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "m",
-                    "to": "__power_5"
-                  },
-                  {
-                    "from": "__power_5",
-                    "to": "__multiply_2"
-                  },
-                  {
-                    "from": "__multiply_2",
-                    "to": "__equals_1"
-                  }
+                  {"from": "P", "to": "__equals_1"},
+                  {"from": "rho", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                  {"from": "k_{B}", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                  {"from": "T", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                  {"from": "__multiply_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                  {"from": "__multiply_3", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                  {"from": "m", "to": "__power_5"},
+                  {"from": "__power_5", "to": "__multiply_2"},
+                  {"from": "__multiply_2", "to": "__equals_1"}
                 ],
-                "classification": {
-                  "kind": "algebraic"
-                }
+                "classification": {"kind": "algebraic"}
               }
             }
           },
@@ -1095,159 +516,36 @@
             "semanticGraph": {
               "graph": {
                 "nodes": [
-                  {
-                    "id": "__equals_1",
-                    "type": "relation",
-                    "op": "equals",
-                    "subexpr": "T = \\text{const}"
-                  },
-                  {
-                    "id": "T",
-                    "type": "scalar",
-                    "latex": "T",
-                    "subexpr": "T"
-                  },
-                  {
-                    "id": "const",
-                    "type": "text",
-                    "label": "const",
-                    "latex": "\\text{const}",
-                    "subexpr": "\\text{const}"
-                  },
-                  {
-                    "id": "__equals_2",
-                    "type": "relation",
-                    "op": "equals",
-                    "subexpr": "dP = \\frac{k_{B} T}{m} d\\rho"
-                  },
-                  {
-                    "id": "dP",
-                    "type": "scalar",
-                    "latex": "dP",
-                    "subexpr": "dP"
-                  },
-                  {
-                    "id": "__multiply_3",
-                    "type": "operator",
-                    "op": "multiply",
-                    "subexpr": "\\frac{1}{m} T k_{B} \\mathrm{d}\\rho"
-                  },
-                  {
-                    "id": "__multiply_4",
-                    "type": "operator",
-                    "op": "multiply",
-                    "subexpr": "\\frac{1}{m} T k_{B}"
-                  },
-                  {
-                    "id": "__multiply_5",
-                    "type": "operator",
-                    "op": "multiply",
-                    "subexpr": "T k_{B}"
-                  },
-                  {
-                    "id": "k_{B}",
-                    "type": "scalar",
-                    "latex": "k_{B}",
-                    "subexpr": "k_{B}"
-                  },
-                  {
-                    "id": "__power_6",
-                    "type": "operator",
-                    "latex": "\\dfrac{1}{(\\cdot)}",
-                    "op": "power",
-                    "exponent": "-1",
-                    "subexpr": "\\frac{1}{m}"
-                  },
-                  {
-                    "id": "m",
-                    "type": "scalar",
-                    "latex": "m",
-                    "subexpr": "m"
-                  },
-                  {
-                    "id": "drho",
-                    "type": "scalar",
-                    "latex": "\\mathrm{d}\\rho",
-                    "subexpr": "\\mathrm{d}\\rho"
-                  },
-                  {
-                    "id": "__implies_7",
-                    "type": "operator",
-                    "label": "implies",
-                    "emoji": "⇒",
-                    "op": "implies",
-                    "subexpr": "T = \\text{const} \\implies dP = \\frac{k_B T}{m}\\, d\\rho"
-                  }
+                  {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "T = \\text{const}"},
+                  {"id": "T", "type": "scalar", "latex": "T", "subexpr": "T"},
+                  {"id": "const", "type": "text", "label": "const", "latex": "\\text{const}", "subexpr": "\\text{const}"},
+                  {"id": "__equals_2", "type": "relation", "op": "equals", "subexpr": "dP = \\frac{k_{B} T}{m} d\\rho"},
+                  {"id": "dP", "type": "scalar", "latex": "dP", "subexpr": "dP"},
+                  {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{m} T k_{B} \\mathrm{d}\\rho"},
+                  {"id": "__multiply_4", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{m} T k_{B}"},
+                  {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "T k_{B}"},
+                  {"id": "k_{B}", "type": "scalar", "latex": "k_{B}", "subexpr": "k_{B}"},
+                  {"id": "__power_6", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{m}"},
+                  {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m"},
+                  {"id": "drho", "type": "scalar", "latex": "\\mathrm{d}\\rho", "subexpr": "\\mathrm{d}\\rho"},
+                  {"id": "__implies_7", "type": "operator", "label": "implies", "emoji": "⇒", "op": "implies", "subexpr": "T = \\text{const} \\implies dP = \\frac{k_B T}{m}\\, d\\rho"}
                 ],
                 "edges": [
-                  {
-                    "from": "T",
-                    "to": "__equals_1"
-                  },
-                  {
-                    "from": "const",
-                    "to": "__equals_1"
-                  },
-                  {
-                    "from": "dP",
-                    "to": "__equals_2"
-                  },
-                  {
-                    "from": "k_{B}",
-                    "to": "__multiply_5",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "T",
-                    "to": "__multiply_5",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "__multiply_5",
-                    "to": "__multiply_4",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "m",
-                    "to": "__power_6"
-                  },
-                  {
-                    "from": "__power_6",
-                    "to": "__multiply_4"
-                  },
-                  {
-                    "from": "__multiply_4",
-                    "to": "__multiply_3",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "drho",
-                    "to": "__multiply_3",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "__multiply_3",
-                    "to": "__equals_2"
-                  },
-                  {
-                    "from": "__equals_1",
-                    "to": "__implies_7",
-                    "role": "lhs"
-                  },
-                  {
-                    "from": "__equals_2",
-                    "to": "__implies_7",
-                    "role": "rhs"
-                  }
+                  {"from": "T", "to": "__equals_1"},
+                  {"from": "const", "to": "__equals_1"},
+                  {"from": "dP", "to": "__equals_2"},
+                  {"from": "k_{B}", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                  {"from": "T", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                  {"from": "__multiply_5", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                  {"from": "m", "to": "__power_6"},
+                  {"from": "__power_6", "to": "__multiply_4"},
+                  {"from": "__multiply_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                  {"from": "drho", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                  {"from": "__multiply_3", "to": "__equals_2"},
+                  {"from": "__equals_1", "to": "__implies_7", "role": "lhs"},
+                  {"from": "__equals_2", "to": "__implies_7", "role": "rhs"}
                 ],
-                "classification": {
-                  "kind": "algebraic"
-                }
+                "classification": {"kind": "algebraic"}
               }
             }
           },
@@ -1262,174 +560,39 @@
             "semanticGraph": {
               "graph": {
                 "nodes": [
-                  {
-                    "id": "__equals_1",
-                    "type": "relation",
-                    "op": "equals",
-                    "subexpr": "\\frac{d\\rho}{\\rho} = -\\frac{m g}{k_B T}\\, dh"
-                  },
-                  {
-                    "id": "__multiply_2",
-                    "type": "operator",
-                    "op": "multiply",
-                    "subexpr": "\\frac{1}{\\rho} \\mathrm{d}\\rho"
-                  },
-                  {
-                    "id": "drho",
-                    "type": "scalar",
-                    "latex": "\\mathrm{d}\\rho",
-                    "subexpr": "\\mathrm{d}\\rho"
-                  },
-                  {
-                    "id": "__power_3",
-                    "type": "operator",
-                    "latex": "\\dfrac{1}{(\\cdot)}",
-                    "op": "power",
-                    "exponent": "-1",
-                    "subexpr": "\\frac{1}{\\rho}"
-                  },
-                  {
-                    "id": "rho",
-                    "type": "scalar",
-                    "latex": "\\rho",
-                    "subexpr": "\\rho"
-                  },
-                  {
-                    "id": "__negation_4",
-                    "type": "operator",
-                    "op": "negation",
-                    "subexpr": "-m g dh \\frac{1}{T} \\frac{1}{k_{B}}"
-                  },
-                  {
-                    "id": "__multiply_5",
-                    "type": "operator",
-                    "op": "multiply",
-                    "subexpr": "m g dh \\frac{1}{T} \\frac{1}{k_{B}}"
-                  },
-                  {
-                    "id": "dh",
-                    "type": "scalar",
-                    "latex": "dh",
-                    "subexpr": "dh"
-                  },
-                  {
-                    "id": "g",
-                    "type": "scalar",
-                    "latex": "g",
-                    "subexpr": "g"
-                  },
-                  {
-                    "id": "m",
-                    "type": "scalar",
-                    "latex": "m",
-                    "subexpr": "m"
-                  },
-                  {
-                    "id": "__multiply_6",
-                    "type": "operator",
-                    "op": "multiply",
-                    "subexpr": "\\frac{1}{T} \\frac{1}{k_{B}}"
-                  },
-                  {
-                    "id": "__power_7",
-                    "type": "operator",
-                    "latex": "\\dfrac{1}{(\\cdot)}",
-                    "op": "power",
-                    "exponent": "-1",
-                    "subexpr": "\\frac{1}{T}"
-                  },
-                  {
-                    "id": "T",
-                    "type": "scalar",
-                    "latex": "T",
-                    "subexpr": "T"
-                  },
-                  {
-                    "id": "__power_8",
-                    "type": "operator",
-                    "latex": "\\dfrac{1}{(\\cdot)}",
-                    "op": "power",
-                    "exponent": "-1",
-                    "subexpr": "\\frac{1}{k_{B}}"
-                  },
-                  {
-                    "id": "k_{B}",
-                    "type": "scalar",
-                    "latex": "k_{B}",
-                    "subexpr": "k_{B}"
-                  }
+                  {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\frac{d\\rho}{\\rho} = -\\frac{m g}{k_B T}\\, dh"},
+                  {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{\\rho} \\mathrm{d}\\rho"},
+                  {"id": "drho", "type": "scalar", "latex": "\\mathrm{d}\\rho", "subexpr": "\\mathrm{d}\\rho"},
+                  {"id": "__power_3", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\rho}"},
+                  {"id": "rho", "type": "scalar", "latex": "\\rho", "subexpr": "\\rho"},
+                  {"id": "__negation_4", "type": "operator", "op": "negation", "subexpr": "-m g dh \\frac{1}{T} \\frac{1}{k_{B}}"},
+                  {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "m g dh \\frac{1}{T} \\frac{1}{k_{B}}"},
+                  {"id": "dh", "type": "scalar", "latex": "dh", "subexpr": "dh"},
+                  {"id": "g", "type": "scalar", "latex": "g", "subexpr": "g"},
+                  {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m"},
+                  {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{T} \\frac{1}{k_{B}}"},
+                  {"id": "__power_7", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{T}"},
+                  {"id": "T", "type": "scalar", "latex": "T", "subexpr": "T"},
+                  {"id": "__power_8", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{k_{B}}"},
+                  {"id": "k_{B}", "type": "scalar", "latex": "k_{B}", "subexpr": "k_{B}"}
                 ],
                 "edges": [
-                  {
-                    "from": "drho",
-                    "to": "__multiply_2",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "rho",
-                    "to": "__power_3"
-                  },
-                  {
-                    "from": "__power_3",
-                    "to": "__multiply_2"
-                  },
-                  {
-                    "from": "__multiply_2",
-                    "to": "__equals_1"
-                  },
-                  {
-                    "from": "dh",
-                    "to": "__multiply_5",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "g",
-                    "to": "__multiply_5",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "m",
-                    "to": "__multiply_5",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "T",
-                    "to": "__power_7"
-                  },
-                  {
-                    "from": "__power_7",
-                    "to": "__multiply_6"
-                  },
-                  {
-                    "from": "k_{B}",
-                    "to": "__power_8"
-                  },
-                  {
-                    "from": "__power_8",
-                    "to": "__multiply_6"
-                  },
-                  {
-                    "from": "__multiply_6",
-                    "to": "__multiply_5",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "__multiply_5",
-                    "to": "__negation_4"
-                  },
-                  {
-                    "from": "__negation_4",
-                    "to": "__equals_1"
-                  }
+                  {"from": "drho", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                  {"from": "rho", "to": "__power_3"},
+                  {"from": "__power_3", "to": "__multiply_2"},
+                  {"from": "__multiply_2", "to": "__equals_1"},
+                  {"from": "dh", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                  {"from": "g", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                  {"from": "m", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                  {"from": "T", "to": "__power_7"},
+                  {"from": "__power_7", "to": "__multiply_6"},
+                  {"from": "k_{B}", "to": "__power_8"},
+                  {"from": "__power_8", "to": "__multiply_6"},
+                  {"from": "__multiply_6", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                  {"from": "__multiply_5", "to": "__negation_4"},
+                  {"from": "__negation_4", "to": "__equals_1"}
                 ],
-                "classification": {
-                  "kind": "algebraic"
-                }
+                "classification": {"kind": "algebraic"}
               }
             }
           },
@@ -1442,145 +605,38 @@
             "prompt": "Emphasize the physical meaning: $H$ is where gravity and thermal motion are in balance. Below $H$, thermal agitation keeps molecules aloft. Above $H$, gravity wins and density drops rapidly.",
             "sceneStep": 2,
             "highlights": {
-              "H": {
-                "color": "yellow",
-                "label": "scale height — where thermal energy balances gravity"
-              }
+              "H": {"color": "yellow", "label": "scale height — where thermal energy balances gravity"}
             },
             "semanticGraph": {
               "graph": {
                 "nodes": [
-                  {
-                    "id": "H",
-                    "type": "scalar",
-                    "latex": "H",
-                    "subexpr": "H"
-                  },
-                  {
-                    "id": "__multiply_1",
-                    "type": "operator",
-                    "op": "multiply",
-                    "subexpr": "\\frac{k_{B} T}{m g}"
-                  },
-                  {
-                    "id": "__multiply_2",
-                    "type": "operator",
-                    "op": "multiply",
-                    "subexpr": "T k_{B}"
-                  },
-                  {
-                    "id": "k_{B}",
-                    "type": "scalar",
-                    "latex": "k_{B}",
-                    "subexpr": "k_{B}"
-                  },
-                  {
-                    "id": "T",
-                    "type": "scalar",
-                    "latex": "T",
-                    "subexpr": "T"
-                  },
-                  {
-                    "id": "__power_3",
-                    "type": "operator",
-                    "latex": "\\dfrac{1}{(\\cdot)}",
-                    "op": "power",
-                    "exponent": "-1",
-                    "subexpr": "\\frac{1}{g m}"
-                  },
-                  {
-                    "id": "__multiply_4",
-                    "type": "operator",
-                    "op": "multiply",
-                    "subexpr": "m g"
-                  },
-                  {
-                    "id": "m",
-                    "type": "scalar",
-                    "latex": "m",
-                    "subexpr": "m"
-                  },
-                  {
-                    "id": "g",
-                    "type": "scalar",
-                    "latex": "g",
-                    "subexpr": "g"
-                  },
-                  {
-                    "id": "__congruent_5",
-                    "type": "relation",
-                    "label": "congruent to",
-                    "emoji": "≡",
-                    "op": "congruent",
-                    "subexpr": "H \\equiv \\frac{k_B T}{m g}",
-                    "description": "scale height — where thermal energy balances gravity",
-                    "color": "yellow",
-                    "highlight": "H"
-                  }
+                  {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"},
+                  {"id": "__multiply_1", "type": "operator", "op": "multiply", "subexpr": "\\frac{k_{B} T}{m g}"},
+                  {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "T k_{B}"},
+                  {"id": "k_{B}", "type": "scalar", "latex": "k_{B}", "subexpr": "k_{B}"},
+                  {"id": "T", "type": "scalar", "latex": "T", "subexpr": "T"},
+                  {"id": "__power_3", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{g m}"},
+                  {"id": "__multiply_4", "type": "operator", "op": "multiply", "subexpr": "m g"},
+                  {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m"},
+                  {"id": "g", "type": "scalar", "latex": "g", "subexpr": "g"},
+                  {"id": "__congruent_5", "type": "relation", "label": "congruent to", "emoji": "≡", "op": "congruent", "subexpr": "H \\equiv \\frac{k_B T}{m g}", "description": "scale height — where thermal energy balances gravity", "color": "yellow", "highlight": "H"}
                 ],
                 "edges": [
-                  {
-                    "from": "k_{B}",
-                    "to": "__multiply_2",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "T",
-                    "to": "__multiply_2",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "__multiply_2",
-                    "to": "__multiply_1",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "m",
-                    "to": "__multiply_4",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "g",
-                    "to": "__multiply_4",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "__multiply_4",
-                    "to": "__power_3"
-                  },
-                  {
-                    "from": "__power_3",
-                    "to": "__multiply_1"
-                  },
-                  {
-                    "from": "H",
-                    "to": "__congruent_5"
-                  },
-                  {
-                    "from": "__multiply_1",
-                    "to": "__congruent_5"
-                  }
+                  {"from": "k_{B}", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                  {"from": "T", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                  {"from": "__multiply_2", "to": "__multiply_1", "semantic": "direct", "weight": 1.0},
+                  {"from": "m", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                  {"from": "g", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                  {"from": "__multiply_4", "to": "__power_3"},
+                  {"from": "__power_3", "to": "__multiply_1"},
+                  {"from": "H", "to": "__congruent_5"},
+                  {"from": "__multiply_1", "to": "__congruent_5"}
                 ],
-                "classification": {
-                  "kind": "algebraic"
-                }
+                "classification": {"kind": "algebraic"}
               }
             }
           },
-          {
-            "type": "step",
-            "label": "Integrate",
-            "math": "\\int_{\\rho_0}^{\\rho} \\frac{d\\rho'}{\\rho'} = -\\frac{1}{H} \\int_0^h dh' \\implies \\ln\\frac{\\rho}{\\rho_0} = -\\frac{h}{H}",
-            "justification": "Definite integral from sea level ($h=0$, $\\rho = \\rho_0$) to altitude $h$.",
-            "explanation": "The left side gives a logarithm, the right side is linear in $h$. This is the standard result for any exponential decay process.",
-            "prompt": "Remind the student: $\\int d\\rho/\\rho = \\ln\\rho$. The boundary condition $\\rho(0) = \\rho_0$ fixes the constant of integration.",
-            "sceneStep": 2
-          },
+          {"type": "step", "label": "Integrate", "math": "\\int_{\\rho_0}^{\\rho} \\frac{d\\rho'}{\\rho'} = -\\frac{1}{H} \\int_0^h dh' \\implies \\ln\\frac{\\rho}{\\rho_0} = -\\frac{h}{H}", "justification": "Definite integral from sea level ($h=0$, $\\rho = \\rho_0$) to altitude $h$.", "explanation": "The left side gives a logarithm, the right side is linear in $h$. This is the standard result for any exponential decay process.", "prompt": "Remind the student: $\\int d\\rho/\\rho = \\ln\\rho$. The boundary condition $\\rho(0) = \\rho_0$ fixes the constant of integration.", "sceneStep": 2},
           {
             "type": "conclusion",
             "label": "Exponential Atmosphere",
@@ -1590,143 +646,37 @@
             "prompt": "Connect to the visualization: the curve you see is exactly this equation. Drag the scale height slider to see how $H$ controls the rate of thinning.",
             "sceneStep": 1,
             "highlights": {
-              "result": {
-                "color": "green",
-                "label": "the exponential atmosphere model"
-              }
+              "result": {"color": "green", "label": "the exponential atmosphere model"}
             },
             "semanticGraph": {
               "graph": {
                 "nodes": [
-                  {
-                    "id": "__equals_1",
-                    "type": "relation",
-                    "op": "equals",
-                    "subexpr": "\\rho(h) = \\rho_0\\, e^{-h/H}",
-                    "description": "the exponential atmosphere model",
-                    "color": "green",
-                    "highlight": "result"
-                  },
-                  {
-                    "id": "__rho_2",
-                    "type": "function",
-                    "latex": "\\rho",
-                    "op": "rho",
-                    "subexpr": "\\rho{\\left(h \\right)}"
-                  },
-                  {
-                    "id": "h",
-                    "type": "scalar",
-                    "latex": "h",
-                    "subexpr": "h"
-                  },
-                  {
-                    "id": "__multiply_3",
-                    "type": "operator",
-                    "op": "multiply",
-                    "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0}"
-                  },
-                  {
-                    "id": "rho_{0}",
-                    "type": "scalar",
-                    "latex": "\\rho_{0}",
-                    "subexpr": "\\rho_{0}"
-                  },
-                  {
-                    "id": "__power_4",
-                    "type": "operator",
-                    "op": "power",
-                    "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"
-                  },
-                  {
-                    "id": "e",
-                    "type": "scalar",
-                    "latex": "e",
-                    "subexpr": "e"
-                  },
-                  {
-                    "id": "__multiply_5",
-                    "type": "operator",
-                    "op": "multiply",
-                    "subexpr": "\\frac{1}{H} -h"
-                  },
-                  {
-                    "id": "__negation_6",
-                    "type": "operator",
-                    "op": "negation",
-                    "subexpr": "-h"
-                  },
-                  {
-                    "id": "__power_7",
-                    "type": "operator",
-                    "latex": "\\dfrac{1}{(\\cdot)}",
-                    "op": "power",
-                    "exponent": "-1",
-                    "subexpr": "\\frac{1}{H}"
-                  },
-                  {
-                    "id": "H",
-                    "type": "scalar",
-                    "latex": "H",
-                    "subexpr": "H"
-                  }
+                  {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\rho(h) = \\rho_0\\, e^{-h/H}", "description": "the exponential atmosphere model", "color": "green", "highlight": "result"},
+                  {"id": "__rho_2", "type": "function", "latex": "\\rho", "op": "rho", "subexpr": "\\rho{\\left(h \\right)}"},
+                  {"id": "h", "type": "scalar", "latex": "h", "subexpr": "h"},
+                  {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0}"},
+                  {"id": "rho_{0}", "type": "scalar", "latex": "\\rho_{0}", "subexpr": "\\rho_{0}"},
+                  {"id": "__power_4", "type": "operator", "op": "power", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"},
+                  {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                  {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{H} -h"},
+                  {"id": "__negation_6", "type": "operator", "op": "negation", "subexpr": "-h"},
+                  {"id": "__power_7", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{H}"},
+                  {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"}
                 ],
                 "edges": [
-                  {
-                    "from": "h",
-                    "to": "__rho_2"
-                  },
-                  {
-                    "from": "__rho_2",
-                    "to": "__equals_1"
-                  },
-                  {
-                    "from": "rho_{0}",
-                    "to": "__multiply_3",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "e",
-                    "to": "__power_4"
-                  },
-                  {
-                    "from": "h",
-                    "to": "__negation_6"
-                  },
-                  {
-                    "from": "__negation_6",
-                    "to": "__multiply_5",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "H",
-                    "to": "__power_7"
-                  },
-                  {
-                    "from": "__power_7",
-                    "to": "__multiply_5"
-                  },
-                  {
-                    "from": "__multiply_5",
-                    "to": "__power_4",
-                    "role": "exp"
-                  },
-                  {
-                    "from": "__power_4",
-                    "to": "__multiply_3",
-                    "semantic": "direct",
-                    "weight": 1.0
-                  },
-                  {
-                    "from": "__multiply_3",
-                    "to": "__equals_1"
-                  }
+                  {"from": "h", "to": "__rho_2"},
+                  {"from": "__rho_2", "to": "__equals_1"},
+                  {"from": "rho_{0}", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                  {"from": "e", "to": "__power_4"},
+                  {"from": "h", "to": "__negation_6"},
+                  {"from": "__negation_6", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                  {"from": "H", "to": "__power_7"},
+                  {"from": "__power_7", "to": "__multiply_5"},
+                  {"from": "__multiply_5", "to": "__power_4", "role": "exp"},
+                  {"from": "__power_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                  {"from": "__multiply_3", "to": "__equals_1"}
                 ],
-                "classification": {
-                  "kind": "algebraic"
-                }
+                "classification": {"kind": "algebraic"}
               }
             }
           }
@@ -1739,118 +689,47 @@
       "markdown": "# Simulated Entry Corridor\n\nThis scene replaces the hand-drawn path with a simplified **pre-parachute point-mass entry model**. The capsule starts at the Earth entry interface ($121.92\\,\\text{km}$) and is propagated under gravity, drag, and in-plane lift:\n\n$$\\mathbf{a}=\\mathbf{g}+\\mathbf{a}_D+\\mathbf{a}_L.$$\n\nThe atmosphere is exponential, each vehicle preset uses a fixed blunt-body $C_d$, and capsules with known lifting behavior get a fixed $L/D$ estimate.\n\n## Corridor Definition In This Lesson\nFor this scene, an entry angle counts as **inside the corridor** if the simulated capsule:\n\n- does **not** skip back out above the entry interface,\n- reaches the selected vehicle's parachute-deployment altitude,\n- stays below the chosen peak-$g$ limit.\n\nThis remains a low-order educational model. It does **not** include winds, Earth rotation, mission-specific guidance, or full aero tables $C_d(M,\\alpha)$ and $C_l(M,\\alpha)$.",
       "prompt": "Teach the corridor as a computed result of the simulation rather than a fixed wedge. Encourage the user to switch vehicles, change gamma and bank, and scrub the animated time slider to connect path shape with current altitude, speed, and g-load.",
       "range": [
-        [
-          375,
-          895
-        ],
-        [
-          -260,
-          260
-        ],
-        [
-          -260,
-          260
-        ]
+        [375, 895],
+        [-260, 260],
+        [-260, 260]
       ],
-      "scale": [
-        1,
-        1,
-        1
-      ],
+      "scale": [1, 1, 1],
       "camera": {
-        "position": [
-          647.424,
-          111.171,
-          188.686
-        ],
-        "target": [
-          638.333,
-          122.792,
-          38.678
-        ],
-        "up": [
-          0.998,
-          0.011,
-          -0.06
-        ]
+        "position": [647.424, 111.171, 188.686],
+        "target": [638.333, 122.792, 38.678],
+        "up": [0.998, 0.011, -0.06]
       },
       "views": [
         {
           "name": "Corridor Overview",
-          "position": [
-            669.339,
-            -59.353,
-            40.26
-          ],
-          "target": [
-            617.474,
-            140.115,
-            -22.13
-          ],
-          "up": [
-            0.945,
-            0.325,
-            -0.019
-          ],
+          "position": [669.339, -59.353, 40.26],
+          "target": [617.474, 140.115, -22.13],
+          "up": [0.945, 0.325, -0.019],
           "description": "Side view showing the full entry corridor with Earth limb"
         },
         {
           "name": "Planar",
-          "position": [
-            900,
-            0,
-            0
-          ],
-          "target": [
-            635,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [900, 0, 0],
+          "target": [635, 0, 0],
+          "up": [0, 0, 1],
           "description": "Face-on to the simulated entry plane"
         },
         {
           "name": "Graph View",
-          "position": [
-            683.399,
-            35.905,
-            148.221
-          ],
-          "target": [
-            688.647,
-            33.277,
-            31.735
-          ],
-          "up": [
-            0.999,
-            -0.017,
-            0.045
-          ],
+          "position": [683.399, 35.905, 148.221],
+          "target": [688.647, 33.277, 31.735],
+          "up": [0.999, -0.017, 0.045],
           "description": "Focus on the live g-load graph"
         },
         {
           "name": "Follow Capsule",
           "follow": "capsule_live",
-          "offset": [
-            0,
-            0,
-            30
-          ],
+          "offset": [0, 0, 30],
           "description": "Camera tracks the capsule along its trajectory"
         }
       ],
       "elements": [
-        {
-          "type": "grid",
-          "id": "_mathbox_init",
-          "plane": "xz",
-          "opacity": 0,
-          "divisions": 1
-        }
+        {"type": "grid", "id": "_mathbox_init", "plane": "xz", "opacity": 0, "divisions": 1}
       ],
       "steps": [
         {
@@ -1861,30 +740,18 @@
             {
               "type": "sphere",
               "id": "earth",
-              "center": [
-                0,
-                0,
-                0
-              ],
+              "center": [0, 0, 0],
               "radius": 637.1,
               "widthSegments": 96,
               "heightSegments": 64,
               "color": "#2d6ea3",
               "opacity": 0.88,
-              "shader": {
-                "shininess": 42,
-                "specular": "#95c8f0",
-                "emissive": "#0f2135"
-              }
+              "shader": {"shininess": 42, "specular": "#95c8f0", "emissive": "#0f2135"}
             },
             {
               "type": "sphere",
               "id": "atmosphere",
-              "center": [
-                0,
-                0,
-                0
-              ],
+              "center": [0, 0, 0],
               "radius": 649.292,
               "widthSegments": 96,
               "heightSegments": 64,
@@ -1895,16 +762,8 @@
               "type": "animated_line",
               "id": "local_horizontal",
               "points": [
-                [
-                  "649.292",
-                  "-62",
-                  "0"
-                ],
-                [
-                  "649.292",
-                  "62",
-                  "0"
-                ]
+                ["649.292", "-62", "0"],
+                ["649.292", "62", "0"]
               ],
               "color": "#8f97a8",
               "width": 1.5,
@@ -1915,11 +774,7 @@
               "type": "text",
               "id": "horizontal_label",
               "text": "Local Horizontal",
-              "position": [
-                661,
-                70,
-                0
-              ],
+              "position": [661, 70, 0],
               "color": "#8f97a8",
               "label": "Local Horizontal"
             },
@@ -1928,21 +783,9 @@
               "id": "corridor_fill",
               "legendGroup": "Entry Corridor",
               "vertices": [
-                [
-                  "649.292",
-                  "0",
-                  "0"
-                ],
-                [
-                  "649.292 - 130 * sin(entryCorridorLo() * pi / 180)",
-                  "130 * cos(entryCorridorLo() * pi / 180)",
-                  "0"
-                ],
-                [
-                  "649.292 - 130 * sin(entryCorridorHi() * pi / 180)",
-                  "130 * cos(entryCorridorHi() * pi / 180)",
-                  "0"
-                ]
+                ["649.292", "0", "0"],
+                ["649.292 - 130 * sin(entryCorridorLo() * pi / 180)", "130 * cos(entryCorridorLo() * pi / 180)", "0"],
+                ["649.292 - 130 * sin(entryCorridorHi() * pi / 180)", "130 * cos(entryCorridorHi() * pi / 180)", "0"]
               ],
               "color": "#2ecc71",
               "opacity": 0.4
@@ -1951,22 +794,14 @@
               "type": "text",
               "id": "corridor_label",
               "text": "Computed Corridor",
-              "position": [
-                633,
-                93,
-                0
-              ],
+              "position": [633, 93, 0],
               "color": "#2ecc71",
               "label": "Entry Corridor"
             },
             {
               "type": "animated_point",
               "id": "corridor_lo_marker",
-              "expr": [
-                "649.292 - 130 * sin(entryCorridorLo() * pi / 180)",
-                "130 * cos(entryCorridorLo() * pi / 180)",
-                "0"
-              ],
+              "expr": ["649.292 - 130 * sin(entryCorridorLo() * pi / 180)", "130 * cos(entryCorridorLo() * pi / 180)", "0"],
               "color": "#b8ffcc",
               "size": 5,
               "labelExpr": "concat('lo ', toFixed(entryCorridorLo(), 2), ' deg')",
@@ -1975,11 +810,7 @@
             {
               "type": "animated_point",
               "id": "corridor_hi_marker",
-              "expr": [
-                "649.292 - 130 * sin(entryCorridorHi() * pi / 180)",
-                "130 * cos(entryCorridorHi() * pi / 180)",
-                "0"
-              ],
+              "expr": ["649.292 - 130 * sin(entryCorridorHi() * pi / 180)", "130 * cos(entryCorridorHi() * pi / 180)", "0"],
               "color": "#b8ffcc",
               "size": 5,
               "labelExpr": "concat('hi ', toFixed(entryCorridorHi(), 2), ' deg')",
@@ -1988,11 +819,7 @@
             {
               "type": "animated_point",
               "id": "corridor_warning",
-              "expr": [
-                "620",
-                "145",
-                "0"
-              ],
+              "expr": ["620", "145", "0"],
               "color": "#ff8a80",
               "size": 6,
               "label": "No survivable corridor at this g-limit",
@@ -2001,16 +828,8 @@
             {
               "type": "animated_vector",
               "id": "entry_vector",
-              "fromExpr": [
-                "649.292 + 21 * sin(s2_gamma * pi / 180)",
-                "-21 * cos(s2_gamma * pi / 180)",
-                "0"
-              ],
-              "toExpr": [
-                "649.292",
-                "0",
-                "0"
-              ],
+              "fromExpr": ["649.292 + 21 * sin(s2_gamma * pi / 180)", "-21 * cos(s2_gamma * pi / 180)", "0"],
+              "toExpr": ["649.292", "0", "0"],
               "color": "#ffd166",
               "width": 0.5,
               "scale": 0.25,
@@ -2022,10 +841,7 @@
               "x": "entryX(t) / 10",
               "y": "entryY(t) / 10",
               "z": "0",
-              "range": [
-                0,
-                1500
-              ],
+              "range": [0, 1500],
               "samples": 420,
               "color": "#f6c453",
               "width": 1.5,
@@ -2034,11 +850,7 @@
             {
               "type": "animated_point",
               "id": "capsule_live",
-              "expr": [
-                "entryX(s2_t) / 10",
-                "entryY(s2_t) / 10",
-                "0"
-              ],
+              "expr": ["entryX(s2_t) / 10", "entryY(s2_t) / 10", "0"],
               "color": "#ffffff",
               "size": 11,
               "label": "Capsule"
@@ -2046,101 +858,36 @@
             {
               "type": "animated_vector",
               "id": "velocity_vector",
-              "fromExpr": [
-                "entryX(s2_t) / 10",
-                "entryY(s2_t) / 10",
-                "0"
-              ],
-              "toExpr": [
-                "entryX(s2_t) / 10 + 20 * entryVx(s2_t) / max(0.2, entrySpeed(s2_t))",
-                "entryY(s2_t) / 10 + 20 * entryVy(s2_t) / max(0.2, entrySpeed(s2_t))",
-                "0"
-              ],
+              "fromExpr": ["entryX(s2_t) / 10", "entryY(s2_t) / 10", "0"],
+              "toExpr": ["entryX(s2_t) / 10 + 20 * entryVx(s2_t) / max(0.2, entrySpeed(s2_t))", "entryY(s2_t) / 10 + 20 * entryVy(s2_t) / max(0.2, entrySpeed(s2_t))", "0"],
               "color": "#4db6ff",
               "width": 3,
               "scale": 0.75,
               "label": "$\\vec{v}$",
-              "labelOffset": [
-                0,
-                0,
-                5
-              ]
+              "labelOffset": [0, 0, 5]
             },
             {
               "type": "animated_vector",
               "id": "drag_vector",
-              "fromExpr": [
-                "entryX(s2_t) / 10",
-                "entryY(s2_t) / 10",
-                "0"
-              ],
-              "toExpr": [
-                "entryX(s2_t) / 10 - min(entryG(s2_t), 10) * 1.5 * entryVx(s2_t) / max(0.2, entrySpeed(s2_t))",
-                "entryY(s2_t) / 10 - min(entryG(s2_t), 10) * 1.5 * entryVy(s2_t) / max(0.2, entrySpeed(s2_t))",
-                "0"
-              ],
+              "fromExpr": ["entryX(s2_t) / 10", "entryY(s2_t) / 10", "0"],
+              "toExpr": ["entryX(s2_t) / 10 - min(entryG(s2_t), 10) * 1.5 * entryVx(s2_t) / max(0.2, entrySpeed(s2_t))", "entryY(s2_t) / 10 - min(entryG(s2_t), 10) * 1.5 * entryVy(s2_t) / max(0.2, entrySpeed(s2_t))", "0"],
               "color": "#ff6b5f",
               "width": 3,
               "scale": 0.75,
               "label": "$\\vec{D}$",
-              "labelOffset": [
-                0,
-                0,
-                -5
-              ]
+              "labelOffset": [0, 0, -5]
             }
           ],
           "remove": [],
           "sliders": [
-            {
-              "id": "s2_vehicle",
-              "label": "Vehicle (0:Dragon, 1:Gemini, 2:Apollo, 3:Orion)",
-              "min": 0,
-              "max": 3,
-              "default": 3,
-              "step": 1
-            },
-            {
-              "id": "s2_gamma",
-              "label": "$\\gamma$ (deg below horizontal)",
-              "min": 1,
-              "max": 12,
-              "default": 6.5,
-              "step": 0.1
-            },
-            {
-              "id": "s2_bank",
-              "label": "Bank Angle (deg)",
-              "min": -180,
-              "max": 180,
-              "default": 50,
-              "step": 1
-            },
-            {
-              "id": "s2_g_limit",
-              "label": "Corridor g-limit",
-              "min": 4,
-              "max": 12,
-              "default": 9,
-              "step": 0.5
-            },
-            {
-              "id": "s2_t",
-              "label": "Simulation Time t (s)",
-              "min": 0,
-              "max": 1500,
-              "default": 0,
-              "step": 1,
-              "animate": true,
-              "duration": 12000
-            }
+            {"id": "s2_vehicle", "label": "Vehicle (0:Dragon, 1:Gemini, 2:Apollo, 3:Orion)", "min": 0, "max": 3, "default": 3, "step": 1},
+            {"id": "s2_gamma", "label": "$\\gamma$ (deg below horizontal)", "min": 1, "max": 12, "default": 6.5, "step": 0.1},
+            {"id": "s2_bank", "label": "Bank Angle (deg)", "min": -180, "max": 180, "default": 50, "step": 1},
+            {"id": "s2_g_limit", "label": "Corridor g-limit", "min": 4, "max": 12, "default": 9, "step": 0.5},
+            {"id": "s2_t", "label": "Simulation Time t (s)", "min": 0, "max": 1500, "default": 0, "step": 1, "animate": true, "duration": 12000}
           ],
           "info": [
-            {
-              "id": "entry_info",
-              "position": "top-right",
-              "content": "### Simulated Entry State\n**Vehicle:** {{entryVehicleName()}}  \n**Mission:** {{entryVehicleMission()}}  \n**Entry speed:** {{toFixed(entryVehicleSpeed(), 2)}} km/s  \n**Estimated $\\beta$:** {{toFixed(entryVehicleBeta(), 1)}} kg/m$^2$  \n**Reference $L/D$:** {{toFixed(entryVehicleLD(), 2)}}\n\n**Computed corridor:** {{toFixed(entryCorridorLo(), 2)}}° to {{toFixed(entryCorridorHi(), 2)}}°  \n**Selected $\\gamma$:** {{toFixed(s2_gamma, 2)}}°  \n**Effective bank:** {{toFixed(s2_bank, 0)}}°  \n**Time:** {{toFixed(min(s2_t, entryEndTime()), 0)}} s\n\n**Altitude:** {{toFixed(entryAlt(s2_t), 1)}} km  \n**Speed:** {{toFixed(entrySpeed(s2_t), 2)}} km/s  \n**Current aero decel:** {{toFixed(entryG(s2_t), 2)}} g\n\n{{entryOutcome()}}"
-            }
+            {"id": "entry_info", "position": "top-right", "content": "### Simulated Entry State\n**Vehicle:** {{entryVehicleName()}}  \n**Mission:** {{entryVehicleMission()}}  \n**Entry speed:** {{toFixed(entryVehicleSpeed(), 2)}} km/s  \n**Estimated $\\beta$:** {{toFixed(entryVehicleBeta(), 1)}} kg/m$^2$  \n**Reference $L/D$:** {{toFixed(entryVehicleLD(), 2)}}\n\n**Computed corridor:** {{toFixed(entryCorridorLo(), 2)}}° to {{toFixed(entryCorridorHi(), 2)}}°  \n**Selected $\\gamma$:** {{toFixed(s2_gamma, 2)}}°  \n**Effective bank:** {{toFixed(s2_bank, 0)}}°  \n**Time:** {{toFixed(min(s2_t, entryEndTime()), 0)}} s\n\n**Altitude:** {{toFixed(entryAlt(s2_t), 1)}} km  \n**Speed:** {{toFixed(entrySpeed(s2_t), 2)}} km/s  \n**Current aero decel:** {{toFixed(entryG(s2_t), 2)}} g\n\n{{entryOutcome()}}"}
           ]
         },
         {
@@ -2152,16 +899,8 @@
               "type": "line",
               "id": "g_graph_x",
               "points": [
-                [
-                  660,
-                  60,
-                  0
-                ],
-                [
-                  660,
-                  -60,
-                  0
-                ]
+                [660, 60, 0],
+                [660, -60, 0]
               ],
               "color": "#ffffff",
               "width": 1.5,
@@ -2171,16 +910,8 @@
               "type": "line",
               "id": "g_graph_y",
               "points": [
-                [
-                  660,
-                  60,
-                  0
-                ],
-                [
-                  780,
-                  60,
-                  0
-                ]
+                [660, 60, 0],
+                [780, 60, 0]
               ],
               "color": "#ffffff",
               "width": 1.5,
@@ -2190,16 +921,8 @@
               "type": "animated_line",
               "id": "g_limit_line",
               "points": [
-                [
-                  "660 + 10 * s2_g_limit",
-                  "60",
-                  "0"
-                ],
-                [
-                  "660 + 10 * s2_g_limit",
-                  "-60",
-                  "0"
-                ]
+                ["660 + 10 * s2_g_limit", "60", "0"],
+                ["660 + 10 * s2_g_limit", "-60", "0"]
               ],
               "color": "#2ecc71",
               "width": 1.5,
@@ -2208,11 +931,7 @@
             {
               "type": "animated_point",
               "id": "g_limit_marker",
-              "expr": [
-                "660 + 10 * s2_g_limit",
-                "60",
-                "0"
-              ],
+              "expr": ["660 + 10 * s2_g_limit", "60", "0"],
               "color": "#2ecc71",
               "size": 4,
               "labelExpr": "concat(toFixed(s2_g_limit, 1), ' g')"
@@ -2223,10 +942,7 @@
               "x": "660 + 10 * entryG(t)",
               "y": "60 - 120 * t / 1500",
               "z": "0",
-              "range": [
-                0,
-                1500
-              ],
+              "range": [0, 1500],
               "samples": 420,
               "color": "#ff6b5f",
               "width": 3,
@@ -2235,28 +951,16 @@
             {
               "type": "animated_point",
               "id": "g_marker",
-              "expr": [
-                "660 + 10 * entryG(s2_t)",
-                "60 - 120 * min(s2_t, entryEndTime()) / 1500",
-                "0"
-              ],
+              "expr": ["660 + 10 * entryG(s2_t)", "60 - 120 * min(s2_t, entryEndTime()) / 1500", "0"],
               "color": "#ff6b5f",
               "radius": 2,
               "labelExpr": "concat(toFixed(entryG(s2_t), 1), ' g')",
-              "labelOffset": [
-                5,
-                5,
-                0
-              ]
+              "labelOffset": [5, 5, 0]
             },
             {
               "type": "animated_point",
               "id": "g_peak",
-              "expr": [
-                "660 + 10 * entryPeakG()",
-                "60 - 120 * entryPeakGT() / 1500",
-                "0"
-              ],
+              "expr": ["660 + 10 * entryPeakG()", "60 - 120 * entryPeakGT() / 1500", "0"],
               "color": "#ffd166",
               "size": 8,
               "labelExpr": "concat('peak: ', toFixed(entryPeakG(), 1), ' g')"
@@ -2265,77 +969,49 @@
               "type": "text",
               "id": "g_axis_title",
               "text": "Aero decel vs time",
-              "position": [
-                720,
-                76,
-                0
-              ],
+              "position": [720, 76, 0],
               "color": "#ffffff"
             },
             {
               "type": "text",
               "id": "g_x0",
               "text": "0 s",
-              "position": [
-                652,
-                60,
-                0
-              ],
+              "position": [652, 60, 0],
               "color": "#cccccc"
             },
             {
               "type": "text",
               "id": "g_x1",
               "text": "750 s",
-              "position": [
-                652,
-                0,
-                0
-              ],
+              "position": [652, 0, 0],
               "color": "#cccccc"
             },
             {
               "type": "text",
               "id": "g_x2",
               "text": "1500 s",
-              "position": [
-                652,
-                -60,
-                0
-              ],
+              "position": [652, -60, 0],
               "color": "#cccccc"
             },
             {
               "type": "text",
               "id": "g_y0",
               "text": "0 g",
-              "position": [
-                660,
-                66,
-                0
-              ],
+              "position": [660, 66, 0],
               "color": "#cccccc"
             },
             {
               "type": "text",
               "id": "g_y1",
               "text": "6 g",
-              "position": [
-                720,
-                66,
-                0
-              ],
+              "position": [720, 66, 0],
               "color": "#cccccc"
             },
             {
               "type": "text",
               "id": "g_y2",
               "text": "12 g",
-              "position": [
-                780,
-                66,
-                0
-              ],
+              "position": [780, 66, 0],
               "color": "#cccccc"
             },
             {
@@ -2344,10 +1020,7 @@
               "x": "660 + 10 * entrySpeed(t)",
               "y": "60 - 120 * t / 1500",
               "z": "0",
-              "range": [
-                0,
-                1500
-              ],
+              "range": [0, 1500],
               "samples": 420,
               "color": "#4db6ff",
               "width": 2,
@@ -2356,28 +1029,16 @@
             {
               "type": "animated_point",
               "id": "speed_marker",
-              "expr": [
-                "660 + 10 * entrySpeed(s2_t)",
-                "60 - 120 * min(s2_t, entryEndTime()) / 1500",
-                "0"
-              ],
+              "expr": ["660 + 10 * entrySpeed(s2_t)", "60 - 120 * min(s2_t, entryEndTime()) / 1500", "0"],
               "color": "#4db6ff",
               "radius": 2,
               "labelExpr": "concat(toFixed(entrySpeed(s2_t), 1), ' km/s')",
-              "labelOffset": [
-                5,
-                5,
-                0
-              ]
+              "labelOffset": [5, 5, 0]
             },
             {
               "type": "animated_point",
               "id": "outcome_label",
-              "expr": [
-                "720",
-                "-50",
-                "0"
-              ],
+              "expr": ["720", "-50", "0"],
               "color": "#ffd166",
               "size": 0,
               "labelExpr": "entryOutcome()"
@@ -2385,21 +1046,10 @@
           ],
           "remove": [],
           "info": [
-            {
-              "id": "g_history_info",
-              "position": "top-left",
-              "content": "### Entry Summary\n**Vehicle:** {{entryVehicleName()}} ({{entryVehicleMission()}})\n**Peak aero decel:** {{toFixed(entryPeakG(), 2)}} g at {{toFixed(entryPeakGT(), 0)}} s  \n**Peak heating index:** {{toFixed(entryPeakHeat(), 2)}} at {{toFixed(entryPeakHeatT(), 0)}} s  \n**Minimum altitude reached:** {{toFixed(entryMinAlt(), 1)}} km  \n**Parachute deployment altitude:** {{toFixed(entryChuteAlt(), 2)}} km  \n**Simulation end:** {{toFixed(entryEndTime(), 0)}} s\n\nThe green line is the corridor threshold chosen for this lesson. Angles steeper than the upper corridor bound reach the chute window too harshly; angles shallower than the lower bound skip out before getting there."
-            }
+            {"id": "g_history_info", "position": "top-left", "content": "### Entry Summary\n**Vehicle:** {{entryVehicleName()}} ({{entryVehicleMission()}})\n**Peak aero decel:** {{toFixed(entryPeakG(), 2)}} g at {{toFixed(entryPeakGT(), 0)}} s  \n**Peak heating index:** {{toFixed(entryPeakHeat(), 2)}} at {{toFixed(entryPeakHeatT(), 0)}} s  \n**Minimum altitude reached:** {{toFixed(entryMinAlt(), 1)}} km  \n**Parachute deployment altitude:** {{toFixed(entryChuteAlt(), 2)}} km  \n**Simulation end:** {{toFixed(entryEndTime(), 0)}} s\n\nThe green line is the corridor threshold chosen for this lesson. Angles steeper than the upper corridor bound reach the chute window too harshly; angles shallower than the lower bound skip out before getting there."}
           ],
           "sliders": [
-            {
-              "id": "s2_vehicle",
-              "label": "Vehicle (0:Dragon, 1:Gemini, 2:Apollo, 3:Orion)",
-              "min": 0,
-              "max": 3,
-              "default": 3,
-              "step": 1
-            }
+            {"id": "s2_vehicle", "label": "Vehicle (0:Dragon, 1:Gemini, 2:Apollo, 3:Orion)", "min": 0, "max": 3, "default": 3, "step": 1}
           ]
         }
       ],
@@ -2412,15 +1062,7 @@
           "prompt": "Walk through the physical forces acting on a capsule during entry. Build up from gravity alone, add drag, then lift. Emphasize that this ODE is what the simulation integrates numerically.",
           "sceneStep": 0,
           "steps": [
-            {
-              "type": "given",
-              "label": "Planet-Centered Coordinates",
-              "math": "\\mathbf{r} = (x, y), \\quad r = \\|\\mathbf{r}\\| = \\sqrt{x^2 + y^2}",
-              "justification": "Position vector in the 2D entry plane, measured from the planet center.",
-              "explanation": "We work in a plane containing the entry trajectory. The altitude above the surface is $h = r - R_p$ where $R_p$ is the planet radius.",
-              "prompt": "Relate the math to the 3D view: the Earth sphere has radius $R_p = 6371\\,\\text{km}$, and $r$ is measured from the center.",
-              "sceneStep": 0
-            },
+            {"type": "given", "label": "Planet-Centered Coordinates", "math": "\\mathbf{r} = (x, y), \\quad r = \\|\\mathbf{r}\\| = \\sqrt{x^2 + y^2}", "justification": "Position vector in the 2D entry plane, measured from the planet center.", "explanation": "We work in a plane containing the entry trajectory. The altitude above the surface is $h = r - R_p$ where $R_p$ is the planet radius.", "prompt": "Relate the math to the 3D view: the Earth sphere has radius $R_p = 6371\\,\\text{km}$, and $r$ is measured from the center.", "sceneStep": 0},
             {
               "type": "given",
               "label": "Gravitational Acceleration",
@@ -2432,87 +1074,24 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "a_g = -\\frac{\\mu}{r^3}r"
-                    },
-                    {
-                      "id": "a_{g}",
-                      "type": "scalar",
-                      "latex": "a_{g}",
-                      "subexpr": "a_{g}"
-                    },
-                    {
-                      "id": "__negation_2",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-r \\frac{1}{r^{3}} \\mu"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "r \\frac{1}{r^{3}} \\mu"
-                    },
-                    {
-                      "id": "mu",
-                      "type": "scalar",
-                      "latex": "\\mu",
-                      "subexpr": "\\mu"
-                    },
-                    {
-                      "id": "r",
-                      "type": "scalar",
-                      "latex": "r",
-                      "subexpr": "r"
-                    },
-                    {
-                      "id": "__power_4",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "-3",
-                      "subexpr": "\\frac{1}{r^{3}}"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "a_g = -\\frac{\\mu}{r^3}r"},
+                    {"id": "a_{g}", "type": "scalar", "latex": "a_{g}", "subexpr": "a_{g}"},
+                    {"id": "__negation_2", "type": "operator", "op": "negation", "subexpr": "-r \\frac{1}{r^{3}} \\mu"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "r \\frac{1}{r^{3}} \\mu"},
+                    {"id": "mu", "type": "scalar", "latex": "\\mu", "subexpr": "\\mu"},
+                    {"id": "r", "type": "scalar", "latex": "r", "subexpr": "r"},
+                    {"id": "__power_4", "type": "operator", "op": "power", "exponent": "-3", "subexpr": "\\frac{1}{r^{3}}"}
                   ],
                   "edges": [
-                    {
-                      "from": "a_{g}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "mu",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "r",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "r",
-                      "to": "__power_4"
-                    },
-                    {
-                      "from": "__power_4",
-                      "to": "__multiply_3"
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__negation_2"
-                    },
-                    {
-                      "from": "__negation_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "a_{g}", "to": "__equals_1"},
+                    {"from": "mu", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "r", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "r", "to": "__power_4"},
+                    {"from": "__power_4", "to": "__multiply_3"},
+                    {"from": "__multiply_3", "to": "__negation_2"},
+                    {"from": "__negation_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -2527,135 +1106,32 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\rho(h) = \\rho_0\\, e^{-h/H}",
-                      "description": "the exponential atmosphere model",
-                      "color": "green",
-                      "highlight": "result"
-                    },
-                    {
-                      "id": "__rho_2",
-                      "type": "function",
-                      "latex": "\\rho",
-                      "op": "rho",
-                      "subexpr": "\\rho{\\left(h \\right)}"
-                    },
-                    {
-                      "id": "h",
-                      "type": "scalar",
-                      "latex": "h",
-                      "subexpr": "h"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0}"
-                    },
-                    {
-                      "id": "rho_{0}",
-                      "type": "scalar",
-                      "latex": "\\rho_{0}",
-                      "subexpr": "\\rho_{0}"
-                    },
-                    {
-                      "id": "__power_4",
-                      "type": "operator",
-                      "op": "power",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"
-                    },
-                    {
-                      "id": "e",
-                      "type": "scalar",
-                      "latex": "e",
-                      "subexpr": "e"
-                    },
-                    {
-                      "id": "__multiply_5",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{H} -h"
-                    },
-                    {
-                      "id": "__negation_6",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-h"
-                    },
-                    {
-                      "id": "__power_7",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{H}"
-                    },
-                    {
-                      "id": "H",
-                      "type": "scalar",
-                      "latex": "H",
-                      "subexpr": "H"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\rho(h) = \\rho_0\\, e^{-h/H}", "description": "the exponential atmosphere model", "color": "green", "highlight": "result"},
+                    {"id": "__rho_2", "type": "function", "latex": "\\rho", "op": "rho", "subexpr": "\\rho{\\left(h \\right)}"},
+                    {"id": "h", "type": "scalar", "latex": "h", "subexpr": "h"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0}"},
+                    {"id": "rho_{0}", "type": "scalar", "latex": "\\rho_{0}", "subexpr": "\\rho_{0}"},
+                    {"id": "__power_4", "type": "operator", "op": "power", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{H} -h"},
+                    {"id": "__negation_6", "type": "operator", "op": "negation", "subexpr": "-h"},
+                    {"id": "__power_7", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{H}"},
+                    {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"}
                   ],
                   "edges": [
-                    {
-                      "from": "h",
-                      "to": "__rho_2"
-                    },
-                    {
-                      "from": "__rho_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "rho_{0}",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "e",
-                      "to": "__power_4"
-                    },
-                    {
-                      "from": "h",
-                      "to": "__negation_6"
-                    },
-                    {
-                      "from": "__negation_6",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__power_7"
-                    },
-                    {
-                      "from": "__power_7",
-                      "to": "__multiply_5"
-                    },
-                    {
-                      "from": "__multiply_5",
-                      "to": "__power_4",
-                      "role": "exp"
-                    },
-                    {
-                      "from": "__power_4",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__equals_1"
-                    }
+                    {"from": "h", "to": "__rho_2"},
+                    {"from": "__rho_2", "to": "__equals_1"},
+                    {"from": "rho_{0}", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "e", "to": "__power_4"},
+                    {"from": "h", "to": "__negation_6"},
+                    {"from": "__negation_6", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__power_7"},
+                    {"from": "__power_7", "to": "__multiply_5"},
+                    {"from": "__multiply_5", "to": "__power_4", "role": "exp"},
+                    {"from": "__power_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_3", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -2670,222 +1146,51 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "a_{D}",
-                      "type": "scalar",
-                      "latex": "a_{D}",
-                      "subexpr": "a_D"
-                    },
-                    {
-                      "id": "s1___negation_1",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-\\frac{1}{2m}\\rho \\hat{V}^2 C_d A\\,\\hat{V}"
-                    },
-                    {
-                      "id": "s1___multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho \\hat{V}^{3} A C_{d} \\frac{1}{m} \\frac{1}{2}"
-                    },
-                    {
-                      "id": "A",
-                      "type": "scalar",
-                      "latex": "A",
-                      "subexpr": "A"
-                    },
-                    {
-                      "id": "C_{d}",
-                      "type": "scalar",
-                      "latex": "C_{d}",
-                      "subexpr": "C_{d}"
-                    },
-                    {
-                      "id": "rho",
-                      "type": "scalar",
-                      "latex": "\\rho",
-                      "subexpr": "\\rho"
-                    },
-                    {
-                      "id": "s1___power_3",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "3",
-                      "subexpr": "\\hat{V}^{3}"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "\\hat{V}",
-                      "subexpr": "\\hat{V}"
-                    },
-                    {
-                      "id": "s1___multiply_4",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{m} \\frac{1}{2}"
-                    },
-                    {
-                      "id": "s1___num_5",
-                      "type": "number",
-                      "label": "1/2",
-                      "subexpr": "\\frac{1}{2}"
-                    },
-                    {
-                      "id": "s1___power_6",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{m}"
-                    },
-                    {
-                      "id": "m",
-                      "type": "scalar",
-                      "latex": "m",
-                      "subexpr": "m"
-                    },
-                    {
-                      "id": "s2___negation_1",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-\\frac{\\rho V}{2\\beta}V"
-                    },
-                    {
-                      "id": "s2___multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho V^{2} \\frac{1}{\\beta} \\frac{1}{2}"
-                    },
-                    {
-                      "id": "s2___power_3",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V^{2}"
-                    },
-                    {
-                      "id": "s2___multiply_4",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{\\beta} \\frac{1}{2}"
-                    },
-                    {
-                      "id": "s2___num_5",
-                      "type": "number",
-                      "label": "1/2",
-                      "subexpr": "\\frac{1}{2}"
-                    },
-                    {
-                      "id": "s2___power_6",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\beta}"
-                    },
-                    {
-                      "id": "beta",
-                      "type": "scalar",
-                      "latex": "\\beta",
-                      "subexpr": "\\beta"
-                    },
-                    {
-                      "id": "__equals_1",
-                      "type": "operator",
-                      "op": "equals",
-                      "subexpr": "\\mathbf{a}_D = -\\frac{1}{2m}\\rho V^2 C_d A\\,\\hat{V} = -\\frac{\\rho V}{2\\beta}\\mathbf{V}"
-                    }
+                    {"id": "a_{D}", "type": "scalar", "latex": "a_{D}", "subexpr": "a_D"},
+                    {"id": "s1___negation_1", "type": "operator", "op": "negation", "subexpr": "-\\frac{1}{2m}\\rho \\hat{V}^2 C_d A\\,\\hat{V}"},
+                    {"id": "s1___multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\rho \\hat{V}^{3} A C_{d} \\frac{1}{m} \\frac{1}{2}"},
+                    {"id": "A", "type": "scalar", "latex": "A", "subexpr": "A"},
+                    {"id": "C_{d}", "type": "scalar", "latex": "C_{d}", "subexpr": "C_{d}"},
+                    {"id": "rho", "type": "scalar", "latex": "\\rho", "subexpr": "\\rho"},
+                    {"id": "s1___power_3", "type": "operator", "op": "power", "exponent": "3", "subexpr": "\\hat{V}^{3}"},
+                    {"id": "V", "type": "scalar", "latex": "\\hat{V}", "subexpr": "\\hat{V}"},
+                    {"id": "s1___multiply_4", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{m} \\frac{1}{2}"},
+                    {"id": "s1___num_5", "type": "number", "label": "1/2", "subexpr": "\\frac{1}{2}"},
+                    {"id": "s1___power_6", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{m}"},
+                    {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m"},
+                    {"id": "s2___negation_1", "type": "operator", "op": "negation", "subexpr": "-\\frac{\\rho V}{2\\beta}V"},
+                    {"id": "s2___multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\rho V^{2} \\frac{1}{\\beta} \\frac{1}{2}"},
+                    {"id": "s2___power_3", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V^{2}"},
+                    {"id": "s2___multiply_4", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{\\beta} \\frac{1}{2}"},
+                    {"id": "s2___num_5", "type": "number", "label": "1/2", "subexpr": "\\frac{1}{2}"},
+                    {"id": "s2___power_6", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\beta}"},
+                    {"id": "beta", "type": "scalar", "latex": "\\beta", "subexpr": "\\beta"},
+                    {"id": "__equals_1", "type": "operator", "op": "equals", "subexpr": "\\mathbf{a}_D = -\\frac{1}{2m}\\rho V^2 C_d A\\,\\hat{V} = -\\frac{\\rho V}{2\\beta}\\mathbf{V}"}
                   ],
                   "edges": [
-                    {
-                      "from": "A",
-                      "to": "s1___multiply_2"
-                    },
-                    {
-                      "from": "C_{d}",
-                      "to": "s1___multiply_2"
-                    },
-                    {
-                      "from": "rho",
-                      "to": "s1___multiply_2"
-                    },
-                    {
-                      "from": "V",
-                      "to": "s1___power_3"
-                    },
-                    {
-                      "from": "s1___power_3",
-                      "to": "s1___multiply_2"
-                    },
-                    {
-                      "from": "s1___num_5",
-                      "to": "s1___multiply_4"
-                    },
-                    {
-                      "from": "m",
-                      "to": "s1___power_6"
-                    },
-                    {
-                      "from": "s1___power_6",
-                      "to": "s1___multiply_4"
-                    },
-                    {
-                      "from": "s1___multiply_4",
-                      "to": "s1___multiply_2"
-                    },
-                    {
-                      "from": "s1___multiply_2",
-                      "to": "s1___negation_1"
-                    },
-                    {
-                      "from": "rho",
-                      "to": "s2___multiply_2"
-                    },
-                    {
-                      "from": "V",
-                      "to": "s2___power_3"
-                    },
-                    {
-                      "from": "s2___power_3",
-                      "to": "s2___multiply_2"
-                    },
-                    {
-                      "from": "s2___num_5",
-                      "to": "s2___multiply_4"
-                    },
-                    {
-                      "from": "beta",
-                      "to": "s2___power_6"
-                    },
-                    {
-                      "from": "s2___power_6",
-                      "to": "s2___multiply_4"
-                    },
-                    {
-                      "from": "s2___multiply_4",
-                      "to": "s2___multiply_2"
-                    },
-                    {
-                      "from": "s2___multiply_2",
-                      "to": "s2___negation_1"
-                    },
-                    {
-                      "from": "a_{D}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "s1___negation_1",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "s2___negation_1",
-                      "to": "__equals_1"
-                    }
+                    {"from": "A", "to": "s1___multiply_2"},
+                    {"from": "C_{d}", "to": "s1___multiply_2"},
+                    {"from": "rho", "to": "s1___multiply_2"},
+                    {"from": "V", "to": "s1___power_3"},
+                    {"from": "s1___power_3", "to": "s1___multiply_2"},
+                    {"from": "s1___num_5", "to": "s1___multiply_4"},
+                    {"from": "m", "to": "s1___power_6"},
+                    {"from": "s1___power_6", "to": "s1___multiply_4"},
+                    {"from": "s1___multiply_4", "to": "s1___multiply_2"},
+                    {"from": "s1___multiply_2", "to": "s1___negation_1"},
+                    {"from": "rho", "to": "s2___multiply_2"},
+                    {"from": "V", "to": "s2___power_3"},
+                    {"from": "s2___power_3", "to": "s2___multiply_2"},
+                    {"from": "s2___num_5", "to": "s2___multiply_4"},
+                    {"from": "beta", "to": "s2___power_6"},
+                    {"from": "s2___power_6", "to": "s2___multiply_4"},
+                    {"from": "s2___multiply_4", "to": "s2___multiply_2"},
+                    {"from": "s2___multiply_2", "to": "s2___negation_1"},
+                    {"from": "a_{D}", "to": "__equals_1"},
+                    {"from": "s1___negation_1", "to": "__equals_1"},
+                    {"from": "s2___negation_1", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -2900,167 +1205,39 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "a_L = \\frac{L}{D}\\cos\\phi \\cdot a_D \\cdot \\hat{n}"
-                    },
-                    {
-                      "id": "a_{L}",
-                      "type": "scalar",
-                      "latex": "a_{L}",
-                      "subexpr": "a_{L}"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "L \\frac{1}{D} \\cos{\\left(\\hat{n} a_{D} \\phi \\right)}"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "L \\frac{1}{D}"
-                    },
-                    {
-                      "id": "L",
-                      "type": "scalar",
-                      "latex": "L",
-                      "subexpr": "L"
-                    },
-                    {
-                      "id": "__power_4",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{D}"
-                    },
-                    {
-                      "id": "D",
-                      "type": "scalar",
-                      "latex": "D",
-                      "subexpr": "D"
-                    },
-                    {
-                      "id": "__cos_5",
-                      "type": "function",
-                      "latex": "\\cos",
-                      "op": "cos",
-                      "subexpr": "\\cos{\\left(\\hat{n} a_{D} \\phi \\right)}"
-                    },
-                    {
-                      "id": "__multiply_6",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\hat{n} \\phi a_{D}"
-                    },
-                    {
-                      "id": "__multiply_7",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\phi a_{D}"
-                    },
-                    {
-                      "id": "phi",
-                      "type": "scalar",
-                      "latex": "\\phi",
-                      "subexpr": "\\phi"
-                    },
-                    {
-                      "id": "a_{D}",
-                      "type": "scalar",
-                      "latex": "a_{D}",
-                      "subexpr": "a_{D}"
-                    },
-                    {
-                      "id": "n",
-                      "type": "scalar",
-                      "latex": "\\hat{n}",
-                      "subexpr": "\\hat{n}"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "a_L = \\frac{L}{D}\\cos\\phi \\cdot a_D \\cdot \\hat{n}"},
+                    {"id": "a_{L}", "type": "scalar", "latex": "a_{L}", "subexpr": "a_{L}"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "L \\frac{1}{D} \\cos{\\left(\\hat{n} a_{D} \\phi \\right)}"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "L \\frac{1}{D}"},
+                    {"id": "L", "type": "scalar", "latex": "L", "subexpr": "L"},
+                    {"id": "__power_4", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{D}"},
+                    {"id": "D", "type": "scalar", "latex": "D", "subexpr": "D"},
+                    {"id": "__cos_5", "type": "function", "latex": "\\cos", "op": "cos", "subexpr": "\\cos{\\left(\\hat{n} a_{D} \\phi \\right)}"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "\\hat{n} \\phi a_{D}"},
+                    {"id": "__multiply_7", "type": "operator", "op": "multiply", "subexpr": "\\phi a_{D}"},
+                    {"id": "phi", "type": "scalar", "latex": "\\phi", "subexpr": "\\phi"},
+                    {"id": "a_{D}", "type": "scalar", "latex": "a_{D}", "subexpr": "a_{D}"},
+                    {"id": "n", "type": "scalar", "latex": "\\hat{n}", "subexpr": "\\hat{n}"}
                   ],
                   "edges": [
-                    {
-                      "from": "a_{L}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "L",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "D",
-                      "to": "__power_4"
-                    },
-                    {
-                      "from": "__power_4",
-                      "to": "__multiply_3"
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "phi",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "a_{D}",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_7",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "n",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_6",
-                      "to": "__cos_5"
-                    },
-                    {
-                      "from": "__cos_5",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "a_{L}", "to": "__equals_1"},
+                    {"from": "L", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "D", "to": "__power_4"},
+                    {"from": "__power_4", "to": "__multiply_3"},
+                    {"from": "__multiply_3", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "phi", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "a_{D}", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_7", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "n", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_6", "to": "__cos_5"},
+                    {"from": "__cos_5", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
-            {
-              "type": "step",
-              "label": "Upward Normal Vector",
-              "math": "\\hat{n} = \\frac{1}{V}\\begin{pmatrix} -v_y \\\\ v_x \\end{pmatrix}, \\quad \\text{chosen so } \\hat{n} \\cdot \\hat{r} > 0",
-              "justification": "Rotate the velocity vector $90°$ and pick the direction pointing away from the planet.",
-              "explanation": "There are two perpendicular directions to any velocity vector. We choose the one that has a positive component along the radial (outward) direction, so that positive lift pushes the capsule away from the planet.",
-              "prompt": "Explain the sign choice: if we picked the wrong perpendicular, 'lift' would push the capsule toward the ground.",
-              "sceneStep": 0
-            },
+            {"type": "step", "label": "Upward Normal Vector", "math": "\\hat{n} = \\frac{1}{V}\\begin{pmatrix} -v_y \\\\ v_x \\end{pmatrix}, \\quad \\text{chosen so } \\hat{n} \\cdot \\hat{r} > 0", "justification": "Rotate the velocity vector $90°$ and pick the direction pointing away from the planet.", "explanation": "There are two perpendicular directions to any velocity vector. We choose the one that has a positive component along the radial (outward) direction, so that positive lift pushes the capsule away from the planet.", "prompt": "Explain the sign choice: if we picked the wrong perpendicular, 'lift' would push the capsule toward the ground.", "sceneStep": 0},
             {
               "type": "conclusion",
               "label": "Full Equation of Motion",
@@ -3070,462 +1247,97 @@
               "prompt": "Emphasize: this one equation generates every trajectory you see in the visualization. Changing the vehicle changes $\\beta$ and $L/D$. Changing $\\gamma$ changes the initial velocity direction. Changing bank angle changes $\\cos\\phi$.",
               "sceneStep": 0,
               "highlights": {
-                "eom": {
-                  "color": "cyan",
-                  "label": "Complete entry dynamics equation"
-                }
+                "eom": {"color": "cyan", "label": "Complete entry dynamics equation"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\frac{d}{d t} \\frac{d}{d t} r = -\\frac{\\mu}{r^3}r - \\frac{\\rho V}{2\\beta}V + \\frac{L}{D}\\cos\\phi\\cdot\\frac{\\rho V^2}{2\\beta}\\hat{n}"
-                    },
-                    {
-                      "id": "r",
-                      "type": "scalar",
-                      "latex": "r",
-                      "subexpr": "r"
-                    },
-                    {
-                      "id": "t",
-                      "type": "scalar",
-                      "latex": "t",
-                      "subexpr": "t"
-                    },
-                    {
-                      "id": "__deriv_2",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t",
-                      "subexpr": "\\frac{d^{2}}{d t^{2}} r"
-                    },
-                    {
-                      "id": "__add_3",
-                      "type": "operator",
-                      "op": "add",
-                      "subexpr": "L \\frac{1}{D} \\cos{\\left(\\phi \\hat{n} \\frac{V^{2} \\rho}{2 \\beta} \\right)} - V \\rho V \\frac{1}{2 \\beta} - r \\frac{1}{r^{3}} \\mu"
-                    },
-                    {
-                      "id": "__add_4",
-                      "type": "operator",
-                      "op": "add",
-                      "subexpr": "-V \\rho V \\frac{1}{2 \\beta} - r \\frac{1}{r^{3}} \\mu"
-                    },
-                    {
-                      "id": "__negation_5",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-r \\frac{1}{r^{3}} \\mu"
-                    },
-                    {
-                      "id": "__multiply_6",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "r \\frac{1}{r^{3}} \\mu"
-                    },
-                    {
-                      "id": "mu",
-                      "type": "scalar",
-                      "latex": "\\mu",
-                      "subexpr": "\\mu"
-                    },
-                    {
-                      "id": "__power_7",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "-3",
-                      "subexpr": "\\frac{1}{r^{3}}"
-                    },
-                    {
-                      "id": "__negation_8",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-V \\rho V \\frac{1}{2 \\beta}"
-                    },
-                    {
-                      "id": "__multiply_9",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V \\rho V \\frac{1}{2 \\beta}"
-                    },
-                    {
-                      "id": "__multiply_10",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho V \\frac{1}{2 \\beta}"
-                    },
-                    {
-                      "id": "__multiply_11",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho V"
-                    },
-                    {
-                      "id": "rho",
-                      "type": "scalar",
-                      "latex": "\\rho",
-                      "subexpr": "\\rho"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    },
-                    {
-                      "id": "__power_12",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2 \\beta}"
-                    },
-                    {
-                      "id": "__multiply_13",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\beta 2"
-                    },
-                    {
-                      "id": "__num_14",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "beta",
-                      "type": "scalar",
-                      "latex": "\\beta",
-                      "subexpr": "\\beta"
-                    },
-                    {
-                      "id": "__multiply_15",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "L \\frac{1}{D} \\cos{\\left(\\phi \\hat{n} \\frac{V^{2} \\rho}{2 \\beta} \\right)}"
-                    },
-                    {
-                      "id": "__multiply_16",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "L \\frac{1}{D}"
-                    },
-                    {
-                      "id": "L",
-                      "type": "scalar",
-                      "latex": "L",
-                      "subexpr": "L"
-                    },
-                    {
-                      "id": "__power_17",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{D}"
-                    },
-                    {
-                      "id": "D",
-                      "type": "scalar",
-                      "latex": "D",
-                      "subexpr": "D"
-                    },
-                    {
-                      "id": "__cos_18",
-                      "type": "function",
-                      "latex": "\\cos",
-                      "op": "cos",
-                      "subexpr": "\\cos{\\left(\\phi \\hat{n} \\frac{V^{2} \\rho}{2 \\beta} \\right)}"
-                    },
-                    {
-                      "id": "__multiply_19",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\phi \\hat{n} \\rho V^{2} \\frac{1}{2 \\beta}"
-                    },
-                    {
-                      "id": "phi",
-                      "type": "scalar",
-                      "latex": "\\phi",
-                      "subexpr": "\\phi"
-                    },
-                    {
-                      "id": "__multiply_20",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\hat{n} \\rho V^{2} \\frac{1}{2 \\beta}"
-                    },
-                    {
-                      "id": "__multiply_21",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho V^{2} \\frac{1}{2 \\beta}"
-                    },
-                    {
-                      "id": "__multiply_22",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho V^{2}"
-                    },
-                    {
-                      "id": "__power_23",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V^{2}"
-                    },
-                    {
-                      "id": "__power_24",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2 \\beta}"
-                    },
-                    {
-                      "id": "__multiply_25",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\beta 2"
-                    },
-                    {
-                      "id": "__num_26",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "n",
-                      "type": "scalar",
-                      "latex": "\\hat{n}",
-                      "subexpr": "\\hat{n}"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\frac{d}{d t} \\frac{d}{d t} r = -\\frac{\\mu}{r^3}r - \\frac{\\rho V}{2\\beta}V + \\frac{L}{D}\\cos\\phi\\cdot\\frac{\\rho V^2}{2\\beta}\\hat{n}"},
+                    {"id": "r", "type": "scalar", "latex": "r", "subexpr": "r"},
+                    {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                    {"id": "__deriv_2", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\frac{d^{2}}{d t^{2}} r"},
+                    {"id": "__add_3", "type": "operator", "op": "add", "subexpr": "L \\frac{1}{D} \\cos{\\left(\\phi \\hat{n} \\frac{V^{2} \\rho}{2 \\beta} \\right)} - V \\rho V \\frac{1}{2 \\beta} - r \\frac{1}{r^{3}} \\mu"},
+                    {"id": "__add_4", "type": "operator", "op": "add", "subexpr": "-V \\rho V \\frac{1}{2 \\beta} - r \\frac{1}{r^{3}} \\mu"},
+                    {"id": "__negation_5", "type": "operator", "op": "negation", "subexpr": "-r \\frac{1}{r^{3}} \\mu"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "r \\frac{1}{r^{3}} \\mu"},
+                    {"id": "mu", "type": "scalar", "latex": "\\mu", "subexpr": "\\mu"},
+                    {"id": "__power_7", "type": "operator", "op": "power", "exponent": "-3", "subexpr": "\\frac{1}{r^{3}}"},
+                    {"id": "__negation_8", "type": "operator", "op": "negation", "subexpr": "-V \\rho V \\frac{1}{2 \\beta}"},
+                    {"id": "__multiply_9", "type": "operator", "op": "multiply", "subexpr": "V \\rho V \\frac{1}{2 \\beta}"},
+                    {"id": "__multiply_10", "type": "operator", "op": "multiply", "subexpr": "\\rho V \\frac{1}{2 \\beta}"},
+                    {"id": "__multiply_11", "type": "operator", "op": "multiply", "subexpr": "\\rho V"},
+                    {"id": "rho", "type": "scalar", "latex": "\\rho", "subexpr": "\\rho"},
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"},
+                    {"id": "__power_12", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2 \\beta}"},
+                    {"id": "__multiply_13", "type": "operator", "op": "multiply", "subexpr": "\\beta 2"},
+                    {"id": "__num_14", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "beta", "type": "scalar", "latex": "\\beta", "subexpr": "\\beta"},
+                    {"id": "__multiply_15", "type": "operator", "op": "multiply", "subexpr": "L \\frac{1}{D} \\cos{\\left(\\phi \\hat{n} \\frac{V^{2} \\rho}{2 \\beta} \\right)}"},
+                    {"id": "__multiply_16", "type": "operator", "op": "multiply", "subexpr": "L \\frac{1}{D}"},
+                    {"id": "L", "type": "scalar", "latex": "L", "subexpr": "L"},
+                    {"id": "__power_17", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{D}"},
+                    {"id": "D", "type": "scalar", "latex": "D", "subexpr": "D"},
+                    {"id": "__cos_18", "type": "function", "latex": "\\cos", "op": "cos", "subexpr": "\\cos{\\left(\\phi \\hat{n} \\frac{V^{2} \\rho}{2 \\beta} \\right)}"},
+                    {"id": "__multiply_19", "type": "operator", "op": "multiply", "subexpr": "\\phi \\hat{n} \\rho V^{2} \\frac{1}{2 \\beta}"},
+                    {"id": "phi", "type": "scalar", "latex": "\\phi", "subexpr": "\\phi"},
+                    {"id": "__multiply_20", "type": "operator", "op": "multiply", "subexpr": "\\hat{n} \\rho V^{2} \\frac{1}{2 \\beta}"},
+                    {"id": "__multiply_21", "type": "operator", "op": "multiply", "subexpr": "\\rho V^{2} \\frac{1}{2 \\beta}"},
+                    {"id": "__multiply_22", "type": "operator", "op": "multiply", "subexpr": "\\rho V^{2}"},
+                    {"id": "__power_23", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V^{2}"},
+                    {"id": "__power_24", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2 \\beta}"},
+                    {"id": "__multiply_25", "type": "operator", "op": "multiply", "subexpr": "\\beta 2"},
+                    {"id": "__num_26", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "n", "type": "scalar", "latex": "\\hat{n}", "subexpr": "\\hat{n}"}
                   ],
                   "edges": [
-                    {
-                      "from": "r",
-                      "to": "__deriv_2"
-                    },
-                    {
-                      "from": "t",
-                      "to": "__deriv_2",
-                      "role": "wrt"
-                    },
-                    {
-                      "from": "__deriv_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "mu",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "r",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "r",
-                      "to": "__power_7"
-                    },
-                    {
-                      "from": "__power_7",
-                      "to": "__multiply_6"
-                    },
-                    {
-                      "from": "__multiply_6",
-                      "to": "__negation_5"
-                    },
-                    {
-                      "from": "__negation_5",
-                      "to": "__add_4"
-                    },
-                    {
-                      "from": "rho",
-                      "to": "__multiply_11",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V",
-                      "to": "__multiply_11",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_11",
-                      "to": "__multiply_10",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_14",
-                      "to": "__multiply_13",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "beta",
-                      "to": "__multiply_13",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_13",
-                      "to": "__power_12"
-                    },
-                    {
-                      "from": "__power_12",
-                      "to": "__multiply_10"
-                    },
-                    {
-                      "from": "__multiply_10",
-                      "to": "__multiply_9",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V",
-                      "to": "__multiply_9",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_9",
-                      "to": "__negation_8"
-                    },
-                    {
-                      "from": "__negation_8",
-                      "to": "__add_4"
-                    },
-                    {
-                      "from": "__add_4",
-                      "to": "__add_3"
-                    },
-                    {
-                      "from": "L",
-                      "to": "__multiply_16",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "D",
-                      "to": "__power_17"
-                    },
-                    {
-                      "from": "__power_17",
-                      "to": "__multiply_16"
-                    },
-                    {
-                      "from": "__multiply_16",
-                      "to": "__multiply_15",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "phi",
-                      "to": "__multiply_19",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "rho",
-                      "to": "__multiply_22",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V",
-                      "to": "__power_23"
-                    },
-                    {
-                      "from": "__power_23",
-                      "to": "__multiply_22",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_22",
-                      "to": "__multiply_21",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_26",
-                      "to": "__multiply_25",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "beta",
-                      "to": "__multiply_25",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_25",
-                      "to": "__power_24"
-                    },
-                    {
-                      "from": "__power_24",
-                      "to": "__multiply_21"
-                    },
-                    {
-                      "from": "__multiply_21",
-                      "to": "__multiply_20",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "n",
-                      "to": "__multiply_20",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_20",
-                      "to": "__multiply_19",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_19",
-                      "to": "__cos_18"
-                    },
-                    {
-                      "from": "__cos_18",
-                      "to": "__multiply_15",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_15",
-                      "to": "__add_3"
-                    },
-                    {
-                      "from": "__add_3",
-                      "to": "__equals_1"
-                    }
+                    {"from": "r", "to": "__deriv_2"},
+                    {"from": "t", "to": "__deriv_2", "role": "wrt"},
+                    {"from": "__deriv_2", "to": "__equals_1"},
+                    {"from": "mu", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "r", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "r", "to": "__power_7"},
+                    {"from": "__power_7", "to": "__multiply_6"},
+                    {"from": "__multiply_6", "to": "__negation_5"},
+                    {"from": "__negation_5", "to": "__add_4"},
+                    {"from": "rho", "to": "__multiply_11", "semantic": "direct", "weight": 1.0},
+                    {"from": "V", "to": "__multiply_11", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_11", "to": "__multiply_10", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_14", "to": "__multiply_13", "semantic": "direct", "weight": 1.0},
+                    {"from": "beta", "to": "__multiply_13", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_13", "to": "__power_12"},
+                    {"from": "__power_12", "to": "__multiply_10"},
+                    {"from": "__multiply_10", "to": "__multiply_9", "semantic": "direct", "weight": 1.0},
+                    {"from": "V", "to": "__multiply_9", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_9", "to": "__negation_8"},
+                    {"from": "__negation_8", "to": "__add_4"},
+                    {"from": "__add_4", "to": "__add_3"},
+                    {"from": "L", "to": "__multiply_16", "semantic": "direct", "weight": 1.0},
+                    {"from": "D", "to": "__power_17"},
+                    {"from": "__power_17", "to": "__multiply_16"},
+                    {"from": "__multiply_16", "to": "__multiply_15", "semantic": "direct", "weight": 1.0},
+                    {"from": "phi", "to": "__multiply_19", "semantic": "direct", "weight": 1.0},
+                    {"from": "rho", "to": "__multiply_22", "semantic": "direct", "weight": 1.0},
+                    {"from": "V", "to": "__power_23"},
+                    {"from": "__power_23", "to": "__multiply_22", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_22", "to": "__multiply_21", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_26", "to": "__multiply_25", "semantic": "direct", "weight": 1.0},
+                    {"from": "beta", "to": "__multiply_25", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_25", "to": "__power_24"},
+                    {"from": "__power_24", "to": "__multiply_21"},
+                    {"from": "__multiply_21", "to": "__multiply_20", "semantic": "direct", "weight": 1.0},
+                    {"from": "n", "to": "__multiply_20", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_20", "to": "__multiply_19", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_19", "to": "__cos_18"},
+                    {"from": "__cos_18", "to": "__multiply_15", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_15", "to": "__add_3"},
+                    {"from": "__add_3", "to": "__equals_1"}
                   ],
                   "classification": {
                     "kind": "ODE",
                     "order": 2,
-                    "dependent_variables": [
-                      "r"
-                    ],
-                    "independent_variables": [
-                      "t"
-                    ],
-                    "sympy_hints": [
-                      "2nd_nonlinear_autonomous_conserved"
-                    ],
+                    "dependent_variables": ["r"],
+                    "independent_variables": ["t"],
+                    "sympy_hints": ["2nd_nonlinear_autonomous_conserved"],
                     "linear": true,
                     "homogeneous": false,
                     "constant_coefficients": false
@@ -3554,174 +1366,41 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "m\\frac{d}{d t} V = -\\frac{1}{2}\\rho V^2 C_d A"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "m \\frac{d}{d t} V"
-                    },
-                    {
-                      "id": "m",
-                      "type": "scalar",
-                      "latex": "m",
-                      "subexpr": "m"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    },
-                    {
-                      "id": "t",
-                      "type": "scalar",
-                      "latex": "t",
-                      "subexpr": "t"
-                    },
-                    {
-                      "id": "__deriv_3",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t",
-                      "subexpr": "\\frac{d}{d t} V"
-                    },
-                    {
-                      "id": "__negation_4",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-V^{2} \\rho A \\frac{1}{2} C_{d}"
-                    },
-                    {
-                      "id": "__multiply_5",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V^{2} \\rho A \\frac{1}{2} C_{d}"
-                    },
-                    {
-                      "id": "__num_6",
-                      "type": "number",
-                      "label": "1/2",
-                      "subexpr": "\\frac{1}{2}"
-                    },
-                    {
-                      "id": "A",
-                      "type": "scalar",
-                      "latex": "A",
-                      "subexpr": "A"
-                    },
-                    {
-                      "id": "C_{d}",
-                      "type": "scalar",
-                      "latex": "C_{d}",
-                      "subexpr": "C_{d}"
-                    },
-                    {
-                      "id": "rho",
-                      "type": "scalar",
-                      "latex": "\\rho",
-                      "subexpr": "\\rho"
-                    },
-                    {
-                      "id": "__power_7",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V^{2}"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "m\\frac{d}{d t} V = -\\frac{1}{2}\\rho V^2 C_d A"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "m \\frac{d}{d t} V"},
+                    {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m"},
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"},
+                    {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                    {"id": "__deriv_3", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\frac{d}{d t} V"},
+                    {"id": "__negation_4", "type": "operator", "op": "negation", "subexpr": "-V^{2} \\rho A \\frac{1}{2} C_{d}"},
+                    {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "V^{2} \\rho A \\frac{1}{2} C_{d}"},
+                    {"id": "__num_6", "type": "number", "label": "1/2", "subexpr": "\\frac{1}{2}"},
+                    {"id": "A", "type": "scalar", "latex": "A", "subexpr": "A"},
+                    {"id": "C_{d}", "type": "scalar", "latex": "C_{d}", "subexpr": "C_{d}"},
+                    {"id": "rho", "type": "scalar", "latex": "\\rho", "subexpr": "\\rho"},
+                    {"id": "__power_7", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V^{2}"}
                   ],
                   "edges": [
-                    {
-                      "from": "m",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V",
-                      "to": "__deriv_3"
-                    },
-                    {
-                      "from": "t",
-                      "to": "__deriv_3",
-                      "role": "wrt"
-                    },
-                    {
-                      "from": "__deriv_3",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "__num_6",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "A",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "C_{d}",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "rho",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V",
-                      "to": "__power_7"
-                    },
-                    {
-                      "from": "__power_7",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_5",
-                      "to": "__negation_4"
-                    },
-                    {
-                      "from": "__negation_4",
-                      "to": "__equals_1"
-                    }
+                    {"from": "m", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "V", "to": "__deriv_3"},
+                    {"from": "t", "to": "__deriv_3", "role": "wrt"},
+                    {"from": "__deriv_3", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_2", "to": "__equals_1"},
+                    {"from": "__num_6", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "A", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "C_{d}", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "rho", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "V", "to": "__power_7"},
+                    {"from": "__power_7", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_5", "to": "__negation_4"},
+                    {"from": "__negation_4", "to": "__equals_1"}
                   ],
                   "classification": {
                     "kind": "ODE",
                     "order": 1,
-                    "dependent_variables": [
-                      "V"
-                    ],
-                    "independent_variables": [
-                      "t"
-                    ],
-                    "sympy_hints": [
-                      "factorable",
-                      "separable",
-                      "1st_exact",
-                      "Bernoulli",
-                      "Riccati_special_minus2",
-                      "1st_power_series",
-                      "lie_group"
-                    ],
+                    "dependent_variables": ["V"],
+                    "independent_variables": ["t"],
+                    "sympy_hints": ["factorable", "separable", "1st_exact", "Bernoulli", "Riccati_special_minus2", "1st_power_series", "lie_group"],
                     "linear": false,
                     "homogeneous": false,
                     "constant_coefficients": false
@@ -3740,122 +1419,29 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "c0___equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\frac{d}{d t} h = -V\\sin\\gamma"
-                    },
-                    {
-                      "id": "h",
-                      "type": "scalar",
-                      "latex": "h",
-                      "subexpr": "h"
-                    },
-                    {
-                      "id": "t",
-                      "type": "scalar",
-                      "latex": "t",
-                      "subexpr": "t"
-                    },
-                    {
-                      "id": "c0___deriv_2",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t",
-                      "subexpr": "\\frac{d}{d t} h"
-                    },
-                    {
-                      "id": "c0___negation_3",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-V \\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "c0___multiply_4",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V \\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    },
-                    {
-                      "id": "c0___sin_5",
-                      "type": "function",
-                      "latex": "\\sin",
-                      "op": "sin",
-                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "gamma",
-                      "type": "scalar",
-                      "latex": "\\gamma",
-                      "subexpr": "\\gamma"
-                    },
-                    {
-                      "id": "c1___equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\gamma = \\text{const}"
-                    },
-                    {
-                      "id": "const",
-                      "type": "text",
-                      "label": "const",
-                      "latex": "\\text{const}",
-                      "subexpr": "\\text{const}"
-                    }
+                    {"id": "c0___equals_1", "type": "relation", "op": "equals", "subexpr": "\\frac{d}{d t} h = -V\\sin\\gamma"},
+                    {"id": "h", "type": "scalar", "latex": "h", "subexpr": "h"},
+                    {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                    {"id": "c0___deriv_2", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\frac{d}{d t} h"},
+                    {"id": "c0___negation_3", "type": "operator", "op": "negation", "subexpr": "-V \\sin{\\left(\\gamma \\right)}"},
+                    {"id": "c0___multiply_4", "type": "operator", "op": "multiply", "subexpr": "V \\sin{\\left(\\gamma \\right)}"},
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"},
+                    {"id": "c0___sin_5", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\gamma \\right)}"},
+                    {"id": "gamma", "type": "scalar", "latex": "\\gamma", "subexpr": "\\gamma"},
+                    {"id": "c1___equals_1", "type": "relation", "op": "equals", "subexpr": "\\gamma = \\text{const}"},
+                    {"id": "const", "type": "text", "label": "const", "latex": "\\text{const}", "subexpr": "\\text{const}"}
                   ],
                   "edges": [
-                    {
-                      "from": "h",
-                      "to": "c0___deriv_2"
-                    },
-                    {
-                      "from": "t",
-                      "to": "c0___deriv_2",
-                      "role": "wrt"
-                    },
-                    {
-                      "from": "c0___deriv_2",
-                      "to": "c0___equals_1"
-                    },
-                    {
-                      "from": "V",
-                      "to": "c0___multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "gamma",
-                      "to": "c0___sin_5"
-                    },
-                    {
-                      "from": "c0___sin_5",
-                      "to": "c0___multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "c0___multiply_4",
-                      "to": "c0___negation_3"
-                    },
-                    {
-                      "from": "c0___negation_3",
-                      "to": "c0___equals_1"
-                    },
-                    {
-                      "from": "gamma",
-                      "to": "c1___equals_1"
-                    },
-                    {
-                      "from": "const",
-                      "to": "c1___equals_1"
-                    }
+                    {"from": "h", "to": "c0___deriv_2"},
+                    {"from": "t", "to": "c0___deriv_2", "role": "wrt"},
+                    {"from": "c0___deriv_2", "to": "c0___equals_1"},
+                    {"from": "V", "to": "c0___multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "gamma", "to": "c0___sin_5"},
+                    {"from": "c0___sin_5", "to": "c0___multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "c0___multiply_4", "to": "c0___negation_3"},
+                    {"from": "c0___negation_3", "to": "c0___equals_1"},
+                    {"from": "gamma", "to": "c1___equals_1"},
+                    {"from": "const", "to": "c1___equals_1"}
                   ],
                   "classification": {
                     "kind": "statements",
@@ -3864,32 +1450,14 @@
                       {
                         "kind": "ODE",
                         "order": 1,
-                        "dependent_variables": [
-                          "h"
-                        ],
-                        "independent_variables": [
-                          "t"
-                        ],
-                        "sympy_hints": [
-                          "nth_algebraic",
-                          "separable",
-                          "1st_exact",
-                          "1st_linear",
-                          "Bernoulli",
-                          "1st_power_series",
-                          "lie_group",
-                          "nth_linear_constant_coeff_undetermined_coefficients",
-                          "nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients",
-                          "nth_linear_constant_coeff_variation_of_parameters",
-                          "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters"
-                        ],
+                        "dependent_variables": ["h"],
+                        "independent_variables": ["t"],
+                        "sympy_hints": ["nth_algebraic", "separable", "1st_exact", "1st_linear", "Bernoulli", "1st_power_series", "lie_group", "nth_linear_constant_coeff_undetermined_coefficients", "nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients", "nth_linear_constant_coeff_variation_of_parameters", "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters"],
                         "linear": true,
                         "homogeneous": true,
                         "constant_coefficients": true
                       },
-                      {
-                        "kind": "algebraic"
-                      }
+                      {"kind": "algebraic"}
                     ]
                   }
                 }
@@ -3906,177 +1474,43 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    },
-                    {
-                      "id": "t",
-                      "type": "scalar",
-                      "latex": "t",
-                      "subexpr": "t"
-                    },
-                    {
-                      "id": "s0___deriv_1",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t",
-                      "subexpr": "\\frac{d}{d t} V"
-                    },
-                    {
-                      "id": "s1___multiply_1",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{dV}{dh}\\cdot\\frac{d}{d t} h"
-                    },
-                    {
-                      "id": "h",
-                      "type": "scalar",
-                      "latex": "h",
-                      "subexpr": "h"
-                    },
-                    {
-                      "id": "s1___deriv_2",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "h",
-                      "subexpr": "\\frac{d}{d h} V"
-                    },
-                    {
-                      "id": "s1___deriv_3",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t",
-                      "subexpr": "\\frac{d}{d t} h"
-                    },
-                    {
-                      "id": "s2___negation_1",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-V\\sin\\gamma\\,\\frac{dV}{dh}"
-                    },
-                    {
-                      "id": "s2___multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V \\sin{\\left(\\gamma \\frac{d}{d h} V \\right)}"
-                    },
-                    {
-                      "id": "s2___sin_3",
-                      "type": "function",
-                      "latex": "\\sin",
-                      "op": "sin",
-                      "subexpr": "\\sin{\\left(\\gamma \\frac{d}{d h} V \\right)}"
-                    },
-                    {
-                      "id": "s2___multiply_4",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\gamma \\frac{d}{d h} V"
-                    },
-                    {
-                      "id": "gamma",
-                      "type": "scalar",
-                      "latex": "\\gamma",
-                      "subexpr": "\\gamma"
-                    },
-                    {
-                      "id": "s2___deriv_5",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "h",
-                      "subexpr": "\\frac{d}{d h} V"
-                    },
-                    {
-                      "id": "__equals_1",
-                      "type": "operator",
-                      "op": "equals",
-                      "subexpr": "\\frac{dV}{dt} = \\frac{dV}{dh}\\cdot\\frac{dh}{dt} = -V\\sin\\gamma\\,\\frac{dV}{dh}"
-                    }
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"},
+                    {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                    {"id": "s0___deriv_1", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\frac{d}{d t} V"},
+                    {"id": "s1___multiply_1", "type": "operator", "op": "multiply", "subexpr": "\\frac{dV}{dh}\\cdot\\frac{d}{d t} h"},
+                    {"id": "h", "type": "scalar", "latex": "h", "subexpr": "h"},
+                    {"id": "s1___deriv_2", "type": "operator", "op": "derivative", "with_respect_to": "h", "subexpr": "\\frac{d}{d h} V"},
+                    {"id": "s1___deriv_3", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\frac{d}{d t} h"},
+                    {"id": "s2___negation_1", "type": "operator", "op": "negation", "subexpr": "-V\\sin\\gamma\\,\\frac{dV}{dh}"},
+                    {"id": "s2___multiply_2", "type": "operator", "op": "multiply", "subexpr": "V \\sin{\\left(\\gamma \\frac{d}{d h} V \\right)}"},
+                    {"id": "s2___sin_3", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\gamma \\frac{d}{d h} V \\right)}"},
+                    {"id": "s2___multiply_4", "type": "operator", "op": "multiply", "subexpr": "\\gamma \\frac{d}{d h} V"},
+                    {"id": "gamma", "type": "scalar", "latex": "\\gamma", "subexpr": "\\gamma"},
+                    {"id": "s2___deriv_5", "type": "operator", "op": "derivative", "with_respect_to": "h", "subexpr": "\\frac{d}{d h} V"},
+                    {"id": "__equals_1", "type": "operator", "op": "equals", "subexpr": "\\frac{dV}{dt} = \\frac{dV}{dh}\\cdot\\frac{dh}{dt} = -V\\sin\\gamma\\,\\frac{dV}{dh}"}
                   ],
                   "edges": [
-                    {
-                      "from": "V",
-                      "to": "s0___deriv_1"
-                    },
-                    {
-                      "from": "t",
-                      "to": "s0___deriv_1"
-                    },
-                    {
-                      "from": "V",
-                      "to": "s1___deriv_2"
-                    },
-                    {
-                      "from": "h",
-                      "to": "s1___deriv_2"
-                    },
-                    {
-                      "from": "s1___deriv_2",
-                      "to": "s1___multiply_1"
-                    },
-                    {
-                      "from": "h",
-                      "to": "s1___deriv_3"
-                    },
-                    {
-                      "from": "t",
-                      "to": "s1___deriv_3"
-                    },
-                    {
-                      "from": "s1___deriv_3",
-                      "to": "s1___multiply_1"
-                    },
-                    {
-                      "from": "V",
-                      "to": "s2___multiply_2"
-                    },
-                    {
-                      "from": "gamma",
-                      "to": "s2___multiply_4"
-                    },
-                    {
-                      "from": "V",
-                      "to": "s2___deriv_5"
-                    },
-                    {
-                      "from": "h",
-                      "to": "s2___deriv_5"
-                    },
-                    {
-                      "from": "s2___deriv_5",
-                      "to": "s2___multiply_4"
-                    },
-                    {
-                      "from": "s2___multiply_4",
-                      "to": "s2___sin_3"
-                    },
-                    {
-                      "from": "s2___sin_3",
-                      "to": "s2___multiply_2"
-                    },
-                    {
-                      "from": "s2___multiply_2",
-                      "to": "s2___negation_1"
-                    },
-                    {
-                      "from": "s0___deriv_1",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "s1___multiply_1",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "s2___negation_1",
-                      "to": "__equals_1"
-                    }
+                    {"from": "V", "to": "s0___deriv_1"},
+                    {"from": "t", "to": "s0___deriv_1"},
+                    {"from": "V", "to": "s1___deriv_2"},
+                    {"from": "h", "to": "s1___deriv_2"},
+                    {"from": "s1___deriv_2", "to": "s1___multiply_1"},
+                    {"from": "h", "to": "s1___deriv_3"},
+                    {"from": "t", "to": "s1___deriv_3"},
+                    {"from": "s1___deriv_3", "to": "s1___multiply_1"},
+                    {"from": "V", "to": "s2___multiply_2"},
+                    {"from": "gamma", "to": "s2___multiply_4"},
+                    {"from": "V", "to": "s2___deriv_5"},
+                    {"from": "h", "to": "s2___deriv_5"},
+                    {"from": "s2___deriv_5", "to": "s2___multiply_4"},
+                    {"from": "s2___multiply_4", "to": "s2___sin_3"},
+                    {"from": "s2___sin_3", "to": "s2___multiply_2"},
+                    {"from": "s2___multiply_2", "to": "s2___negation_1"},
+                    {"from": "s0___deriv_1", "to": "__equals_1"},
+                    {"from": "s1___multiply_1", "to": "__equals_1"},
+                    {"from": "s2___negation_1", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -4091,290 +1525,61 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\frac{dV}{V} = \\frac{\\rho_0\\, e^{-h/H}}{2\\beta\\sin\\gamma}\\,dh"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{V} dV"
-                    },
-                    {
-                      "id": "dV",
-                      "type": "scalar",
-                      "latex": "dV",
-                      "subexpr": "dV"
-                    },
-                    {
-                      "id": "__power_3",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{V}"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    },
-                    {
-                      "id": "__multiply_4",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0} \\frac{1}{2 \\beta \\sin{\\left(\\gamma \\right)}} dh"
-                    },
-                    {
-                      "id": "__multiply_5",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0} \\frac{1}{2 \\beta \\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__multiply_6",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0}"
-                    },
-                    {
-                      "id": "rho_{0}",
-                      "type": "scalar",
-                      "latex": "\\rho_{0}",
-                      "subexpr": "\\rho_{0}"
-                    },
-                    {
-                      "id": "__power_7",
-                      "type": "operator",
-                      "op": "power",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"
-                    },
-                    {
-                      "id": "e",
-                      "type": "scalar",
-                      "latex": "e",
-                      "subexpr": "e"
-                    },
-                    {
-                      "id": "__multiply_8",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{H} -h"
-                    },
-                    {
-                      "id": "__negation_9",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-h"
-                    },
-                    {
-                      "id": "h",
-                      "type": "scalar",
-                      "latex": "h",
-                      "subexpr": "h"
-                    },
-                    {
-                      "id": "__power_10",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{H}"
-                    },
-                    {
-                      "id": "H",
-                      "type": "scalar",
-                      "latex": "H",
-                      "subexpr": "H"
-                    },
-                    {
-                      "id": "__power_11",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2 \\beta \\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__multiply_12",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "2 \\beta \\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "__num_13",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "__multiply_14",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\beta \\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "beta",
-                      "type": "scalar",
-                      "latex": "\\beta",
-                      "subexpr": "\\beta"
-                    },
-                    {
-                      "id": "__sin_15",
-                      "type": "function",
-                      "latex": "\\sin",
-                      "op": "sin",
-                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "gamma",
-                      "type": "scalar",
-                      "latex": "\\gamma",
-                      "subexpr": "\\gamma"
-                    },
-                    {
-                      "id": "dh",
-                      "type": "scalar",
-                      "latex": "dh",
-                      "subexpr": "dh"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\frac{dV}{V} = \\frac{\\rho_0\\, e^{-h/H}}{2\\beta\\sin\\gamma}\\,dh"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{V} dV"},
+                    {"id": "dV", "type": "scalar", "latex": "dV", "subexpr": "dV"},
+                    {"id": "__power_3", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{V}"},
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"},
+                    {"id": "__multiply_4", "type": "operator", "op": "multiply", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0} \\frac{1}{2 \\beta \\sin{\\left(\\gamma \\right)}} dh"},
+                    {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0} \\frac{1}{2 \\beta \\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0}"},
+                    {"id": "rho_{0}", "type": "scalar", "latex": "\\rho_{0}", "subexpr": "\\rho_{0}"},
+                    {"id": "__power_7", "type": "operator", "op": "power", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "__multiply_8", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{H} -h"},
+                    {"id": "__negation_9", "type": "operator", "op": "negation", "subexpr": "-h"},
+                    {"id": "h", "type": "scalar", "latex": "h", "subexpr": "h"},
+                    {"id": "__power_10", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{H}"},
+                    {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"},
+                    {"id": "__power_11", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2 \\beta \\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__multiply_12", "type": "operator", "op": "multiply", "subexpr": "2 \\beta \\sin{\\left(\\gamma \\right)}"},
+                    {"id": "__num_13", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__multiply_14", "type": "operator", "op": "multiply", "subexpr": "\\beta \\sin{\\left(\\gamma \\right)}"},
+                    {"id": "beta", "type": "scalar", "latex": "\\beta", "subexpr": "\\beta"},
+                    {"id": "__sin_15", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\gamma \\right)}"},
+                    {"id": "gamma", "type": "scalar", "latex": "\\gamma", "subexpr": "\\gamma"},
+                    {"id": "dh", "type": "scalar", "latex": "dh", "subexpr": "dh"}
                   ],
                   "edges": [
-                    {
-                      "from": "dV",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V",
-                      "to": "__power_3"
-                    },
-                    {
-                      "from": "__power_3",
-                      "to": "__multiply_2"
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "rho_{0}",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "e",
-                      "to": "__power_7"
-                    },
-                    {
-                      "from": "h",
-                      "to": "__negation_9"
-                    },
-                    {
-                      "from": "__negation_9",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__power_10"
-                    },
-                    {
-                      "from": "__power_10",
-                      "to": "__multiply_8"
-                    },
-                    {
-                      "from": "__multiply_8",
-                      "to": "__power_7",
-                      "role": "exp"
-                    },
-                    {
-                      "from": "__power_7",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_6",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_13",
-                      "to": "__multiply_12",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "beta",
-                      "to": "__multiply_14",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "gamma",
-                      "to": "__sin_15"
-                    },
-                    {
-                      "from": "__sin_15",
-                      "to": "__multiply_14",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_14",
-                      "to": "__multiply_12",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_12",
-                      "to": "__power_11"
-                    },
-                    {
-                      "from": "__power_11",
-                      "to": "__multiply_5"
-                    },
-                    {
-                      "from": "__multiply_5",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "dh",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_4",
-                      "to": "__equals_1"
-                    }
+                    {"from": "dV", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "V", "to": "__power_3"},
+                    {"from": "__power_3", "to": "__multiply_2"},
+                    {"from": "__multiply_2", "to": "__equals_1"},
+                    {"from": "rho_{0}", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "e", "to": "__power_7"},
+                    {"from": "h", "to": "__negation_9"},
+                    {"from": "__negation_9", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__power_10"},
+                    {"from": "__power_10", "to": "__multiply_8"},
+                    {"from": "__multiply_8", "to": "__power_7", "role": "exp"},
+                    {"from": "__power_7", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_6", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_13", "to": "__multiply_12", "semantic": "direct", "weight": 1.0},
+                    {"from": "beta", "to": "__multiply_14", "semantic": "direct", "weight": 1.0},
+                    {"from": "gamma", "to": "__sin_15"},
+                    {"from": "__sin_15", "to": "__multiply_14", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_14", "to": "__multiply_12", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_12", "to": "__power_11"},
+                    {"from": "__power_11", "to": "__multiply_5"},
+                    {"from": "__multiply_5", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "dh", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_4", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
-            {
-              "type": "step",
-              "label": "Integrate Both Sides",
-              "math": "\\int_{V_E}^{V}\\frac{dV'}{V'} = \\int_{h_E}^{h}\\frac{\\rho_0\\,e^{-h'/H}}{2\\beta\\sin\\gamma}\\,dh'",
-              "justification": "Definite integral from the entry interface ($h_E$, $V_E$) down to altitude $h$.",
-              "explanation": "The left side integrates to $\\ln(V/V_E)$. The right side has the integral of an exponential.",
-              "prompt": "Remind the student: $\\int e^{-h/H}dh = -H e^{-h/H}$.",
-              "sceneStep": 0
-            },
+            {"type": "step", "label": "Integrate Both Sides", "math": "\\int_{V_E}^{V}\\frac{dV'}{V'} = \\int_{h_E}^{h}\\frac{\\rho_0\\,e^{-h'/H}}{2\\beta\\sin\\gamma}\\,dh'", "justification": "Definite integral from the entry interface ($h_E$, $V_E$) down to altitude $h$.", "explanation": "The left side integrates to $\\ln(V/V_E)$. The right side has the integral of an exponential.", "prompt": "Remind the student: $\\int e^{-h/H}dh = -H e^{-h/H}$.", "sceneStep": 0},
             {
               "type": "step",
               "label": "Evaluate the Integrals",
@@ -4384,389 +1589,82 @@
               "prompt": "Point out the signs carefully: we are descending, so $h < h_E$, meaning $e^{-h/H} > e^{-h_E/H}$.",
               "sceneStep": 0,
               "highlights": {
-                "exit": {
-                  "color": "green",
-                  "label": "≈ 0 because entry altitude is very high"
-                },
-                "curr": {
-                  "color": "yellow",
-                  "label": "grows as the capsule descends"
-                }
+                "exit": {"color": "green", "label": "≈ 0 because entry altitude is very high"},
+                "curr": {"color": "yellow", "label": "grows as the capsule descends"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\ln\\frac{V}{V_E} = \\frac{\\rho_0 H}{2\\beta\\sin\\gamma}\\left(e^{-h_E/H} - e^{-h/H}\\right)"
-                    },
-                    {
-                      "id": "__log_2",
-                      "type": "function",
-                      "op": "log",
-                      "subexpr": "\\ln{\\left(\\frac{V}{V_{E}} \\right)}"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V \\frac{1}{V_{E}}"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    },
-                    {
-                      "id": "__power_4",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{V_{E}}"
-                    },
-                    {
-                      "id": "V_{E}",
-                      "type": "scalar",
-                      "latex": "V_{E}",
-                      "subexpr": "V_{E}"
-                    },
-                    {
-                      "id": "__const_5",
-                      "type": "constant",
-                      "label": "e (Euler's number)",
-                      "latex": "e",
-                      "subexpr": "e"
-                    },
-                    {
-                      "id": "__multiply_6",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "H \\rho_{0} \\frac{1}{2 \\beta \\sin{\\left(\\gamma \\right)}} \\left(e^{\\frac{\\left(-1\\right) h_{E}}{H}} - e^{\\frac{\\left(-1\\right) h}{H}}\\right)"
-                    },
-                    {
-                      "id": "__multiply_7",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "H \\rho_{0} \\frac{1}{2 \\beta \\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__multiply_8",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "H \\rho_{0}"
-                    },
-                    {
-                      "id": "rho_{0}",
-                      "type": "scalar",
-                      "latex": "\\rho_{0}",
-                      "subexpr": "\\rho_{0}"
-                    },
-                    {
-                      "id": "H",
-                      "type": "scalar",
-                      "latex": "H",
-                      "subexpr": "H"
-                    },
-                    {
-                      "id": "__power_9",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2 \\beta \\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__multiply_10",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "2 \\beta \\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "__num_11",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "__multiply_12",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\beta \\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "beta",
-                      "type": "scalar",
-                      "latex": "\\beta",
-                      "subexpr": "\\beta"
-                    },
-                    {
-                      "id": "__sin_13",
-                      "type": "function",
-                      "latex": "\\sin",
-                      "op": "sin",
-                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "gamma",
-                      "type": "scalar",
-                      "latex": "\\gamma",
-                      "subexpr": "\\gamma"
-                    },
-                    {
-                      "id": "__add_14",
-                      "type": "operator",
-                      "op": "add",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}} - e^{\\frac{\\left(-1\\right) h}{H}}"
-                    },
-                    {
-                      "id": "__power_15",
-                      "type": "operator",
-                      "op": "power",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}}"
-                    },
-                    {
-                      "id": "e",
-                      "type": "scalar",
-                      "latex": "e",
-                      "subexpr": "e"
-                    },
-                    {
-                      "id": "__multiply_16",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{H} -h_{E}"
-                    },
-                    {
-                      "id": "__negation_17",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-h_{E}"
-                    },
-                    {
-                      "id": "h_{E}",
-                      "type": "scalar",
-                      "latex": "h_{E}",
-                      "subexpr": "h_{E}"
-                    },
-                    {
-                      "id": "__power_18",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{H}"
-                    },
-                    {
-                      "id": "__negation_19",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-e^{\\frac{\\left(-1\\right) h}{H}}"
-                    },
-                    {
-                      "id": "__power_20",
-                      "type": "operator",
-                      "op": "power",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"
-                    },
-                    {
-                      "id": "__multiply_21",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{H} -h"
-                    },
-                    {
-                      "id": "__negation_22",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-h"
-                    },
-                    {
-                      "id": "h",
-                      "type": "scalar",
-                      "latex": "h",
-                      "subexpr": "h"
-                    },
-                    {
-                      "id": "__power_23",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{H}"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\ln\\frac{V}{V_E} = \\frac{\\rho_0 H}{2\\beta\\sin\\gamma}\\left(e^{-h_E/H} - e^{-h/H}\\right)"},
+                    {"id": "__log_2", "type": "function", "op": "log", "subexpr": "\\ln{\\left(\\frac{V}{V_{E}} \\right)}"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "V \\frac{1}{V_{E}}"},
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"},
+                    {"id": "__power_4", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{V_{E}}"},
+                    {"id": "V_{E}", "type": "scalar", "latex": "V_{E}", "subexpr": "V_{E}"},
+                    {"id": "__const_5", "type": "constant", "label": "e (Euler's number)", "latex": "e", "subexpr": "e"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "H \\rho_{0} \\frac{1}{2 \\beta \\sin{\\left(\\gamma \\right)}} \\left(e^{\\frac{\\left(-1\\right) h_{E}}{H}} - e^{\\frac{\\left(-1\\right) h}{H}}\\right)"},
+                    {"id": "__multiply_7", "type": "operator", "op": "multiply", "subexpr": "H \\rho_{0} \\frac{1}{2 \\beta \\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__multiply_8", "type": "operator", "op": "multiply", "subexpr": "H \\rho_{0}"},
+                    {"id": "rho_{0}", "type": "scalar", "latex": "\\rho_{0}", "subexpr": "\\rho_{0}"},
+                    {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"},
+                    {"id": "__power_9", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2 \\beta \\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__multiply_10", "type": "operator", "op": "multiply", "subexpr": "2 \\beta \\sin{\\left(\\gamma \\right)}"},
+                    {"id": "__num_11", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__multiply_12", "type": "operator", "op": "multiply", "subexpr": "\\beta \\sin{\\left(\\gamma \\right)}"},
+                    {"id": "beta", "type": "scalar", "latex": "\\beta", "subexpr": "\\beta"},
+                    {"id": "__sin_13", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\gamma \\right)}"},
+                    {"id": "gamma", "type": "scalar", "latex": "\\gamma", "subexpr": "\\gamma"},
+                    {"id": "__add_14", "type": "operator", "op": "add", "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}} - e^{\\frac{\\left(-1\\right) h}{H}}"},
+                    {"id": "__power_15", "type": "operator", "op": "power", "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}}"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "__multiply_16", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{H} -h_{E}"},
+                    {"id": "__negation_17", "type": "operator", "op": "negation", "subexpr": "-h_{E}"},
+                    {"id": "h_{E}", "type": "scalar", "latex": "h_{E}", "subexpr": "h_{E}"},
+                    {"id": "__power_18", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{H}"},
+                    {"id": "__negation_19", "type": "operator", "op": "negation", "subexpr": "-e^{\\frac{\\left(-1\\right) h}{H}}"},
+                    {"id": "__power_20", "type": "operator", "op": "power", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"},
+                    {"id": "__multiply_21", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{H} -h"},
+                    {"id": "__negation_22", "type": "operator", "op": "negation", "subexpr": "-h"},
+                    {"id": "h", "type": "scalar", "latex": "h", "subexpr": "h"},
+                    {"id": "__power_23", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{H}"}
                   ],
                   "edges": [
-                    {
-                      "from": "V",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V_{E}",
-                      "to": "__power_4"
-                    },
-                    {
-                      "from": "__power_4",
-                      "to": "__multiply_3"
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__log_2"
-                    },
-                    {
-                      "from": "__const_5",
-                      "to": "__log_2",
-                      "role": "base"
-                    },
-                    {
-                      "from": "__log_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "rho_{0}",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_8",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_11",
-                      "to": "__multiply_10",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "beta",
-                      "to": "__multiply_12",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "gamma",
-                      "to": "__sin_13"
-                    },
-                    {
-                      "from": "__sin_13",
-                      "to": "__multiply_12",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_12",
-                      "to": "__multiply_10",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_10",
-                      "to": "__power_9"
-                    },
-                    {
-                      "from": "__power_9",
-                      "to": "__multiply_7"
-                    },
-                    {
-                      "from": "__multiply_7",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "e",
-                      "to": "__power_15"
-                    },
-                    {
-                      "from": "h_{E}",
-                      "to": "__negation_17"
-                    },
-                    {
-                      "from": "__negation_17",
-                      "to": "__multiply_16",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__power_18"
-                    },
-                    {
-                      "from": "__power_18",
-                      "to": "__multiply_16"
-                    },
-                    {
-                      "from": "__multiply_16",
-                      "to": "__power_15",
-                      "role": "exp"
-                    },
-                    {
-                      "from": "__power_15",
-                      "to": "__add_14"
-                    },
-                    {
-                      "from": "e",
-                      "to": "__power_20"
-                    },
-                    {
-                      "from": "h",
-                      "to": "__negation_22"
-                    },
-                    {
-                      "from": "__negation_22",
-                      "to": "__multiply_21",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__power_23"
-                    },
-                    {
-                      "from": "__power_23",
-                      "to": "__multiply_21"
-                    },
-                    {
-                      "from": "__multiply_21",
-                      "to": "__power_20",
-                      "role": "exp"
-                    },
-                    {
-                      "from": "__power_20",
-                      "to": "__negation_19"
-                    },
-                    {
-                      "from": "__negation_19",
-                      "to": "__add_14"
-                    },
-                    {
-                      "from": "__add_14",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_6",
-                      "to": "__equals_1"
-                    }
+                    {"from": "V", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "V_{E}", "to": "__power_4"},
+                    {"from": "__power_4", "to": "__multiply_3"},
+                    {"from": "__multiply_3", "to": "__log_2"},
+                    {"from": "__const_5", "to": "__log_2", "role": "base"},
+                    {"from": "__log_2", "to": "__equals_1"},
+                    {"from": "rho_{0}", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_8", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_11", "to": "__multiply_10", "semantic": "direct", "weight": 1.0},
+                    {"from": "beta", "to": "__multiply_12", "semantic": "direct", "weight": 1.0},
+                    {"from": "gamma", "to": "__sin_13"},
+                    {"from": "__sin_13", "to": "__multiply_12", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_12", "to": "__multiply_10", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_10", "to": "__power_9"},
+                    {"from": "__power_9", "to": "__multiply_7"},
+                    {"from": "__multiply_7", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "e", "to": "__power_15"},
+                    {"from": "h_{E}", "to": "__negation_17"},
+                    {"from": "__negation_17", "to": "__multiply_16", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__power_18"},
+                    {"from": "__power_18", "to": "__multiply_16"},
+                    {"from": "__multiply_16", "to": "__power_15", "role": "exp"},
+                    {"from": "__power_15", "to": "__add_14"},
+                    {"from": "e", "to": "__power_20"},
+                    {"from": "h", "to": "__negation_22"},
+                    {"from": "__negation_22", "to": "__multiply_21", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__power_23"},
+                    {"from": "__power_23", "to": "__multiply_21"},
+                    {"from": "__multiply_21", "to": "__power_20", "role": "exp"},
+                    {"from": "__power_20", "to": "__negation_19"},
+                    {"from": "__negation_19", "to": "__add_14"},
+                    {"from": "__add_14", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_6", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -4781,197 +1679,46 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "s0___power_1",
-                      "type": "operator",
-                      "op": "power",
-                      "subexpr": "e^{-h_E/H}"
-                    },
-                    {
-                      "id": "e",
-                      "type": "scalar",
-                      "latex": "e",
-                      "subexpr": "e"
-                    },
-                    {
-                      "id": "s0___multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{H} -h_{E}"
-                    },
-                    {
-                      "id": "s0___negation_3",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-h_{E}"
-                    },
-                    {
-                      "id": "h_{E}",
-                      "type": "scalar",
-                      "latex": "h_{E}",
-                      "subexpr": "h_{E}"
-                    },
-                    {
-                      "id": "s0___power_4",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{H}"
-                    },
-                    {
-                      "id": "H",
-                      "type": "scalar",
-                      "latex": "H",
-                      "subexpr": "H"
-                    },
-                    {
-                      "id": "s1___power_1",
-                      "type": "operator",
-                      "op": "power",
-                      "subexpr": "e^{-122/7.2}"
-                    },
-                    {
-                      "id": "s1___multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "-122 \\frac{1}{7.2}"
-                    },
-                    {
-                      "id": "s1___num_3",
-                      "type": "number",
-                      "label": "-122",
-                      "subexpr": "-122"
-                    },
-                    {
-                      "id": "s1___power_4",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{7.2}"
-                    },
-                    {
-                      "id": "s1___num_5",
-                      "type": "number",
-                      "label": "7.2",
-                      "subexpr": "7.2"
-                    },
-                    {
-                      "id": "s2___multiply_1",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "4 \\times 10^{-8}"
-                    },
-                    {
-                      "id": "s2___num_2",
-                      "type": "number",
-                      "label": "4",
-                      "subexpr": "4"
-                    },
-                    {
-                      "id": "s2___power_3",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "-8",
-                      "subexpr": "\\frac{1}{100000000}"
-                    },
-                    {
-                      "id": "s2___num_4",
-                      "type": "number",
-                      "label": "10",
-                      "subexpr": "10"
-                    },
-                    {
-                      "id": "s3___num_1",
-                      "type": "number",
-                      "label": "0",
-                      "subexpr": "0"
-                    },
-                    {
-                      "id": "__equals_1",
-                      "type": "operator",
-                      "op": "equals",
-                      "subexpr": "e^{-h_E/H} = e^{-122/7.2} = 4 \\times 10^{-8} = 0"
-                    }
+                    {"id": "s0___power_1", "type": "operator", "op": "power", "subexpr": "e^{-h_E/H}"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "s0___multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{H} -h_{E}"},
+                    {"id": "s0___negation_3", "type": "operator", "op": "negation", "subexpr": "-h_{E}"},
+                    {"id": "h_{E}", "type": "scalar", "latex": "h_{E}", "subexpr": "h_{E}"},
+                    {"id": "s0___power_4", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{H}"},
+                    {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"},
+                    {"id": "s1___power_1", "type": "operator", "op": "power", "subexpr": "e^{-122/7.2}"},
+                    {"id": "s1___multiply_2", "type": "operator", "op": "multiply", "subexpr": "-122 \\frac{1}{7.2}"},
+                    {"id": "s1___num_3", "type": "number", "label": "-122", "subexpr": "-122"},
+                    {"id": "s1___power_4", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{7.2}"},
+                    {"id": "s1___num_5", "type": "number", "label": "7.2", "subexpr": "7.2"},
+                    {"id": "s2___multiply_1", "type": "operator", "op": "multiply", "subexpr": "4 \\times 10^{-8}"},
+                    {"id": "s2___num_2", "type": "number", "label": "4", "subexpr": "4"},
+                    {"id": "s2___power_3", "type": "operator", "op": "power", "exponent": "-8", "subexpr": "\\frac{1}{100000000}"},
+                    {"id": "s2___num_4", "type": "number", "label": "10", "subexpr": "10"},
+                    {"id": "s3___num_1", "type": "number", "label": "0", "subexpr": "0"},
+                    {"id": "__equals_1", "type": "operator", "op": "equals", "subexpr": "e^{-h_E/H} = e^{-122/7.2} = 4 \\times 10^{-8} = 0"}
                   ],
                   "edges": [
-                    {
-                      "from": "e",
-                      "to": "s0___power_1"
-                    },
-                    {
-                      "from": "h_{E}",
-                      "to": "s0___negation_3"
-                    },
-                    {
-                      "from": "s0___negation_3",
-                      "to": "s0___multiply_2"
-                    },
-                    {
-                      "from": "H",
-                      "to": "s0___power_4"
-                    },
-                    {
-                      "from": "s0___power_4",
-                      "to": "s0___multiply_2"
-                    },
-                    {
-                      "from": "s0___multiply_2",
-                      "to": "s0___power_1"
-                    },
-                    {
-                      "from": "e",
-                      "to": "s1___power_1"
-                    },
-                    {
-                      "from": "s1___num_3",
-                      "to": "s1___multiply_2"
-                    },
-                    {
-                      "from": "s1___num_5",
-                      "to": "s1___power_4"
-                    },
-                    {
-                      "from": "s1___power_4",
-                      "to": "s1___multiply_2"
-                    },
-                    {
-                      "from": "s1___multiply_2",
-                      "to": "s1___power_1"
-                    },
-                    {
-                      "from": "s2___num_2",
-                      "to": "s2___multiply_1"
-                    },
-                    {
-                      "from": "s2___num_4",
-                      "to": "s2___power_3"
-                    },
-                    {
-                      "from": "s2___power_3",
-                      "to": "s2___multiply_1"
-                    },
-                    {
-                      "from": "s0___power_1",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "s1___power_1",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "s2___multiply_1",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "s3___num_1",
-                      "to": "__equals_1"
-                    }
+                    {"from": "e", "to": "s0___power_1"},
+                    {"from": "h_{E}", "to": "s0___negation_3"},
+                    {"from": "s0___negation_3", "to": "s0___multiply_2"},
+                    {"from": "H", "to": "s0___power_4"},
+                    {"from": "s0___power_4", "to": "s0___multiply_2"},
+                    {"from": "s0___multiply_2", "to": "s0___power_1"},
+                    {"from": "e", "to": "s1___power_1"},
+                    {"from": "s1___num_3", "to": "s1___multiply_2"},
+                    {"from": "s1___num_5", "to": "s1___power_4"},
+                    {"from": "s1___power_4", "to": "s1___multiply_2"},
+                    {"from": "s1___multiply_2", "to": "s1___power_1"},
+                    {"from": "s2___num_2", "to": "s2___multiply_1"},
+                    {"from": "s2___num_4", "to": "s2___power_3"},
+                    {"from": "s2___power_3", "to": "s2___multiply_1"},
+                    {"from": "s0___power_1", "to": "__equals_1"},
+                    {"from": "s1___power_1", "to": "__equals_1"},
+                    {"from": "s2___multiply_1", "to": "__equals_1"},
+                    {"from": "s3___num_1", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -4984,272 +1731,60 @@
               "prompt": "Key insight: a heavier vehicle ($\\beta$ large) loses speed more slowly — it 'punches through' the atmosphere. A steep entry ($\\gamma$ large) means less path length through thin upper air, so deceleration is concentrated lower down.",
               "sceneStep": 0,
               "highlights": {
-                "result": {
-                  "color": "green",
-                  "label": "Allen-Eggers velocity solution"
-                }
+                "result": {"color": "green", "label": "Allen-Eggers velocity solution"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "V(h) = V_E \\exp\\!\\left(-\\frac{\\rho_0 H}{2\\beta\\sin\\gamma}\\,e^{-h/H}\\right)",
-                      "description": "Allen-Eggers velocity solution",
-                      "color": "green",
-                      "highlight": "result"
-                    },
-                    {
-                      "id": "__V_2",
-                      "type": "function",
-                      "op": "V",
-                      "subexpr": "V{\\left(h \\right)}"
-                    },
-                    {
-                      "id": "h",
-                      "type": "scalar",
-                      "latex": "h",
-                      "subexpr": "h"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{E} e^{- e^{\\frac{\\left(-1\\right) h}{H}} \\frac{H \\rho_{0}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"
-                    },
-                    {
-                      "id": "V_{E}",
-                      "type": "scalar",
-                      "latex": "V_{E}",
-                      "subexpr": "V_{E}"
-                    },
-                    {
-                      "id": "__exp_4",
-                      "type": "function",
-                      "latex": "\\exp",
-                      "op": "exp",
-                      "subexpr": "e^{- e^{\\frac{\\left(-1\\right) h}{H}} \\frac{H \\rho_{0}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"
-                    },
-                    {
-                      "id": "__negation_5",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-e^{\\frac{\\left(-1\\right) h}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__multiply_6",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "H",
-                      "type": "scalar",
-                      "latex": "H",
-                      "subexpr": "H"
-                    },
-                    {
-                      "id": "rho_{0}",
-                      "type": "scalar",
-                      "latex": "\\rho_{0}",
-                      "subexpr": "\\rho_{0}"
-                    },
-                    {
-                      "id": "__power_7",
-                      "type": "operator",
-                      "op": "power",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"
-                    },
-                    {
-                      "id": "e",
-                      "type": "scalar",
-                      "latex": "e",
-                      "subexpr": "e"
-                    },
-                    {
-                      "id": "__multiply_8",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{H} -h"
-                    },
-                    {
-                      "id": "__negation_9",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-h"
-                    },
-                    {
-                      "id": "__power_10",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{H}"
-                    },
-                    {
-                      "id": "__multiply_11",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__num_12",
-                      "type": "number",
-                      "label": "1/2",
-                      "subexpr": "\\frac{1}{2}"
-                    },
-                    {
-                      "id": "__power_13",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\beta}"
-                    },
-                    {
-                      "id": "beta",
-                      "type": "scalar",
-                      "latex": "\\beta",
-                      "subexpr": "\\beta"
-                    },
-                    {
-                      "id": "__power_14",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__sin_15",
-                      "type": "function",
-                      "latex": "\\sin",
-                      "op": "sin",
-                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "gamma",
-                      "type": "scalar",
-                      "latex": "\\gamma",
-                      "subexpr": "\\gamma"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "V(h) = V_E \\exp\\!\\left(-\\frac{\\rho_0 H}{2\\beta\\sin\\gamma}\\,e^{-h/H}\\right)", "description": "Allen-Eggers velocity solution", "color": "green", "highlight": "result"},
+                    {"id": "__V_2", "type": "function", "op": "V", "subexpr": "V{\\left(h \\right)}"},
+                    {"id": "h", "type": "scalar", "latex": "h", "subexpr": "h"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "V_{E} e^{- e^{\\frac{\\left(-1\\right) h}{H}} \\frac{H \\rho_{0}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"},
+                    {"id": "V_{E}", "type": "scalar", "latex": "V_{E}", "subexpr": "V_{E}"},
+                    {"id": "__exp_4", "type": "function", "latex": "\\exp", "op": "exp", "subexpr": "e^{- e^{\\frac{\\left(-1\\right) h}{H}} \\frac{H \\rho_{0}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"},
+                    {"id": "__negation_5", "type": "operator", "op": "negation", "subexpr": "-e^{\\frac{\\left(-1\\right) h}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"},
+                    {"id": "rho_{0}", "type": "scalar", "latex": "\\rho_{0}", "subexpr": "\\rho_{0}"},
+                    {"id": "__power_7", "type": "operator", "op": "power", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "__multiply_8", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{H} -h"},
+                    {"id": "__negation_9", "type": "operator", "op": "negation", "subexpr": "-h"},
+                    {"id": "__power_10", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{H}"},
+                    {"id": "__multiply_11", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__num_12", "type": "number", "label": "1/2", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__power_13", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\beta}"},
+                    {"id": "beta", "type": "scalar", "latex": "\\beta", "subexpr": "\\beta"},
+                    {"id": "__power_14", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__sin_15", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\gamma \\right)}"},
+                    {"id": "gamma", "type": "scalar", "latex": "\\gamma", "subexpr": "\\gamma"}
                   ],
                   "edges": [
-                    {
-                      "from": "h",
-                      "to": "__V_2"
-                    },
-                    {
-                      "from": "__V_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "V_{E}",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "rho_{0}",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "e",
-                      "to": "__power_7"
-                    },
-                    {
-                      "from": "h",
-                      "to": "__negation_9"
-                    },
-                    {
-                      "from": "__negation_9",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__power_10"
-                    },
-                    {
-                      "from": "__power_10",
-                      "to": "__multiply_8"
-                    },
-                    {
-                      "from": "__multiply_8",
-                      "to": "__power_7",
-                      "role": "exp"
-                    },
-                    {
-                      "from": "__power_7",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_12",
-                      "to": "__multiply_11",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "beta",
-                      "to": "__power_13"
-                    },
-                    {
-                      "from": "__power_13",
-                      "to": "__multiply_11"
-                    },
-                    {
-                      "from": "gamma",
-                      "to": "__sin_15"
-                    },
-                    {
-                      "from": "__sin_15",
-                      "to": "__power_14"
-                    },
-                    {
-                      "from": "__power_14",
-                      "to": "__multiply_11"
-                    },
-                    {
-                      "from": "__multiply_11",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_6",
-                      "to": "__negation_5"
-                    },
-                    {
-                      "from": "__negation_5",
-                      "to": "__exp_4"
-                    },
-                    {
-                      "from": "__exp_4",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__equals_1"
-                    }
+                    {"from": "h", "to": "__V_2"},
+                    {"from": "__V_2", "to": "__equals_1"},
+                    {"from": "V_{E}", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "rho_{0}", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "e", "to": "__power_7"},
+                    {"from": "h", "to": "__negation_9"},
+                    {"from": "__negation_9", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__power_10"},
+                    {"from": "__power_10", "to": "__multiply_8"},
+                    {"from": "__multiply_8", "to": "__power_7", "role": "exp"},
+                    {"from": "__power_7", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_12", "to": "__multiply_11", "semantic": "direct", "weight": 1.0},
+                    {"from": "beta", "to": "__power_13"},
+                    {"from": "__power_13", "to": "__multiply_11"},
+                    {"from": "gamma", "to": "__sin_15"},
+                    {"from": "__sin_15", "to": "__power_14"},
+                    {"from": "__power_14", "to": "__multiply_11"},
+                    {"from": "__multiply_11", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_6", "to": "__negation_5"},
+                    {"from": "__negation_5", "to": "__exp_4"},
+                    {"from": "__exp_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_3", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             }
@@ -5274,62 +1809,19 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "F_{\\text{net}} = m a"
-                    },
-                    {
-                      "id": "F_{\\text{net}}",
-                      "type": "scalar",
-                      "latex": "F_{\\text{net}}",
-                      "subexpr": "F_{\\text{net}}"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "a m"
-                    },
-                    {
-                      "id": "m",
-                      "type": "scalar",
-                      "latex": "m",
-                      "subexpr": "m"
-                    },
-                    {
-                      "id": "a",
-                      "type": "scalar",
-                      "latex": "a",
-                      "subexpr": "a"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "F_{\\text{net}} = m a"},
+                    {"id": "F_{\\text{net}}", "type": "scalar", "latex": "F_{\\text{net}}", "subexpr": "F_{\\text{net}}"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "a m"},
+                    {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m"},
+                    {"id": "a", "type": "scalar", "latex": "a", "subexpr": "a"}
                   ],
                   "edges": [
-                    {
-                      "from": "F_{\\text{net}}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "m",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "a",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "F_{\\text{net}}", "to": "__equals_1"},
+                    {"from": "m", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "a", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -5345,155 +1837,35 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "F_D = \\frac{1}{2}\\rho V^2 C_d A"
-                    },
-                    {
-                      "id": "F_{D}",
-                      "type": "scalar",
-                      "latex": "F_{D}",
-                      "subexpr": "F_{D}"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{2} \\rho V^{2} A C_{d}"
-                    },
-                    {
-                      "id": "__power_3",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2}"
-                    },
-                    {
-                      "id": "__num_4",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "__multiply_5",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho V^{2} A C_{d}"
-                    },
-                    {
-                      "id": "rho",
-                      "type": "scalar",
-                      "latex": "\\rho",
-                      "subexpr": "\\rho"
-                    },
-                    {
-                      "id": "__multiply_6",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V^{2} A C_{d}"
-                    },
-                    {
-                      "id": "__power_7",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V^{2}"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    },
-                    {
-                      "id": "__multiply_8",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "A C_{d}"
-                    },
-                    {
-                      "id": "C_{d}",
-                      "type": "scalar",
-                      "latex": "C_{d}",
-                      "subexpr": "C_{d}"
-                    },
-                    {
-                      "id": "A",
-                      "type": "scalar",
-                      "latex": "A",
-                      "subexpr": "A"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "F_D = \\frac{1}{2}\\rho V^2 C_d A"},
+                    {"id": "F_{D}", "type": "scalar", "latex": "F_{D}", "subexpr": "F_{D}"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{2} \\rho V^{2} A C_{d}"},
+                    {"id": "__power_3", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__num_4", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "\\rho V^{2} A C_{d}"},
+                    {"id": "rho", "type": "scalar", "latex": "\\rho", "subexpr": "\\rho"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "V^{2} A C_{d}"},
+                    {"id": "__power_7", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V^{2}"},
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"},
+                    {"id": "__multiply_8", "type": "operator", "op": "multiply", "subexpr": "A C_{d}"},
+                    {"id": "C_{d}", "type": "scalar", "latex": "C_{d}", "subexpr": "C_{d}"},
+                    {"id": "A", "type": "scalar", "latex": "A", "subexpr": "A"}
                   ],
                   "edges": [
-                    {
-                      "from": "F_{D}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "__num_4",
-                      "to": "__power_3"
-                    },
-                    {
-                      "from": "__power_3",
-                      "to": "__multiply_2"
-                    },
-                    {
-                      "from": "rho",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V",
-                      "to": "__power_7"
-                    },
-                    {
-                      "from": "__power_7",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "C_{d}",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "A",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_8",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_6",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_5",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "F_{D}", "to": "__equals_1"},
+                    {"from": "__num_4", "to": "__power_3"},
+                    {"from": "__power_3", "to": "__multiply_2"},
+                    {"from": "rho", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "V", "to": "__power_7"},
+                    {"from": "__power_7", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "C_{d}", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "A", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_8", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_6", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_5", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -5509,48 +1881,17 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "F_{\\text{net}} = -F_D"
-                    },
-                    {
-                      "id": "F_{\\text{net}}",
-                      "type": "scalar",
-                      "latex": "F_{\\text{net}}",
-                      "subexpr": "F_{\\text{net}}"
-                    },
-                    {
-                      "id": "__negation_2",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-F_{D}"
-                    },
-                    {
-                      "id": "F_{D}",
-                      "type": "scalar",
-                      "latex": "F_{D}",
-                      "subexpr": "F_{D}"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "F_{\\text{net}} = -F_D"},
+                    {"id": "F_{\\text{net}}", "type": "scalar", "latex": "F_{\\text{net}}", "subexpr": "F_{\\text{net}}"},
+                    {"id": "__negation_2", "type": "operator", "op": "negation", "subexpr": "-F_{D}"},
+                    {"id": "F_{D}", "type": "scalar", "latex": "F_{D}", "subexpr": "F_{D}"}
                   ],
                   "edges": [
-                    {
-                      "from": "F_{\\text{net}}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "F_{D}",
-                      "to": "__negation_2"
-                    },
-                    {
-                      "from": "__negation_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "F_{\\text{net}}", "to": "__equals_1"},
+                    {"from": "F_{D}", "to": "__negation_2"},
+                    {"from": "__negation_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -5566,174 +1907,41 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "m \\frac{d}{d t} V = -\\frac{1}{2}\\rho V^2 C_d A"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "m \\frac{d}{d t} V"
-                    },
-                    {
-                      "id": "m",
-                      "type": "scalar",
-                      "latex": "m",
-                      "subexpr": "m"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    },
-                    {
-                      "id": "t",
-                      "type": "scalar",
-                      "latex": "t",
-                      "subexpr": "t"
-                    },
-                    {
-                      "id": "__deriv_3",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t",
-                      "subexpr": "\\frac{d}{d t} V"
-                    },
-                    {
-                      "id": "__negation_4",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-V^{2} \\rho A \\frac{1}{2} C_{d}"
-                    },
-                    {
-                      "id": "__multiply_5",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V^{2} \\rho A \\frac{1}{2} C_{d}"
-                    },
-                    {
-                      "id": "__num_6",
-                      "type": "number",
-                      "label": "1/2",
-                      "subexpr": "\\frac{1}{2}"
-                    },
-                    {
-                      "id": "A",
-                      "type": "scalar",
-                      "latex": "A",
-                      "subexpr": "A"
-                    },
-                    {
-                      "id": "C_{d}",
-                      "type": "scalar",
-                      "latex": "C_{d}",
-                      "subexpr": "C_{d}"
-                    },
-                    {
-                      "id": "rho",
-                      "type": "scalar",
-                      "latex": "\\rho",
-                      "subexpr": "\\rho"
-                    },
-                    {
-                      "id": "__power_7",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V^{2}"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "m \\frac{d}{d t} V = -\\frac{1}{2}\\rho V^2 C_d A"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "m \\frac{d}{d t} V"},
+                    {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m"},
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"},
+                    {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                    {"id": "__deriv_3", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\frac{d}{d t} V"},
+                    {"id": "__negation_4", "type": "operator", "op": "negation", "subexpr": "-V^{2} \\rho A \\frac{1}{2} C_{d}"},
+                    {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "V^{2} \\rho A \\frac{1}{2} C_{d}"},
+                    {"id": "__num_6", "type": "number", "label": "1/2", "subexpr": "\\frac{1}{2}"},
+                    {"id": "A", "type": "scalar", "latex": "A", "subexpr": "A"},
+                    {"id": "C_{d}", "type": "scalar", "latex": "C_{d}", "subexpr": "C_{d}"},
+                    {"id": "rho", "type": "scalar", "latex": "\\rho", "subexpr": "\\rho"},
+                    {"id": "__power_7", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V^{2}"}
                   ],
                   "edges": [
-                    {
-                      "from": "m",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V",
-                      "to": "__deriv_3"
-                    },
-                    {
-                      "from": "t",
-                      "to": "__deriv_3",
-                      "role": "wrt"
-                    },
-                    {
-                      "from": "__deriv_3",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "__num_6",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "A",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "C_{d}",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "rho",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V",
-                      "to": "__power_7"
-                    },
-                    {
-                      "from": "__power_7",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_5",
-                      "to": "__negation_4"
-                    },
-                    {
-                      "from": "__negation_4",
-                      "to": "__equals_1"
-                    }
+                    {"from": "m", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "V", "to": "__deriv_3"},
+                    {"from": "t", "to": "__deriv_3", "role": "wrt"},
+                    {"from": "__deriv_3", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_2", "to": "__equals_1"},
+                    {"from": "__num_6", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "A", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "C_{d}", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "rho", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "V", "to": "__power_7"},
+                    {"from": "__power_7", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_5", "to": "__negation_4"},
+                    {"from": "__negation_4", "to": "__equals_1"}
                   ],
                   "classification": {
                     "kind": "ODE",
                     "order": 1,
-                    "dependent_variables": [
-                      "V"
-                    ],
-                    "independent_variables": [
-                      "t"
-                    ],
-                    "sympy_hints": [
-                      "factorable",
-                      "separable",
-                      "1st_exact",
-                      "Bernoulli",
-                      "Riccati_special_minus2",
-                      "1st_power_series",
-                      "lie_group"
-                    ],
+                    "dependent_variables": ["V"],
+                    "independent_variables": ["t"],
+                    "sympy_hints": ["factorable", "separable", "1st_exact", "Bernoulli", "Riccati_special_minus2", "1st_power_series", "lie_group"],
                     "linear": false,
                     "homogeneous": false,
                     "constant_coefficients": false
@@ -5753,177 +1961,43 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    },
-                    {
-                      "id": "t",
-                      "type": "scalar",
-                      "latex": "t",
-                      "subexpr": "t"
-                    },
-                    {
-                      "id": "s0___deriv_1",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t",
-                      "subexpr": "\\frac{d}{d t} V"
-                    },
-                    {
-                      "id": "s1___multiply_1",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{dV}{dh} \\frac{d}{d t} h"
-                    },
-                    {
-                      "id": "h",
-                      "type": "scalar",
-                      "latex": "h",
-                      "subexpr": "h"
-                    },
-                    {
-                      "id": "s1___deriv_2",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "h",
-                      "subexpr": "\\frac{d}{d h} V"
-                    },
-                    {
-                      "id": "s1___deriv_3",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t",
-                      "subexpr": "\\frac{d}{d t} h"
-                    },
-                    {
-                      "id": "s2___negation_1",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-V \\sin \\gamma \\frac{dV}{dh}"
-                    },
-                    {
-                      "id": "s2___multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V \\sin{\\left(\\gamma \\frac{d}{d h} V \\right)}"
-                    },
-                    {
-                      "id": "s2___sin_3",
-                      "type": "function",
-                      "latex": "\\sin",
-                      "op": "sin",
-                      "subexpr": "\\sin{\\left(\\gamma \\frac{d}{d h} V \\right)}"
-                    },
-                    {
-                      "id": "s2___multiply_4",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\gamma \\frac{d}{d h} V"
-                    },
-                    {
-                      "id": "gamma",
-                      "type": "scalar",
-                      "latex": "\\gamma",
-                      "subexpr": "\\gamma"
-                    },
-                    {
-                      "id": "s2___deriv_5",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "h",
-                      "subexpr": "\\frac{d}{d h} V"
-                    },
-                    {
-                      "id": "__equals_1",
-                      "type": "operator",
-                      "op": "equals",
-                      "subexpr": "\\frac{dV}{dt} = \\frac{dV}{dh} \\frac{dh}{dt} = -V \\sin \\gamma \\frac{dV}{dh}"
-                    }
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"},
+                    {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                    {"id": "s0___deriv_1", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\frac{d}{d t} V"},
+                    {"id": "s1___multiply_1", "type": "operator", "op": "multiply", "subexpr": "\\frac{dV}{dh} \\frac{d}{d t} h"},
+                    {"id": "h", "type": "scalar", "latex": "h", "subexpr": "h"},
+                    {"id": "s1___deriv_2", "type": "operator", "op": "derivative", "with_respect_to": "h", "subexpr": "\\frac{d}{d h} V"},
+                    {"id": "s1___deriv_3", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\frac{d}{d t} h"},
+                    {"id": "s2___negation_1", "type": "operator", "op": "negation", "subexpr": "-V \\sin \\gamma \\frac{dV}{dh}"},
+                    {"id": "s2___multiply_2", "type": "operator", "op": "multiply", "subexpr": "V \\sin{\\left(\\gamma \\frac{d}{d h} V \\right)}"},
+                    {"id": "s2___sin_3", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\gamma \\frac{d}{d h} V \\right)}"},
+                    {"id": "s2___multiply_4", "type": "operator", "op": "multiply", "subexpr": "\\gamma \\frac{d}{d h} V"},
+                    {"id": "gamma", "type": "scalar", "latex": "\\gamma", "subexpr": "\\gamma"},
+                    {"id": "s2___deriv_5", "type": "operator", "op": "derivative", "with_respect_to": "h", "subexpr": "\\frac{d}{d h} V"},
+                    {"id": "__equals_1", "type": "operator", "op": "equals", "subexpr": "\\frac{dV}{dt} = \\frac{dV}{dh} \\frac{dh}{dt} = -V \\sin \\gamma \\frac{dV}{dh}"}
                   ],
                   "edges": [
-                    {
-                      "from": "V",
-                      "to": "s0___deriv_1"
-                    },
-                    {
-                      "from": "t",
-                      "to": "s0___deriv_1"
-                    },
-                    {
-                      "from": "V",
-                      "to": "s1___deriv_2"
-                    },
-                    {
-                      "from": "h",
-                      "to": "s1___deriv_2"
-                    },
-                    {
-                      "from": "s1___deriv_2",
-                      "to": "s1___multiply_1"
-                    },
-                    {
-                      "from": "h",
-                      "to": "s1___deriv_3"
-                    },
-                    {
-                      "from": "t",
-                      "to": "s1___deriv_3"
-                    },
-                    {
-                      "from": "s1___deriv_3",
-                      "to": "s1___multiply_1"
-                    },
-                    {
-                      "from": "V",
-                      "to": "s2___multiply_2"
-                    },
-                    {
-                      "from": "gamma",
-                      "to": "s2___multiply_4"
-                    },
-                    {
-                      "from": "V",
-                      "to": "s2___deriv_5"
-                    },
-                    {
-                      "from": "h",
-                      "to": "s2___deriv_5"
-                    },
-                    {
-                      "from": "s2___deriv_5",
-                      "to": "s2___multiply_4"
-                    },
-                    {
-                      "from": "s2___multiply_4",
-                      "to": "s2___sin_3"
-                    },
-                    {
-                      "from": "s2___sin_3",
-                      "to": "s2___multiply_2"
-                    },
-                    {
-                      "from": "s2___multiply_2",
-                      "to": "s2___negation_1"
-                    },
-                    {
-                      "from": "s0___deriv_1",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "s1___multiply_1",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "s2___negation_1",
-                      "to": "__equals_1"
-                    }
+                    {"from": "V", "to": "s0___deriv_1"},
+                    {"from": "t", "to": "s0___deriv_1"},
+                    {"from": "V", "to": "s1___deriv_2"},
+                    {"from": "h", "to": "s1___deriv_2"},
+                    {"from": "s1___deriv_2", "to": "s1___multiply_1"},
+                    {"from": "h", "to": "s1___deriv_3"},
+                    {"from": "t", "to": "s1___deriv_3"},
+                    {"from": "s1___deriv_3", "to": "s1___multiply_1"},
+                    {"from": "V", "to": "s2___multiply_2"},
+                    {"from": "gamma", "to": "s2___multiply_4"},
+                    {"from": "V", "to": "s2___deriv_5"},
+                    {"from": "h", "to": "s2___deriv_5"},
+                    {"from": "s2___deriv_5", "to": "s2___multiply_4"},
+                    {"from": "s2___multiply_4", "to": "s2___sin_3"},
+                    {"from": "s2___sin_3", "to": "s2___multiply_2"},
+                    {"from": "s2___multiply_2", "to": "s2___negation_1"},
+                    {"from": "s0___deriv_1", "to": "__equals_1"},
+                    {"from": "s1___multiply_1", "to": "__equals_1"},
+                    {"from": "s2___negation_1", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -5939,261 +2013,55 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "V(h) = V_E \\exp\\left(-\\frac{\\rho_0 H}{2\\beta \\sin\\gamma}\\,e^{-h/H}\\right)"
-                    },
-                    {
-                      "id": "__V_2",
-                      "type": "function",
-                      "op": "V",
-                      "subexpr": "V{\\left(h \\right)}"
-                    },
-                    {
-                      "id": "h",
-                      "type": "scalar",
-                      "latex": "h",
-                      "subexpr": "h"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{E} e^{- e^{\\frac{\\left(-1\\right) h}{H}} \\frac{H \\rho_{0}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"
-                    },
-                    {
-                      "id": "V_{E}",
-                      "type": "scalar",
-                      "latex": "V_{E}",
-                      "subexpr": "V_{E}"
-                    },
-                    {
-                      "id": "__exp_4",
-                      "type": "function",
-                      "latex": "\\exp",
-                      "op": "exp",
-                      "subexpr": "e^{- e^{\\frac{\\left(-1\\right) h}{H}} \\frac{H \\rho_{0}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"
-                    },
-                    {
-                      "id": "__negation_5",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-e^{\\frac{\\left(-1\\right) h}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__multiply_6",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "H",
-                      "type": "scalar",
-                      "latex": "H",
-                      "subexpr": "H"
-                    },
-                    {
-                      "id": "rho_{0}",
-                      "type": "scalar",
-                      "latex": "\\rho_{0}",
-                      "subexpr": "\\rho_{0}"
-                    },
-                    {
-                      "id": "__power_7",
-                      "type": "operator",
-                      "op": "power",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"
-                    },
-                    {
-                      "id": "e",
-                      "type": "scalar",
-                      "latex": "e",
-                      "subexpr": "e"
-                    },
-                    {
-                      "id": "__multiply_8",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{H} -h"
-                    },
-                    {
-                      "id": "__negation_9",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-h"
-                    },
-                    {
-                      "id": "__power_10",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{H}"
-                    },
-                    {
-                      "id": "__multiply_11",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__num_12",
-                      "type": "number",
-                      "label": "1/2",
-                      "subexpr": "\\frac{1}{2}"
-                    },
-                    {
-                      "id": "__power_13",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\beta}"
-                    },
-                    {
-                      "id": "beta",
-                      "type": "scalar",
-                      "latex": "\\beta",
-                      "subexpr": "\\beta"
-                    },
-                    {
-                      "id": "__power_14",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__sin_15",
-                      "type": "function",
-                      "latex": "\\sin",
-                      "op": "sin",
-                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "gamma",
-                      "type": "scalar",
-                      "latex": "\\gamma",
-                      "subexpr": "\\gamma"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "V(h) = V_E \\exp\\left(-\\frac{\\rho_0 H}{2\\beta \\sin\\gamma}\\,e^{-h/H}\\right)"},
+                    {"id": "__V_2", "type": "function", "op": "V", "subexpr": "V{\\left(h \\right)}"},
+                    {"id": "h", "type": "scalar", "latex": "h", "subexpr": "h"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "V_{E} e^{- e^{\\frac{\\left(-1\\right) h}{H}} \\frac{H \\rho_{0}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"},
+                    {"id": "V_{E}", "type": "scalar", "latex": "V_{E}", "subexpr": "V_{E}"},
+                    {"id": "__exp_4", "type": "function", "latex": "\\exp", "op": "exp", "subexpr": "e^{- e^{\\frac{\\left(-1\\right) h}{H}} \\frac{H \\rho_{0}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"},
+                    {"id": "__negation_5", "type": "operator", "op": "negation", "subexpr": "-e^{\\frac{\\left(-1\\right) h}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"},
+                    {"id": "rho_{0}", "type": "scalar", "latex": "\\rho_{0}", "subexpr": "\\rho_{0}"},
+                    {"id": "__power_7", "type": "operator", "op": "power", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "__multiply_8", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{H} -h"},
+                    {"id": "__negation_9", "type": "operator", "op": "negation", "subexpr": "-h"},
+                    {"id": "__power_10", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{H}"},
+                    {"id": "__multiply_11", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__num_12", "type": "number", "label": "1/2", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__power_13", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\beta}"},
+                    {"id": "beta", "type": "scalar", "latex": "\\beta", "subexpr": "\\beta"},
+                    {"id": "__power_14", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__sin_15", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\gamma \\right)}"},
+                    {"id": "gamma", "type": "scalar", "latex": "\\gamma", "subexpr": "\\gamma"}
                   ],
                   "edges": [
-                    {
-                      "from": "h",
-                      "to": "__V_2"
-                    },
-                    {
-                      "from": "__V_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "V_{E}",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "rho_{0}",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "e",
-                      "to": "__power_7"
-                    },
-                    {
-                      "from": "h",
-                      "to": "__negation_9"
-                    },
-                    {
-                      "from": "__negation_9",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__power_10"
-                    },
-                    {
-                      "from": "__power_10",
-                      "to": "__multiply_8"
-                    },
-                    {
-                      "from": "__multiply_8",
-                      "to": "__power_7",
-                      "role": "exp"
-                    },
-                    {
-                      "from": "__power_7",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_12",
-                      "to": "__multiply_11",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "beta",
-                      "to": "__power_13"
-                    },
-                    {
-                      "from": "__power_13",
-                      "to": "__multiply_11"
-                    },
-                    {
-                      "from": "gamma",
-                      "to": "__sin_15"
-                    },
-                    {
-                      "from": "__sin_15",
-                      "to": "__power_14"
-                    },
-                    {
-                      "from": "__power_14",
-                      "to": "__multiply_11"
-                    },
-                    {
-                      "from": "__multiply_11",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_6",
-                      "to": "__negation_5"
-                    },
-                    {
-                      "from": "__negation_5",
-                      "to": "__exp_4"
-                    },
-                    {
-                      "from": "__exp_4",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__equals_1"
-                    }
+                    {"from": "h", "to": "__V_2"},
+                    {"from": "__V_2", "to": "__equals_1"},
+                    {"from": "V_{E}", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "rho_{0}", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "e", "to": "__power_7"},
+                    {"from": "h", "to": "__negation_9"},
+                    {"from": "__negation_9", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__power_10"},
+                    {"from": "__power_10", "to": "__multiply_8"},
+                    {"from": "__multiply_8", "to": "__power_7", "role": "exp"},
+                    {"from": "__power_7", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_12", "to": "__multiply_11", "semantic": "direct", "weight": 1.0},
+                    {"from": "beta", "to": "__power_13"},
+                    {"from": "__power_13", "to": "__multiply_11"},
+                    {"from": "gamma", "to": "__sin_15"},
+                    {"from": "__sin_15", "to": "__power_14"},
+                    {"from": "__power_14", "to": "__multiply_11"},
+                    {"from": "__multiply_11", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_6", "to": "__negation_5"},
+                    {"from": "__negation_5", "to": "__exp_4"},
+                    {"from": "__exp_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_3", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -6209,78 +2077,25 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\frac{d}{dh} \\left( \\frac{d}{d t} V \\right) = 0"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    },
-                    {
-                      "id": "t",
-                      "type": "scalar",
-                      "latex": "t",
-                      "subexpr": "t"
-                    },
-                    {
-                      "id": "h",
-                      "type": "scalar",
-                      "latex": "h",
-                      "subexpr": "h"
-                    },
-                    {
-                      "id": "__deriv_2",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t, h",
-                      "subexpr": "\\frac{d^{2}}{d hd t} V"
-                    },
-                    {
-                      "id": "__num_3",
-                      "type": "number",
-                      "label": "0",
-                      "subexpr": "0"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\frac{d}{dh} \\left( \\frac{d}{d t} V \\right) = 0"},
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"},
+                    {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                    {"id": "h", "type": "scalar", "latex": "h", "subexpr": "h"},
+                    {"id": "__deriv_2", "type": "operator", "op": "derivative", "with_respect_to": "t, h", "subexpr": "\\frac{d^{2}}{d hd t} V"},
+                    {"id": "__num_3", "type": "number", "label": "0", "subexpr": "0"}
                   ],
                   "edges": [
-                    {
-                      "from": "V",
-                      "to": "__deriv_2"
-                    },
-                    {
-                      "from": "t",
-                      "to": "__deriv_2",
-                      "role": "wrt"
-                    },
-                    {
-                      "from": "h",
-                      "to": "__deriv_2",
-                      "role": "wrt"
-                    },
-                    {
-                      "from": "__deriv_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "__num_3",
-                      "to": "__equals_1"
-                    }
+                    {"from": "V", "to": "__deriv_2"},
+                    {"from": "t", "to": "__deriv_2", "role": "wrt"},
+                    {"from": "h", "to": "__deriv_2", "role": "wrt"},
+                    {"from": "__deriv_2", "to": "__equals_1"},
+                    {"from": "__num_3", "to": "__equals_1"}
                   ],
                   "classification": {
                     "kind": "PDE",
                     "order": 2,
-                    "dependent_variables": [
-                      "V"
-                    ],
-                    "independent_variables": [
-                      "h",
-                      "t"
-                    ]
+                    "dependent_variables": ["V"],
+                    "independent_variables": ["h", "t"]
                   }
                 }
               }
@@ -6294,184 +2109,43 @@
               "prompt": "Make sure the student realizes the profound implication: you can't build a 'heavier' ship to lower the peak G-forces. You MUST come in slower or shallower.",
               "sceneStep": 1,
               "highlights": {
-                "ve": {
-                  "color": "cyan",
-                  "label": "Entry Velocity"
-                },
-                "gamma": {
-                  "color": "yellow",
-                  "label": "Flight Path Angle"
-                }
+                "ve": {"color": "cyan", "label": "Entry Velocity"},
+                "gamma": {"color": "yellow", "label": "Flight Path Angle"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "a_{\\text{max}} = \\frac{V_E^2 \\sin \\gamma}{2e H}"
-                    },
-                    {
-                      "id": "a_{\\text{max}}",
-                      "type": "scalar",
-                      "latex": "a_{\\text{max}}",
-                      "subexpr": "a_{\\text{max}}"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma \\right)} \\frac{1}{2 H e}"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "__power_4",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V_{E}^{2}",
-                      "description": "Entry Velocity",
-                      "color": "cyan",
-                      "highlight": "ve"
-                    },
-                    {
-                      "id": "V_{E}",
-                      "type": "scalar",
-                      "latex": "V_{E}",
-                      "subexpr": "V_{E}"
-                    },
-                    {
-                      "id": "__sin_5",
-                      "type": "function",
-                      "latex": "\\sin",
-                      "op": "sin",
-                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "gamma",
-                      "type": "scalar",
-                      "latex": "\\gamma",
-                      "subexpr": "\\gamma",
-                      "description": "Flight Path Angle",
-                      "color": "yellow",
-                      "highlight": "gamma"
-                    },
-                    {
-                      "id": "__power_6",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2 H e}"
-                    },
-                    {
-                      "id": "__multiply_7",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "2 e H"
-                    },
-                    {
-                      "id": "__num_8",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "__multiply_9",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "e H"
-                    },
-                    {
-                      "id": "e",
-                      "type": "scalar",
-                      "latex": "e",
-                      "subexpr": "e"
-                    },
-                    {
-                      "id": "H",
-                      "type": "scalar",
-                      "latex": "H",
-                      "subexpr": "H"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "a_{\\text{max}} = \\frac{V_E^2 \\sin \\gamma}{2e H}"},
+                    {"id": "a_{\\text{max}}", "type": "scalar", "latex": "a_{\\text{max}}", "subexpr": "a_{\\text{max}}"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma \\right)} \\frac{1}{2 H e}"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma \\right)}"},
+                    {"id": "__power_4", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V_{E}^{2}", "description": "Entry Velocity", "color": "cyan", "highlight": "ve"},
+                    {"id": "V_{E}", "type": "scalar", "latex": "V_{E}", "subexpr": "V_{E}"},
+                    {"id": "__sin_5", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\gamma \\right)}"},
+                    {"id": "gamma", "type": "scalar", "latex": "\\gamma", "subexpr": "\\gamma", "description": "Flight Path Angle", "color": "yellow", "highlight": "gamma"},
+                    {"id": "__power_6", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2 H e}"},
+                    {"id": "__multiply_7", "type": "operator", "op": "multiply", "subexpr": "2 e H"},
+                    {"id": "__num_8", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__multiply_9", "type": "operator", "op": "multiply", "subexpr": "e H"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"}
                   ],
                   "edges": [
-                    {
-                      "from": "a_{\\text{max}}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "V_{E}",
-                      "to": "__power_4"
-                    },
-                    {
-                      "from": "__power_4",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "gamma",
-                      "to": "__sin_5"
-                    },
-                    {
-                      "from": "__sin_5",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_8",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "e",
-                      "to": "__multiply_9",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__multiply_9",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_9",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_7",
-                      "to": "__power_6"
-                    },
-                    {
-                      "from": "__power_6",
-                      "to": "__multiply_2"
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "a_{\\text{max}}", "to": "__equals_1"},
+                    {"from": "V_{E}", "to": "__power_4"},
+                    {"from": "__power_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "gamma", "to": "__sin_5"},
+                    {"from": "__sin_5", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_3", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_8", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "e", "to": "__multiply_9", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__multiply_9", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_9", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_7", "to": "__power_6"},
+                    {"from": "__power_6", "to": "__multiply_2"},
+                    {"from": "__multiply_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             }
@@ -6496,131 +2170,31 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "a_D = \\frac{\\rho V^2}{2\\beta}"
-                    },
-                    {
-                      "id": "a_{D}",
-                      "type": "scalar",
-                      "latex": "a_{D}",
-                      "subexpr": "a_{D}"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho V^{2} \\frac{1}{2 \\beta}"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho V^{2}"
-                    },
-                    {
-                      "id": "rho",
-                      "type": "scalar",
-                      "latex": "\\rho",
-                      "subexpr": "\\rho"
-                    },
-                    {
-                      "id": "__power_4",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V^{2}"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    },
-                    {
-                      "id": "__power_5",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2 \\beta}"
-                    },
-                    {
-                      "id": "__multiply_6",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\beta 2"
-                    },
-                    {
-                      "id": "__num_7",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "beta",
-                      "type": "scalar",
-                      "latex": "\\beta",
-                      "subexpr": "\\beta"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "a_D = \\frac{\\rho V^2}{2\\beta}"},
+                    {"id": "a_{D}", "type": "scalar", "latex": "a_{D}", "subexpr": "a_{D}"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\rho V^{2} \\frac{1}{2 \\beta}"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "\\rho V^{2}"},
+                    {"id": "rho", "type": "scalar", "latex": "\\rho", "subexpr": "\\rho"},
+                    {"id": "__power_4", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V^{2}"},
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"},
+                    {"id": "__power_5", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2 \\beta}"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "\\beta 2"},
+                    {"id": "__num_7", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "beta", "type": "scalar", "latex": "\\beta", "subexpr": "\\beta"}
                   ],
                   "edges": [
-                    {
-                      "from": "a_{D}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "rho",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V",
-                      "to": "__power_4"
-                    },
-                    {
-                      "from": "__power_4",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_7",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "beta",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_6",
-                      "to": "__power_5"
-                    },
-                    {
-                      "from": "__power_5",
-                      "to": "__multiply_2"
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "a_{D}", "to": "__equals_1"},
+                    {"from": "rho", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "V", "to": "__power_4"},
+                    {"from": "__power_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_3", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_7", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "beta", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_6", "to": "__power_5"},
+                    {"from": "__power_5", "to": "__multiply_2"},
+                    {"from": "__multiply_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -6635,401 +2209,80 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "a_D(h) = \\frac{\\rho_0\\,e^{-h/H}\\cdot V_E^2}{2\\beta}\\exp\\!\\left(-\\frac{\\rho_0 H}{\\beta\\sin\\gamma}\\,e^{-h/H}\\right)"
-                    },
-                    {
-                      "id": "__a_{D}_2",
-                      "type": "function",
-                      "op": "a_{D}",
-                      "subexpr": "a_{D}{\\left(h \\right)}"
-                    },
-                    {
-                      "id": "h",
-                      "type": "scalar",
-                      "latex": "h",
-                      "subexpr": "h"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0} V_{E}^{2} \\frac{1}{2 \\beta} e^{- e^{\\frac{\\left(-1\\right) h}{H}} \\frac{H \\rho_{0}}{\\beta \\sin{\\left(\\gamma \\right)}}}"
-                    },
-                    {
-                      "id": "__multiply_4",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0} V_{E}^{2} \\frac{1}{2 \\beta}"
-                    },
-                    {
-                      "id": "__multiply_5",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0} V_{E}^{2}"
-                    },
-                    {
-                      "id": "__multiply_6",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0}"
-                    },
-                    {
-                      "id": "rho_{0}",
-                      "type": "scalar",
-                      "latex": "\\rho_{0}",
-                      "subexpr": "\\rho_{0}"
-                    },
-                    {
-                      "id": "__power_7",
-                      "type": "operator",
-                      "op": "power",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"
-                    },
-                    {
-                      "id": "e",
-                      "type": "scalar",
-                      "latex": "e",
-                      "subexpr": "e"
-                    },
-                    {
-                      "id": "__multiply_8",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{H} -h"
-                    },
-                    {
-                      "id": "__negation_9",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-h"
-                    },
-                    {
-                      "id": "__power_10",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{H}"
-                    },
-                    {
-                      "id": "H",
-                      "type": "scalar",
-                      "latex": "H",
-                      "subexpr": "H"
-                    },
-                    {
-                      "id": "__power_11",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V_{E}^{2}"
-                    },
-                    {
-                      "id": "V_{E}",
-                      "type": "scalar",
-                      "latex": "V_{E}",
-                      "subexpr": "V_{E}"
-                    },
-                    {
-                      "id": "__power_12",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2 \\beta}"
-                    },
-                    {
-                      "id": "__multiply_13",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\beta 2"
-                    },
-                    {
-                      "id": "__num_14",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "beta",
-                      "type": "scalar",
-                      "latex": "\\beta",
-                      "subexpr": "\\beta"
-                    },
-                    {
-                      "id": "__exp_15",
-                      "type": "function",
-                      "latex": "\\exp",
-                      "op": "exp",
-                      "subexpr": "e^{- e^{\\frac{\\left(-1\\right) h}{H}} \\frac{H \\rho_{0}}{\\beta \\sin{\\left(\\gamma \\right)}}}"
-                    },
-                    {
-                      "id": "__negation_16",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-e^{\\frac{\\left(-1\\right) h}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__multiply_17",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__power_18",
-                      "type": "operator",
-                      "op": "power",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"
-                    },
-                    {
-                      "id": "__multiply_19",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{H} -h"
-                    },
-                    {
-                      "id": "__negation_20",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-h"
-                    },
-                    {
-                      "id": "__power_21",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{H}"
-                    },
-                    {
-                      "id": "__multiply_22",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{\\beta} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__power_23",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\beta}"
-                    },
-                    {
-                      "id": "__power_24",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__sin_25",
-                      "type": "function",
-                      "latex": "\\sin",
-                      "op": "sin",
-                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "gamma",
-                      "type": "scalar",
-                      "latex": "\\gamma",
-                      "subexpr": "\\gamma"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "a_D(h) = \\frac{\\rho_0\\,e^{-h/H}\\cdot V_E^2}{2\\beta}\\exp\\!\\left(-\\frac{\\rho_0 H}{\\beta\\sin\\gamma}\\,e^{-h/H}\\right)"},
+                    {"id": "__a_{D}_2", "type": "function", "op": "a_{D}", "subexpr": "a_{D}{\\left(h \\right)}"},
+                    {"id": "h", "type": "scalar", "latex": "h", "subexpr": "h"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0} V_{E}^{2} \\frac{1}{2 \\beta} e^{- e^{\\frac{\\left(-1\\right) h}{H}} \\frac{H \\rho_{0}}{\\beta \\sin{\\left(\\gamma \\right)}}}"},
+                    {"id": "__multiply_4", "type": "operator", "op": "multiply", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0} V_{E}^{2} \\frac{1}{2 \\beta}"},
+                    {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0} V_{E}^{2}"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} \\rho_{0}"},
+                    {"id": "rho_{0}", "type": "scalar", "latex": "\\rho_{0}", "subexpr": "\\rho_{0}"},
+                    {"id": "__power_7", "type": "operator", "op": "power", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "__multiply_8", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{H} -h"},
+                    {"id": "__negation_9", "type": "operator", "op": "negation", "subexpr": "-h"},
+                    {"id": "__power_10", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{H}"},
+                    {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"},
+                    {"id": "__power_11", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V_{E}^{2}"},
+                    {"id": "V_{E}", "type": "scalar", "latex": "V_{E}", "subexpr": "V_{E}"},
+                    {"id": "__power_12", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2 \\beta}"},
+                    {"id": "__multiply_13", "type": "operator", "op": "multiply", "subexpr": "\\beta 2"},
+                    {"id": "__num_14", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "beta", "type": "scalar", "latex": "\\beta", "subexpr": "\\beta"},
+                    {"id": "__exp_15", "type": "function", "latex": "\\exp", "op": "exp", "subexpr": "e^{- e^{\\frac{\\left(-1\\right) h}{H}} \\frac{H \\rho_{0}}{\\beta \\sin{\\left(\\gamma \\right)}}}"},
+                    {"id": "__negation_16", "type": "operator", "op": "negation", "subexpr": "-e^{\\frac{\\left(-1\\right) h}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__multiply_17", "type": "operator", "op": "multiply", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__power_18", "type": "operator", "op": "power", "subexpr": "e^{\\frac{\\left(-1\\right) h}{H}}"},
+                    {"id": "__multiply_19", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{H} -h"},
+                    {"id": "__negation_20", "type": "operator", "op": "negation", "subexpr": "-h"},
+                    {"id": "__power_21", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{H}"},
+                    {"id": "__multiply_22", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{\\beta} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__power_23", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\beta}"},
+                    {"id": "__power_24", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__sin_25", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\gamma \\right)}"},
+                    {"id": "gamma", "type": "scalar", "latex": "\\gamma", "subexpr": "\\gamma"}
                   ],
                   "edges": [
-                    {
-                      "from": "h",
-                      "to": "__a_{D}_2"
-                    },
-                    {
-                      "from": "__a_{D}_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "rho_{0}",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "e",
-                      "to": "__power_7"
-                    },
-                    {
-                      "from": "h",
-                      "to": "__negation_9"
-                    },
-                    {
-                      "from": "__negation_9",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__power_10"
-                    },
-                    {
-                      "from": "__power_10",
-                      "to": "__multiply_8"
-                    },
-                    {
-                      "from": "__multiply_8",
-                      "to": "__power_7",
-                      "role": "exp"
-                    },
-                    {
-                      "from": "__power_7",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_6",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V_{E}",
-                      "to": "__power_11"
-                    },
-                    {
-                      "from": "__power_11",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_5",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_14",
-                      "to": "__multiply_13",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "beta",
-                      "to": "__multiply_13",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_13",
-                      "to": "__power_12"
-                    },
-                    {
-                      "from": "__power_12",
-                      "to": "__multiply_4"
-                    },
-                    {
-                      "from": "__multiply_4",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__multiply_17",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "rho_{0}",
-                      "to": "__multiply_17",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "e",
-                      "to": "__power_18"
-                    },
-                    {
-                      "from": "h",
-                      "to": "__negation_20"
-                    },
-                    {
-                      "from": "__negation_20",
-                      "to": "__multiply_19",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__power_21"
-                    },
-                    {
-                      "from": "__power_21",
-                      "to": "__multiply_19"
-                    },
-                    {
-                      "from": "__multiply_19",
-                      "to": "__power_18",
-                      "role": "exp"
-                    },
-                    {
-                      "from": "__power_18",
-                      "to": "__multiply_17",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "beta",
-                      "to": "__power_23"
-                    },
-                    {
-                      "from": "__power_23",
-                      "to": "__multiply_22"
-                    },
-                    {
-                      "from": "gamma",
-                      "to": "__sin_25"
-                    },
-                    {
-                      "from": "__sin_25",
-                      "to": "__power_24"
-                    },
-                    {
-                      "from": "__power_24",
-                      "to": "__multiply_22"
-                    },
-                    {
-                      "from": "__multiply_22",
-                      "to": "__multiply_17",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_17",
-                      "to": "__negation_16"
-                    },
-                    {
-                      "from": "__negation_16",
-                      "to": "__exp_15"
-                    },
-                    {
-                      "from": "__exp_15",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__equals_1"
-                    }
+                    {"from": "h", "to": "__a_{D}_2"},
+                    {"from": "__a_{D}_2", "to": "__equals_1"},
+                    {"from": "rho_{0}", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "e", "to": "__power_7"},
+                    {"from": "h", "to": "__negation_9"},
+                    {"from": "__negation_9", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__power_10"},
+                    {"from": "__power_10", "to": "__multiply_8"},
+                    {"from": "__multiply_8", "to": "__power_7", "role": "exp"},
+                    {"from": "__power_7", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_6", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "V_{E}", "to": "__power_11"},
+                    {"from": "__power_11", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_5", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_14", "to": "__multiply_13", "semantic": "direct", "weight": 1.0},
+                    {"from": "beta", "to": "__multiply_13", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_13", "to": "__power_12"},
+                    {"from": "__power_12", "to": "__multiply_4"},
+                    {"from": "__multiply_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__multiply_17", "semantic": "direct", "weight": 1.0},
+                    {"from": "rho_{0}", "to": "__multiply_17", "semantic": "direct", "weight": 1.0},
+                    {"from": "e", "to": "__power_18"},
+                    {"from": "h", "to": "__negation_20"},
+                    {"from": "__negation_20", "to": "__multiply_19", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__power_21"},
+                    {"from": "__power_21", "to": "__multiply_19"},
+                    {"from": "__multiply_19", "to": "__power_18", "role": "exp"},
+                    {"from": "__power_18", "to": "__multiply_17", "semantic": "direct", "weight": 1.0},
+                    {"from": "beta", "to": "__power_23"},
+                    {"from": "__power_23", "to": "__multiply_22"},
+                    {"from": "gamma", "to": "__sin_25"},
+                    {"from": "__sin_25", "to": "__power_24"},
+                    {"from": "__power_24", "to": "__multiply_22"},
+                    {"from": "__multiply_22", "to": "__multiply_17", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_17", "to": "__negation_16"},
+                    {"from": "__negation_16", "to": "__exp_15"},
+                    {"from": "__exp_15", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_3", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -7042,364 +2295,82 @@
               "prompt": "Ask: what happens at very high altitude ($u \\to 0$)? Almost no air, so $a_D \\to 0$. At very low altitude ($u$ large)? The vehicle has already slowed down, so $a_D \\to 0$ again. The peak must be somewhere in between.",
               "sceneStep": 1,
               "highlights": {
-                "u": {
-                  "color": "yellow",
-                  "label": "density factor (grows during descent)"
-                },
-                "k": {
-                  "color": "cyan",
-                  "label": "dimensionless drag parameter"
-                }
+                "u": {"color": "yellow", "label": "density factor (grows during descent)"},
+                "k": {"color": "cyan", "label": "dimensionless drag parameter"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "c0___equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "a_D = \\frac{\\rho_0 V_E^2}{2\\beta}\\;u\\;\\exp\\!\\left(-k\\,u\\right)"
-                    },
-                    {
-                      "id": "a_{D}",
-                      "type": "scalar",
-                      "latex": "a_{D}",
-                      "subexpr": "a_{D}"
-                    },
-                    {
-                      "id": "c0___multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho_{0} V_{E}^{2} \\frac{1}{2 \\beta} u e^{- k u}"
-                    },
-                    {
-                      "id": "c0___multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho_{0} V_{E}^{2} \\frac{1}{2 \\beta}"
-                    },
-                    {
-                      "id": "c0___multiply_4",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho_{0} V_{E}^{2}"
-                    },
-                    {
-                      "id": "c0_rho_{0}",
-                      "type": "scalar",
-                      "latex": "\\rho_{0}",
-                      "subexpr": "\\rho_{0}"
-                    },
-                    {
-                      "id": "c0___power_5",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V_{E}^{2}"
-                    },
-                    {
-                      "id": "V_{E}",
-                      "type": "scalar",
-                      "latex": "V_{E}",
-                      "subexpr": "V_{E}"
-                    },
-                    {
-                      "id": "c0___power_6",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2 \\beta}"
-                    },
-                    {
-                      "id": "c0___multiply_7",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\beta 2"
-                    },
-                    {
-                      "id": "c0___num_8",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "beta",
-                      "type": "scalar",
-                      "latex": "\\beta",
-                      "subexpr": "\\beta"
-                    },
-                    {
-                      "id": "c0___multiply_9",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "u e^{- k u}"
-                    },
-                    {
-                      "id": "u",
-                      "type": "scalar",
-                      "latex": "u",
-                      "subexpr": "u",
-                      "description": "density factor (grows during descent)",
-                      "color": "yellow",
-                      "highlight": "u"
-                    },
-                    {
-                      "id": "c0___exp_10",
-                      "type": "function",
-                      "latex": "\\exp",
-                      "op": "exp",
-                      "subexpr": "e^{- k u}"
-                    },
-                    {
-                      "id": "c0___negation_11",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-u k"
-                    },
-                    {
-                      "id": "c0___multiply_12",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "u k"
-                    },
-                    {
-                      "id": "k",
-                      "type": "scalar",
-                      "latex": "k",
-                      "subexpr": "k",
-                      "description": "dimensionless drag parameter",
-                      "color": "cyan",
-                      "highlight": "k"
-                    },
-                    {
-                      "id": "c1___equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "k = \\frac{\\rho_0 H}{\\beta\\sin\\gamma}"
-                    },
-                    {
-                      "id": "c1___multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "H \\rho_{0} \\frac{1}{\\beta \\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "c1___multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "H \\rho_{0}"
-                    },
-                    {
-                      "id": "c1_rho_{0}",
-                      "type": "scalar",
-                      "latex": "\\rho_{0}",
-                      "subexpr": "\\rho_{0}"
-                    },
-                    {
-                      "id": "H",
-                      "type": "scalar",
-                      "latex": "H",
-                      "subexpr": "H"
-                    },
-                    {
-                      "id": "c1___power_4",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\beta \\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "c1___multiply_5",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\beta \\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "c1___sin_6",
-                      "type": "function",
-                      "latex": "\\sin",
-                      "op": "sin",
-                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "gamma",
-                      "type": "scalar",
-                      "latex": "\\gamma",
-                      "subexpr": "\\gamma"
-                    }
+                    {"id": "c0___equals_1", "type": "relation", "op": "equals", "subexpr": "a_D = \\frac{\\rho_0 V_E^2}{2\\beta}\\;u\\;\\exp\\!\\left(-k\\,u\\right)"},
+                    {"id": "a_{D}", "type": "scalar", "latex": "a_{D}", "subexpr": "a_{D}"},
+                    {"id": "c0___multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\rho_{0} V_{E}^{2} \\frac{1}{2 \\beta} u e^{- k u}"},
+                    {"id": "c0___multiply_3", "type": "operator", "op": "multiply", "subexpr": "\\rho_{0} V_{E}^{2} \\frac{1}{2 \\beta}"},
+                    {"id": "c0___multiply_4", "type": "operator", "op": "multiply", "subexpr": "\\rho_{0} V_{E}^{2}"},
+                    {"id": "c0_rho_{0}", "type": "scalar", "latex": "\\rho_{0}", "subexpr": "\\rho_{0}"},
+                    {"id": "c0___power_5", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V_{E}^{2}"},
+                    {"id": "V_{E}", "type": "scalar", "latex": "V_{E}", "subexpr": "V_{E}"},
+                    {"id": "c0___power_6", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2 \\beta}"},
+                    {"id": "c0___multiply_7", "type": "operator", "op": "multiply", "subexpr": "\\beta 2"},
+                    {"id": "c0___num_8", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "beta", "type": "scalar", "latex": "\\beta", "subexpr": "\\beta"},
+                    {"id": "c0___multiply_9", "type": "operator", "op": "multiply", "subexpr": "u e^{- k u}"},
+                    {"id": "u", "type": "scalar", "latex": "u", "subexpr": "u", "description": "density factor (grows during descent)", "color": "yellow", "highlight": "u"},
+                    {"id": "c0___exp_10", "type": "function", "latex": "\\exp", "op": "exp", "subexpr": "e^{- k u}"},
+                    {"id": "c0___negation_11", "type": "operator", "op": "negation", "subexpr": "-u k"},
+                    {"id": "c0___multiply_12", "type": "operator", "op": "multiply", "subexpr": "u k"},
+                    {"id": "k", "type": "scalar", "latex": "k", "subexpr": "k", "description": "dimensionless drag parameter", "color": "cyan", "highlight": "k"},
+                    {"id": "c1___equals_1", "type": "relation", "op": "equals", "subexpr": "k = \\frac{\\rho_0 H}{\\beta\\sin\\gamma}"},
+                    {"id": "c1___multiply_2", "type": "operator", "op": "multiply", "subexpr": "H \\rho_{0} \\frac{1}{\\beta \\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "c1___multiply_3", "type": "operator", "op": "multiply", "subexpr": "H \\rho_{0}"},
+                    {"id": "c1_rho_{0}", "type": "scalar", "latex": "\\rho_{0}", "subexpr": "\\rho_{0}"},
+                    {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"},
+                    {"id": "c1___power_4", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\beta \\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "c1___multiply_5", "type": "operator", "op": "multiply", "subexpr": "\\beta \\sin{\\left(\\gamma \\right)}"},
+                    {"id": "c1___sin_6", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\gamma \\right)}"},
+                    {"id": "gamma", "type": "scalar", "latex": "\\gamma", "subexpr": "\\gamma"}
                   ],
                   "edges": [
-                    {
-                      "from": "a_{D}",
-                      "to": "c0___equals_1"
-                    },
-                    {
-                      "from": "c0_rho_{0}",
-                      "to": "c0___multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V_{E}",
-                      "to": "c0___power_5"
-                    },
-                    {
-                      "from": "c0___power_5",
-                      "to": "c0___multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "c0___multiply_4",
-                      "to": "c0___multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "c0___num_8",
-                      "to": "c0___multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "beta",
-                      "to": "c0___multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "c0___multiply_7",
-                      "to": "c0___power_6"
-                    },
-                    {
-                      "from": "c0___power_6",
-                      "to": "c0___multiply_3"
-                    },
-                    {
-                      "from": "c0___multiply_3",
-                      "to": "c0___multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "u",
-                      "to": "c0___multiply_9",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "k",
-                      "to": "c0___multiply_12",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "u",
-                      "to": "c0___multiply_12",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "c0___multiply_12",
-                      "to": "c0___negation_11"
-                    },
-                    {
-                      "from": "c0___negation_11",
-                      "to": "c0___exp_10"
-                    },
-                    {
-                      "from": "c0___exp_10",
-                      "to": "c0___multiply_9",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "c0___multiply_9",
-                      "to": "c0___multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "c0___multiply_2",
-                      "to": "c0___equals_1"
-                    },
-                    {
-                      "from": "k",
-                      "to": "c1___equals_1"
-                    },
-                    {
-                      "from": "c1_rho_{0}",
-                      "to": "c1___multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "c1___multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "c1___multiply_3",
-                      "to": "c1___multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "beta",
-                      "to": "c1___multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "gamma",
-                      "to": "c1___sin_6"
-                    },
-                    {
-                      "from": "c1___sin_6",
-                      "to": "c1___multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "c1___multiply_5",
-                      "to": "c1___power_4"
-                    },
-                    {
-                      "from": "c1___power_4",
-                      "to": "c1___multiply_2"
-                    },
-                    {
-                      "from": "c1___multiply_2",
-                      "to": "c1___equals_1"
-                    }
+                    {"from": "a_{D}", "to": "c0___equals_1"},
+                    {"from": "c0_rho_{0}", "to": "c0___multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "V_{E}", "to": "c0___power_5"},
+                    {"from": "c0___power_5", "to": "c0___multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "c0___multiply_4", "to": "c0___multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "c0___num_8", "to": "c0___multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "beta", "to": "c0___multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "c0___multiply_7", "to": "c0___power_6"},
+                    {"from": "c0___power_6", "to": "c0___multiply_3"},
+                    {"from": "c0___multiply_3", "to": "c0___multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "u", "to": "c0___multiply_9", "semantic": "direct", "weight": 1.0},
+                    {"from": "k", "to": "c0___multiply_12", "semantic": "direct", "weight": 1.0},
+                    {"from": "u", "to": "c0___multiply_12", "semantic": "direct", "weight": 1.0},
+                    {"from": "c0___multiply_12", "to": "c0___negation_11"},
+                    {"from": "c0___negation_11", "to": "c0___exp_10"},
+                    {"from": "c0___exp_10", "to": "c0___multiply_9", "semantic": "direct", "weight": 1.0},
+                    {"from": "c0___multiply_9", "to": "c0___multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "c0___multiply_2", "to": "c0___equals_1"},
+                    {"from": "k", "to": "c1___equals_1"},
+                    {"from": "c1_rho_{0}", "to": "c1___multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "c1___multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "c1___multiply_3", "to": "c1___multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "beta", "to": "c1___multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "gamma", "to": "c1___sin_6"},
+                    {"from": "c1___sin_6", "to": "c1___multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "c1___multiply_5", "to": "c1___power_4"},
+                    {"from": "c1___power_4", "to": "c1___multiply_2"},
+                    {"from": "c1___multiply_2", "to": "c1___equals_1"}
                   ],
                   "classification": {
                     "kind": "statements",
                     "count": 2,
                     "clauses": [
-                      {
-                        "kind": "algebraic"
-                      },
-                      {
-                        "kind": "algebraic"
-                      }
+                      {"kind": "algebraic"},
+                      {"kind": "algebraic"}
                     ]
                   }
                 }
               }
             },
-            {
-              "type": "step",
-              "label": "Differentiate to Find the Peak",
-              "math": "\\frac{da_D}{du} = \\frac{\\rho_0 V_E^2}{2\\beta}\\,e^{-ku}(1 - ku) = 0",
-              "justification": "Product rule: $\\frac{d}{du}[u\\,e^{-ku}] = e^{-ku} - ku\\,e^{-ku} = e^{-ku}(1-ku)$.",
-              "explanation": "Setting the derivative to zero, and noting that $e^{-ku} > 0$ always, the only solution is $1 - ku^* = 0$.",
-              "prompt": "This is a standard calculus optimization. The exponential is never zero, so the bracket must vanish.",
-              "sceneStep": 1
-            },
+            {"type": "step", "label": "Differentiate to Find the Peak", "math": "\\frac{da_D}{du} = \\frac{\\rho_0 V_E^2}{2\\beta}\\,e^{-ku}(1 - ku) = 0", "justification": "Product rule: $\\frac{d}{du}[u\\,e^{-ku}] = e^{-ku} - ku\\,e^{-ku} = e^{-ku}(1-ku)$.", "explanation": "Setting the derivative to zero, and noting that $e^{-ku} > 0$ always, the only solution is $1 - ku^* = 0$.", "prompt": "This is a standard calculus optimization. The exponential is never zero, so the bracket must vanish.", "sceneStep": 1},
             {
               "type": "step",
               "label": "Critical Density Parameter",
@@ -7411,143 +2382,35 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "u",
-                      "type": "scalar",
-                      "latex": "u",
-                      "subexpr": "u^*"
-                    },
-                    {
-                      "id": "s1___power_1",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{k}"
-                    },
-                    {
-                      "id": "k",
-                      "type": "scalar",
-                      "latex": "k",
-                      "subexpr": "k"
-                    },
-                    {
-                      "id": "s2___multiply_1",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{\\beta\\sin\\gamma}{\\rho_0 H}"
-                    },
-                    {
-                      "id": "s2___multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\beta \\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "beta",
-                      "type": "scalar",
-                      "latex": "\\beta",
-                      "subexpr": "\\beta"
-                    },
-                    {
-                      "id": "s2___sin_3",
-                      "type": "function",
-                      "latex": "\\sin",
-                      "op": "sin",
-                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "gamma",
-                      "type": "scalar",
-                      "latex": "\\gamma",
-                      "subexpr": "\\gamma"
-                    },
-                    {
-                      "id": "s2___power_4",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{H \\rho_{0}}"
-                    },
-                    {
-                      "id": "s2___multiply_5",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "H \\rho_{0}"
-                    },
-                    {
-                      "id": "rho_{0}",
-                      "type": "scalar",
-                      "latex": "\\rho_{0}",
-                      "subexpr": "\\rho_{0}"
-                    },
-                    {
-                      "id": "H",
-                      "type": "scalar",
-                      "latex": "H",
-                      "subexpr": "H"
-                    },
-                    {
-                      "id": "__equals_1",
-                      "type": "operator",
-                      "op": "equals",
-                      "subexpr": "u^* = \\frac{1}{k} = \\frac{\\beta\\sin\\gamma}{\\rho_0 H}"
-                    }
+                    {"id": "u", "type": "scalar", "latex": "u", "subexpr": "u^*"},
+                    {"id": "s1___power_1", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{k}"},
+                    {"id": "k", "type": "scalar", "latex": "k", "subexpr": "k"},
+                    {"id": "s2___multiply_1", "type": "operator", "op": "multiply", "subexpr": "\\frac{\\beta\\sin\\gamma}{\\rho_0 H}"},
+                    {"id": "s2___multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\beta \\sin{\\left(\\gamma \\right)}"},
+                    {"id": "beta", "type": "scalar", "latex": "\\beta", "subexpr": "\\beta"},
+                    {"id": "s2___sin_3", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\gamma \\right)}"},
+                    {"id": "gamma", "type": "scalar", "latex": "\\gamma", "subexpr": "\\gamma"},
+                    {"id": "s2___power_4", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{H \\rho_{0}}"},
+                    {"id": "s2___multiply_5", "type": "operator", "op": "multiply", "subexpr": "H \\rho_{0}"},
+                    {"id": "rho_{0}", "type": "scalar", "latex": "\\rho_{0}", "subexpr": "\\rho_{0}"},
+                    {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"},
+                    {"id": "__equals_1", "type": "operator", "op": "equals", "subexpr": "u^* = \\frac{1}{k} = \\frac{\\beta\\sin\\gamma}{\\rho_0 H}"}
                   ],
                   "edges": [
-                    {
-                      "from": "k",
-                      "to": "s1___power_1"
-                    },
-                    {
-                      "from": "beta",
-                      "to": "s2___multiply_2"
-                    },
-                    {
-                      "from": "gamma",
-                      "to": "s2___sin_3"
-                    },
-                    {
-                      "from": "s2___sin_3",
-                      "to": "s2___multiply_2"
-                    },
-                    {
-                      "from": "s2___multiply_2",
-                      "to": "s2___multiply_1"
-                    },
-                    {
-                      "from": "rho_{0}",
-                      "to": "s2___multiply_5"
-                    },
-                    {
-                      "from": "H",
-                      "to": "s2___multiply_5"
-                    },
-                    {
-                      "from": "s2___multiply_5",
-                      "to": "s2___power_4"
-                    },
-                    {
-                      "from": "s2___power_4",
-                      "to": "s2___multiply_1"
-                    },
-                    {
-                      "from": "u",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "s1___power_1",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "s2___multiply_1",
-                      "to": "__equals_1"
-                    }
+                    {"from": "k", "to": "s1___power_1"},
+                    {"from": "beta", "to": "s2___multiply_2"},
+                    {"from": "gamma", "to": "s2___sin_3"},
+                    {"from": "s2___sin_3", "to": "s2___multiply_2"},
+                    {"from": "s2___multiply_2", "to": "s2___multiply_1"},
+                    {"from": "rho_{0}", "to": "s2___multiply_5"},
+                    {"from": "H", "to": "s2___multiply_5"},
+                    {"from": "s2___multiply_5", "to": "s2___power_4"},
+                    {"from": "s2___power_4", "to": "s2___multiply_1"},
+                    {"from": "u", "to": "__equals_1"},
+                    {"from": "s1___power_1", "to": "__equals_1"},
+                    {"from": "s2___multiply_1", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -7560,28 +2423,15 @@
               "prompt": "Have the student estimate $h^*$ for the current vehicle and compare with where the peak appears on the g-load chart.",
               "sceneStep": 1,
               "highlights": {
-                "hstar": {
-                  "color": "magenta",
-                  "label": "altitude of peak g-load"
-                }
+                "hstar": {"color": "magenta", "label": "altitude of peak g-load"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "h",
-                      "type": "scalar",
-                      "latex": "h",
-                      "subexpr": "h^* = H\\ln\\frac{\\rho_0 H}{\\beta\\sin\\gamma}",
-                      "description": "altitude of peak g-load",
-                      "color": "magenta",
-                      "highlight": "hstar"
-                    }
+                    {"id": "h", "type": "scalar", "latex": "h", "subexpr": "h^* = H\\ln\\frac{\\rho_0 H}{\\beta\\sin\\gamma}", "description": "altitude of peak g-load", "color": "magenta", "highlight": "hstar"}
                   ],
                   "edges": [],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -7594,211 +2444,48 @@
               "prompt": "Key insight: the SHAPE of the g-load curve is universal for all ballistic entries. Only the peak value and the altitude shift change.",
               "sceneStep": 1,
               "highlights": {
-                "profile": {
-                  "color": "green",
-                  "label": "universal g-load profile"
-                }
+                "profile": {"color": "green", "label": "universal g-load profile"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "n(h) = \\frac{V_E^2\\sin\\gamma}{2eHg_0}\\;\\left(\\frac{u}{u^*}\\right)\\exp\\!\\left(1 - \\frac{u}{u^*}\\right)",
-                      "description": "universal g-load profile",
-                      "color": "green",
-                      "highlight": "profile"
-                    },
-                    {
-                      "id": "__n_2",
-                      "type": "function",
-                      "op": "n",
-                      "subexpr": "n{\\left(h \\right)}"
-                    },
-                    {
-                      "id": "h",
-                      "type": "scalar",
-                      "latex": "h",
-                      "subexpr": "h"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma \\right)} \\frac{1}{2 e H g_{0}}"
-                    },
-                    {
-                      "id": "__multiply_4",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "__power_5",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V_{E}^{2}"
-                    },
-                    {
-                      "id": "V_{E}",
-                      "type": "scalar",
-                      "latex": "V_{E}",
-                      "subexpr": "V_{E}"
-                    },
-                    {
-                      "id": "__sin_6",
-                      "type": "function",
-                      "latex": "\\sin",
-                      "op": "sin",
-                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "gamma",
-                      "type": "scalar",
-                      "latex": "\\gamma",
-                      "subexpr": "\\gamma"
-                    },
-                    {
-                      "id": "__power_7",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2 e H g_{0}}"
-                    },
-                    {
-                      "id": "__multiply_8",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "2 e H g_{0}"
-                    },
-                    {
-                      "id": "__num_9",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "__multiply_10",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "e H g_{0}"
-                    },
-                    {
-                      "id": "e",
-                      "type": "scalar",
-                      "latex": "e",
-                      "subexpr": "e"
-                    },
-                    {
-                      "id": "__multiply_11",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "H g_{0}"
-                    },
-                    {
-                      "id": "H",
-                      "type": "scalar",
-                      "latex": "H",
-                      "subexpr": "H"
-                    },
-                    {
-                      "id": "g_{0}",
-                      "type": "scalar",
-                      "latex": "g_{0}",
-                      "subexpr": "g_{0}"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "n(h) = \\frac{V_E^2\\sin\\gamma}{2eHg_0}\\;\\left(\\frac{u}{u^*}\\right)\\exp\\!\\left(1 - \\frac{u}{u^*}\\right)", "description": "universal g-load profile", "color": "green", "highlight": "profile"},
+                    {"id": "__n_2", "type": "function", "op": "n", "subexpr": "n{\\left(h \\right)}"},
+                    {"id": "h", "type": "scalar", "latex": "h", "subexpr": "h"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma \\right)} \\frac{1}{2 e H g_{0}}"},
+                    {"id": "__multiply_4", "type": "operator", "op": "multiply", "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma \\right)}"},
+                    {"id": "__power_5", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V_{E}^{2}"},
+                    {"id": "V_{E}", "type": "scalar", "latex": "V_{E}", "subexpr": "V_{E}"},
+                    {"id": "__sin_6", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\gamma \\right)}"},
+                    {"id": "gamma", "type": "scalar", "latex": "\\gamma", "subexpr": "\\gamma"},
+                    {"id": "__power_7", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2 e H g_{0}}"},
+                    {"id": "__multiply_8", "type": "operator", "op": "multiply", "subexpr": "2 e H g_{0}"},
+                    {"id": "__num_9", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__multiply_10", "type": "operator", "op": "multiply", "subexpr": "e H g_{0}"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "__multiply_11", "type": "operator", "op": "multiply", "subexpr": "H g_{0}"},
+                    {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"},
+                    {"id": "g_{0}", "type": "scalar", "latex": "g_{0}", "subexpr": "g_{0}"}
                   ],
                   "edges": [
-                    {
-                      "from": "h",
-                      "to": "__n_2"
-                    },
-                    {
-                      "from": "__n_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "V_{E}",
-                      "to": "__power_5"
-                    },
-                    {
-                      "from": "__power_5",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "gamma",
-                      "to": "__sin_6"
-                    },
-                    {
-                      "from": "__sin_6",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_4",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_9",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "e",
-                      "to": "__multiply_10",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__multiply_11",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "g_{0}",
-                      "to": "__multiply_11",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_11",
-                      "to": "__multiply_10",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_10",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_8",
-                      "to": "__power_7"
-                    },
-                    {
-                      "from": "__power_7",
-                      "to": "__multiply_3"
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__equals_1"
-                    }
+                    {"from": "h", "to": "__n_2"},
+                    {"from": "__n_2", "to": "__equals_1"},
+                    {"from": "V_{E}", "to": "__power_5"},
+                    {"from": "__power_5", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "gamma", "to": "__sin_6"},
+                    {"from": "__sin_6", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_9", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "e", "to": "__multiply_10", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__multiply_11", "semantic": "direct", "weight": 1.0},
+                    {"from": "g_{0}", "to": "__multiply_11", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_11", "to": "__multiply_10", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_10", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_8", "to": "__power_7"},
+                    {"from": "__power_7", "to": "__multiply_3"},
+                    {"from": "__multiply_3", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             }
@@ -7823,64 +2510,19 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "gamma_{\\text{steep}}",
-                      "type": "scalar",
-                      "latex": "\\gamma_{\\text{steep}}",
-                      "subexpr": "\\gamma_{\\text{steep}}"
-                    },
-                    {
-                      "id": "__less_equal_1",
-                      "type": "relation",
-                      "op": "less_equal",
-                      "subexpr": "\\gamma \\leq \\gamma_{\\text{shallow}}"
-                    },
-                    {
-                      "id": "gamma",
-                      "type": "scalar",
-                      "latex": "\\gamma",
-                      "subexpr": "\\gamma"
-                    },
-                    {
-                      "id": "gamma_{\\text{shallow}}",
-                      "type": "scalar",
-                      "latex": "\\gamma_{\\text{shallow}}",
-                      "subexpr": "\\gamma_{\\text{shallow}}"
-                    },
-                    {
-                      "id": "__less_equal_2",
-                      "type": "relation",
-                      "label": "less than or equal to",
-                      "emoji": "≤",
-                      "op": "less_equal",
-                      "subexpr": "\\gamma_{\\text{steep}} \\leq \\gamma \\leq \\gamma_{\\text{shallow}}"
-                    }
+                    {"id": "gamma_{\\text{steep}}", "type": "scalar", "latex": "\\gamma_{\\text{steep}}", "subexpr": "\\gamma_{\\text{steep}}"},
+                    {"id": "__less_equal_1", "type": "relation", "op": "less_equal", "subexpr": "\\gamma \\leq \\gamma_{\\text{shallow}}"},
+                    {"id": "gamma", "type": "scalar", "latex": "\\gamma", "subexpr": "\\gamma"},
+                    {"id": "gamma_{\\text{shallow}}", "type": "scalar", "latex": "\\gamma_{\\text{shallow}}", "subexpr": "\\gamma_{\\text{shallow}}"},
+                    {"id": "__less_equal_2", "type": "relation", "label": "less than or equal to", "emoji": "≤", "op": "less_equal", "subexpr": "\\gamma_{\\text{steep}} \\leq \\gamma \\leq \\gamma_{\\text{shallow}}"}
                   ],
                   "edges": [
-                    {
-                      "from": "gamma",
-                      "to": "__less_equal_1",
-                      "role": "lhs"
-                    },
-                    {
-                      "from": "gamma_{\\text{shallow}}",
-                      "to": "__less_equal_1",
-                      "role": "rhs"
-                    },
-                    {
-                      "from": "gamma_{\\text{steep}}",
-                      "to": "__less_equal_2",
-                      "role": "lhs"
-                    },
-                    {
-                      "from": "__less_equal_1",
-                      "to": "__less_equal_2",
-                      "role": "rhs"
-                    }
+                    {"from": "gamma", "to": "__less_equal_1", "role": "lhs"},
+                    {"from": "gamma_{\\text{shallow}}", "to": "__less_equal_1", "role": "rhs"},
+                    {"from": "gamma_{\\text{steep}}", "to": "__less_equal_2", "role": "lhs"},
+                    {"from": "__less_equal_1", "to": "__less_equal_2", "role": "rhs"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -7895,166 +2537,37 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "a_{\\max} = \\frac{V_E^2\\sin\\gamma}{2eH}"
-                    },
-                    {
-                      "id": "a_{max}",
-                      "type": "scalar",
-                      "latex": "a_{max}",
-                      "subexpr": "a_{max}"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma \\right)} \\frac{1}{2 H e}"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "__power_4",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V_{E}^{2}"
-                    },
-                    {
-                      "id": "V_{E}",
-                      "type": "scalar",
-                      "latex": "V_{E}",
-                      "subexpr": "V_{E}"
-                    },
-                    {
-                      "id": "__sin_5",
-                      "type": "function",
-                      "latex": "\\sin",
-                      "op": "sin",
-                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "gamma",
-                      "type": "scalar",
-                      "latex": "\\gamma",
-                      "subexpr": "\\gamma"
-                    },
-                    {
-                      "id": "__power_6",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2 H e}"
-                    },
-                    {
-                      "id": "__multiply_7",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "2 e H"
-                    },
-                    {
-                      "id": "__num_8",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "__multiply_9",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "e H"
-                    },
-                    {
-                      "id": "e",
-                      "type": "scalar",
-                      "latex": "e",
-                      "subexpr": "e"
-                    },
-                    {
-                      "id": "H",
-                      "type": "scalar",
-                      "latex": "H",
-                      "subexpr": "H"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "a_{\\max} = \\frac{V_E^2\\sin\\gamma}{2eH}"},
+                    {"id": "a_{max}", "type": "scalar", "latex": "a_{max}", "subexpr": "a_{max}"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma \\right)} \\frac{1}{2 H e}"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma \\right)}"},
+                    {"id": "__power_4", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V_{E}^{2}"},
+                    {"id": "V_{E}", "type": "scalar", "latex": "V_{E}", "subexpr": "V_{E}"},
+                    {"id": "__sin_5", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\gamma \\right)}"},
+                    {"id": "gamma", "type": "scalar", "latex": "\\gamma", "subexpr": "\\gamma"},
+                    {"id": "__power_6", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2 H e}"},
+                    {"id": "__multiply_7", "type": "operator", "op": "multiply", "subexpr": "2 e H"},
+                    {"id": "__num_8", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__multiply_9", "type": "operator", "op": "multiply", "subexpr": "e H"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"}
                   ],
                   "edges": [
-                    {
-                      "from": "a_{max}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "V_{E}",
-                      "to": "__power_4"
-                    },
-                    {
-                      "from": "__power_4",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "gamma",
-                      "to": "__sin_5"
-                    },
-                    {
-                      "from": "__sin_5",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_8",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "e",
-                      "to": "__multiply_9",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__multiply_9",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_9",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_7",
-                      "to": "__power_6"
-                    },
-                    {
-                      "from": "__power_6",
-                      "to": "__multiply_2"
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "a_{max}", "to": "__equals_1"},
+                    {"from": "V_{E}", "to": "__power_4"},
+                    {"from": "__power_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "gamma", "to": "__sin_5"},
+                    {"from": "__sin_5", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_3", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_8", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "e", "to": "__multiply_9", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__multiply_9", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_9", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_7", "to": "__power_6"},
+                    {"from": "__power_6", "to": "__multiply_2"},
+                    {"from": "__multiply_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -8067,198 +2580,46 @@
               "prompt": "Have the student adjust the g-limit slider and watch how the steep boundary moves. Lower g-tolerance → shallower steep limit → narrower corridor.",
               "sceneStep": 0,
               "highlights": {
-                "glimit": {
-                  "color": "red",
-                  "label": "crew survivability limit"
-                }
+                "glimit": {"color": "red", "label": "crew survivability limit"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\frac{V_E^2\\sin\\gamma_{\\text{steep}}}{2eH} = n_{\\max}\\cdot g_0"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma_{\\text{steep}} \\right)} \\frac{1}{2 H e}"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma_{\\text{steep}} \\right)}"
-                    },
-                    {
-                      "id": "__power_4",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V_{E}^{2}"
-                    },
-                    {
-                      "id": "V_{E}",
-                      "type": "scalar",
-                      "latex": "V_{E}",
-                      "subexpr": "V_{E}"
-                    },
-                    {
-                      "id": "__sin_5",
-                      "type": "function",
-                      "latex": "\\sin",
-                      "op": "sin",
-                      "subexpr": "\\sin{\\left(\\gamma_{\\text{steep}} \\right)}"
-                    },
-                    {
-                      "id": "gamma_{\\text{steep}}",
-                      "type": "scalar",
-                      "latex": "\\gamma_{\\text{steep}}",
-                      "subexpr": "\\gamma_{\\text{steep}}"
-                    },
-                    {
-                      "id": "__power_6",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2 H e}"
-                    },
-                    {
-                      "id": "__multiply_7",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "2 e H"
-                    },
-                    {
-                      "id": "__num_8",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "__multiply_9",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "e H"
-                    },
-                    {
-                      "id": "e",
-                      "type": "scalar",
-                      "latex": "e",
-                      "subexpr": "e"
-                    },
-                    {
-                      "id": "H",
-                      "type": "scalar",
-                      "latex": "H",
-                      "subexpr": "H"
-                    },
-                    {
-                      "id": "__multiply_10",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "n_{max} g_{0}"
-                    },
-                    {
-                      "id": "n_{max}",
-                      "type": "scalar",
-                      "latex": "n_{max}",
-                      "subexpr": "n_{max}"
-                    },
-                    {
-                      "id": "g_{0}",
-                      "type": "scalar",
-                      "latex": "g_{0}",
-                      "subexpr": "g_{0}"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\frac{V_E^2\\sin\\gamma_{\\text{steep}}}{2eH} = n_{\\max}\\cdot g_0"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma_{\\text{steep}} \\right)} \\frac{1}{2 H e}"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "V_{E}^{2} \\sin{\\left(\\gamma_{\\text{steep}} \\right)}"},
+                    {"id": "__power_4", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V_{E}^{2}"},
+                    {"id": "V_{E}", "type": "scalar", "latex": "V_{E}", "subexpr": "V_{E}"},
+                    {"id": "__sin_5", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\gamma_{\\text{steep}} \\right)}"},
+                    {"id": "gamma_{\\text{steep}}", "type": "scalar", "latex": "\\gamma_{\\text{steep}}", "subexpr": "\\gamma_{\\text{steep}}"},
+                    {"id": "__power_6", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2 H e}"},
+                    {"id": "__multiply_7", "type": "operator", "op": "multiply", "subexpr": "2 e H"},
+                    {"id": "__num_8", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__multiply_9", "type": "operator", "op": "multiply", "subexpr": "e H"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"},
+                    {"id": "__multiply_10", "type": "operator", "op": "multiply", "subexpr": "n_{max} g_{0}"},
+                    {"id": "n_{max}", "type": "scalar", "latex": "n_{max}", "subexpr": "n_{max}"},
+                    {"id": "g_{0}", "type": "scalar", "latex": "g_{0}", "subexpr": "g_{0}"}
                   ],
                   "edges": [
-                    {
-                      "from": "V_{E}",
-                      "to": "__power_4"
-                    },
-                    {
-                      "from": "__power_4",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "gamma_{\\text{steep}}",
-                      "to": "__sin_5"
-                    },
-                    {
-                      "from": "__sin_5",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_8",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "e",
-                      "to": "__multiply_9",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__multiply_9",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_9",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_7",
-                      "to": "__power_6"
-                    },
-                    {
-                      "from": "__power_6",
-                      "to": "__multiply_2"
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "n_{max}",
-                      "to": "__multiply_10",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "g_{0}",
-                      "to": "__multiply_10",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_10",
-                      "to": "__equals_1"
-                    }
+                    {"from": "V_{E}", "to": "__power_4"},
+                    {"from": "__power_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "gamma_{\\text{steep}}", "to": "__sin_5"},
+                    {"from": "__sin_5", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_3", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_8", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "e", "to": "__multiply_9", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__multiply_9", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_9", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_7", "to": "__power_6"},
+                    {"from": "__power_6", "to": "__multiply_2"},
+                    {"from": "__multiply_2", "to": "__equals_1"},
+                    {"from": "n_{max}", "to": "__multiply_10", "semantic": "direct", "weight": 1.0},
+                    {"from": "g_{0}", "to": "__multiply_10", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_10", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -8271,200 +2632,46 @@
               "prompt": "Key insight: the steep boundary depends only on the entry speed and the g-tolerance, NOT on the vehicle's mass or shape. A heavier capsule hits the same peak g at the same angle — it just happens deeper in the atmosphere.",
               "sceneStep": 0,
               "highlights": {
-                "steep": {
-                  "color": "red",
-                  "label": "maximum entry angle for crew survival"
-                }
+                "steep": {"color": "red", "label": "maximum entry angle for crew survival"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\gamma_{\\text{steep}} = \\arcsin\\!\\left(\\frac{2eHg_0\\,n_{\\max}}{V_E^2}\\right)",
-                      "description": "maximum entry angle for crew survival",
-                      "color": "red",
-                      "highlight": "steep"
-                    },
-                    {
-                      "id": "gamma_{\\text{steep}}",
-                      "type": "scalar",
-                      "latex": "\\gamma_{\\text{steep}}",
-                      "subexpr": "\\gamma_{\\text{steep}}"
-                    },
-                    {
-                      "id": "__asin_2",
-                      "type": "function",
-                      "op": "asin",
-                      "subexpr": "\\operatorname{asin}{\\left(\\frac{2 e H g_{0} n_{max}}{V_{E}^{2}} \\right)}"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "2 e H g_{0} n_{max} \\frac{1}{V_{E}^{2}}"
-                    },
-                    {
-                      "id": "__multiply_4",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "2 e H g_{0} n_{max}"
-                    },
-                    {
-                      "id": "__num_5",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "__multiply_6",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "e H g_{0} n_{max}"
-                    },
-                    {
-                      "id": "e",
-                      "type": "scalar",
-                      "latex": "e",
-                      "subexpr": "e"
-                    },
-                    {
-                      "id": "__multiply_7",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "H g_{0} n_{max}"
-                    },
-                    {
-                      "id": "H",
-                      "type": "scalar",
-                      "latex": "H",
-                      "subexpr": "H"
-                    },
-                    {
-                      "id": "__multiply_8",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "g_{0} n_{max}"
-                    },
-                    {
-                      "id": "g_{0}",
-                      "type": "scalar",
-                      "latex": "g_{0}",
-                      "subexpr": "g_{0}"
-                    },
-                    {
-                      "id": "n_{max}",
-                      "type": "scalar",
-                      "latex": "n_{max}",
-                      "subexpr": "n_{max}"
-                    },
-                    {
-                      "id": "__power_9",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{V_{E}^{2}}"
-                    },
-                    {
-                      "id": "__power_10",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V_{E}^{2}"
-                    },
-                    {
-                      "id": "V_{E}",
-                      "type": "scalar",
-                      "latex": "V_{E}",
-                      "subexpr": "V_{E}"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\gamma_{\\text{steep}} = \\arcsin\\!\\left(\\frac{2eHg_0\\,n_{\\max}}{V_E^2}\\right)", "description": "maximum entry angle for crew survival", "color": "red", "highlight": "steep"},
+                    {"id": "gamma_{\\text{steep}}", "type": "scalar", "latex": "\\gamma_{\\text{steep}}", "subexpr": "\\gamma_{\\text{steep}}"},
+                    {"id": "__asin_2", "type": "function", "op": "asin", "subexpr": "\\operatorname{asin}{\\left(\\frac{2 e H g_{0} n_{max}}{V_{E}^{2}} \\right)}"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "2 e H g_{0} n_{max} \\frac{1}{V_{E}^{2}}"},
+                    {"id": "__multiply_4", "type": "operator", "op": "multiply", "subexpr": "2 e H g_{0} n_{max}"},
+                    {"id": "__num_5", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "e H g_{0} n_{max}"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "__multiply_7", "type": "operator", "op": "multiply", "subexpr": "H g_{0} n_{max}"},
+                    {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"},
+                    {"id": "__multiply_8", "type": "operator", "op": "multiply", "subexpr": "g_{0} n_{max}"},
+                    {"id": "g_{0}", "type": "scalar", "latex": "g_{0}", "subexpr": "g_{0}"},
+                    {"id": "n_{max}", "type": "scalar", "latex": "n_{max}", "subexpr": "n_{max}"},
+                    {"id": "__power_9", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{V_{E}^{2}}"},
+                    {"id": "__power_10", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V_{E}^{2}"},
+                    {"id": "V_{E}", "type": "scalar", "latex": "V_{E}", "subexpr": "V_{E}"}
                   ],
                   "edges": [
-                    {
-                      "from": "gamma_{\\text{steep}}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "__num_5",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "e",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "g_{0}",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "n_{max}",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_8",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_7",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_6",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_4",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V_{E}",
-                      "to": "__power_10"
-                    },
-                    {
-                      "from": "__power_10",
-                      "to": "__power_9"
-                    },
-                    {
-                      "from": "__power_9",
-                      "to": "__multiply_3"
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__asin_2"
-                    },
-                    {
-                      "from": "__asin_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "gamma_{\\text{steep}}", "to": "__equals_1"},
+                    {"from": "__num_5", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "e", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "g_{0}", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "n_{max}", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_8", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_7", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_6", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "V_{E}", "to": "__power_10"},
+                    {"from": "__power_10", "to": "__power_9"},
+                    {"from": "__power_9", "to": "__multiply_3"},
+                    {"from": "__multiply_3", "to": "__asin_2"},
+                    {"from": "__asin_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -8479,257 +2686,54 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "V_{\\text{exit}} = V_E\\exp\\!\\left(-\\frac{\\rho_0 H}{2\\beta\\sin\\gamma}\\,e^{-h_E/H}\\right)"
-                    },
-                    {
-                      "id": "V_{\\text{exit}}",
-                      "type": "scalar",
-                      "latex": "V_{\\text{exit}}",
-                      "subexpr": "V_{\\text{exit}}"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{E} e^{- e^{\\frac{\\left(-1\\right) h_{E}}{H}} \\frac{H \\rho_{0}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"
-                    },
-                    {
-                      "id": "V_{E}",
-                      "type": "scalar",
-                      "latex": "V_{E}",
-                      "subexpr": "V_{E}"
-                    },
-                    {
-                      "id": "__exp_3",
-                      "type": "function",
-                      "latex": "\\exp",
-                      "op": "exp",
-                      "subexpr": "e^{- e^{\\frac{\\left(-1\\right) h_{E}}{H}} \\frac{H \\rho_{0}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"
-                    },
-                    {
-                      "id": "__negation_4",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-e^{\\frac{\\left(-1\\right) h_{E}}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__multiply_5",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "H",
-                      "type": "scalar",
-                      "latex": "H",
-                      "subexpr": "H"
-                    },
-                    {
-                      "id": "rho_{0}",
-                      "type": "scalar",
-                      "latex": "\\rho_{0}",
-                      "subexpr": "\\rho_{0}"
-                    },
-                    {
-                      "id": "__power_6",
-                      "type": "operator",
-                      "op": "power",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}}"
-                    },
-                    {
-                      "id": "e",
-                      "type": "scalar",
-                      "latex": "e",
-                      "subexpr": "e"
-                    },
-                    {
-                      "id": "__multiply_7",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{H} -h_{E}"
-                    },
-                    {
-                      "id": "__negation_8",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-h_{E}"
-                    },
-                    {
-                      "id": "h_{E}",
-                      "type": "scalar",
-                      "latex": "h_{E}",
-                      "subexpr": "h_{E}"
-                    },
-                    {
-                      "id": "__power_9",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{H}"
-                    },
-                    {
-                      "id": "__multiply_10",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__num_11",
-                      "type": "number",
-                      "label": "1/2",
-                      "subexpr": "\\frac{1}{2}"
-                    },
-                    {
-                      "id": "__power_12",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\beta}"
-                    },
-                    {
-                      "id": "beta",
-                      "type": "scalar",
-                      "latex": "\\beta",
-                      "subexpr": "\\beta"
-                    },
-                    {
-                      "id": "__power_13",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__sin_14",
-                      "type": "function",
-                      "latex": "\\sin",
-                      "op": "sin",
-                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "gamma",
-                      "type": "scalar",
-                      "latex": "\\gamma",
-                      "subexpr": "\\gamma"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "V_{\\text{exit}} = V_E\\exp\\!\\left(-\\frac{\\rho_0 H}{2\\beta\\sin\\gamma}\\,e^{-h_E/H}\\right)"},
+                    {"id": "V_{\\text{exit}}", "type": "scalar", "latex": "V_{\\text{exit}}", "subexpr": "V_{\\text{exit}}"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "V_{E} e^{- e^{\\frac{\\left(-1\\right) h_{E}}{H}} \\frac{H \\rho_{0}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"},
+                    {"id": "V_{E}", "type": "scalar", "latex": "V_{E}", "subexpr": "V_{E}"},
+                    {"id": "__exp_3", "type": "function", "latex": "\\exp", "op": "exp", "subexpr": "e^{- e^{\\frac{\\left(-1\\right) h_{E}}{H}} \\frac{H \\rho_{0}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"},
+                    {"id": "__negation_4", "type": "operator", "op": "negation", "subexpr": "-e^{\\frac{\\left(-1\\right) h_{E}}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"},
+                    {"id": "rho_{0}", "type": "scalar", "latex": "\\rho_{0}", "subexpr": "\\rho_{0}"},
+                    {"id": "__power_6", "type": "operator", "op": "power", "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}}"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "__multiply_7", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{H} -h_{E}"},
+                    {"id": "__negation_8", "type": "operator", "op": "negation", "subexpr": "-h_{E}"},
+                    {"id": "h_{E}", "type": "scalar", "latex": "h_{E}", "subexpr": "h_{E}"},
+                    {"id": "__power_9", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{H}"},
+                    {"id": "__multiply_10", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__num_11", "type": "number", "label": "1/2", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__power_12", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\beta}"},
+                    {"id": "beta", "type": "scalar", "latex": "\\beta", "subexpr": "\\beta"},
+                    {"id": "__power_13", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__sin_14", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\gamma \\right)}"},
+                    {"id": "gamma", "type": "scalar", "latex": "\\gamma", "subexpr": "\\gamma"}
                   ],
                   "edges": [
-                    {
-                      "from": "V_{\\text{exit}}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "V_{E}",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "rho_{0}",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "e",
-                      "to": "__power_6"
-                    },
-                    {
-                      "from": "h_{E}",
-                      "to": "__negation_8"
-                    },
-                    {
-                      "from": "__negation_8",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__power_9"
-                    },
-                    {
-                      "from": "__power_9",
-                      "to": "__multiply_7"
-                    },
-                    {
-                      "from": "__multiply_7",
-                      "to": "__power_6",
-                      "role": "exp"
-                    },
-                    {
-                      "from": "__power_6",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_11",
-                      "to": "__multiply_10",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "beta",
-                      "to": "__power_12"
-                    },
-                    {
-                      "from": "__power_12",
-                      "to": "__multiply_10"
-                    },
-                    {
-                      "from": "gamma",
-                      "to": "__sin_14"
-                    },
-                    {
-                      "from": "__sin_14",
-                      "to": "__power_13"
-                    },
-                    {
-                      "from": "__power_13",
-                      "to": "__multiply_10"
-                    },
-                    {
-                      "from": "__multiply_10",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_5",
-                      "to": "__negation_4"
-                    },
-                    {
-                      "from": "__negation_4",
-                      "to": "__exp_3"
-                    },
-                    {
-                      "from": "__exp_3",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "V_{\\text{exit}}", "to": "__equals_1"},
+                    {"from": "V_{E}", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "rho_{0}", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "e", "to": "__power_6"},
+                    {"from": "h_{E}", "to": "__negation_8"},
+                    {"from": "__negation_8", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__power_9"},
+                    {"from": "__power_9", "to": "__multiply_7"},
+                    {"from": "__multiply_7", "to": "__power_6", "role": "exp"},
+                    {"from": "__power_6", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_11", "to": "__multiply_10", "semantic": "direct", "weight": 1.0},
+                    {"from": "beta", "to": "__power_12"},
+                    {"from": "__power_12", "to": "__multiply_10"},
+                    {"from": "gamma", "to": "__sin_14"},
+                    {"from": "__sin_14", "to": "__power_13"},
+                    {"from": "__power_13", "to": "__multiply_10"},
+                    {"from": "__multiply_10", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_5", "to": "__negation_4"},
+                    {"from": "__negation_4", "to": "__exp_3"},
+                    {"from": "__exp_3", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -8742,360 +2746,77 @@
               "prompt": "This is the critical quantity: $\\delta$ measures how effective the atmosphere is at capturing the vehicle. Too little $\\delta$ → skip-out.",
               "sceneStep": 0,
               "highlights": {
-                "delta": {
-                  "color": "orange",
-                  "label": "fractional speed loss during atmospheric pass"
-                }
+                "delta": {"color": "orange", "label": "fractional speed loss during atmospheric pass"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "delta",
-                      "type": "scalar",
-                      "latex": "\\delta",
-                      "subexpr": "\\delta",
-                      "description": "fractional speed loss during atmospheric pass",
-                      "color": "orange",
-                      "highlight": "delta"
-                    },
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "1 - \\frac{V_{\\text{exit}}}{V_{E}} = 1 - \\exp \\left(-\\frac{\\rho_{0} H e^{-h_{E}/H}}{2\\beta\\sin\\gamma}\\right)"
-                    },
-                    {
-                      "id": "__add_2",
-                      "type": "operator",
-                      "op": "add",
-                      "subexpr": "1 - V_{\\text{exit}} \\frac{1}{V_{E}}"
-                    },
-                    {
-                      "id": "__num_3",
-                      "type": "number",
-                      "label": "1",
-                      "subexpr": "1"
-                    },
-                    {
-                      "id": "__negation_4",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-V_{\\text{exit}} \\frac{1}{V_{E}}"
-                    },
-                    {
-                      "id": "__multiply_5",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{\\text{exit}} \\frac{1}{V_{E}}"
-                    },
-                    {
-                      "id": "V_{\\text{exit}}",
-                      "type": "scalar",
-                      "latex": "V_{\\text{exit}}",
-                      "subexpr": "V_{\\text{exit}}"
-                    },
-                    {
-                      "id": "__power_6",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{V_{E}}"
-                    },
-                    {
-                      "id": "V_{E}",
-                      "type": "scalar",
-                      "latex": "V_{E}",
-                      "subexpr": "V_{E}"
-                    },
-                    {
-                      "id": "__add_7",
-                      "type": "operator",
-                      "op": "add",
-                      "subexpr": "1 - e^{- \\frac{\\rho_{0} H e^{\\frac{\\left(-1\\right) h_{E}}{H}}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"
-                    },
-                    {
-                      "id": "__num_8",
-                      "type": "number",
-                      "label": "1",
-                      "subexpr": "1"
-                    },
-                    {
-                      "id": "__negation_9",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-e^{- \\frac{\\rho_{0} H e^{\\frac{\\left(-1\\right) h_{E}}{H}}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"
-                    },
-                    {
-                      "id": "__exp_10",
-                      "type": "function",
-                      "latex": "\\exp",
-                      "op": "exp",
-                      "subexpr": "e^{- \\frac{\\rho_{0} H e^{\\frac{\\left(-1\\right) h_{E}}{H}}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"
-                    },
-                    {
-                      "id": "__negation_11",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-e^{\\frac{\\left(-1\\right) h_{E}}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__multiply_12",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "H",
-                      "type": "scalar",
-                      "latex": "H",
-                      "subexpr": "H"
-                    },
-                    {
-                      "id": "rho_{0}",
-                      "type": "scalar",
-                      "latex": "\\rho_{0}",
-                      "subexpr": "\\rho_{0}"
-                    },
-                    {
-                      "id": "__power_13",
-                      "type": "operator",
-                      "op": "power",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}}"
-                    },
-                    {
-                      "id": "e",
-                      "type": "scalar",
-                      "latex": "e",
-                      "subexpr": "e"
-                    },
-                    {
-                      "id": "__multiply_14",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{H} -h_{E}"
-                    },
-                    {
-                      "id": "__negation_15",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-h_{E}"
-                    },
-                    {
-                      "id": "h_{E}",
-                      "type": "scalar",
-                      "latex": "h_{E}",
-                      "subexpr": "h_{E}"
-                    },
-                    {
-                      "id": "__power_16",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{H}"
-                    },
-                    {
-                      "id": "__multiply_17",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__num_18",
-                      "type": "number",
-                      "label": "1/2",
-                      "subexpr": "\\frac{1}{2}"
-                    },
-                    {
-                      "id": "__power_19",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\beta}"
-                    },
-                    {
-                      "id": "beta",
-                      "type": "scalar",
-                      "latex": "\\beta",
-                      "subexpr": "\\beta"
-                    },
-                    {
-                      "id": "__power_20",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\sin{\\left(\\gamma \\right)}}"
-                    },
-                    {
-                      "id": "__sin_21",
-                      "type": "function",
-                      "latex": "\\sin",
-                      "op": "sin",
-                      "subexpr": "\\sin{\\left(\\gamma \\right)}"
-                    },
-                    {
-                      "id": "gamma",
-                      "type": "scalar",
-                      "latex": "\\gamma",
-                      "subexpr": "\\gamma"
-                    },
-                    {
-                      "id": "__congruent_22",
-                      "type": "relation",
-                      "label": "congruent to",
-                      "emoji": "≡",
-                      "op": "congruent",
-                      "subexpr": "\\delta \\equiv 1 - \\frac{V_{\\text{exit}}}{V_E} = 1 - \\exp\\!\\left(-\\frac{\\rho_0 H\\,e^{-h_E/H}}{2\\beta\\sin\\gamma}\\right)"
-                    }
+                    {"id": "delta", "type": "scalar", "latex": "\\delta", "subexpr": "\\delta", "description": "fractional speed loss during atmospheric pass", "color": "orange", "highlight": "delta"},
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "1 - \\frac{V_{\\text{exit}}}{V_{E}} = 1 - \\exp \\left(-\\frac{\\rho_{0} H e^{-h_{E}/H}}{2\\beta\\sin\\gamma}\\right)"},
+                    {"id": "__add_2", "type": "operator", "op": "add", "subexpr": "1 - V_{\\text{exit}} \\frac{1}{V_{E}}"},
+                    {"id": "__num_3", "type": "number", "label": "1", "subexpr": "1"},
+                    {"id": "__negation_4", "type": "operator", "op": "negation", "subexpr": "-V_{\\text{exit}} \\frac{1}{V_{E}}"},
+                    {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "V_{\\text{exit}} \\frac{1}{V_{E}}"},
+                    {"id": "V_{\\text{exit}}", "type": "scalar", "latex": "V_{\\text{exit}}", "subexpr": "V_{\\text{exit}}"},
+                    {"id": "__power_6", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{V_{E}}"},
+                    {"id": "V_{E}", "type": "scalar", "latex": "V_{E}", "subexpr": "V_{E}"},
+                    {"id": "__add_7", "type": "operator", "op": "add", "subexpr": "1 - e^{- \\frac{\\rho_{0} H e^{\\frac{\\left(-1\\right) h_{E}}{H}}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"},
+                    {"id": "__num_8", "type": "number", "label": "1", "subexpr": "1"},
+                    {"id": "__negation_9", "type": "operator", "op": "negation", "subexpr": "-e^{- \\frac{\\rho_{0} H e^{\\frac{\\left(-1\\right) h_{E}}{H}}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"},
+                    {"id": "__exp_10", "type": "function", "latex": "\\exp", "op": "exp", "subexpr": "e^{- \\frac{\\rho_{0} H e^{\\frac{\\left(-1\\right) h_{E}}{H}}}{2 \\beta \\sin{\\left(\\gamma \\right)}}}"},
+                    {"id": "__negation_11", "type": "operator", "op": "negation", "subexpr": "-e^{\\frac{\\left(-1\\right) h_{E}}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__multiply_12", "type": "operator", "op": "multiply", "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}} H \\rho_{0} \\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"},
+                    {"id": "rho_{0}", "type": "scalar", "latex": "\\rho_{0}", "subexpr": "\\rho_{0}"},
+                    {"id": "__power_13", "type": "operator", "op": "power", "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}}"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "__multiply_14", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{H} -h_{E}"},
+                    {"id": "__negation_15", "type": "operator", "op": "negation", "subexpr": "-h_{E}"},
+                    {"id": "h_{E}", "type": "scalar", "latex": "h_{E}", "subexpr": "h_{E}"},
+                    {"id": "__power_16", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{H}"},
+                    {"id": "__multiply_17", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{\\beta} \\frac{1}{2} \\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__num_18", "type": "number", "label": "1/2", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__power_19", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\beta}"},
+                    {"id": "beta", "type": "scalar", "latex": "\\beta", "subexpr": "\\beta"},
+                    {"id": "__power_20", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\sin{\\left(\\gamma \\right)}}"},
+                    {"id": "__sin_21", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\gamma \\right)}"},
+                    {"id": "gamma", "type": "scalar", "latex": "\\gamma", "subexpr": "\\gamma"},
+                    {"id": "__congruent_22", "type": "relation", "label": "congruent to", "emoji": "≡", "op": "congruent", "subexpr": "\\delta \\equiv 1 - \\frac{V_{\\text{exit}}}{V_E} = 1 - \\exp\\!\\left(-\\frac{\\rho_0 H\\,e^{-h_E/H}}{2\\beta\\sin\\gamma}\\right)"}
                   ],
                   "edges": [
-                    {
-                      "from": "__num_3",
-                      "to": "__add_2"
-                    },
-                    {
-                      "from": "V_{\\text{exit}}",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V_{E}",
-                      "to": "__power_6"
-                    },
-                    {
-                      "from": "__power_6",
-                      "to": "__multiply_5"
-                    },
-                    {
-                      "from": "__multiply_5",
-                      "to": "__negation_4"
-                    },
-                    {
-                      "from": "__negation_4",
-                      "to": "__add_2"
-                    },
-                    {
-                      "from": "__add_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "__num_8",
-                      "to": "__add_7"
-                    },
-                    {
-                      "from": "H",
-                      "to": "__multiply_12",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "rho_{0}",
-                      "to": "__multiply_12",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "e",
-                      "to": "__power_13"
-                    },
-                    {
-                      "from": "h_{E}",
-                      "to": "__negation_15"
-                    },
-                    {
-                      "from": "__negation_15",
-                      "to": "__multiply_14",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__power_16"
-                    },
-                    {
-                      "from": "__power_16",
-                      "to": "__multiply_14"
-                    },
-                    {
-                      "from": "__multiply_14",
-                      "to": "__power_13",
-                      "role": "exp"
-                    },
-                    {
-                      "from": "__power_13",
-                      "to": "__multiply_12",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_18",
-                      "to": "__multiply_17",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "beta",
-                      "to": "__power_19"
-                    },
-                    {
-                      "from": "__power_19",
-                      "to": "__multiply_17"
-                    },
-                    {
-                      "from": "gamma",
-                      "to": "__sin_21"
-                    },
-                    {
-                      "from": "__sin_21",
-                      "to": "__power_20"
-                    },
-                    {
-                      "from": "__power_20",
-                      "to": "__multiply_17"
-                    },
-                    {
-                      "from": "__multiply_17",
-                      "to": "__multiply_12",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_12",
-                      "to": "__negation_11"
-                    },
-                    {
-                      "from": "__negation_11",
-                      "to": "__exp_10"
-                    },
-                    {
-                      "from": "__exp_10",
-                      "to": "__negation_9"
-                    },
-                    {
-                      "from": "__negation_9",
-                      "to": "__add_7"
-                    },
-                    {
-                      "from": "__add_7",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "delta",
-                      "to": "__congruent_22"
-                    },
-                    {
-                      "from": "__equals_1",
-                      "to": "__congruent_22"
-                    }
+                    {"from": "__num_3", "to": "__add_2"},
+                    {"from": "V_{\\text{exit}}", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "V_{E}", "to": "__power_6"},
+                    {"from": "__power_6", "to": "__multiply_5"},
+                    {"from": "__multiply_5", "to": "__negation_4"},
+                    {"from": "__negation_4", "to": "__add_2"},
+                    {"from": "__add_2", "to": "__equals_1"},
+                    {"from": "__num_8", "to": "__add_7"},
+                    {"from": "H", "to": "__multiply_12", "semantic": "direct", "weight": 1.0},
+                    {"from": "rho_{0}", "to": "__multiply_12", "semantic": "direct", "weight": 1.0},
+                    {"from": "e", "to": "__power_13"},
+                    {"from": "h_{E}", "to": "__negation_15"},
+                    {"from": "__negation_15", "to": "__multiply_14", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__power_16"},
+                    {"from": "__power_16", "to": "__multiply_14"},
+                    {"from": "__multiply_14", "to": "__power_13", "role": "exp"},
+                    {"from": "__power_13", "to": "__multiply_12", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_18", "to": "__multiply_17", "semantic": "direct", "weight": 1.0},
+                    {"from": "beta", "to": "__power_19"},
+                    {"from": "__power_19", "to": "__multiply_17"},
+                    {"from": "gamma", "to": "__sin_21"},
+                    {"from": "__sin_21", "to": "__power_20"},
+                    {"from": "__power_20", "to": "__multiply_17"},
+                    {"from": "__multiply_17", "to": "__multiply_12", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_12", "to": "__negation_11"},
+                    {"from": "__negation_11", "to": "__exp_10"},
+                    {"from": "__exp_10", "to": "__negation_9"},
+                    {"from": "__negation_9", "to": "__add_7"},
+                    {"from": "__add_7", "to": "__equals_1"},
+                    {"from": "delta", "to": "__congruent_22"},
+                    {"from": "__equals_1", "to": "__congruent_22"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -9108,250 +2829,56 @@
               "prompt": "For super-orbital entries (like lunar or Mars return), the vehicle comes in much faster than orbital speed, so even a small fractional loss matters enormously.",
               "sceneStep": 0,
               "highlights": {
-                "dmin": {
-                  "color": "magenta",
-                  "label": "minimum fractional speed loss for atmospheric capture"
-                }
+                "dmin": {"color": "magenta", "label": "minimum fractional speed loss for atmospheric capture"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "delta",
-                      "type": "scalar",
-                      "latex": "\\delta",
-                      "subexpr": "\\delta"
-                    },
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\delta_{\\min} = 1 - \\frac{V_{\\text{circ}}}{V_{E}}\\sqrt{1 + \\frac{2h_{E}}{R_{p}}}"
-                    },
-                    {
-                      "id": "delta_{\\min}",
-                      "type": "scalar",
-                      "latex": "\\delta_{\\min}",
-                      "subexpr": "\\delta_{\\min}",
-                      "description": "minimum fractional speed loss for atmospheric capture",
-                      "color": "magenta",
-                      "highlight": "dmin"
-                    },
-                    {
-                      "id": "__add_2",
-                      "type": "operator",
-                      "op": "add",
-                      "subexpr": "1 - V_{\\text{circ}} \\frac{1}{V_{E}} \\sqrt{1 + \\frac{2 h_{E}}{R_{p}}}"
-                    },
-                    {
-                      "id": "__num_3",
-                      "type": "number",
-                      "label": "1",
-                      "subexpr": "1"
-                    },
-                    {
-                      "id": "__negation_4",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-V_{\\text{circ}} \\frac{1}{V_{E}} \\sqrt{1 + \\frac{2 h_{E}}{R_{p}}}"
-                    },
-                    {
-                      "id": "__multiply_5",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{\\text{circ}} \\frac{1}{V_{E}} \\sqrt{1 + \\frac{2 h_{E}}{R_{p}}}"
-                    },
-                    {
-                      "id": "__multiply_6",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{\\text{circ}} \\frac{1}{V_{E}}"
-                    },
-                    {
-                      "id": "V_{\\text{circ}}",
-                      "type": "scalar",
-                      "latex": "V_{\\text{circ}}",
-                      "subexpr": "V_{\\text{circ}}"
-                    },
-                    {
-                      "id": "__power_7",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{V_{E}}"
-                    },
-                    {
-                      "id": "V_{E}",
-                      "type": "scalar",
-                      "latex": "V_{E}",
-                      "subexpr": "V_{E}"
-                    },
-                    {
-                      "id": "__power_8",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "1/2",
-                      "subexpr": "\\sqrt{1 + \\frac{2 h_{E}}{R_{p}}}"
-                    },
-                    {
-                      "id": "__add_9",
-                      "type": "operator",
-                      "op": "add",
-                      "subexpr": "1 + 2 h_{E} \\frac{1}{R_{p}}"
-                    },
-                    {
-                      "id": "__num_10",
-                      "type": "number",
-                      "label": "1",
-                      "subexpr": "1"
-                    },
-                    {
-                      "id": "__multiply_11",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "2 h_{E} \\frac{1}{R_{p}}"
-                    },
-                    {
-                      "id": "__multiply_12",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "2 h_{E}"
-                    },
-                    {
-                      "id": "__num_13",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "h_{E}",
-                      "type": "scalar",
-                      "latex": "h_{E}",
-                      "subexpr": "h_{E}"
-                    },
-                    {
-                      "id": "__power_14",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{R_{p}}"
-                    },
-                    {
-                      "id": "R_{p}",
-                      "type": "scalar",
-                      "latex": "R_{p}",
-                      "subexpr": "R_{p}"
-                    },
-                    {
-                      "id": "__greater_equal_15",
-                      "type": "relation",
-                      "label": "greater than or equal to",
-                      "emoji": "≥",
-                      "op": "greater_equal",
-                      "subexpr": "\\delta \\geq \\delta_{\\min} = 1 - \\frac{V_{\\text{circ}}}{V_E}\\sqrt{1 + \\frac{2h_E}{R_p}}"
-                    }
+                    {"id": "delta", "type": "scalar", "latex": "\\delta", "subexpr": "\\delta"},
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\delta_{\\min} = 1 - \\frac{V_{\\text{circ}}}{V_{E}}\\sqrt{1 + \\frac{2h_{E}}{R_{p}}}"},
+                    {"id": "delta_{\\min}", "type": "scalar", "latex": "\\delta_{\\min}", "subexpr": "\\delta_{\\min}", "description": "minimum fractional speed loss for atmospheric capture", "color": "magenta", "highlight": "dmin"},
+                    {"id": "__add_2", "type": "operator", "op": "add", "subexpr": "1 - V_{\\text{circ}} \\frac{1}{V_{E}} \\sqrt{1 + \\frac{2 h_{E}}{R_{p}}}"},
+                    {"id": "__num_3", "type": "number", "label": "1", "subexpr": "1"},
+                    {"id": "__negation_4", "type": "operator", "op": "negation", "subexpr": "-V_{\\text{circ}} \\frac{1}{V_{E}} \\sqrt{1 + \\frac{2 h_{E}}{R_{p}}}"},
+                    {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "V_{\\text{circ}} \\frac{1}{V_{E}} \\sqrt{1 + \\frac{2 h_{E}}{R_{p}}}"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "V_{\\text{circ}} \\frac{1}{V_{E}}"},
+                    {"id": "V_{\\text{circ}}", "type": "scalar", "latex": "V_{\\text{circ}}", "subexpr": "V_{\\text{circ}}"},
+                    {"id": "__power_7", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{V_{E}}"},
+                    {"id": "V_{E}", "type": "scalar", "latex": "V_{E}", "subexpr": "V_{E}"},
+                    {"id": "__power_8", "type": "operator", "op": "power", "exponent": "1/2", "subexpr": "\\sqrt{1 + \\frac{2 h_{E}}{R_{p}}}"},
+                    {"id": "__add_9", "type": "operator", "op": "add", "subexpr": "1 + 2 h_{E} \\frac{1}{R_{p}}"},
+                    {"id": "__num_10", "type": "number", "label": "1", "subexpr": "1"},
+                    {"id": "__multiply_11", "type": "operator", "op": "multiply", "subexpr": "2 h_{E} \\frac{1}{R_{p}}"},
+                    {"id": "__multiply_12", "type": "operator", "op": "multiply", "subexpr": "2 h_{E}"},
+                    {"id": "__num_13", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "h_{E}", "type": "scalar", "latex": "h_{E}", "subexpr": "h_{E}"},
+                    {"id": "__power_14", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{R_{p}}"},
+                    {"id": "R_{p}", "type": "scalar", "latex": "R_{p}", "subexpr": "R_{p}"},
+                    {"id": "__greater_equal_15", "type": "relation", "label": "greater than or equal to", "emoji": "≥", "op": "greater_equal", "subexpr": "\\delta \\geq \\delta_{\\min} = 1 - \\frac{V_{\\text{circ}}}{V_E}\\sqrt{1 + \\frac{2h_E}{R_p}}"}
                   ],
                   "edges": [
-                    {
-                      "from": "delta_{\\min}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "__num_3",
-                      "to": "__add_2"
-                    },
-                    {
-                      "from": "V_{\\text{circ}}",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V_{E}",
-                      "to": "__power_7"
-                    },
-                    {
-                      "from": "__power_7",
-                      "to": "__multiply_6"
-                    },
-                    {
-                      "from": "__multiply_6",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_10",
-                      "to": "__add_9"
-                    },
-                    {
-                      "from": "__num_13",
-                      "to": "__multiply_12",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "h_{E}",
-                      "to": "__multiply_12",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_12",
-                      "to": "__multiply_11",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "R_{p}",
-                      "to": "__power_14"
-                    },
-                    {
-                      "from": "__power_14",
-                      "to": "__multiply_11"
-                    },
-                    {
-                      "from": "__multiply_11",
-                      "to": "__add_9"
-                    },
-                    {
-                      "from": "__add_9",
-                      "to": "__power_8"
-                    },
-                    {
-                      "from": "__power_8",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_5",
-                      "to": "__negation_4"
-                    },
-                    {
-                      "from": "__negation_4",
-                      "to": "__add_2"
-                    },
-                    {
-                      "from": "__add_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "delta",
-                      "to": "__greater_equal_15",
-                      "role": "lhs"
-                    },
-                    {
-                      "from": "__equals_1",
-                      "to": "__greater_equal_15",
-                      "role": "rhs"
-                    }
+                    {"from": "delta_{\\min}", "to": "__equals_1"},
+                    {"from": "__num_3", "to": "__add_2"},
+                    {"from": "V_{\\text{circ}}", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "V_{E}", "to": "__power_7"},
+                    {"from": "__power_7", "to": "__multiply_6"},
+                    {"from": "__multiply_6", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_10", "to": "__add_9"},
+                    {"from": "__num_13", "to": "__multiply_12", "semantic": "direct", "weight": 1.0},
+                    {"from": "h_{E}", "to": "__multiply_12", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_12", "to": "__multiply_11", "semantic": "direct", "weight": 1.0},
+                    {"from": "R_{p}", "to": "__power_14"},
+                    {"from": "__power_14", "to": "__multiply_11"},
+                    {"from": "__multiply_11", "to": "__add_9"},
+                    {"from": "__add_9", "to": "__power_8"},
+                    {"from": "__power_8", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_5", "to": "__negation_4"},
+                    {"from": "__negation_4", "to": "__add_2"},
+                    {"from": "__add_2", "to": "__equals_1"},
+                    {"from": "delta", "to": "__greater_equal_15", "role": "lhs"},
+                    {"from": "__equals_1", "to": "__greater_equal_15", "role": "rhs"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -9366,302 +2893,62 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\sin\\gamma_{\\text{shallow}} = \\frac{\\rho_0 H\\,e^{-h_E/H}}{2\\beta\\,\\ln\\!\\left(\\frac{1}{1 - \\delta_{\\min}}\\right)}"
-                    },
-                    {
-                      "id": "__sin_2",
-                      "type": "function",
-                      "latex": "\\sin",
-                      "op": "sin",
-                      "subexpr": "\\sin{\\left(\\gamma_{\\text{shallow}} \\right)}"
-                    },
-                    {
-                      "id": "gamma_{\\text{shallow}}",
-                      "type": "scalar",
-                      "latex": "\\gamma_{\\text{shallow}}",
-                      "subexpr": "\\gamma_{\\text{shallow}}"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho_{0} H e^{\\frac{\\left(-1\\right) h_{E}}{H}} \\frac{1}{2 \\beta \\ln{\\left(\\frac{1}{1 - \\delta_{\\min}} \\right)}}"
-                    },
-                    {
-                      "id": "__multiply_4",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho_{0} H e^{\\frac{\\left(-1\\right) h_{E}}{H}}"
-                    },
-                    {
-                      "id": "rho_{0}",
-                      "type": "scalar",
-                      "latex": "\\rho_{0}",
-                      "subexpr": "\\rho_{0}"
-                    },
-                    {
-                      "id": "__multiply_5",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "H e^{\\frac{\\left(-1\\right) h_{E}}{H}}"
-                    },
-                    {
-                      "id": "H",
-                      "type": "scalar",
-                      "latex": "H",
-                      "subexpr": "H"
-                    },
-                    {
-                      "id": "__power_6",
-                      "type": "operator",
-                      "op": "power",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}}"
-                    },
-                    {
-                      "id": "e",
-                      "type": "scalar",
-                      "latex": "e",
-                      "subexpr": "e"
-                    },
-                    {
-                      "id": "__multiply_7",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{H} -h_{E}"
-                    },
-                    {
-                      "id": "__negation_8",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-h_{E}"
-                    },
-                    {
-                      "id": "h_{E}",
-                      "type": "scalar",
-                      "latex": "h_{E}",
-                      "subexpr": "h_{E}"
-                    },
-                    {
-                      "id": "__power_9",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{H}"
-                    },
-                    {
-                      "id": "__power_10",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2 \\beta \\ln{\\left(\\frac{1}{1 - \\delta_{\\min}} \\right)}}"
-                    },
-                    {
-                      "id": "__multiply_11",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "2 \\beta \\ln{\\left(\\frac{1}{1 - \\delta_{\\min}} \\right)}"
-                    },
-                    {
-                      "id": "__num_12",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "__multiply_13",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\beta \\ln{\\left(\\frac{1}{1 - \\delta_{\\min}} \\right)}"
-                    },
-                    {
-                      "id": "beta",
-                      "type": "scalar",
-                      "latex": "\\beta",
-                      "subexpr": "\\beta"
-                    },
-                    {
-                      "id": "__log_14",
-                      "type": "function",
-                      "op": "log",
-                      "subexpr": "\\ln{\\left(\\frac{1}{1 - \\delta_{\\min}} \\right)}"
-                    },
-                    {
-                      "id": "__power_15",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{1 - \\delta_{\\min}}"
-                    },
-                    {
-                      "id": "__add_16",
-                      "type": "operator",
-                      "op": "add",
-                      "subexpr": "1 - \\delta_{\\min}"
-                    },
-                    {
-                      "id": "__num_17",
-                      "type": "number",
-                      "label": "1",
-                      "subexpr": "1"
-                    },
-                    {
-                      "id": "__negation_18",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-\\delta_{\\min}"
-                    },
-                    {
-                      "id": "delta_{\\min}",
-                      "type": "scalar",
-                      "latex": "\\delta_{\\min}",
-                      "subexpr": "\\delta_{\\min}"
-                    },
-                    {
-                      "id": "__const_19",
-                      "type": "constant",
-                      "label": "e (Euler's number)",
-                      "latex": "e",
-                      "subexpr": "e"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\sin\\gamma_{\\text{shallow}} = \\frac{\\rho_0 H\\,e^{-h_E/H}}{2\\beta\\,\\ln\\!\\left(\\frac{1}{1 - \\delta_{\\min}}\\right)}"},
+                    {"id": "__sin_2", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\gamma_{\\text{shallow}} \\right)}"},
+                    {"id": "gamma_{\\text{shallow}}", "type": "scalar", "latex": "\\gamma_{\\text{shallow}}", "subexpr": "\\gamma_{\\text{shallow}}"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "\\rho_{0} H e^{\\frac{\\left(-1\\right) h_{E}}{H}} \\frac{1}{2 \\beta \\ln{\\left(\\frac{1}{1 - \\delta_{\\min}} \\right)}}"},
+                    {"id": "__multiply_4", "type": "operator", "op": "multiply", "subexpr": "\\rho_{0} H e^{\\frac{\\left(-1\\right) h_{E}}{H}}"},
+                    {"id": "rho_{0}", "type": "scalar", "latex": "\\rho_{0}", "subexpr": "\\rho_{0}"},
+                    {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "H e^{\\frac{\\left(-1\\right) h_{E}}{H}}"},
+                    {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"},
+                    {"id": "__power_6", "type": "operator", "op": "power", "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}}"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "__multiply_7", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{H} -h_{E}"},
+                    {"id": "__negation_8", "type": "operator", "op": "negation", "subexpr": "-h_{E}"},
+                    {"id": "h_{E}", "type": "scalar", "latex": "h_{E}", "subexpr": "h_{E}"},
+                    {"id": "__power_9", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{H}"},
+                    {"id": "__power_10", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2 \\beta \\ln{\\left(\\frac{1}{1 - \\delta_{\\min}} \\right)}}"},
+                    {"id": "__multiply_11", "type": "operator", "op": "multiply", "subexpr": "2 \\beta \\ln{\\left(\\frac{1}{1 - \\delta_{\\min}} \\right)}"},
+                    {"id": "__num_12", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__multiply_13", "type": "operator", "op": "multiply", "subexpr": "\\beta \\ln{\\left(\\frac{1}{1 - \\delta_{\\min}} \\right)}"},
+                    {"id": "beta", "type": "scalar", "latex": "\\beta", "subexpr": "\\beta"},
+                    {"id": "__log_14", "type": "function", "op": "log", "subexpr": "\\ln{\\left(\\frac{1}{1 - \\delta_{\\min}} \\right)}"},
+                    {"id": "__power_15", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{1 - \\delta_{\\min}}"},
+                    {"id": "__add_16", "type": "operator", "op": "add", "subexpr": "1 - \\delta_{\\min}"},
+                    {"id": "__num_17", "type": "number", "label": "1", "subexpr": "1"},
+                    {"id": "__negation_18", "type": "operator", "op": "negation", "subexpr": "-\\delta_{\\min}"},
+                    {"id": "delta_{\\min}", "type": "scalar", "latex": "\\delta_{\\min}", "subexpr": "\\delta_{\\min}"},
+                    {"id": "__const_19", "type": "constant", "label": "e (Euler's number)", "latex": "e", "subexpr": "e"}
                   ],
                   "edges": [
-                    {
-                      "from": "gamma_{\\text{shallow}}",
-                      "to": "__sin_2"
-                    },
-                    {
-                      "from": "__sin_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "rho_{0}",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "e",
-                      "to": "__power_6"
-                    },
-                    {
-                      "from": "h_{E}",
-                      "to": "__negation_8"
-                    },
-                    {
-                      "from": "__negation_8",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__power_9"
-                    },
-                    {
-                      "from": "__power_9",
-                      "to": "__multiply_7"
-                    },
-                    {
-                      "from": "__multiply_7",
-                      "to": "__power_6",
-                      "role": "exp"
-                    },
-                    {
-                      "from": "__power_6",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_5",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_4",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_12",
-                      "to": "__multiply_11",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "beta",
-                      "to": "__multiply_13",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_17",
-                      "to": "__add_16"
-                    },
-                    {
-                      "from": "delta_{\\min}",
-                      "to": "__negation_18"
-                    },
-                    {
-                      "from": "__negation_18",
-                      "to": "__add_16"
-                    },
-                    {
-                      "from": "__add_16",
-                      "to": "__power_15"
-                    },
-                    {
-                      "from": "__power_15",
-                      "to": "__log_14"
-                    },
-                    {
-                      "from": "__const_19",
-                      "to": "__log_14",
-                      "role": "base"
-                    },
-                    {
-                      "from": "__log_14",
-                      "to": "__multiply_13",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_13",
-                      "to": "__multiply_11",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_11",
-                      "to": "__power_10"
-                    },
-                    {
-                      "from": "__power_10",
-                      "to": "__multiply_3"
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__equals_1"
-                    }
+                    {"from": "gamma_{\\text{shallow}}", "to": "__sin_2"},
+                    {"from": "__sin_2", "to": "__equals_1"},
+                    {"from": "rho_{0}", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "e", "to": "__power_6"},
+                    {"from": "h_{E}", "to": "__negation_8"},
+                    {"from": "__negation_8", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__power_9"},
+                    {"from": "__power_9", "to": "__multiply_7"},
+                    {"from": "__multiply_7", "to": "__power_6", "role": "exp"},
+                    {"from": "__power_6", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_5", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_12", "to": "__multiply_11", "semantic": "direct", "weight": 1.0},
+                    {"from": "beta", "to": "__multiply_13", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_17", "to": "__add_16"},
+                    {"from": "delta_{\\min}", "to": "__negation_18"},
+                    {"from": "__negation_18", "to": "__add_16"},
+                    {"from": "__add_16", "to": "__power_15"},
+                    {"from": "__power_15", "to": "__log_14"},
+                    {"from": "__const_19", "to": "__log_14", "role": "base"},
+                    {"from": "__log_14", "to": "__multiply_13", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_13", "to": "__multiply_11", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_11", "to": "__power_10"},
+                    {"from": "__power_10", "to": "__multiply_3"},
+                    {"from": "__multiply_3", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -9674,245 +2961,55 @@
               "prompt": "Compare with the steep bound: the steep bound is vehicle-independent (depends only on $V_E$ and $n_{\\max}$), but the shallow bound depends on $\\beta$. This means different vehicles have different corridor widths even at the same entry speed.",
               "sceneStep": 0,
               "highlights": {
-                "shallow": {
-                  "color": "orange",
-                  "label": "minimum entry angle to avoid skip-out"
-                }
+                "shallow": {"color": "orange", "label": "minimum entry angle to avoid skip-out"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\gamma_{\\text{shallow}} = \\arcsin\\!\\left(\\frac{\\rho_0 H\\,e^{-h_E/H}}{2\\beta\\,\\delta_{\\min}}\\right)"
-                    },
-                    {
-                      "id": "gamma_{\\text{shallow}}",
-                      "type": "scalar",
-                      "latex": "\\gamma_{\\text{shallow}}",
-                      "subexpr": "\\gamma_{\\text{shallow}}"
-                    },
-                    {
-                      "id": "__asin_2",
-                      "type": "function",
-                      "op": "asin",
-                      "subexpr": "\\operatorname{asin}{\\left(\\frac{\\rho_{0} H e^{\\frac{\\left(-1\\right) h_{E}}{H}}}{2 \\delta_{\\min} \\beta} \\right)}"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho_{0} e^{\\frac{\\left(-1\\right) h_{E}}{H}} H \\frac{1}{2 \\delta_{\\min} \\beta}"
-                    },
-                    {
-                      "id": "__multiply_4",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho_{0} e^{\\frac{\\left(-1\\right) h_{E}}{H}} H"
-                    },
-                    {
-                      "id": "rho_{0}",
-                      "type": "scalar",
-                      "latex": "\\rho_{0}",
-                      "subexpr": "\\rho_{0}"
-                    },
-                    {
-                      "id": "__multiply_5",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}} H"
-                    },
-                    {
-                      "id": "H",
-                      "type": "scalar",
-                      "latex": "H",
-                      "subexpr": "H"
-                    },
-                    {
-                      "id": "__power_6",
-                      "type": "operator",
-                      "op": "power",
-                      "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}}"
-                    },
-                    {
-                      "id": "e",
-                      "type": "scalar",
-                      "latex": "e",
-                      "subexpr": "e"
-                    },
-                    {
-                      "id": "__multiply_7",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{H} -h_{E}"
-                    },
-                    {
-                      "id": "__negation_8",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-h_{E}"
-                    },
-                    {
-                      "id": "h_{E}",
-                      "type": "scalar",
-                      "latex": "h_{E}",
-                      "subexpr": "h_{E}"
-                    },
-                    {
-                      "id": "__power_9",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{H}"
-                    },
-                    {
-                      "id": "__power_10",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2 \\delta_{\\min} \\beta}"
-                    },
-                    {
-                      "id": "__multiply_11",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "2 \\beta \\delta_{\\min}"
-                    },
-                    {
-                      "id": "__num_12",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "__multiply_13",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\beta \\delta_{\\min}"
-                    },
-                    {
-                      "id": "beta",
-                      "type": "scalar",
-                      "latex": "\\beta",
-                      "subexpr": "\\beta"
-                    },
-                    {
-                      "id": "delta_{\\min}",
-                      "type": "scalar",
-                      "latex": "\\delta_{\\min}",
-                      "subexpr": "\\delta_{\\min}"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\gamma_{\\text{shallow}} = \\arcsin\\!\\left(\\frac{\\rho_0 H\\,e^{-h_E/H}}{2\\beta\\,\\delta_{\\min}}\\right)"},
+                    {"id": "gamma_{\\text{shallow}}", "type": "scalar", "latex": "\\gamma_{\\text{shallow}}", "subexpr": "\\gamma_{\\text{shallow}}"},
+                    {"id": "__asin_2", "type": "function", "op": "asin", "subexpr": "\\operatorname{asin}{\\left(\\frac{\\rho_{0} H e^{\\frac{\\left(-1\\right) h_{E}}{H}}}{2 \\delta_{\\min} \\beta} \\right)}"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "\\rho_{0} e^{\\frac{\\left(-1\\right) h_{E}}{H}} H \\frac{1}{2 \\delta_{\\min} \\beta}"},
+                    {"id": "__multiply_4", "type": "operator", "op": "multiply", "subexpr": "\\rho_{0} e^{\\frac{\\left(-1\\right) h_{E}}{H}} H"},
+                    {"id": "rho_{0}", "type": "scalar", "latex": "\\rho_{0}", "subexpr": "\\rho_{0}"},
+                    {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}} H"},
+                    {"id": "H", "type": "scalar", "latex": "H", "subexpr": "H"},
+                    {"id": "__power_6", "type": "operator", "op": "power", "subexpr": "e^{\\frac{\\left(-1\\right) h_{E}}{H}}"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "__multiply_7", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{H} -h_{E}"},
+                    {"id": "__negation_8", "type": "operator", "op": "negation", "subexpr": "-h_{E}"},
+                    {"id": "h_{E}", "type": "scalar", "latex": "h_{E}", "subexpr": "h_{E}"},
+                    {"id": "__power_9", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{H}"},
+                    {"id": "__power_10", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2 \\delta_{\\min} \\beta}"},
+                    {"id": "__multiply_11", "type": "operator", "op": "multiply", "subexpr": "2 \\beta \\delta_{\\min}"},
+                    {"id": "__num_12", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__multiply_13", "type": "operator", "op": "multiply", "subexpr": "\\beta \\delta_{\\min}"},
+                    {"id": "beta", "type": "scalar", "latex": "\\beta", "subexpr": "\\beta"},
+                    {"id": "delta_{\\min}", "type": "scalar", "latex": "\\delta_{\\min}", "subexpr": "\\delta_{\\min}"}
                   ],
                   "edges": [
-                    {
-                      "from": "gamma_{\\text{shallow}}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "rho_{0}",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "e",
-                      "to": "__power_6"
-                    },
-                    {
-                      "from": "h_{E}",
-                      "to": "__negation_8"
-                    },
-                    {
-                      "from": "__negation_8",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "H",
-                      "to": "__power_9"
-                    },
-                    {
-                      "from": "__power_9",
-                      "to": "__multiply_7"
-                    },
-                    {
-                      "from": "__multiply_7",
-                      "to": "__power_6",
-                      "role": "exp"
-                    },
-                    {
-                      "from": "__power_6",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_5",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_4",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_12",
-                      "to": "__multiply_11",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "beta",
-                      "to": "__multiply_13",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "delta_{\\min}",
-                      "to": "__multiply_13",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_13",
-                      "to": "__multiply_11",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_11",
-                      "to": "__power_10"
-                    },
-                    {
-                      "from": "__power_10",
-                      "to": "__multiply_3"
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__asin_2"
-                    },
-                    {
-                      "from": "__asin_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "gamma_{\\text{shallow}}", "to": "__equals_1"},
+                    {"from": "rho_{0}", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "e", "to": "__power_6"},
+                    {"from": "h_{E}", "to": "__negation_8"},
+                    {"from": "__negation_8", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "H", "to": "__power_9"},
+                    {"from": "__power_9", "to": "__multiply_7"},
+                    {"from": "__multiply_7", "to": "__power_6", "role": "exp"},
+                    {"from": "__power_6", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_5", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_12", "to": "__multiply_11", "semantic": "direct", "weight": 1.0},
+                    {"from": "beta", "to": "__multiply_13", "semantic": "direct", "weight": 1.0},
+                    {"from": "delta_{\\min}", "to": "__multiply_13", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_13", "to": "__multiply_11", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_11", "to": "__power_10"},
+                    {"from": "__power_10", "to": "__multiply_3"},
+                    {"from": "__multiply_3", "to": "__asin_2"},
+                    {"from": "__asin_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -9927,161 +3024,37 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\beta_{\\text{eff}} = \\frac{\\beta}{1 + (L/D)\\cos\\phi}"
-                    },
-                    {
-                      "id": "beta_{\\text{eff}}",
-                      "type": "scalar",
-                      "latex": "\\beta_{\\text{eff}}",
-                      "subexpr": "\\beta_{\\text{eff}}"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\beta \\frac{1}{\\frac{L}{D} \\cos{\\left(\\phi \\right)} + 1}"
-                    },
-                    {
-                      "id": "beta",
-                      "type": "scalar",
-                      "latex": "\\beta",
-                      "subexpr": "\\beta"
-                    },
-                    {
-                      "id": "__power_3",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\frac{L}{D} \\cos{\\left(\\phi \\right)} + 1}"
-                    },
-                    {
-                      "id": "__add_4",
-                      "type": "operator",
-                      "op": "add",
-                      "subexpr": "L \\frac{1}{D} \\cos{\\left(\\phi \\right)} + 1"
-                    },
-                    {
-                      "id": "__num_5",
-                      "type": "number",
-                      "label": "1",
-                      "subexpr": "1"
-                    },
-                    {
-                      "id": "__multiply_6",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "L \\frac{1}{D} \\cos{\\left(\\phi \\right)}"
-                    },
-                    {
-                      "id": "__multiply_7",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "L \\frac{1}{D}"
-                    },
-                    {
-                      "id": "L",
-                      "type": "scalar",
-                      "latex": "L",
-                      "subexpr": "L"
-                    },
-                    {
-                      "id": "__power_8",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{D}"
-                    },
-                    {
-                      "id": "D",
-                      "type": "scalar",
-                      "latex": "D",
-                      "subexpr": "D"
-                    },
-                    {
-                      "id": "__cos_9",
-                      "type": "function",
-                      "latex": "\\cos",
-                      "op": "cos",
-                      "subexpr": "\\cos{\\left(\\phi \\right)}"
-                    },
-                    {
-                      "id": "phi",
-                      "type": "scalar",
-                      "latex": "\\phi",
-                      "subexpr": "\\phi"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\beta_{\\text{eff}} = \\frac{\\beta}{1 + (L/D)\\cos\\phi}"},
+                    {"id": "beta_{\\text{eff}}", "type": "scalar", "latex": "\\beta_{\\text{eff}}", "subexpr": "\\beta_{\\text{eff}}"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\beta \\frac{1}{\\frac{L}{D} \\cos{\\left(\\phi \\right)} + 1}"},
+                    {"id": "beta", "type": "scalar", "latex": "\\beta", "subexpr": "\\beta"},
+                    {"id": "__power_3", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\frac{L}{D} \\cos{\\left(\\phi \\right)} + 1}"},
+                    {"id": "__add_4", "type": "operator", "op": "add", "subexpr": "L \\frac{1}{D} \\cos{\\left(\\phi \\right)} + 1"},
+                    {"id": "__num_5", "type": "number", "label": "1", "subexpr": "1"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "L \\frac{1}{D} \\cos{\\left(\\phi \\right)}"},
+                    {"id": "__multiply_7", "type": "operator", "op": "multiply", "subexpr": "L \\frac{1}{D}"},
+                    {"id": "L", "type": "scalar", "latex": "L", "subexpr": "L"},
+                    {"id": "__power_8", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{D}"},
+                    {"id": "D", "type": "scalar", "latex": "D", "subexpr": "D"},
+                    {"id": "__cos_9", "type": "function", "latex": "\\cos", "op": "cos", "subexpr": "\\cos{\\left(\\phi \\right)}"},
+                    {"id": "phi", "type": "scalar", "latex": "\\phi", "subexpr": "\\phi"}
                   ],
                   "edges": [
-                    {
-                      "from": "beta_{\\text{eff}}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "beta",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_5",
-                      "to": "__add_4"
-                    },
-                    {
-                      "from": "L",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "D",
-                      "to": "__power_8"
-                    },
-                    {
-                      "from": "__power_8",
-                      "to": "__multiply_7"
-                    },
-                    {
-                      "from": "__multiply_7",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "phi",
-                      "to": "__cos_9"
-                    },
-                    {
-                      "from": "__cos_9",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_6",
-                      "to": "__add_4"
-                    },
-                    {
-                      "from": "__add_4",
-                      "to": "__power_3"
-                    },
-                    {
-                      "from": "__power_3",
-                      "to": "__multiply_2"
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "beta_{\\text{eff}}", "to": "__equals_1"},
+                    {"from": "beta", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_5", "to": "__add_4"},
+                    {"from": "L", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "D", "to": "__power_8"},
+                    {"from": "__power_8", "to": "__multiply_7"},
+                    {"from": "__multiply_7", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "phi", "to": "__cos_9"},
+                    {"from": "__cos_9", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_6", "to": "__add_4"},
+                    {"from": "__add_4", "to": "__power_3"},
+                    {"from": "__power_3", "to": "__multiply_2"},
+                    {"from": "__multiply_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -10094,79 +3067,26 @@
               "prompt": "Final takeaway: the entry corridor is a consequence of two competing constraints — not burning up vs. not bouncing off. The numbers show why atmospheric entry is one of the hardest problems in spaceflight.",
               "sceneStep": 0,
               "highlights": {
-                "width": {
-                  "color": "green",
-                  "label": "the survivable entry window"
-                }
+                "width": {"color": "green", "label": "the survivable entry window"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\Delta\\gamma = \\gamma_{\\text{steep}} - \\gamma_{\\text{shallow}}",
-                      "description": "the survivable entry window",
-                      "color": "green",
-                      "highlight": "width"
-                    },
-                    {
-                      "id": "Delta \\gamma",
-                      "type": "scalar",
-                      "latex": "\\Delta \\gamma",
-                      "subexpr": "\\Delta \\gamma"
-                    },
-                    {
-                      "id": "__add_2",
-                      "type": "operator",
-                      "op": "add",
-                      "subexpr": "\\gamma_{\\text{steep}} - \\gamma_{\\text{shallow}}"
-                    },
-                    {
-                      "id": "gamma_{\\text{steep}}",
-                      "type": "scalar",
-                      "latex": "\\gamma_{\\text{steep}}",
-                      "subexpr": "\\gamma_{\\text{steep}}"
-                    },
-                    {
-                      "id": "__negation_3",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-\\gamma_{\\text{shallow}}"
-                    },
-                    {
-                      "id": "gamma_{\\text{shallow}}",
-                      "type": "scalar",
-                      "latex": "\\gamma_{\\text{shallow}}",
-                      "subexpr": "\\gamma_{\\text{shallow}}"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\Delta\\gamma = \\gamma_{\\text{steep}} - \\gamma_{\\text{shallow}}", "description": "the survivable entry window", "color": "green", "highlight": "width"},
+                    {"id": "Delta \\gamma", "type": "scalar", "latex": "\\Delta \\gamma", "subexpr": "\\Delta \\gamma"},
+                    {"id": "__add_2", "type": "operator", "op": "add", "subexpr": "\\gamma_{\\text{steep}} - \\gamma_{\\text{shallow}}"},
+                    {"id": "gamma_{\\text{steep}}", "type": "scalar", "latex": "\\gamma_{\\text{steep}}", "subexpr": "\\gamma_{\\text{steep}}"},
+                    {"id": "__negation_3", "type": "operator", "op": "negation", "subexpr": "-\\gamma_{\\text{shallow}}"},
+                    {"id": "gamma_{\\text{shallow}}", "type": "scalar", "latex": "\\gamma_{\\text{shallow}}", "subexpr": "\\gamma_{\\text{shallow}}"}
                   ],
                   "edges": [
-                    {
-                      "from": "Delta \\gamma",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "gamma_{\\text{steep}}",
-                      "to": "__add_2"
-                    },
-                    {
-                      "from": "gamma_{\\text{shallow}}",
-                      "to": "__negation_3"
-                    },
-                    {
-                      "from": "__negation_3",
-                      "to": "__add_2"
-                    },
-                    {
-                      "from": "__add_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "Delta \\gamma", "to": "__equals_1"},
+                    {"from": "gamma_{\\text{steep}}", "to": "__add_2"},
+                    {"from": "gamma_{\\text{shallow}}", "to": "__negation_3"},
+                    {"from": "__negation_3", "to": "__add_2"},
+                    {"from": "__add_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             }
@@ -10180,55 +3100,24 @@
       "markdown": "# Aerodynamic Heating and the Bow Shock\n\nA common misconception is that spacecraft heat up during re-entry because of friction with the air. In reality, the vast majority of the heating is caused by **adiabatic compression**.\n\n## The Blunt Body Solution\nIn 1958, H. Julian Allen and Alfred J. Eggers demonstrated that a blunt shape is far superior to a sharp, aerodynamic shape for re-entry. A blunt capsule plows through the atmosphere, creating a **detached bow shock**. The air squeezed between this shockwave and the capsule is violently compressed, heating up immensely. This super-heated cushion of air keeps the worst of the heat off the spacecraft's skin.\n\nIf a sharp-nosed vehicle were used, the shockwave would attach directly to the tip, concentrating all the thermal energy there and quickly melting the structure.\n\n## Stagnation Point Heating Rate\nThe heating is most intense at the **stagnation point**—the point on the heat shield where the airflow is brought to a complete stop. The convective heating rate $\\dot{q}_s$ at this point is given by:\n\n$$ \\dot{q}_s \\approx \\frac{K}{\\sqrt{R_N}} \\sqrt{\\rho} \\, V^3 $$\n\nWhere:\n- $\\rho$ is the atmospheric density\n- $V$ is the spacecraft's velocity\n- $R_N$ is the nose radius (larger for blunter bodies)\n\nBecause heating scales with the *cube* of velocity ($V^3$), a lunar-return speed of $11\\,\\text{km/s}$ produces about $2.81\\times$ the convective heating of a $7.8\\,\\text{km/s}$ LEO return from speed alone.",
       "prompt": "You are a tutor explaining the physics of atmospheric entry. Emphasize that heating is due to adiabatic compression, not friction. Guide the student to experiment with the bluntness slider to see how the bow shock detaches. Ask follow up questions like: 'If velocity doubles, how much does the heating rate increase according to the V^3 law?'",
       "range": [
-        [
-          -5,
-          5
-        ],
-        [
-          -5,
-          5
-        ],
-        [
-          -5,
-          5
-        ]
+        [-5, 5],
+        [-5, 5],
+        [-5, 5]
       ],
       "camera": {
-        "position": [
-          0,
-          0,
-          10
-        ],
-        "target": [
-          0,
-          0,
-          0
-        ]
+        "position": [0, 0, 10],
+        "target": [0, 0, 0]
       },
       "views": [
         {
           "name": "Side Profile",
-          "position": [
-            0,
-            0,
-            10
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
+          "position": [0, 0, 10],
+          "target": [0, 0, 0],
           "description": "2D side cross-section view of the capsule and airflow"
         }
       ],
       "elements": [
-        {
-          "id": "_mathbox_init",
-          "type": "grid",
-          "plane": "xy",
-          "opacity": 0,
-          "divisions": 1
-        }
+        {"id": "_mathbox_init", "type": "grid", "plane": "xy", "opacity": 0, "divisions": 1}
       ],
       "steps": [
         {
@@ -10240,45 +3129,20 @@
               "type": "polygon",
               "id": "capsule_sharp",
               "vertices": [
-                [
-                  -2,
-                  -1.5,
-                  0
-                ],
-                [
-                  2,
-                  0,
-                  0
-                ],
-                [
-                  -2,
-                  1.5,
-                  0
-                ]
+                [-2, -1.5, 0],
+                [2, 0, 0],
+                [-2, 1.5, 0]
               ],
               "color": "#95a5a6",
               "opacity": 1,
               "legendGroup": "Sharp Nose"
             },
-            {
-              "type": "vector_field",
-              "id": "flow_sharp",
-              "fx": "-4",
-              "fy": "x < 2 ? (y > 0 ? 2 : -2) : 0",
-              "fz": "0",
-              "density": 4,
-              "scale": 0.2,
-              "color": "#3498db"
-            },
+            {"type": "vector_field", "id": "flow_sharp", "fx": "-4", "fy": "x < 2 ? (y > 0 ? 2 : -2) : 0", "fz": "0", "density": 4, "scale": 0.2, "color": "#3498db"},
             {
               "type": "text",
               "id": "label_friction",
               "text": "Attached shock, concentrated heating",
-              "position": [
-                2,
-                1.5,
-                0
-              ],
+              "position": [2, 1.5, 0],
               "color": "#95a5a6",
               "label": "Sharp Nose"
             }
@@ -10294,31 +3158,11 @@
               "type": "animated_polygon",
               "id": "capsule_animated",
               "vertices": [
-                [
-                  "-2",
-                  "-1.5",
-                  "0"
-                ],
-                [
-                  "2 - 1.5*s3_bluntness",
-                  "-1.5*s3_bluntness",
-                  "0"
-                ],
-                [
-                  "2 - 0.5*s3_bluntness",
-                  "0",
-                  "0"
-                ],
-                [
-                  "2 - 1.5*s3_bluntness",
-                  "1.5*s3_bluntness",
-                  "0"
-                ],
-                [
-                  "-2",
-                  "1.5",
-                  "0"
-                ]
+                ["-2", "-1.5", "0"],
+                ["2 - 1.5*s3_bluntness", "-1.5*s3_bluntness", "0"],
+                ["2 - 0.5*s3_bluntness", "0", "0"],
+                ["2 - 1.5*s3_bluntness", "1.5*s3_bluntness", "0"],
+                ["-2", "1.5", "0"]
               ],
               "color": "#95a5a6",
               "opacity": 1
@@ -10329,61 +3173,29 @@
               "x": "2 - ((1 - s3_bluntness)*abs(t) + s3_bluntness*0.2*t^2)",
               "y": "t",
               "z": "0",
-              "range": [
-                -3,
-                3
-              ],
+              "range": [-3, 3],
               "color": "#e74c3c",
               "width": 5,
               "opacity": "0.5 + 0.5*s3_bluntness",
               "legendGroup": "Bow Shock"
             },
-            {
-              "type": "vector_field",
-              "id": "flow_blunt",
-              "fx": "x > 0 ? (x < 2 ? (-4 + 3*s3_bluntness) : -4) : -4",
-              "fy": "x < 2 ? (y > 0 ? 2 - s3_bluntness : -2 + s3_bluntness) : 0",
-              "fz": "0",
-              "density": 4,
-              "scale": 0.2,
-              "color": "#3498db"
-            },
+            {"type": "vector_field", "id": "flow_blunt", "fx": "x > 0 ? (x < 2 ? (-4 + 3*s3_bluntness) : -4) : -4", "fy": "x < 2 ? (y > 0 ? 2 - s3_bluntness : -2 + s3_bluntness) : 0", "fz": "0", "density": 4, "scale": 0.2, "color": "#3498db"},
             {
               "type": "text",
               "id": "label_compression",
               "text": "Adiabatic Compression",
-              "positionExpr": [
-                "2.5",
-                "1.5",
-                "0"
-              ],
+              "positionExpr": ["2.5", "1.5", "0"],
               "color": "#e74c3c",
               "label": "Bow Shock"
             }
           ],
           "remove": [
-            {
-              "id": "capsule_sharp"
-            },
-            {
-              "id": "flow_sharp"
-            },
-            {
-              "id": "label_friction"
-            }
+            {"id": "capsule_sharp"},
+            {"id": "flow_sharp"},
+            {"id": "label_friction"}
           ],
           "sliders": [
-            {
-              "id": "s3_bluntness",
-              "label": "Nose Bluntness",
-              "min": 0,
-              "max": 1,
-              "default": 0,
-              "step": 0.01,
-              "animate": true,
-              "animateMode": "once",
-              "duration": 2000
-            }
+            {"id": "s3_bluntness", "label": "Nose Bluntness", "min": 0, "max": 1, "default": 0, "step": 0.01, "animate": true, "animateMode": "once", "duration": 2000}
           ]
         },
         {
@@ -10397,10 +3209,7 @@
               "x": "2 - ((1 - s3_bluntness)*abs(t) + s3_bluntness*0.2*t^2)",
               "y": "t",
               "z": "0",
-              "range": [
-                -3,
-                3
-              ],
+              "range": [-3, 3],
               "color": "#e74c3c",
               "width": 5,
               "opacity": "s3_bluntness * (0.5 + 0.5 * ((s3_velocity - 7.8) / 3.2))"
@@ -10408,54 +3217,32 @@
             {
               "type": "animated_point",
               "id": "stagnation_point",
-              "positionExpr": [
-                "2 - 0.5*s3_bluntness",
-                "0",
-                "0"
-              ],
+              "positionExpr": ["2 - 0.5*s3_bluntness", "0", "0"],
               "color": "#ffffff",
               "size": 12,
               "label": "Stagnation Point"
             }
           ],
           "remove": [
-            {
-              "id": "bow_shock"
-            }
+            {"id": "bow_shock"}
           ],
           "sliders": [
-            {
-              "id": "s3_velocity",
-              "label": "Velocity (km/s)",
-              "min": 7.8,
-              "max": 11,
-              "default": 7.8,
-              "step": 0.1
-            }
+            {"id": "s3_velocity", "label": "Velocity (km/s)", "min": 7.8, "max": 11, "default": 7.8, "step": 0.1}
           ],
           "info": [
-            {
-              "id": "heating_info",
-              "position": "top-right",
-              "content": "### Stagnation Heating\n\n$$\\dot{q}_s \\approx \\frac{K}{\\sqrt{R_N}} \\sqrt{\\rho} \\, V^3$$\n\n$R_N$ (Nose Radius): **{{toFixed(noseRadius(s3_bluntness), 2)}} m**\n\n$V$ (Velocity): **{{s3_velocity}} km/s**\n\nRelative Heating: **{{toFixed(heatingRate(s3_velocity, noseRadius(s3_bluntness)) / heatingRate(7.8, noseRadius(1)), 2)}}×** vs blunt LEO"
-            }
+            {"id": "heating_info", "position": "top-right", "content": "### Stagnation Heating\n\n$$\\dot{q}_s \\approx \\frac{K}{\\sqrt{R_N}} \\sqrt{\\rho} \\, V^3$$\n\n$R_N$ (Nose Radius): **{{toFixed(noseRadius(s3_bluntness), 2)}} m**\n\n$V$ (Velocity): **{{s3_velocity}} km/s**\n\nRelative Heating: **{{toFixed(heatingRate(s3_velocity, noseRadius(s3_bluntness)) / heatingRate(7.8, noseRadius(1)), 2)}}×** vs blunt LEO"}
           ]
         }
       ],
       "functions": [
         {
           "name": "noseRadius",
-          "args": [
-            "b"
-          ],
+          "args": ["b"],
           "expr": "0.1 + 1.9 * b"
         },
         {
           "name": "heatingRate",
-          "args": [
-            "v",
-            "rn"
-          ],
+          "args": ["v", "rn"],
           "expr": "v^3 / sqrt(rn)"
         }
       ],
@@ -10474,118 +3261,32 @@
               "math": "E_k = \\frac{1}{2} m \\htmlClass{hl-vel}{V}^2",
               "explanation": "From the spacecraft frame, air rushes toward it at velocity V. Each parcel of air carries kinetic energy proportional to V².",
               "highlights": {
-                "vel": {
-                  "color": "cyan",
-                  "label": "Freestream velocity"
-                }
+                "vel": {"color": "cyan", "label": "Freestream velocity"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "E_k = \\frac{1}{2} m V^2"
-                    },
-                    {
-                      "id": "E_{k}",
-                      "type": "scalar",
-                      "latex": "E_{k}",
-                      "subexpr": "E_{k}"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{2} m V^{2}"
-                    },
-                    {
-                      "id": "__power_3",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2}"
-                    },
-                    {
-                      "id": "__num_4",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "__multiply_5",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "m V^{2}"
-                    },
-                    {
-                      "id": "m",
-                      "type": "scalar",
-                      "latex": "m",
-                      "subexpr": "m"
-                    },
-                    {
-                      "id": "__power_6",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V^{2}"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V",
-                      "description": "Freestream velocity",
-                      "color": "cyan",
-                      "highlight": "vel"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "E_k = \\frac{1}{2} m V^2"},
+                    {"id": "E_{k}", "type": "scalar", "latex": "E_{k}", "subexpr": "E_{k}"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{2} m V^{2}"},
+                    {"id": "__power_3", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__num_4", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "m V^{2}"},
+                    {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m"},
+                    {"id": "__power_6", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V^{2}"},
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V", "description": "Freestream velocity", "color": "cyan", "highlight": "vel"}
                   ],
                   "edges": [
-                    {
-                      "from": "E_{k}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "__num_4",
-                      "to": "__power_3"
-                    },
-                    {
-                      "from": "__power_3",
-                      "to": "__multiply_2"
-                    },
-                    {
-                      "from": "m",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V",
-                      "to": "__power_6"
-                    },
-                    {
-                      "from": "__power_6",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_5",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "E_{k}", "to": "__equals_1"},
+                    {"from": "__num_4", "to": "__power_3"},
+                    {"from": "__power_3", "to": "__multiply_2"},
+                    {"from": "m", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "V", "to": "__power_6"},
+                    {"from": "__power_6", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_5", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -10597,142 +3298,38 @@
               "justification": "Energy conservation (adiabatic): kinetic energy converts entirely to enthalpy",
               "explanation": "At the stagnation point the flow velocity is zero. All kinetic energy converts to thermal energy via adiabatic compression — not friction. Here $T_0$ is the stagnation temperature (at the surface), $T_\\infty$ is the freestream temperature of the undisturbed air, and $c_p$ is the specific heat at constant pressure.",
               "highlights": {
-                "T0": {
-                  "color": "orange",
-                  "label": "Stagnation temperature (at surface)"
-                },
-                "Tinf": {
-                  "color": "blue",
-                  "label": "Freestream temperature (undisturbed air)"
-                },
-                "cp": {
-                  "color": "green",
-                  "label": "Specific heat at constant pressure"
-                }
+                "T0": {"color": "orange", "label": "Stagnation temperature (at surface)"},
+                "Tinf": {"color": "blue", "label": "Freestream temperature (undisturbed air)"},
+                "cp": {"color": "green", "label": "Specific heat at constant pressure"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\frac{1}{2} V^2 = c_p (T_0 - T_\\infty)"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V^{2} \\frac{1}{2}"
-                    },
-                    {
-                      "id": "__power_3",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2}"
-                    },
-                    {
-                      "id": "__num_4",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "__power_5",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V^{2}"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    },
-                    {
-                      "id": "__c_{p}_6",
-                      "type": "function",
-                      "op": "c_{p}",
-                      "subexpr": "c_{p}{\\left(T_{0} - T_{oo} \\right)}"
-                    },
-                    {
-                      "id": "__add_7",
-                      "type": "operator",
-                      "op": "add",
-                      "subexpr": "T_{0} - T_{oo}"
-                    },
-                    {
-                      "id": "T_{0}",
-                      "type": "scalar",
-                      "latex": "T_{0}",
-                      "subexpr": "T_{0}",
-                      "description": "Stagnation temperature (at surface)",
-                      "color": "orange",
-                      "highlight": "T0"
-                    },
-                    {
-                      "id": "__negation_8",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-T_{oo}"
-                    },
-                    {
-                      "id": "T_{oo}",
-                      "type": "scalar",
-                      "latex": "T_{oo}",
-                      "subexpr": "T_{oo}"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\frac{1}{2} V^2 = c_p (T_0 - T_\\infty)"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "V^{2} \\frac{1}{2}"},
+                    {"id": "__power_3", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__num_4", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__power_5", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V^{2}"},
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"},
+                    {"id": "__c_{p}_6", "type": "function", "op": "c_{p}", "subexpr": "c_{p}{\\left(T_{0} - T_{oo} \\right)}"},
+                    {"id": "__add_7", "type": "operator", "op": "add", "subexpr": "T_{0} - T_{oo}"},
+                    {"id": "T_{0}", "type": "scalar", "latex": "T_{0}", "subexpr": "T_{0}", "description": "Stagnation temperature (at surface)", "color": "orange", "highlight": "T0"},
+                    {"id": "__negation_8", "type": "operator", "op": "negation", "subexpr": "-T_{oo}"},
+                    {"id": "T_{oo}", "type": "scalar", "latex": "T_{oo}", "subexpr": "T_{oo}"}
                   ],
                   "edges": [
-                    {
-                      "from": "__num_4",
-                      "to": "__power_3"
-                    },
-                    {
-                      "from": "__power_3",
-                      "to": "__multiply_2"
-                    },
-                    {
-                      "from": "V",
-                      "to": "__power_5"
-                    },
-                    {
-                      "from": "__power_5",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "T_{0}",
-                      "to": "__add_7"
-                    },
-                    {
-                      "from": "T_{oo}",
-                      "to": "__negation_8"
-                    },
-                    {
-                      "from": "__negation_8",
-                      "to": "__add_7"
-                    },
-                    {
-                      "from": "__add_7",
-                      "to": "__c_{p}_6"
-                    },
-                    {
-                      "from": "__c_{p}_6",
-                      "to": "__equals_1"
-                    }
+                    {"from": "__num_4", "to": "__power_3"},
+                    {"from": "__power_3", "to": "__multiply_2"},
+                    {"from": "V", "to": "__power_5"},
+                    {"from": "__power_5", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_2", "to": "__equals_1"},
+                    {"from": "T_{0}", "to": "__add_7"},
+                    {"from": "T_{oo}", "to": "__negation_8"},
+                    {"from": "__negation_8", "to": "__add_7"},
+                    {"from": "__add_7", "to": "__c_{p}_6"},
+                    {"from": "__c_{p}_6", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -10744,146 +3341,38 @@
               "justification": "Rearrange for T₀",
               "explanation": "At high altitude $T_\\infty \\approx 200\\,\\text{K}$, so the stagnation temperature is dominated by the $V^2$ term.",
               "highlights": {
-                "T0": {
-                  "color": "orange",
-                  "label": "Stagnation temperature"
-                },
-                "Tinf": {
-                  "color": "blue",
-                  "label": "~200 K at altitude — small"
-                },
-                "dom": {
-                  "color": "yellow",
-                  "label": "Dominant term at entry speeds"
-                }
+                "T0": {"color": "orange", "label": "Stagnation temperature"},
+                "Tinf": {"color": "blue", "label": "~200 K at altitude — small"},
+                "dom": {"color": "yellow", "label": "Dominant term at entry speeds"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "T_0 = T_\\infty + \\frac{V^2}{2 c_p}"
-                    },
-                    {
-                      "id": "T_{0}",
-                      "type": "scalar",
-                      "latex": "T_{0}",
-                      "subexpr": "T_{0}",
-                      "description": "Stagnation temperature",
-                      "color": "orange",
-                      "highlight": "T0"
-                    },
-                    {
-                      "id": "__add_2",
-                      "type": "operator",
-                      "op": "add",
-                      "subexpr": "T_{oo} + V^{2} \\frac{1}{2 c_{p}}"
-                    },
-                    {
-                      "id": "T_{oo}",
-                      "type": "scalar",
-                      "latex": "T_{oo}",
-                      "subexpr": "T_{oo}"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V^{2} \\frac{1}{2 c_{p}}"
-                    },
-                    {
-                      "id": "__power_4",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V^{2}"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    },
-                    {
-                      "id": "__power_5",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2 c_{p}}"
-                    },
-                    {
-                      "id": "__multiply_6",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "2 c_{p}"
-                    },
-                    {
-                      "id": "__num_7",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "c_{p}",
-                      "type": "scalar",
-                      "latex": "c_{p}",
-                      "subexpr": "c_{p}"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "T_0 = T_\\infty + \\frac{V^2}{2 c_p}"},
+                    {"id": "T_{0}", "type": "scalar", "latex": "T_{0}", "subexpr": "T_{0}", "description": "Stagnation temperature", "color": "orange", "highlight": "T0"},
+                    {"id": "__add_2", "type": "operator", "op": "add", "subexpr": "T_{oo} + V^{2} \\frac{1}{2 c_{p}}"},
+                    {"id": "T_{oo}", "type": "scalar", "latex": "T_{oo}", "subexpr": "T_{oo}"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "V^{2} \\frac{1}{2 c_{p}}"},
+                    {"id": "__power_4", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V^{2}"},
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"},
+                    {"id": "__power_5", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2 c_{p}}"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "2 c_{p}"},
+                    {"id": "__num_7", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "c_{p}", "type": "scalar", "latex": "c_{p}", "subexpr": "c_{p}"}
                   ],
                   "edges": [
-                    {
-                      "from": "T_{0}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "T_{oo}",
-                      "to": "__add_2"
-                    },
-                    {
-                      "from": "V",
-                      "to": "__power_4"
-                    },
-                    {
-                      "from": "__power_4",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_7",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "c_{p}",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_6",
-                      "to": "__power_5"
-                    },
-                    {
-                      "from": "__power_5",
-                      "to": "__multiply_3"
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__add_2"
-                    },
-                    {
-                      "from": "__add_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "T_{0}", "to": "__equals_1"},
+                    {"from": "T_{oo}", "to": "__add_2"},
+                    {"from": "V", "to": "__power_4"},
+                    {"from": "__power_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_7", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "c_{p}", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_6", "to": "__power_5"},
+                    {"from": "__power_5", "to": "__multiply_3"},
+                    {"from": "__multiply_3", "to": "__add_2"},
+                    {"from": "__add_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -10895,199 +3384,47 @@
               "justification": "Substitute $V = M a$ and $c_p = \\frac{\\gamma R}{(\\gamma-1) M_w}$, where $M$ is the Mach number, $a$ is the speed of sound, and $\\gamma \\approx 1.4$ is the ratio of specific heats for air",
               "explanation": "For a Mach 25 reentry (≈7.8 km/s), this gives T₀/T∞ ≈ 1 + 0.2 × 625 = 126. Even with T∞ = 200 K, that is over 25,000 K.",
               "highlights": {
-                "gamma": {
-                  "color": "green",
-                  "label": "Ratio of specific heats (γ ≈ 1.4 for air)"
-                },
-                "mach": {
-                  "color": "cyan",
-                  "label": "Mach number (M ≈ 25 for LEO entry)"
-                }
+                "gamma": {"color": "green", "label": "Ratio of specific heats (γ ≈ 1.4 for air)"},
+                "mach": {"color": "cyan", "label": "Mach number (M ≈ 25 for LEO entry)"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\frac{T_0}{T_\\infty} = 1 + \\frac{\\gamma - 1}{2} M^2"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "T_{0} \\frac{1}{T_{oo}}"
-                    },
-                    {
-                      "id": "T_{0}",
-                      "type": "scalar",
-                      "latex": "T_{0}",
-                      "subexpr": "T_{0}"
-                    },
-                    {
-                      "id": "__power_3",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{T_{oo}}"
-                    },
-                    {
-                      "id": "T_{oo}",
-                      "type": "scalar",
-                      "latex": "T_{oo}",
-                      "subexpr": "T_{oo}"
-                    },
-                    {
-                      "id": "__add_4",
-                      "type": "operator",
-                      "op": "add",
-                      "subexpr": "M^{2} \\left(\\gamma - 1\\right) \\frac{1}{2} + 1"
-                    },
-                    {
-                      "id": "__num_5",
-                      "type": "number",
-                      "label": "1",
-                      "subexpr": "1"
-                    },
-                    {
-                      "id": "__multiply_6",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "M^{2} \\left(\\gamma - 1\\right) \\frac{1}{2}"
-                    },
-                    {
-                      "id": "__multiply_7",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\left(\\gamma - 1\\right) \\frac{1}{2}"
-                    },
-                    {
-                      "id": "__add_8",
-                      "type": "operator",
-                      "op": "add",
-                      "subexpr": "\\gamma - 1"
-                    },
-                    {
-                      "id": "gamma",
-                      "type": "scalar",
-                      "latex": "\\gamma",
-                      "subexpr": "\\gamma",
-                      "description": "Ratio of specific heats (γ ≈ 1.4 for air)",
-                      "color": "green",
-                      "highlight": "gamma"
-                    },
-                    {
-                      "id": "__num_9",
-                      "type": "number",
-                      "label": "-1",
-                      "subexpr": "-1"
-                    },
-                    {
-                      "id": "__power_10",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2}"
-                    },
-                    {
-                      "id": "__num_11",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "__power_12",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "M^{2}"
-                    },
-                    {
-                      "id": "M",
-                      "type": "scalar",
-                      "latex": "M",
-                      "subexpr": "M",
-                      "description": "Mach number (M ≈ 25 for LEO entry)",
-                      "color": "cyan",
-                      "highlight": "mach"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\frac{T_0}{T_\\infty} = 1 + \\frac{\\gamma - 1}{2} M^2"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "T_{0} \\frac{1}{T_{oo}}"},
+                    {"id": "T_{0}", "type": "scalar", "latex": "T_{0}", "subexpr": "T_{0}"},
+                    {"id": "__power_3", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{T_{oo}}"},
+                    {"id": "T_{oo}", "type": "scalar", "latex": "T_{oo}", "subexpr": "T_{oo}"},
+                    {"id": "__add_4", "type": "operator", "op": "add", "subexpr": "M^{2} \\left(\\gamma - 1\\right) \\frac{1}{2} + 1"},
+                    {"id": "__num_5", "type": "number", "label": "1", "subexpr": "1"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "M^{2} \\left(\\gamma - 1\\right) \\frac{1}{2}"},
+                    {"id": "__multiply_7", "type": "operator", "op": "multiply", "subexpr": "\\left(\\gamma - 1\\right) \\frac{1}{2}"},
+                    {"id": "__add_8", "type": "operator", "op": "add", "subexpr": "\\gamma - 1"},
+                    {"id": "gamma", "type": "scalar", "latex": "\\gamma", "subexpr": "\\gamma", "description": "Ratio of specific heats (γ ≈ 1.4 for air)", "color": "green", "highlight": "gamma"},
+                    {"id": "__num_9", "type": "number", "label": "-1", "subexpr": "-1"},
+                    {"id": "__power_10", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__num_11", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__power_12", "type": "operator", "op": "power", "exponent": "2", "subexpr": "M^{2}"},
+                    {"id": "M", "type": "scalar", "latex": "M", "subexpr": "M", "description": "Mach number (M ≈ 25 for LEO entry)", "color": "cyan", "highlight": "mach"}
                   ],
                   "edges": [
-                    {
-                      "from": "T_{0}",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "T_{oo}",
-                      "to": "__power_3"
-                    },
-                    {
-                      "from": "__power_3",
-                      "to": "__multiply_2"
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "__num_5",
-                      "to": "__add_4"
-                    },
-                    {
-                      "from": "gamma",
-                      "to": "__add_8"
-                    },
-                    {
-                      "from": "__num_9",
-                      "to": "__add_8"
-                    },
-                    {
-                      "from": "__add_8",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_11",
-                      "to": "__power_10"
-                    },
-                    {
-                      "from": "__power_10",
-                      "to": "__multiply_7"
-                    },
-                    {
-                      "from": "__multiply_7",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "M",
-                      "to": "__power_12"
-                    },
-                    {
-                      "from": "__power_12",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_6",
-                      "to": "__add_4"
-                    },
-                    {
-                      "from": "__add_4",
-                      "to": "__equals_1"
-                    }
+                    {"from": "T_{0}", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "T_{oo}", "to": "__power_3"},
+                    {"from": "__power_3", "to": "__multiply_2"},
+                    {"from": "__multiply_2", "to": "__equals_1"},
+                    {"from": "__num_5", "to": "__add_4"},
+                    {"from": "gamma", "to": "__add_8"},
+                    {"from": "__num_9", "to": "__add_8"},
+                    {"from": "__add_8", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_11", "to": "__power_10"},
+                    {"from": "__power_10", "to": "__multiply_7"},
+                    {"from": "__multiply_7", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "M", "to": "__power_12"},
+                    {"from": "__power_12", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_6", "to": "__add_4"},
+                    {"from": "__add_4", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -11099,62 +3436,22 @@
               "justification": "The V² dependence comes from kinetic energy conversion",
               "explanation": "The enormous temperatures at the stagnation point arise from adiabatic compression of the air — the same process that heats air in a bicycle pump. Friction plays a negligible role.",
               "highlights": {
-                "result": {
-                  "color": "yellow",
-                  "label": "Adiabatic compression, not friction"
-                }
+                "result": {"color": "yellow", "label": "Adiabatic compression, not friction"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "T_{0}",
-                      "type": "scalar",
-                      "latex": "T_{0}",
-                      "subexpr": "T_{0}"
-                    },
-                    {
-                      "id": "__power_1",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V^2"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    },
-                    {
-                      "id": "__proportional_2",
-                      "type": "relation",
-                      "label": "proportional to",
-                      "emoji": "∝",
-                      "op": "proportional",
-                      "subexpr": "T_0 \\propto V^2",
-                      "description": "Adiabatic compression, not friction",
-                      "color": "yellow",
-                      "highlight": "result"
-                    }
+                    {"id": "T_{0}", "type": "scalar", "latex": "T_{0}", "subexpr": "T_{0}"},
+                    {"id": "__power_1", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V^2"},
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"},
+                    {"id": "__proportional_2", "type": "relation", "label": "proportional to", "emoji": "∝", "op": "proportional", "subexpr": "T_0 \\propto V^2", "description": "Adiabatic compression, not friction", "color": "yellow", "highlight": "result"}
                   ],
                   "edges": [
-                    {
-                      "from": "V",
-                      "to": "__power_1"
-                    },
-                    {
-                      "from": "T_{0}",
-                      "to": "__proportional_2"
-                    },
-                    {
-                      "from": "__power_1",
-                      "to": "__proportional_2"
-                    }
+                    {"from": "V", "to": "__power_1"},
+                    {"from": "T_{0}", "to": "__proportional_2"},
+                    {"from": "__power_1", "to": "__proportional_2"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             }
@@ -11174,127 +3471,33 @@
               "math": "\\htmlClass{hl-delta}{\\delta} \\propto \\sqrt{\\frac{\\htmlClass{hl-rn}{R_N}}{\\rho V}}",
               "explanation": "The thermal boundary layer at the stagnation point grows with nose radius R_N. A blunter body creates a thicker boundary layer.",
               "highlights": {
-                "delta": {
-                  "color": "orange",
-                  "label": "Boundary layer thickness"
-                },
-                "rn": {
-                  "color": "cyan",
-                  "label": "Nose radius"
-                }
+                "delta": {"color": "orange", "label": "Boundary layer thickness"},
+                "rn": {"color": "cyan", "label": "Nose radius"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "delta",
-                      "type": "scalar",
-                      "latex": "\\delta",
-                      "subexpr": "\\delta",
-                      "description": "Boundary layer thickness",
-                      "color": "orange",
-                      "highlight": "delta"
-                    },
-                    {
-                      "id": "__power_1",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "1/2",
-                      "subexpr": "\\sqrt{\\frac{R_{N}}{\\rho V}}"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "R_{N} \\frac{1}{V \\rho}"
-                    },
-                    {
-                      "id": "R_{N}",
-                      "type": "scalar",
-                      "latex": "R_{N}",
-                      "subexpr": "R_{N}",
-                      "description": "Nose radius",
-                      "color": "cyan",
-                      "highlight": "rn"
-                    },
-                    {
-                      "id": "__power_3",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{V \\rho}"
-                    },
-                    {
-                      "id": "__multiply_4",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho V"
-                    },
-                    {
-                      "id": "rho",
-                      "type": "scalar",
-                      "latex": "\\rho",
-                      "subexpr": "\\rho"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    },
-                    {
-                      "id": "__proportional_5",
-                      "type": "relation",
-                      "label": "proportional to",
-                      "emoji": "∝",
-                      "op": "proportional",
-                      "subexpr": "\\delta \\propto \\sqrt{\\frac{R_N}{\\rho V}}"
-                    }
+                    {"id": "delta", "type": "scalar", "latex": "\\delta", "subexpr": "\\delta", "description": "Boundary layer thickness", "color": "orange", "highlight": "delta"},
+                    {"id": "__power_1", "type": "operator", "op": "power", "exponent": "1/2", "subexpr": "\\sqrt{\\frac{R_{N}}{\\rho V}}"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "R_{N} \\frac{1}{V \\rho}"},
+                    {"id": "R_{N}", "type": "scalar", "latex": "R_{N}", "subexpr": "R_{N}", "description": "Nose radius", "color": "cyan", "highlight": "rn"},
+                    {"id": "__power_3", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{V \\rho}"},
+                    {"id": "__multiply_4", "type": "operator", "op": "multiply", "subexpr": "\\rho V"},
+                    {"id": "rho", "type": "scalar", "latex": "\\rho", "subexpr": "\\rho"},
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"},
+                    {"id": "__proportional_5", "type": "relation", "label": "proportional to", "emoji": "∝", "op": "proportional", "subexpr": "\\delta \\propto \\sqrt{\\frac{R_N}{\\rho V}}"}
                   ],
                   "edges": [
-                    {
-                      "from": "R_{N}",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "rho",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_4",
-                      "to": "__power_3"
-                    },
-                    {
-                      "from": "__power_3",
-                      "to": "__multiply_2"
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__power_1"
-                    },
-                    {
-                      "from": "delta",
-                      "to": "__proportional_5"
-                    },
-                    {
-                      "from": "__power_1",
-                      "to": "__proportional_5"
-                    }
+                    {"from": "R_{N}", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "rho", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "V", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_4", "to": "__power_3"},
+                    {"from": "__power_3", "to": "__multiply_2"},
+                    {"from": "__multiply_2", "to": "__power_1"},
+                    {"from": "delta", "to": "__proportional_5"},
+                    {"from": "__power_1", "to": "__proportional_5"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -11306,133 +3509,36 @@
               "justification": "Fourier's law: heat flux = thermal conductivity × temperature gradient",
               "explanation": "The heat conducted to the surface is proportional to the temperature difference across the boundary layer divided by its thickness.",
               "highlights": {
-                "qdot": {
-                  "color": "red",
-                  "label": "Stagnation point heat flux"
-                },
-                "delta": {
-                  "color": "orange",
-                  "label": "Thicker boundary layer → less heating"
-                }
+                "qdot": {"color": "red", "label": "Stagnation point heat flux"},
+                "delta": {"color": "orange", "label": "Thicker boundary layer → less heating"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "q_{s}",
-                      "type": "scalar",
-                      "latex": "q_{s}",
-                      "subexpr": "q_{s}",
-                      "description": "Stagnation point heat flux",
-                      "color": "red",
-                      "highlight": "qdot"
-                    },
-                    {
-                      "id": "t",
-                      "type": "scalar",
-                      "latex": "t",
-                      "subexpr": "t"
-                    },
-                    {
-                      "id": "__deriv_1",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t",
-                      "subexpr": "\\frac{d}{d t} q_{s}"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{{\\Delta T}}{\\delta}"
-                    },
-                    {
-                      "id": "Delta T",
-                      "type": "scalar",
-                      "latex": "\\Delta T",
-                      "subexpr": "\\Delta T"
-                    },
-                    {
-                      "id": "__power_3",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\delta}"
-                    },
-                    {
-                      "id": "delta",
-                      "type": "scalar",
-                      "latex": "\\delta",
-                      "subexpr": "\\delta",
-                      "description": "Thicker boundary layer → less heating",
-                      "color": "orange",
-                      "highlight": "delta"
-                    },
-                    {
-                      "id": "__proportional_4",
-                      "type": "relation",
-                      "label": "proportional to",
-                      "emoji": "∝",
-                      "op": "proportional",
-                      "subexpr": "\\dot{q_s} \\propto \\frac{\\Delta T}{\\delta}"
-                    }
+                    {"id": "q_{s}", "type": "scalar", "latex": "q_{s}", "subexpr": "q_{s}", "description": "Stagnation point heat flux", "color": "red", "highlight": "qdot"},
+                    {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                    {"id": "__deriv_1", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\frac{d}{d t} q_{s}"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\frac{{\\Delta T}}{\\delta}"},
+                    {"id": "Delta T", "type": "scalar", "latex": "\\Delta T", "subexpr": "\\Delta T"},
+                    {"id": "__power_3", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\delta}"},
+                    {"id": "delta", "type": "scalar", "latex": "\\delta", "subexpr": "\\delta", "description": "Thicker boundary layer → less heating", "color": "orange", "highlight": "delta"},
+                    {"id": "__proportional_4", "type": "relation", "label": "proportional to", "emoji": "∝", "op": "proportional", "subexpr": "\\dot{q_s} \\propto \\frac{\\Delta T}{\\delta}"}
                   ],
                   "edges": [
-                    {
-                      "from": "q_{s}",
-                      "to": "__deriv_1"
-                    },
-                    {
-                      "from": "t",
-                      "to": "__deriv_1",
-                      "role": "wrt"
-                    },
-                    {
-                      "from": "Delta T",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "delta",
-                      "to": "__power_3"
-                    },
-                    {
-                      "from": "__power_3",
-                      "to": "__multiply_2"
-                    },
-                    {
-                      "from": "__deriv_1",
-                      "to": "__proportional_4"
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__proportional_4"
-                    }
+                    {"from": "q_{s}", "to": "__deriv_1"},
+                    {"from": "t", "to": "__deriv_1", "role": "wrt"},
+                    {"from": "Delta T", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "delta", "to": "__power_3"},
+                    {"from": "__power_3", "to": "__multiply_2"},
+                    {"from": "__deriv_1", "to": "__proportional_4"},
+                    {"from": "__multiply_2", "to": "__proportional_4"}
                   ],
                   "classification": {
                     "kind": "ODE",
                     "order": 1,
-                    "dependent_variables": [
-                      "q_{s}"
-                    ],
-                    "independent_variables": [
-                      "t"
-                    ],
-                    "sympy_hints": [
-                      "nth_algebraic",
-                      "separable",
-                      "1st_exact",
-                      "1st_linear",
-                      "Bernoulli",
-                      "1st_power_series",
-                      "lie_group",
-                      "nth_linear_constant_coeff_undetermined_coefficients",
-                      "nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients",
-                      "nth_linear_constant_coeff_variation_of_parameters",
-                      "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters"
-                    ],
+                    "dependent_variables": ["q_{s}"],
+                    "independent_variables": ["t"],
+                    "sympy_hints": ["nth_algebraic", "separable", "1st_exact", "1st_linear", "Bernoulli", "1st_power_series", "lie_group", "nth_linear_constant_coeff_undetermined_coefficients", "nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients", "nth_linear_constant_coeff_variation_of_parameters", "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters"],
                     "linear": true,
                     "homogeneous": true,
                     "constant_coefficients": true
@@ -11448,112 +3554,32 @@
               "justification": "From the stagnation temperature result: T₀ ∝ V²",
               "explanation": "The wall temperature T_w is kept relatively low by the heat shield, so ΔT is dominated by the stagnation temperature.",
               "highlights": {
-                "v2": {
-                  "color": "yellow",
-                  "label": "From stagnation temperature proof"
-                }
+                "v2": {"color": "yellow", "label": "From stagnation temperature proof"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "{\\Delta T} = T_{0} - T_{w}"
-                    },
-                    {
-                      "id": "Delta T",
-                      "type": "scalar",
-                      "latex": "\\Delta T",
-                      "subexpr": "\\Delta T"
-                    },
-                    {
-                      "id": "__add_2",
-                      "type": "operator",
-                      "op": "add",
-                      "subexpr": "T_{0} - T_{w}"
-                    },
-                    {
-                      "id": "T_{0}",
-                      "type": "scalar",
-                      "latex": "T_{0}",
-                      "subexpr": "T_{0}"
-                    },
-                    {
-                      "id": "__negation_3",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-T_{w}"
-                    },
-                    {
-                      "id": "T_{w}",
-                      "type": "scalar",
-                      "latex": "T_{w}",
-                      "subexpr": "T_{w}"
-                    },
-                    {
-                      "id": "__power_4",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V^2",
-                      "description": "From stagnation temperature proof",
-                      "color": "yellow",
-                      "highlight": "v2"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    },
-                    {
-                      "id": "__proportional_5",
-                      "type": "relation",
-                      "label": "proportional to",
-                      "emoji": "∝",
-                      "op": "proportional",
-                      "subexpr": "\\Delta T = T_0 - T_w \\propto V^2"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "{\\Delta T} = T_{0} - T_{w}"},
+                    {"id": "Delta T", "type": "scalar", "latex": "\\Delta T", "subexpr": "\\Delta T"},
+                    {"id": "__add_2", "type": "operator", "op": "add", "subexpr": "T_{0} - T_{w}"},
+                    {"id": "T_{0}", "type": "scalar", "latex": "T_{0}", "subexpr": "T_{0}"},
+                    {"id": "__negation_3", "type": "operator", "op": "negation", "subexpr": "-T_{w}"},
+                    {"id": "T_{w}", "type": "scalar", "latex": "T_{w}", "subexpr": "T_{w}"},
+                    {"id": "__power_4", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V^2", "description": "From stagnation temperature proof", "color": "yellow", "highlight": "v2"},
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"},
+                    {"id": "__proportional_5", "type": "relation", "label": "proportional to", "emoji": "∝", "op": "proportional", "subexpr": "\\Delta T = T_0 - T_w \\propto V^2"}
                   ],
                   "edges": [
-                    {
-                      "from": "Delta T",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "T_{0}",
-                      "to": "__add_2"
-                    },
-                    {
-                      "from": "T_{w}",
-                      "to": "__negation_3"
-                    },
-                    {
-                      "from": "__negation_3",
-                      "to": "__add_2"
-                    },
-                    {
-                      "from": "__add_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "V",
-                      "to": "__power_4"
-                    },
-                    {
-                      "from": "__equals_1",
-                      "to": "__proportional_5"
-                    },
-                    {
-                      "from": "__power_4",
-                      "to": "__proportional_5"
-                    }
+                    {"from": "Delta T", "to": "__equals_1"},
+                    {"from": "T_{0}", "to": "__add_2"},
+                    {"from": "T_{w}", "to": "__negation_3"},
+                    {"from": "__negation_3", "to": "__add_2"},
+                    {"from": "__add_2", "to": "__equals_1"},
+                    {"from": "V", "to": "__power_4"},
+                    {"from": "__equals_1", "to": "__proportional_5"},
+                    {"from": "__power_4", "to": "__proportional_5"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -11565,335 +3591,73 @@
               "justification": "Substitute δ and ΔT into the heat flux expression",
               "explanation": "This simplified analysis gives V^(5/2). The full Fay-Riddell analysis, accounting for dissociation and ionization effects at high temperatures, modifies this to V³.",
               "highlights": {
-                "result": {
-                  "color": "yellow",
-                  "label": "Simplified analysis — real-gas effects modify this"
-                }
+                "result": {"color": "yellow", "label": "Simplified analysis — real-gas effects modify this"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "q_{s}",
-                      "type": "scalar",
-                      "latex": "q_{s}",
-                      "subexpr": "q_{s}"
-                    },
-                    {
-                      "id": "t",
-                      "type": "scalar",
-                      "latex": "t",
-                      "subexpr": "t"
-                    },
-                    {
-                      "id": "__deriv_1",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t",
-                      "subexpr": "\\frac{d}{d t} q_{s}"
-                    },
-                    {
-                      "id": "__equals_2",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\frac{V^2}{\\sqrt{R_{N} / (\\rho V)}} = \\frac{\\sqrt{\\rho} \\cdot V^{5/2}}{\\sqrt{R_{N}}}"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V^{2} \\frac{1}{\\sqrt{\\frac{R_{N}}{V \\rho}}}"
-                    },
-                    {
-                      "id": "__power_4",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V^{2}"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    },
-                    {
-                      "id": "__power_5",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\sqrt{\\frac{R_{N}}{V \\rho}}}"
-                    },
-                    {
-                      "id": "__power_6",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "1/2",
-                      "subexpr": "\\sqrt{\\frac{R_{N}}{V \\rho}}"
-                    },
-                    {
-                      "id": "__multiply_7",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "R_{N} \\frac{1}{V \\rho}"
-                    },
-                    {
-                      "id": "R_{N}",
-                      "type": "scalar",
-                      "latex": "R_{N}",
-                      "subexpr": "R_{N}"
-                    },
-                    {
-                      "id": "__power_8",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{V \\rho}"
-                    },
-                    {
-                      "id": "__multiply_9",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V \\rho"
-                    },
-                    {
-                      "id": "rho",
-                      "type": "scalar",
-                      "latex": "\\rho",
-                      "subexpr": "\\rho"
-                    },
-                    {
-                      "id": "__multiply_10",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V^{\\frac{5}{2}} \\sqrt{\\rho} \\frac{1}{\\sqrt{R_{N}}}"
-                    },
-                    {
-                      "id": "__multiply_11",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V^{\\frac{5}{2}} \\sqrt{\\rho}"
-                    },
-                    {
-                      "id": "__power_12",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "1/2",
-                      "subexpr": "\\sqrt{\\rho}"
-                    },
-                    {
-                      "id": "__power_13",
-                      "type": "operator",
-                      "op": "power",
-                      "subexpr": "V^{\\frac{5}{2}}"
-                    },
-                    {
-                      "id": "__multiply_14",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "5 \\frac{1}{2}"
-                    },
-                    {
-                      "id": "__num_15",
-                      "type": "number",
-                      "label": "5",
-                      "subexpr": "5"
-                    },
-                    {
-                      "id": "__power_16",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2}"
-                    },
-                    {
-                      "id": "__num_17",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "__power_18",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\sqrt{R_{N}}}"
-                    },
-                    {
-                      "id": "__power_19",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "1/2",
-                      "subexpr": "\\sqrt{R_{N}}"
-                    },
-                    {
-                      "id": "__proportional_20",
-                      "type": "relation",
-                      "label": "proportional to",
-                      "emoji": "∝",
-                      "op": "proportional",
-                      "subexpr": "\\dot{q_s} \\propto \\frac{V^2}{\\sqrt{R_N / (\\rho V)}} = \\frac{\\sqrt{\\rho} \\cdot V^{5/2}}{\\sqrt{R_N}}"
-                    }
+                    {"id": "q_{s}", "type": "scalar", "latex": "q_{s}", "subexpr": "q_{s}"},
+                    {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                    {"id": "__deriv_1", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\frac{d}{d t} q_{s}"},
+                    {"id": "__equals_2", "type": "relation", "op": "equals", "subexpr": "\\frac{V^2}{\\sqrt{R_{N} / (\\rho V)}} = \\frac{\\sqrt{\\rho} \\cdot V^{5/2}}{\\sqrt{R_{N}}}"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "V^{2} \\frac{1}{\\sqrt{\\frac{R_{N}}{V \\rho}}}"},
+                    {"id": "__power_4", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V^{2}"},
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"},
+                    {"id": "__power_5", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\sqrt{\\frac{R_{N}}{V \\rho}}}"},
+                    {"id": "__power_6", "type": "operator", "op": "power", "exponent": "1/2", "subexpr": "\\sqrt{\\frac{R_{N}}{V \\rho}}"},
+                    {"id": "__multiply_7", "type": "operator", "op": "multiply", "subexpr": "R_{N} \\frac{1}{V \\rho}"},
+                    {"id": "R_{N}", "type": "scalar", "latex": "R_{N}", "subexpr": "R_{N}"},
+                    {"id": "__power_8", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{V \\rho}"},
+                    {"id": "__multiply_9", "type": "operator", "op": "multiply", "subexpr": "V \\rho"},
+                    {"id": "rho", "type": "scalar", "latex": "\\rho", "subexpr": "\\rho"},
+                    {"id": "__multiply_10", "type": "operator", "op": "multiply", "subexpr": "V^{\\frac{5}{2}} \\sqrt{\\rho} \\frac{1}{\\sqrt{R_{N}}}"},
+                    {"id": "__multiply_11", "type": "operator", "op": "multiply", "subexpr": "V^{\\frac{5}{2}} \\sqrt{\\rho}"},
+                    {"id": "__power_12", "type": "operator", "op": "power", "exponent": "1/2", "subexpr": "\\sqrt{\\rho}"},
+                    {"id": "__power_13", "type": "operator", "op": "power", "subexpr": "V^{\\frac{5}{2}}"},
+                    {"id": "__multiply_14", "type": "operator", "op": "multiply", "subexpr": "5 \\frac{1}{2}"},
+                    {"id": "__num_15", "type": "number", "label": "5", "subexpr": "5"},
+                    {"id": "__power_16", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__num_17", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__power_18", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\sqrt{R_{N}}}"},
+                    {"id": "__power_19", "type": "operator", "op": "power", "exponent": "1/2", "subexpr": "\\sqrt{R_{N}}"},
+                    {"id": "__proportional_20", "type": "relation", "label": "proportional to", "emoji": "∝", "op": "proportional", "subexpr": "\\dot{q_s} \\propto \\frac{V^2}{\\sqrt{R_N / (\\rho V)}} = \\frac{\\sqrt{\\rho} \\cdot V^{5/2}}{\\sqrt{R_N}}"}
                   ],
                   "edges": [
-                    {
-                      "from": "q_{s}",
-                      "to": "__deriv_1"
-                    },
-                    {
-                      "from": "t",
-                      "to": "__deriv_1",
-                      "role": "wrt"
-                    },
-                    {
-                      "from": "V",
-                      "to": "__power_4"
-                    },
-                    {
-                      "from": "__power_4",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "R_{N}",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "rho",
-                      "to": "__multiply_9",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V",
-                      "to": "__multiply_9",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_9",
-                      "to": "__power_8"
-                    },
-                    {
-                      "from": "__power_8",
-                      "to": "__multiply_7"
-                    },
-                    {
-                      "from": "__multiply_7",
-                      "to": "__power_6"
-                    },
-                    {
-                      "from": "__power_6",
-                      "to": "__power_5"
-                    },
-                    {
-                      "from": "__power_5",
-                      "to": "__multiply_3"
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__equals_2"
-                    },
-                    {
-                      "from": "rho",
-                      "to": "__power_12"
-                    },
-                    {
-                      "from": "__power_12",
-                      "to": "__multiply_11",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V",
-                      "to": "__power_13"
-                    },
-                    {
-                      "from": "__num_15",
-                      "to": "__multiply_14",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__num_17",
-                      "to": "__power_16"
-                    },
-                    {
-                      "from": "__power_16",
-                      "to": "__multiply_14"
-                    },
-                    {
-                      "from": "__multiply_14",
-                      "to": "__power_13",
-                      "role": "exp"
-                    },
-                    {
-                      "from": "__power_13",
-                      "to": "__multiply_11",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_11",
-                      "to": "__multiply_10",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "R_{N}",
-                      "to": "__power_19"
-                    },
-                    {
-                      "from": "__power_19",
-                      "to": "__power_18"
-                    },
-                    {
-                      "from": "__power_18",
-                      "to": "__multiply_10"
-                    },
-                    {
-                      "from": "__multiply_10",
-                      "to": "__equals_2"
-                    },
-                    {
-                      "from": "__deriv_1",
-                      "to": "__proportional_20"
-                    },
-                    {
-                      "from": "__equals_2",
-                      "to": "__proportional_20"
-                    }
+                    {"from": "q_{s}", "to": "__deriv_1"},
+                    {"from": "t", "to": "__deriv_1", "role": "wrt"},
+                    {"from": "V", "to": "__power_4"},
+                    {"from": "__power_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "R_{N}", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "rho", "to": "__multiply_9", "semantic": "direct", "weight": 1.0},
+                    {"from": "V", "to": "__multiply_9", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_9", "to": "__power_8"},
+                    {"from": "__power_8", "to": "__multiply_7"},
+                    {"from": "__multiply_7", "to": "__power_6"},
+                    {"from": "__power_6", "to": "__power_5"},
+                    {"from": "__power_5", "to": "__multiply_3"},
+                    {"from": "__multiply_3", "to": "__equals_2"},
+                    {"from": "rho", "to": "__power_12"},
+                    {"from": "__power_12", "to": "__multiply_11", "semantic": "direct", "weight": 1.0},
+                    {"from": "V", "to": "__power_13"},
+                    {"from": "__num_15", "to": "__multiply_14", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_17", "to": "__power_16"},
+                    {"from": "__power_16", "to": "__multiply_14"},
+                    {"from": "__multiply_14", "to": "__power_13", "role": "exp"},
+                    {"from": "__power_13", "to": "__multiply_11", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_11", "to": "__multiply_10", "semantic": "direct", "weight": 1.0},
+                    {"from": "R_{N}", "to": "__power_19"},
+                    {"from": "__power_19", "to": "__power_18"},
+                    {"from": "__power_18", "to": "__multiply_10"},
+                    {"from": "__multiply_10", "to": "__equals_2"},
+                    {"from": "__deriv_1", "to": "__proportional_20"},
+                    {"from": "__equals_2", "to": "__proportional_20"}
                   ],
                   "classification": {
                     "kind": "ODE",
                     "order": 1,
-                    "dependent_variables": [
-                      "q_{s}"
-                    ],
-                    "independent_variables": [
-                      "t"
-                    ],
-                    "sympy_hints": [
-                      "nth_algebraic",
-                      "separable",
-                      "1st_exact",
-                      "1st_linear",
-                      "Bernoulli",
-                      "1st_homogeneous_coeff_best",
-                      "1st_homogeneous_coeff_subs_indep_div_dep",
-                      "1st_homogeneous_coeff_subs_dep_div_indep",
-                      "1st_power_series",
-                      "lie_group",
-                      "nth_linear_constant_coeff_homogeneous",
-                      "nth_linear_euler_eq_homogeneous"
-                    ],
+                    "dependent_variables": ["q_{s}"],
+                    "independent_variables": ["t"],
+                    "sympy_hints": ["nth_algebraic", "separable", "1st_exact", "1st_linear", "Bernoulli", "1st_homogeneous_coeff_best", "1st_homogeneous_coeff_subs_indep_div_dep", "1st_homogeneous_coeff_subs_dep_div_indep", "1st_power_series", "lie_group", "nth_linear_constant_coeff_homogeneous", "nth_linear_euler_eq_homogeneous"],
                     "linear": true,
                     "homogeneous": true,
                     "constant_coefficients": true
@@ -11909,203 +3673,49 @@
               "justification": "Full analysis includes real-gas effects (dissociation, ionization) which steepen the velocity dependence from V^(5/2) to V³",
               "explanation": "This is the key result used in spacecraft design. K depends on gas properties but is roughly constant for Earth entry.",
               "highlights": {
-                "fr": {
-                  "color": "cyan",
-                  "label": "Fay-Riddell (1958) — the spacecraft design formula"
-                }
+                "fr": {"color": "cyan", "label": "Fay-Riddell (1958) — the spacecraft design formula"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\dot{q_s} = \\frac{K}{\\sqrt{R_N}} \\sqrt{\\rho} \\, V^3"
-                    },
-                    {
-                      "id": "q_{s}",
-                      "type": "scalar",
-                      "latex": "q_{s}",
-                      "subexpr": "q_{s}"
-                    },
-                    {
-                      "id": "t",
-                      "type": "scalar",
-                      "latex": "t",
-                      "subexpr": "t"
-                    },
-                    {
-                      "id": "__deriv_2",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t",
-                      "subexpr": "\\frac{d}{d t} q_{s}"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "K \\frac{1}{\\sqrt{R_{N}}} \\sqrt{\\rho} V^{3}"
-                    },
-                    {
-                      "id": "__multiply_4",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "K \\frac{1}{\\sqrt{R_{N}}}"
-                    },
-                    {
-                      "id": "K",
-                      "type": "scalar",
-                      "latex": "K",
-                      "subexpr": "K"
-                    },
-                    {
-                      "id": "__power_5",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\sqrt{R_{N}}}"
-                    },
-                    {
-                      "id": "__power_6",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "1/2",
-                      "subexpr": "\\sqrt{R_{N}}"
-                    },
-                    {
-                      "id": "R_{N}",
-                      "type": "scalar",
-                      "latex": "R_{N}",
-                      "subexpr": "R_{N}"
-                    },
-                    {
-                      "id": "__multiply_7",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\sqrt{\\rho} V^{3}"
-                    },
-                    {
-                      "id": "__power_8",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "1/2",
-                      "subexpr": "\\sqrt{\\rho}"
-                    },
-                    {
-                      "id": "rho",
-                      "type": "scalar",
-                      "latex": "\\rho",
-                      "subexpr": "\\rho"
-                    },
-                    {
-                      "id": "__power_9",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "3",
-                      "subexpr": "V^{3}"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\dot{q_s} = \\frac{K}{\\sqrt{R_N}} \\sqrt{\\rho} \\, V^3"},
+                    {"id": "q_{s}", "type": "scalar", "latex": "q_{s}", "subexpr": "q_{s}"},
+                    {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                    {"id": "__deriv_2", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\frac{d}{d t} q_{s}"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "K \\frac{1}{\\sqrt{R_{N}}} \\sqrt{\\rho} V^{3}"},
+                    {"id": "__multiply_4", "type": "operator", "op": "multiply", "subexpr": "K \\frac{1}{\\sqrt{R_{N}}}"},
+                    {"id": "K", "type": "scalar", "latex": "K", "subexpr": "K"},
+                    {"id": "__power_5", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\sqrt{R_{N}}}"},
+                    {"id": "__power_6", "type": "operator", "op": "power", "exponent": "1/2", "subexpr": "\\sqrt{R_{N}}"},
+                    {"id": "R_{N}", "type": "scalar", "latex": "R_{N}", "subexpr": "R_{N}"},
+                    {"id": "__multiply_7", "type": "operator", "op": "multiply", "subexpr": "\\sqrt{\\rho} V^{3}"},
+                    {"id": "__power_8", "type": "operator", "op": "power", "exponent": "1/2", "subexpr": "\\sqrt{\\rho}"},
+                    {"id": "rho", "type": "scalar", "latex": "\\rho", "subexpr": "\\rho"},
+                    {"id": "__power_9", "type": "operator", "op": "power", "exponent": "3", "subexpr": "V^{3}"},
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"}
                   ],
                   "edges": [
-                    {
-                      "from": "q_{s}",
-                      "to": "__deriv_2"
-                    },
-                    {
-                      "from": "t",
-                      "to": "__deriv_2",
-                      "role": "wrt"
-                    },
-                    {
-                      "from": "__deriv_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "K",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "R_{N}",
-                      "to": "__power_6"
-                    },
-                    {
-                      "from": "__power_6",
-                      "to": "__power_5"
-                    },
-                    {
-                      "from": "__power_5",
-                      "to": "__multiply_4"
-                    },
-                    {
-                      "from": "__multiply_4",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "rho",
-                      "to": "__power_8"
-                    },
-                    {
-                      "from": "__power_8",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V",
-                      "to": "__power_9"
-                    },
-                    {
-                      "from": "__power_9",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_7",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__equals_1"
-                    }
+                    {"from": "q_{s}", "to": "__deriv_2"},
+                    {"from": "t", "to": "__deriv_2", "role": "wrt"},
+                    {"from": "__deriv_2", "to": "__equals_1"},
+                    {"from": "K", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "R_{N}", "to": "__power_6"},
+                    {"from": "__power_6", "to": "__power_5"},
+                    {"from": "__power_5", "to": "__multiply_4"},
+                    {"from": "__multiply_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "rho", "to": "__power_8"},
+                    {"from": "__power_8", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "V", "to": "__power_9"},
+                    {"from": "__power_9", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_7", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_3", "to": "__equals_1"}
                   ],
                   "classification": {
                     "kind": "ODE",
                     "order": 1,
-                    "dependent_variables": [
-                      "q_{s}"
-                    ],
-                    "independent_variables": [
-                      "t"
-                    ],
-                    "sympy_hints": [
-                      "factorable",
-                      "nth_algebraic",
-                      "separable",
-                      "1st_exact",
-                      "1st_linear",
-                      "Bernoulli",
-                      "1st_power_series",
-                      "lie_group",
-                      "nth_linear_constant_coeff_undetermined_coefficients",
-                      "nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients",
-                      "nth_linear_constant_coeff_variation_of_parameters",
-                      "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters"
-                    ],
+                    "dependent_variables": ["q_{s}"],
+                    "independent_variables": ["t"],
+                    "sympy_hints": ["factorable", "nth_algebraic", "separable", "1st_exact", "1st_linear", "Bernoulli", "1st_power_series", "lie_group", "nth_linear_constant_coeff_undetermined_coefficients", "nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients", "nth_linear_constant_coeff_variation_of_parameters", "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters"],
                     "linear": true,
                     "homogeneous": true,
                     "constant_coefficients": true
@@ -12121,163 +3731,41 @@
               "justification": "Doubling the nose radius reduces heating by √2 ≈ 29%",
               "explanation": "This is Allen and Eggers' key insight (1958): a blunt shape is counterintuitively better for reentry. The thicker boundary layer acts as an insulating cushion, and the detached bow shock diverts most of the heated air around the vehicle.",
               "highlights": {
-                "inv": {
-                  "color": "green",
-                  "label": "Double R_N → 29% less heating"
-                }
+                "inv": {"color": "green", "label": "Double R_N → 29% less heating"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "q_{s}",
-                      "type": "scalar",
-                      "latex": "q_{s}",
-                      "subexpr": "q_{s}"
-                    },
-                    {
-                      "id": "t",
-                      "type": "scalar",
-                      "latex": "t",
-                      "subexpr": "t"
-                    },
-                    {
-                      "id": "__deriv_1",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t",
-                      "subexpr": "\\frac{d}{d t} q_{s}"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{\\sqrt{R_{N}}} \\implies \\text{larger nose} \\rightarrow \\text{less heating}"
-                    },
-                    {
-                      "id": "__power_3",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\sqrt{R_{N}}}",
-                      "description": "Double R_N → 29% less heating",
-                      "color": "green",
-                      "highlight": "inv"
-                    },
-                    {
-                      "id": "__power_4",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "1/2",
-                      "subexpr": "\\sqrt{R_{N}}"
-                    },
-                    {
-                      "id": "R_{N}",
-                      "type": "scalar",
-                      "latex": "R_{N}",
-                      "subexpr": "R_{N}"
-                    },
-                    {
-                      "id": "__multiply_5",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\implies \\text{larger nose}"
-                    },
-                    {
-                      "id": "implies",
-                      "type": "scalar",
-                      "latex": "\\implies",
-                      "subexpr": "\\implies"
-                    },
-                    {
-                      "id": "larger nose",
-                      "type": "text",
-                      "label": "larger nose",
-                      "latex": "\\text{larger nose}",
-                      "subexpr": "\\text{larger nose}"
-                    },
-                    {
-                      "id": "__proportional_6",
-                      "type": "relation",
-                      "label": "proportional to",
-                      "emoji": "∝",
-                      "op": "proportional",
-                      "subexpr": "\\dot{q_s} \\propto \\frac{1}{\\sqrt{R_N}} \\implies \\text{larger nose} \\rightarrow \\text{less heating}"
-                    }
+                    {"id": "q_{s}", "type": "scalar", "latex": "q_{s}", "subexpr": "q_{s}"},
+                    {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                    {"id": "__deriv_1", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\frac{d}{d t} q_{s}"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{\\sqrt{R_{N}}} \\implies \\text{larger nose} \\rightarrow \\text{less heating}"},
+                    {"id": "__power_3", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\sqrt{R_{N}}}", "description": "Double R_N → 29% less heating", "color": "green", "highlight": "inv"},
+                    {"id": "__power_4", "type": "operator", "op": "power", "exponent": "1/2", "subexpr": "\\sqrt{R_{N}}"},
+                    {"id": "R_{N}", "type": "scalar", "latex": "R_{N}", "subexpr": "R_{N}"},
+                    {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "\\implies \\text{larger nose}"},
+                    {"id": "implies", "type": "scalar", "latex": "\\implies", "subexpr": "\\implies"},
+                    {"id": "larger nose", "type": "text", "label": "larger nose", "latex": "\\text{larger nose}", "subexpr": "\\text{larger nose}"},
+                    {"id": "__proportional_6", "type": "relation", "label": "proportional to", "emoji": "∝", "op": "proportional", "subexpr": "\\dot{q_s} \\propto \\frac{1}{\\sqrt{R_N}} \\implies \\text{larger nose} \\rightarrow \\text{less heating}"}
                   ],
                   "edges": [
-                    {
-                      "from": "q_{s}",
-                      "to": "__deriv_1"
-                    },
-                    {
-                      "from": "t",
-                      "to": "__deriv_1",
-                      "role": "wrt"
-                    },
-                    {
-                      "from": "R_{N}",
-                      "to": "__power_4"
-                    },
-                    {
-                      "from": "__power_4",
-                      "to": "__power_3"
-                    },
-                    {
-                      "from": "__power_3",
-                      "to": "__multiply_2"
-                    },
-                    {
-                      "from": "implies",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "larger nose",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_5",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__deriv_1",
-                      "to": "__proportional_6"
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__proportional_6"
-                    }
+                    {"from": "q_{s}", "to": "__deriv_1"},
+                    {"from": "t", "to": "__deriv_1", "role": "wrt"},
+                    {"from": "R_{N}", "to": "__power_4"},
+                    {"from": "__power_4", "to": "__power_3"},
+                    {"from": "__power_3", "to": "__multiply_2"},
+                    {"from": "implies", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "larger nose", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_5", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__deriv_1", "to": "__proportional_6"},
+                    {"from": "__multiply_2", "to": "__proportional_6"}
                   ],
                   "classification": {
                     "kind": "ODE",
                     "order": 1,
-                    "dependent_variables": [
-                      "q_{s}"
-                    ],
-                    "independent_variables": [
-                      "t"
-                    ],
-                    "sympy_hints": [
-                      "factorable",
-                      "nth_algebraic",
-                      "separable",
-                      "1st_exact",
-                      "1st_linear",
-                      "Bernoulli",
-                      "1st_power_series",
-                      "lie_group",
-                      "nth_linear_constant_coeff_undetermined_coefficients",
-                      "nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients",
-                      "nth_linear_constant_coeff_variation_of_parameters",
-                      "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters"
-                    ],
+                    "dependent_variables": ["q_{s}"],
+                    "independent_variables": ["t"],
+                    "sympy_hints": ["factorable", "nth_algebraic", "separable", "1st_exact", "1st_linear", "Bernoulli", "1st_power_series", "lie_group", "nth_linear_constant_coeff_undetermined_coefficients", "nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients", "nth_linear_constant_coeff_variation_of_parameters", "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters"],
                     "linear": true,
                     "homogeneous": true,
                     "constant_coefficients": true
@@ -12301,173 +3789,45 @@
               "math": "\\frac{\\dot{q}_{\\text{lunar}}}{\\dot{q}_{\\text{LEO}}} = \\htmlClass{hl-cube}{\\left(\\frac{V_{\\text{lunar}}}{V_{\\text{LEO}}}\\right)^3}",
               "explanation": "At the same altitude (same ρ) and same vehicle (same R_N), only velocity differs between the two returns.",
               "highlights": {
-                "cube": {
-                  "color": "yellow",
-                  "label": "Cubic velocity dependence"
-                }
+                "cube": {"color": "yellow", "label": "Cubic velocity dependence"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\frac{\\dot{q_{\\text{lunar}}}}{\\dot{q_{\\text{LEO}}}} = \\left(\\frac{V_{\\text{lunar}}}{V_{\\text{LEO}}}\\right)^3"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\dot{q_{\\text{lunar}}} \\frac{1}{\\dot{q_{\\text{LEO}}}}"
-                    },
-                    {
-                      "id": "q_{\\text{lunar}}",
-                      "type": "scalar",
-                      "latex": "q_{\\text{lunar}}",
-                      "subexpr": "q_{\\text{lunar}}"
-                    },
-                    {
-                      "id": "t",
-                      "type": "scalar",
-                      "latex": "t",
-                      "subexpr": "t"
-                    },
-                    {
-                      "id": "__deriv_3",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t",
-                      "subexpr": "\\dot{q_{\\text{lunar}}}"
-                    },
-                    {
-                      "id": "__power_4",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\dot{q_{\\text{LEO}}}}"
-                    },
-                    {
-                      "id": "q_{\\text{LEO}}",
-                      "type": "scalar",
-                      "latex": "q_{\\text{LEO}}",
-                      "subexpr": "q_{\\text{LEO}}"
-                    },
-                    {
-                      "id": "__deriv_5",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t",
-                      "subexpr": "\\dot{q_{\\text{LEO}}}"
-                    },
-                    {
-                      "id": "__power_6",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "3",
-                      "subexpr": "\\left(\\frac{V_{\\text{lunar}}}{V_{\\text{LEO}}}\\right)^{3}",
-                      "description": "Cubic velocity dependence",
-                      "color": "yellow",
-                      "highlight": "cube"
-                    },
-                    {
-                      "id": "__multiply_7",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{\\text{lunar}} \\frac{1}{V_{\\text{LEO}}}"
-                    },
-                    {
-                      "id": "V_{\\text{lunar}}",
-                      "type": "scalar",
-                      "latex": "V_{\\text{lunar}}",
-                      "subexpr": "V_{\\text{lunar}}"
-                    },
-                    {
-                      "id": "__power_8",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{V_{\\text{LEO}}}"
-                    },
-                    {
-                      "id": "V_{\\text{LEO}}",
-                      "type": "scalar",
-                      "latex": "V_{\\text{LEO}}",
-                      "subexpr": "V_{\\text{LEO}}"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\frac{\\dot{q_{\\text{lunar}}}}{\\dot{q_{\\text{LEO}}}} = \\left(\\frac{V_{\\text{lunar}}}{V_{\\text{LEO}}}\\right)^3"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\dot{q_{\\text{lunar}}} \\frac{1}{\\dot{q_{\\text{LEO}}}}"},
+                    {"id": "q_{\\text{lunar}}", "type": "scalar", "latex": "q_{\\text{lunar}}", "subexpr": "q_{\\text{lunar}}"},
+                    {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                    {"id": "__deriv_3", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\dot{q_{\\text{lunar}}}"},
+                    {"id": "__power_4", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\dot{q_{\\text{LEO}}}}"},
+                    {"id": "q_{\\text{LEO}}", "type": "scalar", "latex": "q_{\\text{LEO}}", "subexpr": "q_{\\text{LEO}}"},
+                    {"id": "__deriv_5", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\dot{q_{\\text{LEO}}}"},
+                    {"id": "__power_6", "type": "operator", "op": "power", "exponent": "3", "subexpr": "\\left(\\frac{V_{\\text{lunar}}}{V_{\\text{LEO}}}\\right)^{3}", "description": "Cubic velocity dependence", "color": "yellow", "highlight": "cube"},
+                    {"id": "__multiply_7", "type": "operator", "op": "multiply", "subexpr": "V_{\\text{lunar}} \\frac{1}{V_{\\text{LEO}}}"},
+                    {"id": "V_{\\text{lunar}}", "type": "scalar", "latex": "V_{\\text{lunar}}", "subexpr": "V_{\\text{lunar}}"},
+                    {"id": "__power_8", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{V_{\\text{LEO}}}"},
+                    {"id": "V_{\\text{LEO}}", "type": "scalar", "latex": "V_{\\text{LEO}}", "subexpr": "V_{\\text{LEO}}"}
                   ],
                   "edges": [
-                    {
-                      "from": "q_{\\text{lunar}}",
-                      "to": "__deriv_3"
-                    },
-                    {
-                      "from": "t",
-                      "to": "__deriv_3",
-                      "role": "wrt"
-                    },
-                    {
-                      "from": "__deriv_3",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "q_{\\text{LEO}}",
-                      "to": "__deriv_5"
-                    },
-                    {
-                      "from": "t",
-                      "to": "__deriv_5",
-                      "role": "wrt"
-                    },
-                    {
-                      "from": "__deriv_5",
-                      "to": "__power_4"
-                    },
-                    {
-                      "from": "__power_4",
-                      "to": "__multiply_2"
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "V_{\\text{lunar}}",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V_{\\text{LEO}}",
-                      "to": "__power_8"
-                    },
-                    {
-                      "from": "__power_8",
-                      "to": "__multiply_7"
-                    },
-                    {
-                      "from": "__multiply_7",
-                      "to": "__power_6"
-                    },
-                    {
-                      "from": "__power_6",
-                      "to": "__equals_1"
-                    }
+                    {"from": "q_{\\text{lunar}}", "to": "__deriv_3"},
+                    {"from": "t", "to": "__deriv_3", "role": "wrt"},
+                    {"from": "__deriv_3", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "q_{\\text{LEO}}", "to": "__deriv_5"},
+                    {"from": "t", "to": "__deriv_5", "role": "wrt"},
+                    {"from": "__deriv_5", "to": "__power_4"},
+                    {"from": "__power_4", "to": "__multiply_2"},
+                    {"from": "__multiply_2", "to": "__equals_1"},
+                    {"from": "V_{\\text{lunar}}", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "V_{\\text{LEO}}", "to": "__power_8"},
+                    {"from": "__power_8", "to": "__multiply_7"},
+                    {"from": "__multiply_7", "to": "__power_6"},
+                    {"from": "__power_6", "to": "__equals_1"}
                   ],
                   "classification": {
                     "kind": "ODE",
                     "order": 1,
-                    "dependent_variables": [
-                      "Xi_{0}",
-                      "Xi_{1}"
-                    ],
-                    "independent_variables": [
-                      "t"
-                    ]
+                    "dependent_variables": ["Xi_{0}", "Xi_{1}"],
+                    "independent_variables": ["t"]
                   }
                 }
               }
@@ -12480,192 +3840,47 @@
               "justification": "V_lunar ≈ 11.0 km/s (Earth escape), V_LEO ≈ 7.8 km/s (circular orbit)",
               "explanation": "Lunar return velocity is only 41% higher than LEO, but the cubic relationship amplifies this dramatically.",
               "highlights": {
-                "vl": {
-                  "color": "orange",
-                  "label": "Lunar return ≈ Earth escape velocity"
-                },
-                "vleo": {
-                  "color": "cyan",
-                  "label": "LEO circular orbit velocity"
-                },
-                "ratio": {
-                  "color": "yellow",
-                  "label": "Only 41% faster, but cubed..."
-                }
+                "vl": {"color": "orange", "label": "Lunar return ≈ Earth escape velocity"},
+                "vleo": {"color": "cyan", "label": "LEO circular orbit velocity"},
+                "ratio": {"color": "yellow", "label": "Only 41% faster, but cubed..."}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "s0___multiply_1",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{\\dot{q_{\\text{lunar}}}}{\\dot{q_{\\text{LEO}}}}"
-                    },
-                    {
-                      "id": "q_{\\text{lunar}}",
-                      "type": "scalar",
-                      "latex": "q_{\\text{lunar}}",
-                      "subexpr": "q_{\\text{lunar}}"
-                    },
-                    {
-                      "id": "t",
-                      "type": "scalar",
-                      "latex": "t",
-                      "subexpr": "t"
-                    },
-                    {
-                      "id": "s0___deriv_2",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t",
-                      "subexpr": "\\dot{q_{\\text{lunar}}}"
-                    },
-                    {
-                      "id": "s0___power_3",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\dot{q_{\\text{LEO}}}}"
-                    },
-                    {
-                      "id": "q_{\\text{LEO}}",
-                      "type": "scalar",
-                      "latex": "q_{\\text{LEO}}",
-                      "subexpr": "q_{\\text{LEO}}"
-                    },
-                    {
-                      "id": "s0___deriv_4",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t",
-                      "subexpr": "\\dot{q_{\\text{LEO}}}"
-                    },
-                    {
-                      "id": "s1___power_1",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "3",
-                      "subexpr": "\\left(\\frac{11.0}{7.8}\\right)^3"
-                    },
-                    {
-                      "id": "s1___multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "11.0 \\frac{1}{7.8}"
-                    },
-                    {
-                      "id": "s1___num_3",
-                      "type": "number",
-                      "label": "11.0",
-                      "subexpr": "11.0",
-                      "description": "Lunar return ≈ Earth escape velocity",
-                      "color": "orange",
-                      "highlight": "vl"
-                    },
-                    {
-                      "id": "s1___power_4",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{7.8}"
-                    },
-                    {
-                      "id": "s1___num_5",
-                      "type": "number",
-                      "label": "7.8",
-                      "subexpr": "7.8",
-                      "description": "LEO circular orbit velocity",
-                      "color": "cyan",
-                      "highlight": "vleo"
-                    },
-                    {
-                      "id": "s2___power_1",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "3",
-                      "subexpr": "(1.410)^3"
-                    },
-                    {
-                      "id": "s2___num_2",
-                      "type": "number",
-                      "label": "1.41",
-                      "subexpr": "1.41"
-                    },
-                    {
-                      "id": "__equals_1",
-                      "type": "operator",
-                      "op": "equals",
-                      "subexpr": "\\frac{\\dot{q}_{\\text{lunar}}}{\\dot{q}_{\\text{LEO}}} = \\left(\\frac{11.0}{7.8}\\right)^3 = (1.410)^3"
-                    }
+                    {"id": "s0___multiply_1", "type": "operator", "op": "multiply", "subexpr": "\\frac{\\dot{q_{\\text{lunar}}}}{\\dot{q_{\\text{LEO}}}}"},
+                    {"id": "q_{\\text{lunar}}", "type": "scalar", "latex": "q_{\\text{lunar}}", "subexpr": "q_{\\text{lunar}}"},
+                    {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                    {"id": "s0___deriv_2", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\dot{q_{\\text{lunar}}}"},
+                    {"id": "s0___power_3", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\dot{q_{\\text{LEO}}}}"},
+                    {"id": "q_{\\text{LEO}}", "type": "scalar", "latex": "q_{\\text{LEO}}", "subexpr": "q_{\\text{LEO}}"},
+                    {"id": "s0___deriv_4", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\dot{q_{\\text{LEO}}}"},
+                    {"id": "s1___power_1", "type": "operator", "op": "power", "exponent": "3", "subexpr": "\\left(\\frac{11.0}{7.8}\\right)^3"},
+                    {"id": "s1___multiply_2", "type": "operator", "op": "multiply", "subexpr": "11.0 \\frac{1}{7.8}"},
+                    {"id": "s1___num_3", "type": "number", "label": "11.0", "subexpr": "11.0", "description": "Lunar return ≈ Earth escape velocity", "color": "orange", "highlight": "vl"},
+                    {"id": "s1___power_4", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{7.8}"},
+                    {"id": "s1___num_5", "type": "number", "label": "7.8", "subexpr": "7.8", "description": "LEO circular orbit velocity", "color": "cyan", "highlight": "vleo"},
+                    {"id": "s2___power_1", "type": "operator", "op": "power", "exponent": "3", "subexpr": "(1.410)^3"},
+                    {"id": "s2___num_2", "type": "number", "label": "1.41", "subexpr": "1.41"},
+                    {"id": "__equals_1", "type": "operator", "op": "equals", "subexpr": "\\frac{\\dot{q}_{\\text{lunar}}}{\\dot{q}_{\\text{LEO}}} = \\left(\\frac{11.0}{7.8}\\right)^3 = (1.410)^3"}
                   ],
                   "edges": [
-                    {
-                      "from": "q_{\\text{lunar}}",
-                      "to": "s0___deriv_2"
-                    },
-                    {
-                      "from": "t",
-                      "to": "s0___deriv_2"
-                    },
-                    {
-                      "from": "s0___deriv_2",
-                      "to": "s0___multiply_1"
-                    },
-                    {
-                      "from": "q_{\\text{LEO}}",
-                      "to": "s0___deriv_4"
-                    },
-                    {
-                      "from": "t",
-                      "to": "s0___deriv_4"
-                    },
-                    {
-                      "from": "s0___deriv_4",
-                      "to": "s0___power_3"
-                    },
-                    {
-                      "from": "s0___power_3",
-                      "to": "s0___multiply_1"
-                    },
-                    {
-                      "from": "s1___num_3",
-                      "to": "s1___multiply_2"
-                    },
-                    {
-                      "from": "s1___num_5",
-                      "to": "s1___power_4"
-                    },
-                    {
-                      "from": "s1___power_4",
-                      "to": "s1___multiply_2"
-                    },
-                    {
-                      "from": "s1___multiply_2",
-                      "to": "s1___power_1"
-                    },
-                    {
-                      "from": "s2___num_2",
-                      "to": "s2___power_1"
-                    },
-                    {
-                      "from": "s0___multiply_1",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "s1___power_1",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "s2___power_1",
-                      "to": "__equals_1"
-                    }
+                    {"from": "q_{\\text{lunar}}", "to": "s0___deriv_2"},
+                    {"from": "t", "to": "s0___deriv_2"},
+                    {"from": "s0___deriv_2", "to": "s0___multiply_1"},
+                    {"from": "q_{\\text{LEO}}", "to": "s0___deriv_4"},
+                    {"from": "t", "to": "s0___deriv_4"},
+                    {"from": "s0___deriv_4", "to": "s0___power_3"},
+                    {"from": "s0___power_3", "to": "s0___multiply_1"},
+                    {"from": "s1___num_3", "to": "s1___multiply_2"},
+                    {"from": "s1___num_5", "to": "s1___power_4"},
+                    {"from": "s1___power_4", "to": "s1___multiply_2"},
+                    {"from": "s1___multiply_2", "to": "s1___power_1"},
+                    {"from": "s2___num_2", "to": "s2___power_1"},
+                    {"from": "s0___multiply_1", "to": "__equals_1"},
+                    {"from": "s1___power_1", "to": "__equals_1"},
+                    {"from": "s2___power_1", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -12677,128 +3892,37 @@
               "justification": "1.410³ ≈ 2.81",
               "explanation": "Lunar return produces 2.81× the peak heating of LEO return — from speed alone. This is why Apollo needed a massive ablative heat shield, and why Artemis uses a skip entry to spread the heat load over two atmospheric passes.",
               "highlights": {
-                "result": {
-                  "color": "red",
-                  "label": "2.81× more heating from speed alone"
-                }
+                "result": {"color": "red", "label": "2.81× more heating from speed alone"}
               },
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "\\frac{\\dot{q_{\\text{lunar}}}}{\\dot{q_{\\text{LEO}}}} = 2.81"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\dot{q_{\\text{lunar}}} \\frac{1}{\\dot{q_{\\text{LEO}}}}"
-                    },
-                    {
-                      "id": "q_{\\text{lunar}}",
-                      "type": "scalar",
-                      "latex": "q_{\\text{lunar}}",
-                      "subexpr": "q_{\\text{lunar}}"
-                    },
-                    {
-                      "id": "t",
-                      "type": "scalar",
-                      "latex": "t",
-                      "subexpr": "t"
-                    },
-                    {
-                      "id": "__deriv_3",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t",
-                      "subexpr": "\\dot{q_{\\text{lunar}}}"
-                    },
-                    {
-                      "id": "__power_4",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\dot{q_{\\text{LEO}}}}"
-                    },
-                    {
-                      "id": "q_{\\text{LEO}}",
-                      "type": "scalar",
-                      "latex": "q_{\\text{LEO}}",
-                      "subexpr": "q_{\\text{LEO}}"
-                    },
-                    {
-                      "id": "__deriv_5",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t",
-                      "subexpr": "\\dot{q_{\\text{LEO}}}"
-                    },
-                    {
-                      "id": "__num_6",
-                      "type": "number",
-                      "label": "2.81",
-                      "subexpr": "2.81",
-                      "description": "2.81× more heating from speed alone",
-                      "color": "red",
-                      "highlight": "result"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\frac{\\dot{q_{\\text{lunar}}}}{\\dot{q_{\\text{LEO}}}} = 2.81"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\dot{q_{\\text{lunar}}} \\frac{1}{\\dot{q_{\\text{LEO}}}}"},
+                    {"id": "q_{\\text{lunar}}", "type": "scalar", "latex": "q_{\\text{lunar}}", "subexpr": "q_{\\text{lunar}}"},
+                    {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                    {"id": "__deriv_3", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\dot{q_{\\text{lunar}}}"},
+                    {"id": "__power_4", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\dot{q_{\\text{LEO}}}}"},
+                    {"id": "q_{\\text{LEO}}", "type": "scalar", "latex": "q_{\\text{LEO}}", "subexpr": "q_{\\text{LEO}}"},
+                    {"id": "__deriv_5", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\dot{q_{\\text{LEO}}}"},
+                    {"id": "__num_6", "type": "number", "label": "2.81", "subexpr": "2.81", "description": "2.81× more heating from speed alone", "color": "red", "highlight": "result"}
                   ],
                   "edges": [
-                    {
-                      "from": "q_{\\text{lunar}}",
-                      "to": "__deriv_3"
-                    },
-                    {
-                      "from": "t",
-                      "to": "__deriv_3",
-                      "role": "wrt"
-                    },
-                    {
-                      "from": "__deriv_3",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "q_{\\text{LEO}}",
-                      "to": "__deriv_5"
-                    },
-                    {
-                      "from": "t",
-                      "to": "__deriv_5",
-                      "role": "wrt"
-                    },
-                    {
-                      "from": "__deriv_5",
-                      "to": "__power_4"
-                    },
-                    {
-                      "from": "__power_4",
-                      "to": "__multiply_2"
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "__num_6",
-                      "to": "__equals_1"
-                    }
+                    {"from": "q_{\\text{lunar}}", "to": "__deriv_3"},
+                    {"from": "t", "to": "__deriv_3", "role": "wrt"},
+                    {"from": "__deriv_3", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "q_{\\text{LEO}}", "to": "__deriv_5"},
+                    {"from": "t", "to": "__deriv_5", "role": "wrt"},
+                    {"from": "__deriv_5", "to": "__power_4"},
+                    {"from": "__power_4", "to": "__multiply_2"},
+                    {"from": "__multiply_2", "to": "__equals_1"},
+                    {"from": "__num_6", "to": "__equals_1"}
                   ],
                   "classification": {
                     "kind": "ODE",
                     "order": 1,
-                    "dependent_variables": [
-                      "Xi_{0}",
-                      "Xi_{1}"
-                    ],
-                    "independent_variables": [
-                      "t"
-                    ]
+                    "dependent_variables": ["Xi_{0}", "Xi_{1}"],
+                    "independent_variables": ["t"]
                   }
                 }
               }
@@ -12813,76 +3937,34 @@
       "markdown": "# Comparing Spacecraft Profiles\n\nDifferent spacecraft use different reentry trajectories to manage aerodynamic heating and deceleration (G-forces).\n\n### Dragon LEO Return\nReturning from Low Earth Orbit (LEO), a Crew Dragon enters at about $7.8 \\text{ km/s}$ with a shallow angle. Its heat load and G-forces are relatively moderate.\n\n### Apollo Lunar Direct Entry\nReturning from the Moon, Apollo entered at $11 \\text{ km/s}$. It used a direct entry, diving deeper to scrub speed quickly, resulting in very high G-forces and intense heat loads.\n\n### Artemis Skip Entry\nArtemis (Orion) uses a **Skip Entry**: A re-entry trajectory where the spacecraft dips into the atmosphere, uses lift to exit back into space to cool down, and then performs a final descent.\n*Intuition:* Like skipping a stone across a pond to bleed off speed and heat in two stages instead of one.\n\n### Bank Angle Steering\nBecause the capsule has an offset center of mass, it naturally generates lift. By rolling the capsule around its velocity axis (changing the bank angle), the lift vector points up, down, or sideways, steering the capsule without any wings.",
       "prompt": "Ensure the graphs clearly distinguish the single massive peak of Apollo vs the two smaller peaks of Artemis. The colors are Dragon (blue), Apollo (red), Artemis (green), and Lift Vector (orange).",
       "range": [
-        [
-          -1,
-          11
-        ],
-        [
-          -1,
-          11
-        ],
-        [
-          -6,
-          6
-        ]
+        [-1, 11],
+        [-1, 11],
+        [-6, 6]
       ],
       "camera": {
-        "position": [
-          14,
-          8,
-          14
-        ],
-        "target": [
-          5,
-          4,
-          -1
-        ]
+        "position": [14, 8, 14],
+        "target": [5, 4, -1]
       },
       "views": [
         {
           "name": "Isometric",
           "description": "3D isometric showing trajectory paths",
-          "position": [
-            14,
-            8,
-            14
-          ],
-          "target": [
-            5,
-            4,
-            -1
-          ]
+          "position": [14, 8, 14],
+          "target": [5, 4, -1]
         },
         {
           "name": "Graphs Focused",
           "description": "View focused on the G-force graphs",
-          "position": [
-            5,
-            7,
-            -15
-          ],
-          "target": [
-            5,
-            7,
-            -5
-          ]
+          "position": [5, 7, -15],
+          "target": [5, 7, -5]
         }
       ],
       "elements": [
-        {
-          "id": "_mathbox_init",
-          "type": "grid",
-          "plane": "xz",
-          "opacity": 0,
-          "divisions": 1
-        },
+        {"id": "_mathbox_init", "type": "grid", "plane": "xz", "opacity": 0, "divisions": 1},
         {
           "type": "axis",
           "axis": "x",
-          "range": [
-            -1,
-            11
-          ],
+          "range": [-1, 11],
           "color": "#ff4444",
           "width": 1.5,
           "label": "x"
@@ -12890,10 +3972,7 @@
         {
           "type": "axis",
           "axis": "y",
-          "range": [
-            -1,
-            11
-          ],
+          "range": [-1, 11],
           "color": "#44cc44",
           "width": 1.5,
           "label": "y"
@@ -12901,10 +3980,7 @@
         {
           "type": "axis",
           "axis": "z",
-          "range": [
-            -6,
-            6
-          ],
+          "range": [-6, 6],
           "color": "#4488ff",
           "width": 1.5,
           "label": "z"
@@ -12922,21 +3998,14 @@
               "x": "t",
               "y": "4 - 0.4*t",
               "z": "-2",
-              "range": [
-                0,
-                10
-              ],
+              "range": [0, 10],
               "color": "#3498db",
               "width": 3
             },
             {
               "id": "dragon_pt",
               "type": "point",
-              "position": [
-                10,
-                0,
-                -2
-              ],
+              "position": [10, 0, -2],
               "color": "#3498db",
               "size": 8,
               "label": "Dragon"
@@ -12947,10 +4016,7 @@
               "x": "t",
               "y": "5 + 1.5*exp(-(t-5)^2)",
               "z": "-5",
-              "range": [
-                0,
-                10
-              ],
+              "range": [0, 10],
               "color": "#3498db",
               "width": 3
             },
@@ -12958,21 +4024,9 @@
               "id": "graph_axes",
               "type": "line",
               "points": [
-                [
-                  0,
-                  10,
-                  -5
-                ],
-                [
-                  0,
-                  5,
-                  -5
-                ],
-                [
-                  10,
-                  5,
-                  -5
-                ]
+                [0, 10, -5],
+                [0, 5, -5],
+                [10, 5, -5]
               ],
               "color": "#ffffff",
               "width": 2,
@@ -12982,11 +4036,7 @@
               "id": "graph_label",
               "type": "text",
               "text": "G-Force",
-              "position": [
-                0,
-                10.5,
-                -5
-              ],
+              "position": [0, 10.5, -5],
               "color": "#ffffff",
               "label": "G-Force"
             }
@@ -13004,21 +4054,14 @@
               "x": "t",
               "y": "4 - 0.8*t + 0.04*t^2",
               "z": "0",
-              "range": [
-                0,
-                10
-              ],
+              "range": [0, 10],
               "color": "#e74c3c",
               "width": 3
             },
             {
               "id": "apollo_pt",
               "type": "point",
-              "position": [
-                10,
-                0,
-                0
-              ],
+              "position": [10, 0, 0],
               "color": "#e74c3c",
               "size": 8,
               "label": "Apollo"
@@ -13029,10 +4072,7 @@
               "x": "t",
               "y": "5 + 4.5*exp(-(t-4)^2)",
               "z": "-5",
-              "range": [
-                0,
-                10
-              ],
+              "range": [0, 10],
               "color": "#e74c3c",
               "width": 3
             }
@@ -13050,21 +4090,14 @@
               "x": "t",
               "y": "4 - 0.4*t - 1.5*sin(t*pi/5)",
               "z": "2",
-              "range": [
-                0,
-                10
-              ],
+              "range": [0, 10],
               "color": "#2ecc71",
               "width": 3
             },
             {
               "id": "artemis_pt",
               "type": "point",
-              "position": [
-                10,
-                0,
-                2
-              ],
+              "position": [10, 0, 2],
               "color": "#2ecc71",
               "size": 8,
               "label": "Artemis"
@@ -13075,10 +4108,7 @@
               "x": "t",
               "y": "5 + 2.0*exp(-(t-2.5)^2) + 1.5*exp(-(t-9)^2)",
               "z": "-5",
-              "range": [
-                0,
-                10
-              ],
+              "range": [0, 10],
               "color": "#2ecc71",
               "width": 3
             }
@@ -13093,11 +4123,7 @@
             {
               "id": "artemis_pt_mid",
               "type": "point",
-              "position": [
-                5,
-                2,
-                2
-              ],
+              "position": [5, 2, 2],
               "color": "#2ecc71",
               "size": 10,
               "label": "Capsule"
@@ -13105,16 +4131,8 @@
             {
               "id": "velocity_vec",
               "type": "vector",
-              "from": [
-                5,
-                2,
-                2
-              ],
-              "to": [
-                2,
-                2,
-                2
-              ],
+              "from": [5, 2, 2],
+              "to": [2, 2, 2],
               "color": "#3498db",
               "width": 4,
               "label": "$\\vec{V}$ (velocity)"
@@ -13122,16 +4140,8 @@
             {
               "id": "up_ref",
               "type": "vector",
-              "from": [
-                5,
-                2,
-                2
-              ],
-              "to": [
-                5,
-                3.8,
-                2
-              ],
+              "from": [5, 2, 2],
+              "to": [5, 3.8, 2],
               "color": "#888888",
               "width": 2,
               "opacity": 0.5,
@@ -13140,16 +4150,8 @@
             {
               "id": "lift_vec",
               "type": "animated_vector",
-              "from": [
-                5,
-                2,
-                2
-              ],
-              "expr": [
-                "5",
-                "2 + 1.8 * cos(s4_bank_angle * pi / 180)",
-                "2 + 1.8 * sin(s4_bank_angle * pi / 180)"
-              ],
+              "from": [5, 2, 2],
+              "expr": ["5", "2 + 1.8 * cos(s4_bank_angle * pi / 180)", "2 + 1.8 * sin(s4_bank_angle * pi / 180)"],
               "color": "#f39c12",
               "width": 5,
               "label": "$\\vec{L}$ (lift)"
@@ -13160,10 +4162,7 @@
               "x": "5",
               "y": "2 + 0.8 * cos(t * pi / 180)",
               "z": "2 + 0.8 * sin(t * pi / 180)",
-              "range": [
-                0,
-                "s4_bank_angle"
-              ],
+              "range": [0, "s4_bank_angle"],
               "samples": 60,
               "color": "#e74c3c",
               "width": 2,
@@ -13172,11 +4171,7 @@
             {
               "id": "bank_label",
               "type": "animated_point",
-              "expr": [
-                "5",
-                "2 + 1.0 * cos(s4_bank_angle / 2 * pi / 180)",
-                "2 + 1.0 * sin(s4_bank_angle / 2 * pi / 180)"
-              ],
+              "expr": ["5", "2 + 1.0 * cos(s4_bank_angle / 2 * pi / 180)", "2 + 1.0 * sin(s4_bank_angle / 2 * pi / 180)"],
               "color": "#e74c3c",
               "size": 0,
               "labelExpr": "concat('φ = ', toFixed(abs(s4_bank_angle), 0), '°')"
@@ -13184,21 +4179,10 @@
           ],
           "remove": [],
           "sliders": [
-            {
-              "id": "s4_bank_angle",
-              "label": "Bank Angle (deg)",
-              "min": -180,
-              "max": 180,
-              "default": 0,
-              "step": 1
-            }
+            {"id": "s4_bank_angle", "label": "Bank Angle (deg)", "min": -180, "max": 180, "default": 0, "step": 1}
           ],
           "info": [
-            {
-              "id": "bank_info",
-              "content": "### Lift Steering\nBank Angle: ${{s4_bank_angle}}^\\circ$\n\nVertical lift $\\propto \\cos \\phi = {{toFixed(cos(s4_bank_angle * pi / 180), 2)}}$\nLateral lift $\\propto \\sin \\phi = {{toFixed(sin(s4_bank_angle * pi / 180), 2)}}$\n\nTotal lift is fixed by aerodynamics. Banking doesn't create more lift — it **redirects** it. Vertical lift controls descent rate and corridor width. Lateral lift steers the ground track left or right (crossrange). More bank = more crossrange steering but narrower corridor.",
-              "position": "top-right"
-            }
+            {"id": "bank_info", "content": "### Lift Steering\nBank Angle: ${{s4_bank_angle}}^\\circ$\n\nVertical lift $\\propto \\cos \\phi = {{toFixed(cos(s4_bank_angle * pi / 180), 2)}}$\nLateral lift $\\propto \\sin \\phi = {{toFixed(sin(s4_bank_angle * pi / 180), 2)}}$\n\nTotal lift is fixed by aerodynamics. Banking doesn't create more lift — it **redirects** it. Vertical lift controls descent rate and corridor width. Lateral lift steers the ground track left or right (crossrange). More bank = more crossrange steering but narrower corridor.", "position": "top-right"}
           ]
         }
       ]
@@ -13209,49 +4193,20 @@
       "markdown": "# Splashdown Dynamics\n\nAfter surviving the intense heat of reentry, a spacecraft must decelerate to a safe landing speed. In the lower, thicker atmosphere, capsules like Apollo, Crew Dragon, and Orion deploy a series of parachutes to increase their drag area and reduce their **terminal velocity** before splashdown.\n\n### The Force Balance\nTwo forces act on the falling capsule:\n\n* **Gravity** pulls it downward: $F_g = mg$\n* **Aerodynamic drag** pushes upward: $F_d = \\frac{1}{2}\\rho V^2 C_d A$\n\nDrag depends on the square of speed — the faster the capsule falls, the harder the air pushes back.\n\n### Why $F_d = F_g$ Means Constant Speed\nFor the capsule to fall at **constant speed** (zero acceleration), Newton's second law requires the net force to be zero:\n\n$$F_{\\text{net}} = F_d - F_g = 0 \\quad \\Longrightarrow \\quad F_d = F_g$$\n\nThe unique speed at which this balance occurs is the **terminal velocity**. Once the capsule reaches it, there is no more acceleration — the crew feels only **1g** (their own weight), just like sitting in a chair.\n\n### Solving for Terminal Velocity\nSetting $F_g = F_d$:\n\n$$mg = \\frac{1}{2}\\rho V_t^2 C_d A \\quad \\Longrightarrow \\quad V_t = \\sqrt{\\frac{2mg}{\\rho C_d A}}$$\n\n### The Role of Parachutes\nBy deploying parachutes, the spacecraft massively increases its cross-sectional area $A$ and drag coefficient $C_d$. Increasing $A$ in the denominator dramatically reduces $V_t$, allowing the crew to approach a safe splashdown speed.\n\n**Right after deployment**, the capsule is still falling fast from freefall, so $F_d > F_g$ and the crew feels a brief high-g deceleration spike. As the capsule slows, drag decreases until $F_d = F_g$ and the ride becomes a gentle 1g descent.\n\n### Water Impact Loads\nEven after the parachutes do their job, the capsule still reaches the ocean with nonzero speed. If the vertical speed just before contact is $V_t$ and the water brings the capsule to rest over a stopping time $\\Delta t$, then the average deceleration is roughly\n\n$$a_{\\text{impact}} \\approx \\frac{V_t}{\\Delta t}$$\n\nand the corresponding load factor is\n\n$$n \\approx \\frac{a_{\\text{impact}}}{g}$$\n\nA softer, longer splashdown reduces the deceleration the crew feels.",
       "prompt": "Emphasize how terminal velocity is reached when drag equals gravity. Guide the student to see how parachute area inversely affects the final velocity. Suggest asking 'What would happen if the atmosphere were thinner (like on Mars)?'",
       "range": [
-        [
-          -12,
-          12
-        ],
-        [
-          -2,
-          22
-        ],
-        [
-          -12,
-          12
-        ]
+        [-12, 12],
+        [-2, 22],
+        [-12, 12]
       ],
-      "scale": [
-        1,
-        1,
-        1
-      ],
+      "scale": [1, 1, 1],
       "camera": {
-        "position": [
-          0,
-          10,
-          30
-        ],
-        "target": [
-          0,
-          10,
-          0
-        ]
+        "position": [0, 10, 30],
+        "target": [0, 10, 0]
       },
       "views": [
         {
           "name": "Side Profile",
-          "position": [
-            0,
-            10,
-            30
-          ],
-          "target": [
-            0,
-            10,
-            0
-          ],
+          "position": [0, 10, 30],
+          "target": [0, 10, 0],
           "description": "2D side profile tracking the capsule"
         }
       ],
@@ -13259,10 +4214,7 @@
         {
           "type": "axis",
           "axis": "x",
-          "range": [
-            -12,
-            12
-          ],
+          "range": [-12, 12],
           "color": "#ff4444",
           "width": 1.5,
           "label": "x"
@@ -13270,10 +4222,7 @@
         {
           "type": "axis",
           "axis": "y",
-          "range": [
-            -2,
-            22
-          ],
+          "range": [-2, 22],
           "color": "#44cc44",
           "width": 1.5,
           "label": "y"
@@ -13281,10 +4230,7 @@
         {
           "type": "axis",
           "axis": "z",
-          "range": [
-            -12,
-            12
-          ],
+          "range": [-12, 12],
           "color": "#4488ff",
           "width": 1.5,
           "label": "z"
@@ -13293,15 +4239,8 @@
           "id": "grid_bg",
           "type": "grid",
           "plane": "xy",
-          "range": [
-            -12,
-            22
-          ],
-          "color": [
-            0.3,
-            0.3,
-            0.5
-          ],
+          "range": [-12, 22],
+          "color": [0.3, 0.3, 0.5],
           "opacity": 0.15,
           "divisions": 24
         },
@@ -13309,26 +4248,10 @@
           "id": "ocean_surface",
           "type": "polygon",
           "vertices": [
-            [
-              -12,
-              0,
-              -12
-            ],
-            [
-              12,
-              0,
-              -12
-            ],
-            [
-              12,
-              0,
-              12
-            ],
-            [
-              -12,
-              0,
-              12
-            ]
+            [-12, 0, -12],
+            [12, 0, -12],
+            [12, 0, 12],
+            [-12, 0, 12]
           ],
           "color": "#3498db",
           "opacity": 0.4
@@ -13343,11 +4266,7 @@
             {
               "id": "capsule",
               "type": "point",
-              "position": [
-                0,
-                10,
-                0
-              ],
+              "position": [0, 10, 0],
               "color": "#ffffff",
               "size": 18,
               "label": "Capsule"
@@ -13355,16 +4274,8 @@
             {
               "id": "vec_gravity",
               "type": "animated_vector",
-              "from": [
-                0,
-                10,
-                0
-              ],
-              "toExpr": [
-                "0",
-                "10 - dataTable('capsules', s5_capsule, 'mass') / 2000",
-                "0"
-              ],
+              "from": [0, 10, 0],
+              "toExpr": ["0", "10 - dataTable('capsules', s5_capsule, 'mass') / 2000", "0"],
               "color": "#2ecc71",
               "width": 4,
               "label": "$F_g$"
@@ -13372,16 +4283,8 @@
             {
               "id": "vec_drag_freefall",
               "type": "animated_vector",
-              "from": [
-                0,
-                10,
-                0
-              ],
-              "toExpr": [
-                "0",
-                "10 + dataTable('capsules', s5_capsule, 'mass') / 5000",
-                "0"
-              ],
+              "from": [0, 10, 0],
+              "toExpr": ["0", "10 + dataTable('capsules', s5_capsule, 'mass') / 5000", "0"],
               "color": "#e74c3c",
               "width": 4,
               "label": "$F_d$ (small)"
@@ -13389,15 +4292,7 @@
           ],
           "remove": [],
           "sliders": [
-            {
-              "id": "s5_capsule",
-              "label": "Capsule",
-              "min": 0,
-              "max": 3,
-              "step": 1,
-              "default": 2,
-              "valueExpr": "dataTable('capsules', s5_capsule, 'name')"
-            }
+            {"id": "s5_capsule", "label": "Capsule", "min": 0, "max": 3, "step": 1, "default": 2, "valueExpr": "dataTable('capsules', s5_capsule, 'name')"}
           ],
           "info": []
         },
@@ -13412,11 +4307,7 @@
               "regular": {
                 "n": 64,
                 "radius": "sqrt(dataTable('capsules', s5_capsule, 'chuteArea') / pi)",
-                "center": [
-                  "0",
-                  "14",
-                  "0"
-                ],
+                "center": ["0", "14", "0"],
                 "plane": "xz"
               },
               "color": "#ffffff",
@@ -13425,11 +4316,7 @@
             {
               "id": "chute_area_label",
               "type": "animated_point",
-              "expr": [
-                "0",
-                "14",
-                "0"
-              ],
+              "expr": ["0", "14", "0"],
               "color": "#ffffff",
               "size": 0,
               "labelExpr": "concat(dataTable('capsules', s5_capsule, 'name'), ': A = ', toFixed(dataTable('capsules', s5_capsule, 'chuteArea'), 0), ' m²')"
@@ -13438,16 +4325,8 @@
               "id": "cords1",
               "type": "animated_line",
               "points": [
-                [
-                  "-sqrt(dataTable('capsules', s5_capsule, 'chuteArea') / pi)",
-                  "14",
-                  "0"
-                ],
-                [
-                  "0",
-                  "10.2",
-                  "0"
-                ]
+                ["-sqrt(dataTable('capsules', s5_capsule, 'chuteArea') / pi)", "14", "0"],
+                ["0", "10.2", "0"]
               ],
               "color": "#aaaaaa",
               "width": 2
@@ -13456,16 +4335,8 @@
               "id": "cords2",
               "type": "animated_line",
               "points": [
-                [
-                  "sqrt(dataTable('capsules', s5_capsule, 'chuteArea') / pi)",
-                  "14",
-                  "0"
-                ],
-                [
-                  "0",
-                  "10.2",
-                  "0"
-                ]
+                ["sqrt(dataTable('capsules', s5_capsule, 'chuteArea') / pi)", "14", "0"],
+                ["0", "10.2", "0"]
               ],
               "color": "#aaaaaa",
               "width": 2
@@ -13473,33 +4344,19 @@
             {
               "id": "vec_drag_chute",
               "type": "animated_vector",
-              "from": [
-                0,
-                10,
-                0
-              ],
-              "toExpr": [
-                "0",
-                "10 + dataTable('capsules', s5_capsule, 'mass') / 2000 * 1.3",
-                "0"
-              ],
+              "from": [0, 10, 0],
+              "toExpr": ["0", "10 + dataTable('capsules', s5_capsule, 'mass') / 2000 * 1.3", "0"],
               "color": "#e74c3c",
               "width": 4,
               "label": "$F_d > F_g$"
             }
           ],
           "remove": [
-            {
-              "id": "vec_drag_freefall"
-            }
+            {"id": "vec_drag_freefall"}
           ],
           "sliders": [],
           "info": [
-            {
-              "id": "info_drag",
-              "content": "### {{dataTable('capsules', s5_capsule, 'name')}}\n$m = {{dataTable('capsules', s5_capsule, 'mass')}}\\ \\text{kg}$\n$A = {{toFixed(dataTable('capsules', s5_capsule, 'chuteArea'), 0)}}\\ \\text{m}^2$\n$C_d = {{dataTable('capsules', s5_capsule, 'chuteCd')}}$",
-              "position": "top-right"
-            }
+            {"id": "info_drag", "content": "### {{dataTable('capsules', s5_capsule, 'name')}}\n$m = {{dataTable('capsules', s5_capsule, 'mass')}}\\ \\text{kg}$\n$A = {{toFixed(dataTable('capsules', s5_capsule, 'chuteArea'), 0)}}\\ \\text{m}^2$\n$C_d = {{dataTable('capsules', s5_capsule, 'chuteCd')}}$", "position": "top-right"}
           ]
         },
         {
@@ -13510,37 +4367,20 @@
             {
               "id": "vec_drag_terminal",
               "type": "animated_vector",
-              "from": [
-                0,
-                10,
-                0
-              ],
-              "toExpr": [
-                "0",
-                "10 + dataTable('capsules', s5_capsule, 'mass') / 2000",
-                "0"
-              ],
+              "from": [0, 10, 0],
+              "toExpr": ["0", "10 + dataTable('capsules', s5_capsule, 'mass') / 2000", "0"],
               "color": "#e74c3c",
               "width": 4,
               "label": "$F_d = F_g$"
             }
           ],
           "remove": [
-            {
-              "id": "vec_drag_chute"
-            },
-            {
-              "type": "info",
-              "id": "info_drag"
-            }
+            {"id": "vec_drag_chute"},
+            {"type": "info", "id": "info_drag"}
           ],
           "sliders": [],
           "info": [
-            {
-              "id": "info_terminal",
-              "content": "### Terminal Velocity — {{dataTable('capsules', s5_capsule, 'name')}}\n$m = {{dataTable('capsules', s5_capsule, 'mass')}}\\ \\text{kg}$, $\\rho = 1.225\\ \\text{kg/m}^3$, $C_d = {{dataTable('capsules', s5_capsule, 'chuteCd')}}$\n\n$F_g = F_d$\n\n$V_t = \\sqrt{ \\frac{2mg}{\\rho C_d A} } = {{toFixed(sqrt(2 * dataTable('capsules', s5_capsule, 'mass') * 9.81 / (1.225 * dataTable('capsules', s5_capsule, 'chuteCd') * dataTable('capsules', s5_capsule, 'chuteArea'))), 1)}}\\ \\text{m/s}$",
-              "position": "top-right"
-            }
+            {"id": "info_terminal", "content": "### Terminal Velocity — {{dataTable('capsules', s5_capsule, 'name')}}\n$m = {{dataTable('capsules', s5_capsule, 'mass')}}\\ \\text{kg}$, $\\rho = 1.225\\ \\text{kg/m}^3$, $C_d = {{dataTable('capsules', s5_capsule, 'chuteCd')}}$\n\n$F_g = F_d$\n\n$V_t = \\sqrt{ \\frac{2mg}{\\rho C_d A} } = {{toFixed(sqrt(2 * dataTable('capsules', s5_capsule, 'mass') * 9.81 / (1.225 * dataTable('capsules', s5_capsule, 'chuteCd') * dataTable('capsules', s5_capsule, 'chuteArea'))), 1)}}\\ \\text{m/s}$", "position": "top-right"}
           ]
         },
         {
@@ -13551,11 +4391,7 @@
             {
               "id": "capsule_splash",
               "type": "point",
-              "position": [
-                0,
-                0.8,
-                0
-              ],
+              "position": [0, 0.8, 0],
               "color": "#ffffff",
               "size": 18,
               "label": "Capsule"
@@ -13563,16 +4399,8 @@
             {
               "id": "vec_gravity_splash",
               "type": "vector",
-              "from": [
-                0,
-                0.8,
-                0
-              ],
-              "to": [
-                0,
-                -2.2,
-                0
-              ],
+              "from": [0, 0.8, 0],
+              "to": [0, -2.2, 0],
               "color": "#2ecc71",
               "width": 4,
               "label": "$F_g$"
@@ -13580,16 +4408,8 @@
             {
               "id": "vec_water",
               "type": "animated_vector",
-              "from": [
-                0,
-                0.8,
-                0
-              ],
-              "toExpr": [
-                "0",
-                "0.8 + 0.6 * sqrt(2 * dataTable('capsules', s5_capsule, 'mass') * 9.81 / (1.225 * dataTable('capsules', s5_capsule, 'chuteCd') * dataTable('capsules', s5_capsule, 'chuteArea'))) / (9.81 * s5_stop_time)",
-                "0"
-              ],
+              "from": [0, 0.8, 0],
+              "toExpr": ["0", "0.8 + 0.6 * sqrt(2 * dataTable('capsules', s5_capsule, 'mass') * 9.81 / (1.225 * dataTable('capsules', s5_capsule, 'chuteCd') * dataTable('capsules', s5_capsule, 'chuteArea'))) / (9.81 * s5_stop_time)", "0"],
               "color": "#f1c40f",
               "width": 5,
               "label": "$F_{\\text{water}}$"
@@ -13600,67 +4420,30 @@
               "x": "1.2 * cos(t)",
               "y": "0",
               "z": "1.2 * sin(t)",
-              "range": [
-                0,
-                6.2832
-              ],
+              "range": [0, 6.2832],
               "color": "#ffffff",
               "width": 2,
               "opacity": 0.5
             }
           ],
           "remove": [
-            {
-              "id": "capsule"
-            },
-            {
-              "id": "vec_gravity"
-            },
-            {
-              "id": "vec_drag_terminal"
-            },
-            {
-              "id": "parachute"
-            },
-            {
-              "id": "cords1"
-            },
-            {
-              "id": "cords2"
-            },
-            {
-              "type": "info",
-              "id": "info_terminal"
-            }
+            {"id": "capsule"},
+            {"id": "vec_gravity"},
+            {"id": "vec_drag_terminal"},
+            {"id": "parachute"},
+            {"id": "cords1"},
+            {"id": "cords2"},
+            {"type": "info", "id": "info_terminal"}
           ],
           "sliders": [
-            {
-              "id": "s5_stop_time",
-              "label": "Water Stop Time (s)",
-              "min": 0.5,
-              "max": 3,
-              "default": 1.5,
-              "step": 0.1
-            }
+            {"id": "s5_stop_time", "label": "Water Stop Time (s)", "min": 0.5, "max": 3, "default": 1.5, "step": 0.1}
           ],
           "info": [
-            {
-              "id": "info_impact",
-              "content": "### Water Impact — {{dataTable('capsules', s5_capsule, 'name')}}\n$V_t = {{toFixed(sqrt(2 * dataTable('capsules', s5_capsule, 'mass') * 9.81 / (1.225 * dataTable('capsules', s5_capsule, 'chuteCd') * dataTable('capsules', s5_capsule, 'chuteArea'))), 1)}}\\ \\text{m/s}$\n\n$a_{\\text{impact}} \\approx \\frac{V_t}{\\Delta t} = {{toFixed(sqrt(2 * dataTable('capsules', s5_capsule, 'mass') * 9.81 / (1.225 * dataTable('capsules', s5_capsule, 'chuteCd') * dataTable('capsules', s5_capsule, 'chuteArea'))) / s5_stop_time, 1)}}\\ \\text{m/s}^2$\n\n$n \\approx \\frac{a}{g} = {{toFixed(sqrt(2 * dataTable('capsules', s5_capsule, 'mass') * 9.81 / (1.225 * dataTable('capsules', s5_capsule, 'chuteCd') * dataTable('capsules', s5_capsule, 'chuteArea'))) / (9.81 * s5_stop_time), 1)}}\\ g$",
-              "position": "top-right"
-            }
+            {"id": "info_impact", "content": "### Water Impact — {{dataTable('capsules', s5_capsule, 'name')}}\n$V_t = {{toFixed(sqrt(2 * dataTable('capsules', s5_capsule, 'mass') * 9.81 / (1.225 * dataTable('capsules', s5_capsule, 'chuteCd') * dataTable('capsules', s5_capsule, 'chuteArea'))), 1)}}\\ \\text{m/s}$\n\n$a_{\\text{impact}} \\approx \\frac{V_t}{\\Delta t} = {{toFixed(sqrt(2 * dataTable('capsules', s5_capsule, 'mass') * 9.81 / (1.225 * dataTable('capsules', s5_capsule, 'chuteCd') * dataTable('capsules', s5_capsule, 'chuteArea'))) / s5_stop_time, 1)}}\\ \\text{m/s}^2$\n\n$n \\approx \\frac{a}{g} = {{toFixed(sqrt(2 * dataTable('capsules', s5_capsule, 'mass') * 9.81 / (1.225 * dataTable('capsules', s5_capsule, 'chuteCd') * dataTable('capsules', s5_capsule, 'chuteArea'))) / (9.81 * s5_stop_time), 1)}}\\ g$", "position": "top-right"}
           ],
           "camera": {
-            "position": [
-              0,
-              4,
-              22
-            ],
-            "target": [
-              0,
-              2,
-              0
-            ]
+            "position": [0, 4, 22],
+            "target": [0, 2, 0]
           }
         }
       ],
@@ -13685,80 +4468,24 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "a = \\frac{d}{d t} V"
-                    },
-                    {
-                      "id": "a",
-                      "type": "scalar",
-                      "latex": "a",
-                      "subexpr": "a"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    },
-                    {
-                      "id": "t",
-                      "type": "scalar",
-                      "latex": "t",
-                      "subexpr": "t"
-                    },
-                    {
-                      "id": "__deriv_2",
-                      "type": "operator",
-                      "op": "derivative",
-                      "with_respect_to": "t",
-                      "subexpr": "\\frac{d}{d t} V"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "a = \\frac{d}{d t} V"},
+                    {"id": "a", "type": "scalar", "latex": "a", "subexpr": "a"},
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"},
+                    {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                    {"id": "__deriv_2", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\frac{d}{d t} V"}
                   ],
                   "edges": [
-                    {
-                      "from": "a",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "V",
-                      "to": "__deriv_2"
-                    },
-                    {
-                      "from": "t",
-                      "to": "__deriv_2",
-                      "role": "wrt"
-                    },
-                    {
-                      "from": "__deriv_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "a", "to": "__equals_1"},
+                    {"from": "V", "to": "__deriv_2"},
+                    {"from": "t", "to": "__deriv_2", "role": "wrt"},
+                    {"from": "__deriv_2", "to": "__equals_1"}
                   ],
                   "classification": {
                     "kind": "ODE",
                     "order": 1,
-                    "dependent_variables": [
-                      "V"
-                    ],
-                    "independent_variables": [
-                      "t"
-                    ],
-                    "sympy_hints": [
-                      "factorable",
-                      "nth_algebraic",
-                      "separable",
-                      "1st_exact",
-                      "1st_linear",
-                      "Bernoulli",
-                      "1st_power_series",
-                      "lie_group",
-                      "nth_linear_constant_coeff_undetermined_coefficients",
-                      "nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients",
-                      "nth_linear_constant_coeff_variation_of_parameters",
-                      "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters"
-                    ],
+                    "dependent_variables": ["V"],
+                    "independent_variables": ["t"],
+                    "sympy_hints": ["factorable", "nth_algebraic", "separable", "1st_exact", "1st_linear", "Bernoulli", "1st_power_series", "lie_group", "nth_linear_constant_coeff_undetermined_coefficients", "nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients", "nth_linear_constant_coeff_variation_of_parameters", "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters"],
                     "linear": true,
                     "homogeneous": true,
                     "constant_coefficients": true
@@ -13778,62 +4505,19 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "F_{\\text{net}} = ma"
-                    },
-                    {
-                      "id": "F_{\\text{net}}",
-                      "type": "scalar",
-                      "latex": "F_{\\text{net}}",
-                      "subexpr": "F_{\\text{net}}"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "a m"
-                    },
-                    {
-                      "id": "m",
-                      "type": "scalar",
-                      "latex": "m",
-                      "subexpr": "m"
-                    },
-                    {
-                      "id": "a",
-                      "type": "scalar",
-                      "latex": "a",
-                      "subexpr": "a"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "F_{\\text{net}} = ma"},
+                    {"id": "F_{\\text{net}}", "type": "scalar", "latex": "F_{\\text{net}}", "subexpr": "F_{\\text{net}}"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "a m"},
+                    {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m"},
+                    {"id": "a", "type": "scalar", "latex": "a", "subexpr": "a"}
                   ],
                   "edges": [
-                    {
-                      "from": "F_{\\text{net}}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "m",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "a",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "F_{\\text{net}}", "to": "__equals_1"},
+                    {"from": "m", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "a", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -13849,62 +4533,19 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "F_g = mg"
-                    },
-                    {
-                      "id": "F_{g}",
-                      "type": "scalar",
-                      "latex": "F_{g}",
-                      "subexpr": "F_{g}"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "g m"
-                    },
-                    {
-                      "id": "m",
-                      "type": "scalar",
-                      "latex": "m",
-                      "subexpr": "m"
-                    },
-                    {
-                      "id": "g",
-                      "type": "scalar",
-                      "latex": "g",
-                      "subexpr": "g"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "F_g = mg"},
+                    {"id": "F_{g}", "type": "scalar", "latex": "F_{g}", "subexpr": "F_{g}"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "g m"},
+                    {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m"},
+                    {"id": "g", "type": "scalar", "latex": "g", "subexpr": "g"}
                   ],
                   "edges": [
-                    {
-                      "from": "F_{g}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "m",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "g",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "F_{g}", "to": "__equals_1"},
+                    {"from": "m", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "g", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -13916,167 +4557,41 @@
               "explanation": "A bigger parachute area $A$ or a larger drag coefficient $C_d$ makes the upward drag force stronger.",
               "sceneStep": 2,
               "highlights": {
-                "area": {
-                  "color": "cyan",
-                  "label": "Parachute Area"
-                }
+                "area": {"color": "cyan", "label": "Parachute Area"}
               },
               "prompt": "Have the student locate the term that gets larger when the parachute opens.",
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "F_d = \\frac{1}{2}\\rho V^2 C_d A"
-                    },
-                    {
-                      "id": "F_{d}",
-                      "type": "scalar",
-                      "latex": "F_{d}",
-                      "subexpr": "F_{d}"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{2} \\rho V^{2} A C_{d}"
-                    },
-                    {
-                      "id": "__power_3",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2}"
-                    },
-                    {
-                      "id": "__num_4",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "__multiply_5",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho V^{2} A C_{d}"
-                    },
-                    {
-                      "id": "rho",
-                      "type": "scalar",
-                      "latex": "\\rho",
-                      "subexpr": "\\rho"
-                    },
-                    {
-                      "id": "__multiply_6",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V^{2} A C_{d}"
-                    },
-                    {
-                      "id": "__power_7",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V^{2}"
-                    },
-                    {
-                      "id": "V",
-                      "type": "scalar",
-                      "latex": "V",
-                      "subexpr": "V"
-                    },
-                    {
-                      "id": "__multiply_8",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "A C_{d}"
-                    },
-                    {
-                      "id": "C_{d}",
-                      "type": "scalar",
-                      "latex": "C_{d}",
-                      "subexpr": "C_{d}"
-                    },
-                    {
-                      "id": "A",
-                      "type": "scalar",
-                      "latex": "A",
-                      "subexpr": "A",
-                      "description": "Parachute Area",
-                      "color": "cyan",
-                      "highlight": "area"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "F_d = \\frac{1}{2}\\rho V^2 C_d A"},
+                    {"id": "F_{d}", "type": "scalar", "latex": "F_{d}", "subexpr": "F_{d}"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{2} \\rho V^{2} A C_{d}"},
+                    {"id": "__power_3", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__num_4", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "\\rho V^{2} A C_{d}"},
+                    {"id": "rho", "type": "scalar", "latex": "\\rho", "subexpr": "\\rho"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "V^{2} A C_{d}"},
+                    {"id": "__power_7", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V^{2}"},
+                    {"id": "V", "type": "scalar", "latex": "V", "subexpr": "V"},
+                    {"id": "__multiply_8", "type": "operator", "op": "multiply", "subexpr": "A C_{d}"},
+                    {"id": "C_{d}", "type": "scalar", "latex": "C_{d}", "subexpr": "C_{d}"},
+                    {"id": "A", "type": "scalar", "latex": "A", "subexpr": "A", "description": "Parachute Area", "color": "cyan", "highlight": "area"}
                   ],
                   "edges": [
-                    {
-                      "from": "F_{d}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "__num_4",
-                      "to": "__power_3"
-                    },
-                    {
-                      "from": "__power_3",
-                      "to": "__multiply_2"
-                    },
-                    {
-                      "from": "rho",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V",
-                      "to": "__power_7"
-                    },
-                    {
-                      "from": "__power_7",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "C_{d}",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "A",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_8",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_6",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_5",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "F_{d}", "to": "__equals_1"},
+                    {"from": "__num_4", "to": "__power_3"},
+                    {"from": "__power_3", "to": "__multiply_2"},
+                    {"from": "rho", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "V", "to": "__power_7"},
+                    {"from": "__power_7", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "C_{d}", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "A", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_8", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_6", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_5", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -14092,70 +4607,21 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "a",
-                      "type": "scalar",
-                      "latex": "a",
-                      "subexpr": "a"
-                    },
-                    {
-                      "id": "s1___num_1",
-                      "type": "number",
-                      "label": "0",
-                      "subexpr": "0"
-                    },
-                    {
-                      "id": "F_{\\text{net}}",
-                      "type": "scalar",
-                      "latex": "F_{\\text{net}}",
-                      "subexpr": "F_{\\text{net}}"
-                    },
-                    {
-                      "id": "s1___implies_2",
-                      "type": "operator",
-                      "label": "implies",
-                      "emoji": "⟹",
-                      "op": "implies",
-                      "subexpr": "0 \\quad \\Longrightarrow \\quad F_{\\text{net}}"
-                    },
-                    {
-                      "id": "s2___num_1",
-                      "type": "number",
-                      "label": "0",
-                      "subexpr": "0"
-                    },
-                    {
-                      "id": "__equals_1",
-                      "type": "operator",
-                      "op": "equals",
-                      "subexpr": "a = 0 \\quad \\Longrightarrow \\quad F_{\\text{net}} = 0"
-                    }
+                    {"id": "a", "type": "scalar", "latex": "a", "subexpr": "a"},
+                    {"id": "s1___num_1", "type": "number", "label": "0", "subexpr": "0"},
+                    {"id": "F_{\\text{net}}", "type": "scalar", "latex": "F_{\\text{net}}", "subexpr": "F_{\\text{net}}"},
+                    {"id": "s1___implies_2", "type": "operator", "label": "implies", "emoji": "⟹", "op": "implies", "subexpr": "0 \\quad \\Longrightarrow \\quad F_{\\text{net}}"},
+                    {"id": "s2___num_1", "type": "number", "label": "0", "subexpr": "0"},
+                    {"id": "__equals_1", "type": "operator", "op": "equals", "subexpr": "a = 0 \\quad \\Longrightarrow \\quad F_{\\text{net}} = 0"}
                   ],
                   "edges": [
-                    {
-                      "from": "s1___num_1",
-                      "to": "s1___implies_2"
-                    },
-                    {
-                      "from": "F_{\\text{net}}",
-                      "to": "s1___implies_2"
-                    },
-                    {
-                      "from": "a",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "s1___implies_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "s2___num_1",
-                      "to": "__equals_1"
-                    }
+                    {"from": "s1___num_1", "to": "s1___implies_2"},
+                    {"from": "F_{\\text{net}}", "to": "s1___implies_2"},
+                    {"from": "a", "to": "__equals_1"},
+                    {"from": "s1___implies_2", "to": "__equals_1"},
+                    {"from": "s2___num_1", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -14171,38 +4637,15 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "F_g = F_d"
-                    },
-                    {
-                      "id": "F_{g}",
-                      "type": "scalar",
-                      "latex": "F_{g}",
-                      "subexpr": "F_{g}"
-                    },
-                    {
-                      "id": "F_{d}",
-                      "type": "scalar",
-                      "latex": "F_{d}",
-                      "subexpr": "F_{d}"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "F_g = F_d"},
+                    {"id": "F_{g}", "type": "scalar", "latex": "F_{g}", "subexpr": "F_{g}"},
+                    {"id": "F_{d}", "type": "scalar", "latex": "F_{d}", "subexpr": "F_{d}"}
                   ],
                   "edges": [
-                    {
-                      "from": "F_{g}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "F_{d}",
-                      "to": "__equals_1"
-                    }
+                    {"from": "F_{g}", "to": "__equals_1"},
+                    {"from": "F_{d}", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -14214,191 +4657,45 @@
               "explanation": "Now the physics has turned into an algebra problem.",
               "sceneStep": 2,
               "highlights": {
-                "area": {
-                  "color": "cyan",
-                  "label": "Parachute Area"
-                }
+                "area": {"color": "cyan", "label": "Parachute Area"}
               },
               "prompt": "Tell the student this is the key equation for the whole derivation.",
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "mg = \\frac{1}{2}\\rho V_t^2 C_d A"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "m g"
-                    },
-                    {
-                      "id": "m",
-                      "type": "scalar",
-                      "latex": "m",
-                      "subexpr": "m"
-                    },
-                    {
-                      "id": "g",
-                      "type": "scalar",
-                      "latex": "g",
-                      "subexpr": "g"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{2} \\rho V_{t}^{2} A C_{d}"
-                    },
-                    {
-                      "id": "__power_4",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{2}"
-                    },
-                    {
-                      "id": "__num_5",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "__multiply_6",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho V_{t}^{2} A C_{d}"
-                    },
-                    {
-                      "id": "rho",
-                      "type": "scalar",
-                      "latex": "\\rho",
-                      "subexpr": "\\rho"
-                    },
-                    {
-                      "id": "__multiply_7",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{t}^{2} A C_{d}"
-                    },
-                    {
-                      "id": "__power_8",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V_{t}^{2}"
-                    },
-                    {
-                      "id": "V_{t}",
-                      "type": "scalar",
-                      "latex": "V_{t}",
-                      "subexpr": "V_{t}"
-                    },
-                    {
-                      "id": "__multiply_9",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "A C_{d}"
-                    },
-                    {
-                      "id": "C_{d}",
-                      "type": "scalar",
-                      "latex": "C_{d}",
-                      "subexpr": "C_{d}"
-                    },
-                    {
-                      "id": "A",
-                      "type": "scalar",
-                      "latex": "A",
-                      "subexpr": "A",
-                      "description": "Parachute Area",
-                      "color": "cyan",
-                      "highlight": "area"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "mg = \\frac{1}{2}\\rho V_t^2 C_d A"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "m g"},
+                    {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m"},
+                    {"id": "g", "type": "scalar", "latex": "g", "subexpr": "g"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{2} \\rho V_{t}^{2} A C_{d}"},
+                    {"id": "__power_4", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__num_5", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "\\rho V_{t}^{2} A C_{d}"},
+                    {"id": "rho", "type": "scalar", "latex": "\\rho", "subexpr": "\\rho"},
+                    {"id": "__multiply_7", "type": "operator", "op": "multiply", "subexpr": "V_{t}^{2} A C_{d}"},
+                    {"id": "__power_8", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V_{t}^{2}"},
+                    {"id": "V_{t}", "type": "scalar", "latex": "V_{t}", "subexpr": "V_{t}"},
+                    {"id": "__multiply_9", "type": "operator", "op": "multiply", "subexpr": "A C_{d}"},
+                    {"id": "C_{d}", "type": "scalar", "latex": "C_{d}", "subexpr": "C_{d}"},
+                    {"id": "A", "type": "scalar", "latex": "A", "subexpr": "A", "description": "Parachute Area", "color": "cyan", "highlight": "area"}
                   ],
                   "edges": [
-                    {
-                      "from": "m",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "g",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "__num_5",
-                      "to": "__power_4"
-                    },
-                    {
-                      "from": "__power_4",
-                      "to": "__multiply_3"
-                    },
-                    {
-                      "from": "rho",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V_{t}",
-                      "to": "__power_8"
-                    },
-                    {
-                      "from": "__power_8",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "C_{d}",
-                      "to": "__multiply_9",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "A",
-                      "to": "__multiply_9",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_9",
-                      "to": "__multiply_7",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_7",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_6",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__equals_1"
-                    }
+                    {"from": "m", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "g", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_2", "to": "__equals_1"},
+                    {"from": "__num_5", "to": "__power_4"},
+                    {"from": "__power_4", "to": "__multiply_3"},
+                    {"from": "rho", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "V_{t}", "to": "__power_8"},
+                    {"from": "__power_8", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "C_{d}", "to": "__multiply_9", "semantic": "direct", "weight": 1.0},
+                    {"from": "A", "to": "__multiply_9", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_9", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_7", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_6", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_3", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -14410,181 +4707,43 @@
               "explanation": "This removes the fraction and makes the next algebra step easier to see.",
               "sceneStep": 2,
               "highlights": {
-                "area": {
-                  "color": "cyan",
-                  "label": "Parachute Area"
-                }
+                "area": {"color": "cyan", "label": "Parachute Area"}
               },
               "prompt": "Explain that we are simplifying the equation one small move at a time.",
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "2mg = \\rho V_t^2 C_d A"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "2 m g"
-                    },
-                    {
-                      "id": "__num_3",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "__multiply_4",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "m g"
-                    },
-                    {
-                      "id": "m",
-                      "type": "scalar",
-                      "latex": "m",
-                      "subexpr": "m"
-                    },
-                    {
-                      "id": "g",
-                      "type": "scalar",
-                      "latex": "g",
-                      "subexpr": "g"
-                    },
-                    {
-                      "id": "__multiply_5",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho V_{t}^{2} A C_{d}"
-                    },
-                    {
-                      "id": "rho",
-                      "type": "scalar",
-                      "latex": "\\rho",
-                      "subexpr": "\\rho"
-                    },
-                    {
-                      "id": "__multiply_6",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{t}^{2} A C_{d}"
-                    },
-                    {
-                      "id": "__power_7",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V_{t}^{2}"
-                    },
-                    {
-                      "id": "V_{t}",
-                      "type": "scalar",
-                      "latex": "V_{t}",
-                      "subexpr": "V_{t}"
-                    },
-                    {
-                      "id": "__multiply_8",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "A C_{d}"
-                    },
-                    {
-                      "id": "C_{d}",
-                      "type": "scalar",
-                      "latex": "C_{d}",
-                      "subexpr": "C_{d}"
-                    },
-                    {
-                      "id": "A",
-                      "type": "scalar",
-                      "latex": "A",
-                      "subexpr": "A",
-                      "description": "Parachute Area",
-                      "color": "cyan",
-                      "highlight": "area"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "2mg = \\rho V_t^2 C_d A"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "2 m g"},
+                    {"id": "__num_3", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__multiply_4", "type": "operator", "op": "multiply", "subexpr": "m g"},
+                    {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m"},
+                    {"id": "g", "type": "scalar", "latex": "g", "subexpr": "g"},
+                    {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "\\rho V_{t}^{2} A C_{d}"},
+                    {"id": "rho", "type": "scalar", "latex": "\\rho", "subexpr": "\\rho"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "V_{t}^{2} A C_{d}"},
+                    {"id": "__power_7", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V_{t}^{2}"},
+                    {"id": "V_{t}", "type": "scalar", "latex": "V_{t}", "subexpr": "V_{t}"},
+                    {"id": "__multiply_8", "type": "operator", "op": "multiply", "subexpr": "A C_{d}"},
+                    {"id": "C_{d}", "type": "scalar", "latex": "C_{d}", "subexpr": "C_{d}"},
+                    {"id": "A", "type": "scalar", "latex": "A", "subexpr": "A", "description": "Parachute Area", "color": "cyan", "highlight": "area"}
                   ],
                   "edges": [
-                    {
-                      "from": "__num_3",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "m",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "g",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_4",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "rho",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "V_{t}",
-                      "to": "__power_7"
-                    },
-                    {
-                      "from": "__power_7",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "C_{d}",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "A",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_8",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_6",
-                      "to": "__multiply_5",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_5",
-                      "to": "__equals_1"
-                    }
+                    {"from": "__num_3", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "m", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "g", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_4", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_2", "to": "__equals_1"},
+                    {"from": "rho", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "V_{t}", "to": "__power_7"},
+                    {"from": "__power_7", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "C_{d}", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "A", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_8", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_6", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_5", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -14596,191 +4755,45 @@
               "explanation": "The area $A$ ends up in the denominator, which matches intuition: a larger parachute gives a lower terminal speed.",
               "sceneStep": 2,
               "highlights": {
-                "area": {
-                  "color": "cyan",
-                  "label": "Parachute Area"
-                }
+                "area": {"color": "cyan", "label": "Parachute Area"}
               },
               "prompt": "Use the phrase 'get $V_t^2$ alone' so the algebra feels mechanical and safe.",
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "V_t^2 = \\frac{2mg}{\\rho C_d A}"
-                    },
-                    {
-                      "id": "__power_2",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "2",
-                      "subexpr": "V_{t}^{2}"
-                    },
-                    {
-                      "id": "V_{t}",
-                      "type": "scalar",
-                      "latex": "V_{t}",
-                      "subexpr": "V_{t}"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "2 m g \\frac{1}{\\rho A C_{d}}"
-                    },
-                    {
-                      "id": "__multiply_4",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "2 m g"
-                    },
-                    {
-                      "id": "__num_5",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "__multiply_6",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "m g"
-                    },
-                    {
-                      "id": "m",
-                      "type": "scalar",
-                      "latex": "m",
-                      "subexpr": "m"
-                    },
-                    {
-                      "id": "g",
-                      "type": "scalar",
-                      "latex": "g",
-                      "subexpr": "g"
-                    },
-                    {
-                      "id": "__power_7",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\rho A C_{d}}"
-                    },
-                    {
-                      "id": "__multiply_8",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho A C_{d}"
-                    },
-                    {
-                      "id": "rho",
-                      "type": "scalar",
-                      "latex": "\\rho",
-                      "subexpr": "\\rho"
-                    },
-                    {
-                      "id": "__multiply_9",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "A C_{d}"
-                    },
-                    {
-                      "id": "C_{d}",
-                      "type": "scalar",
-                      "latex": "C_{d}",
-                      "subexpr": "C_{d}"
-                    },
-                    {
-                      "id": "A",
-                      "type": "scalar",
-                      "latex": "A",
-                      "subexpr": "A",
-                      "description": "Parachute Area",
-                      "color": "cyan",
-                      "highlight": "area"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "V_t^2 = \\frac{2mg}{\\rho C_d A}"},
+                    {"id": "__power_2", "type": "operator", "op": "power", "exponent": "2", "subexpr": "V_{t}^{2}"},
+                    {"id": "V_{t}", "type": "scalar", "latex": "V_{t}", "subexpr": "V_{t}"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "2 m g \\frac{1}{\\rho A C_{d}}"},
+                    {"id": "__multiply_4", "type": "operator", "op": "multiply", "subexpr": "2 m g"},
+                    {"id": "__num_5", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "m g"},
+                    {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m"},
+                    {"id": "g", "type": "scalar", "latex": "g", "subexpr": "g"},
+                    {"id": "__power_7", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\rho A C_{d}}"},
+                    {"id": "__multiply_8", "type": "operator", "op": "multiply", "subexpr": "\\rho A C_{d}"},
+                    {"id": "rho", "type": "scalar", "latex": "\\rho", "subexpr": "\\rho"},
+                    {"id": "__multiply_9", "type": "operator", "op": "multiply", "subexpr": "A C_{d}"},
+                    {"id": "C_{d}", "type": "scalar", "latex": "C_{d}", "subexpr": "C_{d}"},
+                    {"id": "A", "type": "scalar", "latex": "A", "subexpr": "A", "description": "Parachute Area", "color": "cyan", "highlight": "area"}
                   ],
                   "edges": [
-                    {
-                      "from": "V_{t}",
-                      "to": "__power_2"
-                    },
-                    {
-                      "from": "__power_2",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "__num_5",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "m",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "g",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_6",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_4",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "rho",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "C_{d}",
-                      "to": "__multiply_9",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "A",
-                      "to": "__multiply_9",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_9",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_8",
-                      "to": "__power_7"
-                    },
-                    {
-                      "from": "__power_7",
-                      "to": "__multiply_3"
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__equals_1"
-                    }
+                    {"from": "V_{t}", "to": "__power_2"},
+                    {"from": "__power_2", "to": "__equals_1"},
+                    {"from": "__num_5", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "m", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "g", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_6", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "rho", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "C_{d}", "to": "__multiply_9", "semantic": "direct", "weight": 1.0},
+                    {"from": "A", "to": "__multiply_9", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_9", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_8", "to": "__power_7"},
+                    {"from": "__power_7", "to": "__multiply_3"},
+                    {"from": "__multiply_3", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -14792,198 +4805,46 @@
               "explanation": "The final formula shows the tradeoff clearly: more mass raises terminal speed, while denser air, more drag, or a larger parachute lower it.",
               "sceneStep": 2,
               "highlights": {
-                "vt": {
-                  "color": "green",
-                  "label": "Terminal Velocity"
-                },
-                "area": {
-                  "color": "cyan",
-                  "label": "Parachute Area"
-                }
+                "vt": {"color": "green", "label": "Terminal Velocity"},
+                "area": {"color": "cyan", "label": "Parachute Area"}
               },
               "prompt": "End by connecting back to splashdown: reducing $V_t$ makes the water impact gentler.",
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "V_t = \\sqrt{\\frac{2mg}{\\rho C_d A}}"
-                    },
-                    {
-                      "id": "V_{t}",
-                      "type": "scalar",
-                      "latex": "V_{t}",
-                      "subexpr": "V_{t}",
-                      "description": "Terminal Velocity",
-                      "color": "green",
-                      "highlight": "vt"
-                    },
-                    {
-                      "id": "__power_2",
-                      "type": "operator",
-                      "op": "power",
-                      "exponent": "1/2",
-                      "subexpr": "\\sqrt{\\frac{2 g m}{\\rho A C_{d}}}"
-                    },
-                    {
-                      "id": "__multiply_3",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "2 m g \\frac{1}{\\rho A C_{d}}"
-                    },
-                    {
-                      "id": "__multiply_4",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "2 m g"
-                    },
-                    {
-                      "id": "__num_5",
-                      "type": "number",
-                      "label": "2",
-                      "subexpr": "2"
-                    },
-                    {
-                      "id": "__multiply_6",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "m g"
-                    },
-                    {
-                      "id": "m",
-                      "type": "scalar",
-                      "latex": "m",
-                      "subexpr": "m"
-                    },
-                    {
-                      "id": "g",
-                      "type": "scalar",
-                      "latex": "g",
-                      "subexpr": "g"
-                    },
-                    {
-                      "id": "__power_7",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{\\rho A C_{d}}"
-                    },
-                    {
-                      "id": "__multiply_8",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\rho A C_{d}"
-                    },
-                    {
-                      "id": "rho",
-                      "type": "scalar",
-                      "latex": "\\rho",
-                      "subexpr": "\\rho"
-                    },
-                    {
-                      "id": "__multiply_9",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "A C_{d}"
-                    },
-                    {
-                      "id": "C_{d}",
-                      "type": "scalar",
-                      "latex": "C_{d}",
-                      "subexpr": "C_{d}"
-                    },
-                    {
-                      "id": "A",
-                      "type": "scalar",
-                      "latex": "A",
-                      "subexpr": "A",
-                      "description": "Parachute Area",
-                      "color": "cyan",
-                      "highlight": "area"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "V_t = \\sqrt{\\frac{2mg}{\\rho C_d A}}"},
+                    {"id": "V_{t}", "type": "scalar", "latex": "V_{t}", "subexpr": "V_{t}", "description": "Terminal Velocity", "color": "green", "highlight": "vt"},
+                    {"id": "__power_2", "type": "operator", "op": "power", "exponent": "1/2", "subexpr": "\\sqrt{\\frac{2 g m}{\\rho A C_{d}}}"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "2 m g \\frac{1}{\\rho A C_{d}}"},
+                    {"id": "__multiply_4", "type": "operator", "op": "multiply", "subexpr": "2 m g"},
+                    {"id": "__num_5", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "m g"},
+                    {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m"},
+                    {"id": "g", "type": "scalar", "latex": "g", "subexpr": "g"},
+                    {"id": "__power_7", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{\\rho A C_{d}}"},
+                    {"id": "__multiply_8", "type": "operator", "op": "multiply", "subexpr": "\\rho A C_{d}"},
+                    {"id": "rho", "type": "scalar", "latex": "\\rho", "subexpr": "\\rho"},
+                    {"id": "__multiply_9", "type": "operator", "op": "multiply", "subexpr": "A C_{d}"},
+                    {"id": "C_{d}", "type": "scalar", "latex": "C_{d}", "subexpr": "C_{d}"},
+                    {"id": "A", "type": "scalar", "latex": "A", "subexpr": "A", "description": "Parachute Area", "color": "cyan", "highlight": "area"}
                   ],
                   "edges": [
-                    {
-                      "from": "V_{t}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "__num_5",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "m",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "g",
-                      "to": "__multiply_6",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_6",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_4",
-                      "to": "__multiply_3",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "rho",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "C_{d}",
-                      "to": "__multiply_9",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "A",
-                      "to": "__multiply_9",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_9",
-                      "to": "__multiply_8",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_8",
-                      "to": "__power_7"
-                    },
-                    {
-                      "from": "__power_7",
-                      "to": "__multiply_3"
-                    },
-                    {
-                      "from": "__multiply_3",
-                      "to": "__power_2"
-                    },
-                    {
-                      "from": "__power_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "V_{t}", "to": "__equals_1"},
+                    {"from": "__num_5", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "m", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "g", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_6", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "rho", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "C_{d}", "to": "__multiply_9", "semantic": "direct", "weight": 1.0},
+                    {"from": "A", "to": "__multiply_9", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_9", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_8", "to": "__power_7"},
+                    {"from": "__power_7", "to": "__multiply_3"},
+                    {"from": "__multiply_3", "to": "__power_2"},
+                    {"from": "__power_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             }
@@ -15005,50 +4866,21 @@
               "explanation": "This is the speed we derived in the terminal velocity proof — the starting condition for the water impact.",
               "sceneStep": 3,
               "highlights": {
-                "vt": {
-                  "color": "green",
-                  "label": "Terminal Velocity"
-                }
+                "vt": {"color": "green", "label": "Terminal Velocity"}
               },
               "prompt": "Remind the student that V_t depends on mass, chute area, and drag coefficient.",
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "V_i = V_t"
-                    },
-                    {
-                      "id": "V_{i}",
-                      "type": "scalar",
-                      "latex": "V_{i}",
-                      "subexpr": "V_{i}"
-                    },
-                    {
-                      "id": "V_{t}",
-                      "type": "scalar",
-                      "latex": "V_{t}",
-                      "subexpr": "V_{t}",
-                      "description": "Terminal Velocity",
-                      "color": "green",
-                      "highlight": "vt"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "V_i = V_t"},
+                    {"id": "V_{i}", "type": "scalar", "latex": "V_{i}", "subexpr": "V_{i}"},
+                    {"id": "V_{t}", "type": "scalar", "latex": "V_{t}", "subexpr": "V_{t}", "description": "Terminal Velocity", "color": "green", "highlight": "vt"}
                   ],
                   "edges": [
-                    {
-                      "from": "V_{i}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "V_{t}",
-                      "to": "__equals_1"
-                    }
+                    {"from": "V_{i}", "to": "__equals_1"},
+                    {"from": "V_{t}", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -15064,38 +4896,15 @@
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "V_f = 0"
-                    },
-                    {
-                      "id": "V_{f}",
-                      "type": "scalar",
-                      "latex": "V_{f}",
-                      "subexpr": "V_{f}"
-                    },
-                    {
-                      "id": "__num_2",
-                      "type": "number",
-                      "label": "0",
-                      "subexpr": "0"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "V_f = 0"},
+                    {"id": "V_{f}", "type": "scalar", "latex": "V_{f}", "subexpr": "V_{f}"},
+                    {"id": "__num_2", "type": "number", "label": "0", "subexpr": "0"}
                   ],
                   "edges": [
-                    {
-                      "from": "V_{f}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "__num_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "V_{f}", "to": "__equals_1"},
+                    {"from": "__num_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -15107,148 +4916,40 @@
               "explanation": "This is the kinematic definition — it tells us the average deceleration the crew experiences.",
               "sceneStep": 3,
               "highlights": {
-                "dt": {
-                  "color": "orange",
-                  "label": "Stop Time"
-                }
+                "dt": {"color": "orange", "label": "Stop Time"}
               },
               "prompt": "Point out that a shorter time interval means a larger acceleration.",
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "a",
-                      "type": "scalar",
-                      "latex": "\\bar{a}",
-                      "subexpr": "\\bar{a}"
-                    },
-                    {
-                      "id": "s1___multiply_1",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{\\Delta V}{\\Delta t}"
-                    },
-                    {
-                      "id": "Delta V",
-                      "type": "scalar",
-                      "latex": "\\Delta V",
-                      "subexpr": "\\Delta V"
-                    },
-                    {
-                      "id": "s1___power_2",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{{\\Delta t}}"
-                    },
-                    {
-                      "id": "Delta t",
-                      "type": "scalar",
-                      "latex": "\\Delta t",
-                      "subexpr": "\\Delta t",
-                      "description": "Stop Time",
-                      "color": "orange",
-                      "highlight": "dt"
-                    },
-                    {
-                      "id": "s2___multiply_1",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{V_f - V_i}{\\Delta t}"
-                    },
-                    {
-                      "id": "s2___add_2",
-                      "type": "operator",
-                      "op": "add",
-                      "subexpr": "V_{f} - V_{i}"
-                    },
-                    {
-                      "id": "V_{f}",
-                      "type": "scalar",
-                      "latex": "V_{f}",
-                      "subexpr": "V_{f}"
-                    },
-                    {
-                      "id": "s2___negation_3",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-V_{i}"
-                    },
-                    {
-                      "id": "V_{i}",
-                      "type": "scalar",
-                      "latex": "V_{i}",
-                      "subexpr": "V_{i}"
-                    },
-                    {
-                      "id": "s2___power_4",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{{\\Delta t}}"
-                    },
-                    {
-                      "id": "__equals_1",
-                      "type": "operator",
-                      "op": "equals",
-                      "subexpr": "\\bar{a} = \\frac{\\Delta V}{\\Delta t} = \\frac{V_f - V_i}{\\Delta t}"
-                    }
+                    {"id": "a", "type": "scalar", "latex": "\\bar{a}", "subexpr": "\\bar{a}"},
+                    {"id": "s1___multiply_1", "type": "operator", "op": "multiply", "subexpr": "\\frac{\\Delta V}{\\Delta t}"},
+                    {"id": "Delta V", "type": "scalar", "latex": "\\Delta V", "subexpr": "\\Delta V"},
+                    {"id": "s1___power_2", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{{\\Delta t}}"},
+                    {"id": "Delta t", "type": "scalar", "latex": "\\Delta t", "subexpr": "\\Delta t", "description": "Stop Time", "color": "orange", "highlight": "dt"},
+                    {"id": "s2___multiply_1", "type": "operator", "op": "multiply", "subexpr": "\\frac{V_f - V_i}{\\Delta t}"},
+                    {"id": "s2___add_2", "type": "operator", "op": "add", "subexpr": "V_{f} - V_{i}"},
+                    {"id": "V_{f}", "type": "scalar", "latex": "V_{f}", "subexpr": "V_{f}"},
+                    {"id": "s2___negation_3", "type": "operator", "op": "negation", "subexpr": "-V_{i}"},
+                    {"id": "V_{i}", "type": "scalar", "latex": "V_{i}", "subexpr": "V_{i}"},
+                    {"id": "s2___power_4", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{{\\Delta t}}"},
+                    {"id": "__equals_1", "type": "operator", "op": "equals", "subexpr": "\\bar{a} = \\frac{\\Delta V}{\\Delta t} = \\frac{V_f - V_i}{\\Delta t}"}
                   ],
                   "edges": [
-                    {
-                      "from": "Delta V",
-                      "to": "s1___multiply_1"
-                    },
-                    {
-                      "from": "Delta t",
-                      "to": "s1___power_2"
-                    },
-                    {
-                      "from": "s1___power_2",
-                      "to": "s1___multiply_1"
-                    },
-                    {
-                      "from": "V_{f}",
-                      "to": "s2___add_2"
-                    },
-                    {
-                      "from": "V_{i}",
-                      "to": "s2___negation_3"
-                    },
-                    {
-                      "from": "s2___negation_3",
-                      "to": "s2___add_2"
-                    },
-                    {
-                      "from": "s2___add_2",
-                      "to": "s2___multiply_1"
-                    },
-                    {
-                      "from": "Delta t",
-                      "to": "s2___power_4"
-                    },
-                    {
-                      "from": "s2___power_4",
-                      "to": "s2___multiply_1"
-                    },
-                    {
-                      "from": "a",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "s1___multiply_1",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "s2___multiply_1",
-                      "to": "__equals_1"
-                    }
+                    {"from": "Delta V", "to": "s1___multiply_1"},
+                    {"from": "Delta t", "to": "s1___power_2"},
+                    {"from": "s1___power_2", "to": "s1___multiply_1"},
+                    {"from": "V_{f}", "to": "s2___add_2"},
+                    {"from": "V_{i}", "to": "s2___negation_3"},
+                    {"from": "s2___negation_3", "to": "s2___add_2"},
+                    {"from": "s2___add_2", "to": "s2___multiply_1"},
+                    {"from": "Delta t", "to": "s2___power_4"},
+                    {"from": "s2___power_4", "to": "s2___multiply_1"},
+                    {"from": "a", "to": "__equals_1"},
+                    {"from": "s1___multiply_1", "to": "__equals_1"},
+                    {"from": "s2___multiply_1", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -15260,159 +4961,42 @@
               "explanation": "The negative sign means deceleration (slowing down). We care about the magnitude.",
               "sceneStep": 3,
               "highlights": {
-                "vt": {
-                  "color": "green",
-                  "label": "Terminal Velocity"
-                },
-                "dt": {
-                  "color": "orange",
-                  "label": "Stop Time"
-                }
+                "vt": {"color": "green", "label": "Terminal Velocity"},
+                "dt": {"color": "orange", "label": "Stop Time"}
               },
               "prompt": "Explain that the minus sign just means slowing down, and we take the absolute value.",
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "a",
-                      "type": "scalar",
-                      "latex": "\\bar{a}",
-                      "subexpr": "\\bar{a}"
-                    },
-                    {
-                      "id": "s1___multiply_1",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{0 - V_t}{\\Delta t}"
-                    },
-                    {
-                      "id": "s1___add_2",
-                      "type": "operator",
-                      "op": "add",
-                      "subexpr": "-V_{t} + 0"
-                    },
-                    {
-                      "id": "s1___num_3",
-                      "type": "number",
-                      "label": "0",
-                      "subexpr": "0"
-                    },
-                    {
-                      "id": "s1___negation_4",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-V_{t}"
-                    },
-                    {
-                      "id": "V_{t}",
-                      "type": "scalar",
-                      "latex": "V_{t}",
-                      "subexpr": "V_{t}",
-                      "description": "Terminal Velocity",
-                      "color": "green",
-                      "highlight": "vt"
-                    },
-                    {
-                      "id": "s1___power_5",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{{\\Delta t}}"
-                    },
-                    {
-                      "id": "Delta t",
-                      "type": "scalar",
-                      "latex": "\\Delta t",
-                      "subexpr": "\\Delta t",
-                      "description": "Stop Time",
-                      "color": "orange",
-                      "highlight": "dt"
-                    },
-                    {
-                      "id": "s2___negation_1",
-                      "type": "operator",
-                      "op": "negation",
-                      "subexpr": "-\\frac{V_t}{\\Delta t}"
-                    },
-                    {
-                      "id": "s2___multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{t} \\frac{1}{{\\Delta t}}"
-                    },
-                    {
-                      "id": "s2___power_3",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{{\\Delta t}}"
-                    },
-                    {
-                      "id": "__equals_1",
-                      "type": "operator",
-                      "op": "equals",
-                      "subexpr": "\\bar{a} = \\frac{0 - V_t}{\\Delta t} = -\\frac{V_t}{\\Delta t}"
-                    }
+                    {"id": "a", "type": "scalar", "latex": "\\bar{a}", "subexpr": "\\bar{a}"},
+                    {"id": "s1___multiply_1", "type": "operator", "op": "multiply", "subexpr": "\\frac{0 - V_t}{\\Delta t}"},
+                    {"id": "s1___add_2", "type": "operator", "op": "add", "subexpr": "-V_{t} + 0"},
+                    {"id": "s1___num_3", "type": "number", "label": "0", "subexpr": "0"},
+                    {"id": "s1___negation_4", "type": "operator", "op": "negation", "subexpr": "-V_{t}"},
+                    {"id": "V_{t}", "type": "scalar", "latex": "V_{t}", "subexpr": "V_{t}", "description": "Terminal Velocity", "color": "green", "highlight": "vt"},
+                    {"id": "s1___power_5", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{{\\Delta t}}"},
+                    {"id": "Delta t", "type": "scalar", "latex": "\\Delta t", "subexpr": "\\Delta t", "description": "Stop Time", "color": "orange", "highlight": "dt"},
+                    {"id": "s2___negation_1", "type": "operator", "op": "negation", "subexpr": "-\\frac{V_t}{\\Delta t}"},
+                    {"id": "s2___multiply_2", "type": "operator", "op": "multiply", "subexpr": "V_{t} \\frac{1}{{\\Delta t}}"},
+                    {"id": "s2___power_3", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{{\\Delta t}}"},
+                    {"id": "__equals_1", "type": "operator", "op": "equals", "subexpr": "\\bar{a} = \\frac{0 - V_t}{\\Delta t} = -\\frac{V_t}{\\Delta t}"}
                   ],
                   "edges": [
-                    {
-                      "from": "s1___num_3",
-                      "to": "s1___add_2"
-                    },
-                    {
-                      "from": "V_{t}",
-                      "to": "s1___negation_4"
-                    },
-                    {
-                      "from": "s1___negation_4",
-                      "to": "s1___add_2"
-                    },
-                    {
-                      "from": "s1___add_2",
-                      "to": "s1___multiply_1"
-                    },
-                    {
-                      "from": "Delta t",
-                      "to": "s1___power_5"
-                    },
-                    {
-                      "from": "s1___power_5",
-                      "to": "s1___multiply_1"
-                    },
-                    {
-                      "from": "V_{t}",
-                      "to": "s2___multiply_2"
-                    },
-                    {
-                      "from": "Delta t",
-                      "to": "s2___power_3"
-                    },
-                    {
-                      "from": "s2___power_3",
-                      "to": "s2___multiply_2"
-                    },
-                    {
-                      "from": "s2___multiply_2",
-                      "to": "s2___negation_1"
-                    },
-                    {
-                      "from": "a",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "s1___multiply_1",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "s2___negation_1",
-                      "to": "__equals_1"
-                    }
+                    {"from": "s1___num_3", "to": "s1___add_2"},
+                    {"from": "V_{t}", "to": "s1___negation_4"},
+                    {"from": "s1___negation_4", "to": "s1___add_2"},
+                    {"from": "s1___add_2", "to": "s1___multiply_1"},
+                    {"from": "Delta t", "to": "s1___power_5"},
+                    {"from": "s1___power_5", "to": "s1___multiply_1"},
+                    {"from": "V_{t}", "to": "s2___multiply_2"},
+                    {"from": "Delta t", "to": "s2___power_3"},
+                    {"from": "s2___power_3", "to": "s2___multiply_2"},
+                    {"from": "s2___multiply_2", "to": "s2___negation_1"},
+                    {"from": "a", "to": "__equals_1"},
+                    {"from": "s1___multiply_1", "to": "__equals_1"},
+                    {"from": "s2___negation_1", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -15424,91 +5008,28 @@
               "explanation": "Faster arrival speed or shorter stopping time means harsher impact.",
               "sceneStep": 3,
               "highlights": {
-                "vt": {
-                  "color": "green",
-                  "label": "Terminal Velocity"
-                },
-                "dt": {
-                  "color": "orange",
-                  "label": "Stop Time"
-                }
+                "vt": {"color": "green", "label": "Terminal Velocity"},
+                "dt": {"color": "orange", "label": "Stop Time"}
               },
               "prompt": "Use concrete numbers: if V_t = 8 m/s and stop time is 0.5 s, that is 16 m/s².",
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "a_{\\text{impact}} = \\frac{V_t}{\\Delta t}"
-                    },
-                    {
-                      "id": "a_{\\text{impact}}",
-                      "type": "scalar",
-                      "latex": "a_{\\text{impact}}",
-                      "subexpr": "a_{\\text{impact}}"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{t} \\frac{1}{{\\Delta t}}"
-                    },
-                    {
-                      "id": "V_{t}",
-                      "type": "scalar",
-                      "latex": "V_{t}",
-                      "subexpr": "V_{t}",
-                      "description": "Terminal Velocity",
-                      "color": "green",
-                      "highlight": "vt"
-                    },
-                    {
-                      "id": "__power_3",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{{\\Delta t}}"
-                    },
-                    {
-                      "id": "Delta t",
-                      "type": "scalar",
-                      "latex": "\\Delta t",
-                      "subexpr": "\\Delta t",
-                      "description": "Stop Time",
-                      "color": "orange",
-                      "highlight": "dt"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "a_{\\text{impact}} = \\frac{V_t}{\\Delta t}"},
+                    {"id": "a_{\\text{impact}}", "type": "scalar", "latex": "a_{\\text{impact}}", "subexpr": "a_{\\text{impact}}"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "V_{t} \\frac{1}{{\\Delta t}}"},
+                    {"id": "V_{t}", "type": "scalar", "latex": "V_{t}", "subexpr": "V_{t}", "description": "Terminal Velocity", "color": "green", "highlight": "vt"},
+                    {"id": "__power_3", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{{\\Delta t}}"},
+                    {"id": "Delta t", "type": "scalar", "latex": "\\Delta t", "subexpr": "\\Delta t", "description": "Stop Time", "color": "orange", "highlight": "dt"}
                   ],
                   "edges": [
-                    {
-                      "from": "a_{\\text{impact}}",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "V_{t}",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "Delta t",
-                      "to": "__power_3"
-                    },
-                    {
-                      "from": "__power_3",
-                      "to": "__multiply_2"
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "a_{\\text{impact}}", "to": "__equals_1"},
+                    {"from": "V_{t}", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "Delta t", "to": "__power_3"},
+                    {"from": "__power_3", "to": "__multiply_2"},
+                    {"from": "__multiply_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -15520,84 +5041,27 @@
               "explanation": "Astronauts and engineers think in g-loads — 1g is normal gravity, 3g is uncomfortable, 10g+ is dangerous.",
               "sceneStep": 3,
               "highlights": {
-                "n": {
-                  "color": "yellow",
-                  "label": "Load Factor"
-                }
+                "n": {"color": "yellow", "label": "Load Factor"}
               },
               "prompt": "Compare to everyday examples: a roller coaster is about 3-4g, fighter pilots experience up to 9g.",
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "n = \\frac{a_{\\text{impact}}}{g}"
-                    },
-                    {
-                      "id": "n",
-                      "type": "scalar",
-                      "latex": "n",
-                      "subexpr": "n",
-                      "description": "Load Factor",
-                      "color": "yellow",
-                      "highlight": "n"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "\\frac{1}{g} a_{\\text{impact}}"
-                    },
-                    {
-                      "id": "a_{\\text{impact}}",
-                      "type": "scalar",
-                      "latex": "a_{\\text{impact}}",
-                      "subexpr": "a_{\\text{impact}}"
-                    },
-                    {
-                      "id": "__power_3",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{g}"
-                    },
-                    {
-                      "id": "g",
-                      "type": "scalar",
-                      "latex": "g",
-                      "subexpr": "g"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "n = \\frac{a_{\\text{impact}}}{g}"},
+                    {"id": "n", "type": "scalar", "latex": "n", "subexpr": "n", "description": "Load Factor", "color": "yellow", "highlight": "n"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\frac{1}{g} a_{\\text{impact}}"},
+                    {"id": "a_{\\text{impact}}", "type": "scalar", "latex": "a_{\\text{impact}}", "subexpr": "a_{\\text{impact}}"},
+                    {"id": "__power_3", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{g}"},
+                    {"id": "g", "type": "scalar", "latex": "g", "subexpr": "g"}
                   ],
                   "edges": [
-                    {
-                      "from": "n",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "a_{\\text{impact}}",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "g",
-                      "to": "__power_3"
-                    },
-                    {
-                      "from": "__power_3",
-                      "to": "__multiply_2"
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "n", "to": "__equals_1"},
+                    {"from": "a_{\\text{impact}}", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "g", "to": "__power_3"},
+                    {"from": "__power_3", "to": "__multiply_2"},
+                    {"from": "__multiply_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             },
@@ -15609,122 +5073,33 @@
               "explanation": "A lower terminal velocity (bigger chute) or a longer stopping time (softer water entry) reduces the g-load on the crew.",
               "sceneStep": 3,
               "highlights": {
-                "n": {
-                  "color": "yellow",
-                  "label": "Load Factor"
-                },
-                "vt": {
-                  "color": "green",
-                  "label": "Terminal Velocity"
-                },
-                "dt": {
-                  "color": "orange",
-                  "label": "Stop Time"
-                }
+                "n": {"color": "yellow", "label": "Load Factor"},
+                "vt": {"color": "green", "label": "Terminal Velocity"},
+                "dt": {"color": "orange", "label": "Stop Time"}
               },
               "prompt": "Connect back to design: this is why capsules have crushable structures and why landing in water is gentler than land.",
               "semanticGraph": {
                 "graph": {
                   "nodes": [
-                    {
-                      "id": "__equals_1",
-                      "type": "relation",
-                      "op": "equals",
-                      "subexpr": "n = \\frac{V_t}{g\\,\\Delta t}"
-                    },
-                    {
-                      "id": "n",
-                      "type": "scalar",
-                      "latex": "n",
-                      "subexpr": "n",
-                      "description": "Load Factor",
-                      "color": "yellow",
-                      "highlight": "n"
-                    },
-                    {
-                      "id": "__multiply_2",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "V_{t} \\frac{1}{{\\Delta t} g}"
-                    },
-                    {
-                      "id": "V_{t}",
-                      "type": "scalar",
-                      "latex": "V_{t}",
-                      "subexpr": "V_{t}",
-                      "description": "Terminal Velocity",
-                      "color": "green",
-                      "highlight": "vt"
-                    },
-                    {
-                      "id": "__power_3",
-                      "type": "operator",
-                      "latex": "\\dfrac{1}{(\\cdot)}",
-                      "op": "power",
-                      "exponent": "-1",
-                      "subexpr": "\\frac{1}{{\\Delta t} g}"
-                    },
-                    {
-                      "id": "__multiply_4",
-                      "type": "operator",
-                      "op": "multiply",
-                      "subexpr": "g \\Delta t"
-                    },
-                    {
-                      "id": "g",
-                      "type": "scalar",
-                      "latex": "g",
-                      "subexpr": "g"
-                    },
-                    {
-                      "id": "Delta t",
-                      "type": "scalar",
-                      "latex": "\\Delta t",
-                      "subexpr": "\\Delta t",
-                      "description": "Stop Time",
-                      "color": "orange",
-                      "highlight": "dt"
-                    }
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "n = \\frac{V_t}{g\\,\\Delta t}"},
+                    {"id": "n", "type": "scalar", "latex": "n", "subexpr": "n", "description": "Load Factor", "color": "yellow", "highlight": "n"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "V_{t} \\frac{1}{{\\Delta t} g}"},
+                    {"id": "V_{t}", "type": "scalar", "latex": "V_{t}", "subexpr": "V_{t}", "description": "Terminal Velocity", "color": "green", "highlight": "vt"},
+                    {"id": "__power_3", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{{\\Delta t} g}"},
+                    {"id": "__multiply_4", "type": "operator", "op": "multiply", "subexpr": "g \\Delta t"},
+                    {"id": "g", "type": "scalar", "latex": "g", "subexpr": "g"},
+                    {"id": "Delta t", "type": "scalar", "latex": "\\Delta t", "subexpr": "\\Delta t", "description": "Stop Time", "color": "orange", "highlight": "dt"}
                   ],
                   "edges": [
-                    {
-                      "from": "n",
-                      "to": "__equals_1"
-                    },
-                    {
-                      "from": "V_{t}",
-                      "to": "__multiply_2",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "g",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "Delta t",
-                      "to": "__multiply_4",
-                      "semantic": "direct",
-                      "weight": 1.0
-                    },
-                    {
-                      "from": "__multiply_4",
-                      "to": "__power_3"
-                    },
-                    {
-                      "from": "__power_3",
-                      "to": "__multiply_2"
-                    },
-                    {
-                      "from": "__multiply_2",
-                      "to": "__equals_1"
-                    }
+                    {"from": "n", "to": "__equals_1"},
+                    {"from": "V_{t}", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "g", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "Delta t", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_4", "to": "__power_3"},
+                    {"from": "__power_3", "to": "__multiply_2"},
+                    {"from": "__multiply_2", "to": "__equals_1"}
                   ],
-                  "classification": {
-                    "kind": "algebraic"
-                  }
+                  "classification": {"kind": "algebraic"}
                 }
               }
             }

--- a/scripts/ci_validate_prebaked.py
+++ b/scripts/ci_validate_prebaked.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""CI aggregator for prebaked-graph validation.
+
+Runs the prebake validator (``analyze``) over one or more scene files and emits
+a single compact Markdown report (to stdout) with:
+
+  - an overall verdict (in sync / out of sync),
+  - a per-scene table plus a TOTAL row,
+  - non-blocking prebake suggestions for un-baked scenes whose parse cost is
+    above the worth-it threshold.
+
+Exit code is 1 iff any committed graph is out of sync (stale or broken) — the
+CI gate. Prebake suggestions never affect the exit code.
+
+Usage:
+    ./run.sh scripts/ci_validate_prebaked.py scenes/a.json scenes/b.json
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import json  # noqa: E402
+from scripts.prebake_semantic_graphs import analyze  # noqa: E402
+
+
+def main(paths):
+    rows = []          # (name, report)
+    out_of_sync = 0
+    suggestions = []
+    for p in paths:
+        name = Path(p).name
+        try:
+            spec = json.loads(Path(p).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            print(f"::warning:: skipping {p}: {e}", file=sys.stderr)
+            continue
+        rep = analyze(spec)
+        rows.append((name, rep))
+        out_of_sync += rep["outOfSync"]
+        if rep["recommendPrebake"]:
+            suggestions.append((name, rep))
+
+    # ---- totals ----
+    keys = ("valid", "stale", "errorBroken", "missing", "errorUnbaked")
+    totals = {k: sum(r["counts"][k] for _, r in rows) for k in keys}
+    total_graphs = totals["valid"] + totals["stale"] + totals["errorBroken"]
+
+    # ---- table ----
+    hdr = f"{'scene':<42}{'valid':>6}{'stale':>6}{'broken':>7}{'missing':>8}{'unsup':>6}"
+    sep = "─" * len(hdr)
+    lines = [hdr, sep]
+    for name, r in rows:
+        c = r["counts"]
+        flag = "" if c["valid"] + c["stale"] + c["errorBroken"] else "  (not baked)"
+        lines.append(f"{name[:42]:<42}{c['valid']:>6}{c['stale']:>6}"
+                     f"{c['errorBroken']:>7}{c['missing']:>8}{c['errorUnbaked']:>6}{flag}")
+    lines.append(sep)
+    lines.append(f"{'TOTAL':<42}{totals['valid']:>6}{totals['stale']:>6}"
+                 f"{totals['errorBroken']:>7}{totals['missing']:>8}{totals['errorUnbaked']:>6}")
+    table = "\n".join(lines)
+
+    # ---- verdict ----
+    if out_of_sync:
+        header = f"❌ Prebaked Graphs — {out_of_sync} committed graph(s) out of sync (no longer match their math)"
+    else:
+        header = "✅ Prebaked Graphs — in sync"
+
+    body = [
+        "<!-- prebaked-graphs-report -->",
+        f"**{header}**",
+        "",
+        f"<details><summary>{len(rows)} scene(s) · {total_graphs} baked graph(s) checked</summary>",
+        "",
+        "```",
+        table,
+        "```",
+        "",
+        "</details>",
+    ]
+
+    if suggestions:
+        body += ["", "💡 **Prebake suggested** (advisory):"]
+        for name, r in suggestions:
+            body.append(f"- `{name}` — {r['recommendReason']}; run "
+                        f"`scripts/prebake_semantic_graphs.py <scene> --write`")
+
+    body += [
+        "",
+        "<sub>Fails only on **stale**/**broken** — a committed graph the current "
+        "parser can't reproduce. Suggestions are non-blocking.</sub>",
+    ]
+    print("\n".join(body))
+    return 1 if out_of_sync else 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("usage: ci_validate_prebaked.py <scene.json> [scene.json ...]", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/prebake_semantic_graphs.py
+++ b/scripts/prebake_semantic_graphs.py
@@ -105,6 +105,14 @@ def _propose_strategy(load_before, load_after, pct_increase, baked):
     if baked == 0:
         return {"recommendation": "noop",
                 "rationale": "Already fully baked — no graphs to add."}
+    # `--write --all` re-bakes every step even when all are already valid, so
+    # `baked > 0` but the output is byte-identical (no size growth). Adding a
+    # real graph always grows the file, so a ~0% delta means nothing actually
+    # changed — a noop, not a misleading "skip ... saves 0.00s but grows +0%".
+    if abs(pct_increase) < 0.1:
+        return {"recommendation": "noop",
+                "rationale": "Re-baked identical graphs (--all on an already-baked "
+                             "file) — no change to load or size."}
     if saved >= WORTH_IT_SAVED_SECONDS:
         return {"recommendation": "prebake",
                 "rationale": (
@@ -310,7 +318,10 @@ def main():
         print(f"error: file not found: {path}", file=sys.stderr)
         return 1
     try:
-        original_text = path.read_text()
+        # Explicit utf-8: scenes are written with ensure_ascii=False (may hold
+        # non-ASCII math), and byte sizes below are measured as utf-8 — don't
+        # let the platform default encoding (e.g. cp1252) corrupt or mismatch.
+        original_text = path.read_text(encoding="utf-8")
         spec = json.loads(original_text)
     except json.JSONDecodeError as e:
         print(f"error: invalid JSON in {path}: {e}", file=sys.stderr)
@@ -347,7 +358,7 @@ def main():
     if result["baked"] > 0:
         new_text = json.dumps(spec, indent=2, ensure_ascii=False) + "\n"
         if not args.dry_run:
-            path.write_text(new_text)
+            path.write_text(new_text, encoding="utf-8")
         final_size = len(new_text.encode("utf-8"))
     else:
         final_size = orig_size  # nothing baked → file unchanged
@@ -373,12 +384,13 @@ def main():
         print(f"   {verb} {result['baked']} graph(s); "
               f"left {result['skippedValid']} valid untouched; "
               f"{result['errors']} not derivable.")
-        # Only call out a speedup when baking actually changed something —
-        # otherwise before/after time the same spec and any delta is noise.
+        # Only call out a speedup when baking actually changed something — a
+        # ~0% size delta means nothing was added (e.g. --all on an already-baked
+        # file), so before/after just time the same spec and any delta is noise.
         # When the after-time is negligible the ratio explodes into a silly
         # number, so say "near-instant" instead.
         speed_txt = ""
-        if result["baked"] > 0 and speedup and speedup >= 1.05:
+        if result["baked"] > 0 and abs(pct) >= 0.1 and speedup and speedup >= 1.05:
             speed_txt = ("  (near-instant)" if load_after < 0.02 or speedup >= 100
                          else f"  ({speedup:.0f}× faster)")
         print(f"   load (server parse):  {load_before:.2f}s → {load_after:.2f}s{speed_txt}")

--- a/scripts/prebake_semantic_graphs.py
+++ b/scripts/prebake_semantic_graphs.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Pre-bake semantic graphs into an AlgeBench scene/lesson JSON file.
+
+At runtime the server derives a semantic graph for every proof step that has
+``math`` but no ``semanticGraph`` (see ``_autofill_semantic_graphs`` in
+``backend/server.py``). For a large lesson that is dozens of derivations on
+every load — seconds of CPU on a constrained host. Pre-baking runs those
+derivations *offline* and writes the resulting ``{"graph": {...}}`` blocks
+into the JSON, so the server skips them entirely and the lesson loads fast.
+
+This script reuses the *exact* backend derivation + highlight-overlay
+pipeline, so a baked graph is byte-identical to what the server would have
+produced — baking only changes *when* the work happens, never the result.
+
+Modes (exactly one is required)
+--------------------------------
+  --validate  Read-only. Re-derive every step and compare against any
+              already-baked graph. Classifies each step as:
+                valid    baked graph matches a fresh derivation
+                stale    baked graph differs (math or parser changed)
+                missing  derivable but not yet baked
+                error    derivation fails (cannot be baked)
+              Never writes. Exit code 0 if nothing needs baking, 2 if there
+              are missing/stale graphs.
+  --write     Bake graphs into the file. By default only missing+stale steps
+              are (re)written, keeping the diff minimal; pass --all to rewrite
+              every derivable step.
+
+Usage
+-----
+    ./run.sh scripts/prebake_semantic_graphs.py scene.json --validate          # read-only report
+    ./run.sh scripts/prebake_semantic_graphs.py scene.json --validate --json   # machine output
+    ./run.sh scripts/prebake_semantic_graphs.py scene.json --write             # bake missing+stale
+    ./run.sh scripts/prebake_semantic_graphs.py scene.json --write --all       # rebake everything
+    ./run.sh scripts/prebake_semantic_graphs.py scene.json --write --dry-run
+
+Exit codes
+----------
+    0  Nothing to do (validate: all valid / no derivable steps; write: file written or no-op)
+    1  Usage / IO / parse error
+    2  validate only: there are missing or stale graphs (work suggested)
+"""
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+# Reuse the backend's derivation + highlight pipeline verbatim so baked graphs
+# match server output exactly. Importing backend.server is heavy (pulls in
+# FastAPI/genai) but this is an offline CLI, so that cost is irrelevant.
+from backend.server import (  # noqa: E402
+    _graph_service,
+    _normalize_proofs,
+    _extract_htmlclass_pairs,
+    _strip_html_class,
+    _apply_highlights_to_graph,
+)
+
+
+def _derive_step_graph(step):
+    """Derive a fresh graph dict for one proof step, mirroring the server's
+    ``_autofill_semantic_graphs`` (strip ``\\htmlClass``, derive, overlay
+    highlights). Returns ``(graph_dict | None, error_str | None, seconds)``.
+    """
+    math_src = step.get("math")
+    if not math_src or not isinstance(math_src, str):
+        return None, None, 0.0
+    hl_pairs = _extract_htmlclass_pairs(math_src)
+    cleaned = _strip_html_class(math_src)
+    t0 = time.perf_counter()
+    # Guard the whole derive→highlight→serialize path. Any single step that
+    # blows up (parser crash, highlight-overlay edge case, serialization)
+    # degrades to a counted error so the rest of the lesson still processes —
+    # one bad step never aborts the batch.
+    try:
+        graph = _graph_service.derive(cleaned)
+    except Exception as e:  # parse crash — same class the server guards
+        return None, f"parse_crashed: {str(e).strip() or type(e).__name__}", time.perf_counter() - t0
+    if not graph:
+        return None, "parse_failed: parser returned no graph", time.perf_counter() - t0
+    try:
+        _apply_highlights_to_graph(graph, hl_pairs, step.get("highlights") or {})
+        result = graph.model_dump(by_alias=True, exclude_none=True)
+    except Exception as e:  # highlight overlay / serialization failure
+        return None, f"bake_error: {str(e).strip() or type(e).__name__}", time.perf_counter() - t0
+    return result, None, time.perf_counter() - t0
+
+
+def _iter_steps(spec):
+    """Yield ``(scene_idx, proof_idx, step_idx, step_dict)`` for every proof
+    step in a scene spec. Mirrors the traversal in the server's autofill."""
+    if not isinstance(spec, dict):
+        return
+    scenes_list = spec.get("scenes")
+    if not isinstance(scenes_list, list):
+        return
+    for si, sc in enumerate(scenes_list):
+        if not isinstance(sc, dict):
+            continue
+        for pi, proof in enumerate(_normalize_proofs(sc.get("proof"))):
+            steps = proof.get("steps")
+            if not isinstance(steps, list):
+                continue
+            for ki, step in enumerate(steps):
+                if isinstance(step, dict):
+                    yield si, pi, ki, step
+
+
+def _existing_graph(step):
+    """Return the already-baked graph dict for a step, or ``None``."""
+    sg = step.get("semanticGraph")
+    if isinstance(sg, dict) and isinstance(sg.get("graph"), dict):
+        return sg["graph"]
+    return None
+
+
+def analyze(spec):
+    """Validate pass: classify every step. Returns a report dict (no writes).
+
+    The graph cache is cleared first so results reflect the current parser
+    state, exactly like the server does before autofill.
+    """
+    _graph_service.clear_cache()
+    steps_report = []
+    counts = {"valid": 0, "stale": 0, "missing": 0, "error": 0}
+    total_derive = 0.0    # cost to re-derive every step (the full bake cost)
+    runtime_derive = 0.0  # cost the server still pays at load: steps without a
+                          # valid baked graph (missing/stale/error are re-derived)
+    for si, pi, ki, step in _iter_steps(spec):
+        math_src = step.get("math")
+        if not math_src or not isinstance(math_src, str):
+            continue
+        existing = _existing_graph(step)
+        fresh, err, dt = _derive_step_graph(step)
+        total_derive += dt
+        if err or fresh is None:
+            status = "error"
+            detail = err or "no graph"
+        elif existing is None:
+            status = "missing"
+            detail = "derivable but not baked"
+        elif existing == fresh:
+            status = "valid"
+            detail = "baked graph matches fresh derivation"
+        else:
+            status = "stale"
+            detail = "baked graph differs from fresh derivation"
+        if status != "valid":
+            runtime_derive += dt
+        counts[status] += 1
+        steps_report.append({
+            "scene": si, "proof": pi, "step": ki,
+            "mathPreview": (math_src[:60] + "…") if len(math_src) > 60 else math_src,
+            "status": status,
+            "detail": detail,
+            "deriveMs": round(dt * 1000, 1),
+        })
+
+    needs = counts["missing"] + counts["stale"]
+    # Prebaking is suggested only when there are missing/stale graphs to bake.
+    # A fully-baked lesson derives nothing at runtime, so nothing to recommend —
+    # the full-derive cost is what baking already eliminated, not a reason to bake.
+    recommend = needs > 0
+    return {
+        "title": spec.get("title") if isinstance(spec, dict) else None,
+        "stepsWithMath": len(steps_report),
+        "counts": counts,
+        "needsPrebake": needs,
+        "deriveSeconds": round(total_derive, 2),
+        "runtimeDeriveSeconds": round(runtime_derive, 2),
+        "recommendPrebake": recommend,
+        "recommendReason": (
+            f"{needs} graph(s) missing or stale — ~{runtime_derive:.2f}s derived on every load until baked"
+            if needs > 0
+            else f"all derivable graphs are baked; runtime derives ~{runtime_derive:.2f}s"
+        ),
+        "steps": steps_report,
+    }
+
+
+def bake(spec, *, only_all=False):
+    """Write pass: (re)bake graphs in-place. By default only missing+stale
+    steps are written; ``only_all`` rebakes every derivable step. Returns a
+    summary dict of what changed."""
+    _graph_service.clear_cache()
+    baked, skipped_valid, errors = 0, 0, 0
+    changed = []
+    for si, pi, ki, step in _iter_steps(spec):
+        math_src = step.get("math")
+        if not math_src or not isinstance(math_src, str):
+            continue
+        existing = _existing_graph(step)
+        fresh, err, _ = _derive_step_graph(step)
+        if err or fresh is None:
+            errors += 1
+            continue
+        is_valid = existing is not None and existing == fresh
+        if is_valid and not only_all:
+            skipped_valid += 1
+            continue
+        step["semanticGraph"] = {"graph": fresh}
+        baked += 1
+        changed.append({"scene": si, "proof": pi, "step": ki})
+    return {"baked": baked, "skippedValid": skipped_valid, "errors": errors, "changed": changed}
+
+
+def _print_human(report, path):
+    icon = {"valid": "✅", "stale": "♻️ ", "missing": "➕", "error": "⚠️ "}
+    print(f"📄 {path}  —  {report['title'] or '(untitled)'}")
+    print(f"   steps with math: {report['stepsWithMath']}   "
+          f"derive time: {report['deriveSeconds']}s")
+    c = report["counts"]
+    print(f"   valid={c['valid']}  stale={c['stale']}  missing={c['missing']}  error={c['error']}")
+    for s in report["steps"]:
+        if s["status"] != "valid":
+            print(f"   {icon[s['status']]} [{s['scene']}.{s['proof']}.{s['step']}] "
+                  f"{s['status']:<7} {s['mathPreview']}")
+    print(f"   → recommend prebake: {'YES' if report['recommendPrebake'] else 'no'} "
+          f"({report['recommendReason']})")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Pre-bake semantic graphs into a scene/lesson JSON.")
+    ap.add_argument("scene", help="Path to the scene/lesson JSON file")
+    mode = ap.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--validate", action="store_true",
+                      help="Read-only: classify every step (valid/stale/missing/error); never writes")
+    mode.add_argument("--write", action="store_true",
+                      help="Bake graphs into the file (missing+stale by default; --all for full rebake)")
+    ap.add_argument("--all", action="store_true",
+                    help="With --write, rebake every derivable step (default: only missing+stale)")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="With --write, report what would change without writing")
+    ap.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    args = ap.parse_args()
+
+    if args.validate and (args.all or args.dry_run):
+        ap.error("--all and --dry-run only apply to --write")
+
+    path = Path(args.scene)
+    if not path.is_file():
+        print(f"error: file not found: {path}", file=sys.stderr)
+        return 1
+    try:
+        spec = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        print(f"error: invalid JSON in {path}: {e}", file=sys.stderr)
+        return 1
+
+    # Always analyze first — both modes report the same classification.
+    report = analyze(spec)
+
+    if args.validate:
+        if args.json:
+            print(json.dumps(report, indent=2))
+        else:
+            _print_human(report, path)
+        return 2 if report["needsPrebake"] > 0 else 0
+
+    # write mode
+    result = bake(spec, only_all=args.all)
+    if args.dry_run:
+        result["dryRun"] = True
+    elif result["baked"] > 0:
+        with open(path, "w") as f:
+            json.dump(spec, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+
+    out = {"mode": "write", "file": str(path), "validateBefore": report, "result": result}
+    if args.json:
+        print(json.dumps(out, indent=2))
+    else:
+        verb = "would bake" if args.dry_run else "baked"
+        print(f"📄 {path}  —  {report['title'] or '(untitled)'}")
+        print(f"   {verb} {result['baked']} graph(s); "
+              f"left {result['skippedValid']} valid untouched; "
+              f"{result['errors']} not derivable.")
+        if not args.dry_run and result["baked"] > 0:
+            print(f"   ✅ wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/prebake_semantic_graphs.py
+++ b/scripts/prebake_semantic_graphs.py
@@ -16,12 +16,17 @@ Modes (exactly one is required)
 --------------------------------
   --validate  Read-only. Re-derive every step and compare against any
               already-baked graph. Classifies each step as:
-                valid    baked graph matches a fresh derivation
-                stale    baked graph differs (math or parser changed)
-                missing  derivable but not yet baked
-                error    derivation fails (cannot be baked)
+                valid          baked graph matches a fresh derivation
+                stale          baked graph differs (math or parser changed)
+                missing        derivable but not yet baked
+                errorBroken    HAD a baked graph that no longer derives (a
+                               committed graph the parser can't reproduce)
+                errorUnbaked   never baked, parser can't derive it (unsupported
+                               LaTeX) — expected, fails the same at runtime
               Never writes. Exit code 0 if nothing needs baking, 2 if there
-              are missing/stale graphs.
+              are missing/stale graphs. With --fail-on-stale, exits 1 only when
+              a committed graph is out of sync (stale + errorBroken), 0
+              otherwise — the CI gate; missing/errorUnbaked never fail.
   --write     Bake graphs into the file. By default only missing+stale steps
               are (re)written, keeping the diff minimal; pass --all to rewrite
               every derivable step. Reports the before/after server load time
@@ -193,7 +198,13 @@ def analyze(spec):
     """
     _graph_service.clear_cache()
     steps_report = []
-    counts = {"valid": 0, "stale": 0, "missing": 0, "error": 0}
+    # `error` splits by whether the step already had a committed graph:
+    #   errorUnbaked — never baked, parser can't derive it (unsupported LaTeX);
+    #                  expected, fails identically at runtime, NOT a sync failure.
+    #   errorBroken  — HAD a baked graph but it no longer derives (regression):
+    #                  a committed graph the current parser can't reproduce.
+    counts = {"valid": 0, "stale": 0, "missing": 0,
+              "errorUnbaked": 0, "errorBroken": 0}
     total_derive = 0.0    # cost to re-derive every step (the full bake cost)
     runtime_derive = 0.0  # cost the server still pays at load: steps without a
                           # valid baked graph (missing/stale/error are re-derived)
@@ -202,12 +213,17 @@ def analyze(spec):
         if not math_src or not isinstance(math_src, str):
             continue
         existing = _existing_graph(step)
+        was_baked = existing is not None
         fresh, err, dt = _derive_step_graph(step)
         total_derive += dt
         if err or fresh is None:
-            status = "error"
-            detail = err or "no graph"
-        elif existing is None:
+            if was_baked:
+                status = "errorBroken"
+                detail = "committed graph no longer derives (parser regression)"
+            else:
+                status = "errorUnbaked"
+                detail = err or "unsupported — parser produced no graph"
+        elif not was_baked:
             status = "missing"
             detail = "derivable but not baked"
         elif existing == fresh:
@@ -225,18 +241,21 @@ def analyze(spec):
             "status": status,
             "detail": detail,
             "deriveMs": round(dt * 1000, 1),
+            "wasBaked": was_baked,
         })
 
     needs = counts["missing"] + counts["stale"]
-    # Prebaking is suggested only when there are missing/stale graphs to bake.
-    # A fully-baked lesson derives nothing at runtime, so nothing to recommend —
-    # the full-derive cost is what baking already eliminated, not a reason to bake.
+    # A committed graph the current parser can't reproduce — either it derives
+    # differently now (stale) or no longer derives at all (broken). This is the
+    # CI gate: it means a shipped lesson's graph is out of sync with its math.
+    out_of_sync = counts["stale"] + counts["errorBroken"]
     recommend = needs > 0
     return {
         "title": spec.get("title") if isinstance(spec, dict) else None,
         "stepsWithMath": len(steps_report),
         "counts": counts,
         "needsPrebake": needs,
+        "outOfSync": out_of_sync,
         "deriveSeconds": round(total_derive, 2),
         "runtimeDeriveSeconds": round(runtime_derive, 2),
         "recommendPrebake": recommend,
@@ -319,16 +338,20 @@ def _dumps_compact_leaves(obj, indent=2, level=0):
 
 
 def _print_human(report, path):
-    icon = {"valid": "✅", "stale": "♻️ ", "missing": "➕", "error": "⚠️ "}
+    icon = {"valid": "✅", "stale": "♻️ ", "missing": "➕",
+            "errorBroken": "❌", "errorUnbaked": "⚠️ "}
     print(f"📄 {path}  —  {report['title'] or '(untitled)'}")
     print(f"   steps with math: {report['stepsWithMath']}   "
           f"derive time: {report['deriveSeconds']}s")
     c = report["counts"]
-    print(f"   valid={c['valid']}  stale={c['stale']}  missing={c['missing']}  error={c['error']}")
+    print(f"   valid={c['valid']}  stale={c['stale']}  missing={c['missing']}  "
+          f"broken={c['errorBroken']}  unsupported={c['errorUnbaked']}")
     for s in report["steps"]:
         if s["status"] != "valid":
             print(f"   {icon[s['status']]} [{s['scene']}.{s['proof']}.{s['step']}] "
-                  f"{s['status']:<7} {s['mathPreview']}")
+                  f"{s['status']:<12} {s['mathPreview']}")
+    if report["outOfSync"]:
+        print(f"   ✗ {report['outOfSync']} committed graph(s) out of sync (stale or broken)")
     print(f"   → recommend prebake: {'YES' if report['recommendPrebake'] else 'no'} "
           f"({report['recommendReason']})")
 
@@ -345,11 +368,17 @@ def main():
                     help="With --write, rebake every derivable step (default: only missing+stale)")
     ap.add_argument("--dry-run", action="store_true",
                     help="With --write, report what would change without writing")
+    ap.add_argument("--fail-on-stale", action="store_true",
+                    help="With --validate, exit non-zero only if a committed graph is "
+                         "out of sync (stale or broken). For CI; missing/unsupported "
+                         "steps never fail.")
     ap.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
     args = ap.parse_args()
 
     if args.validate and (args.all or args.dry_run):
         ap.error("--all and --dry-run only apply to --write")
+    if args.write and args.fail_on_stale:
+        ap.error("--fail-on-stale only applies to --validate")
 
     path = Path(args.scene)
     if not path.is_file():
@@ -371,6 +400,10 @@ def main():
             print(json.dumps(report, indent=2))
         else:
             _print_human(report, path)
+        # CI gate: fail only when a committed graph can't be reproduced.
+        if args.fail_on_stale:
+            return 1 if report["outOfSync"] > 0 else 0
+        # Default: signal there is bakeable work (informational).
         return 2 if report["needsPrebake"] > 0 else 0
 
     # ---- write mode ----

--- a/scripts/prebake_semantic_graphs.py
+++ b/scripts/prebake_semantic_graphs.py
@@ -118,14 +118,14 @@ def _propose_strategy(load_before, load_after, pct_increase, baked):
                 "rationale": (
                     f"Prebake. Load {load_before:.2f}s→{load_after:.2f}s locally "
                     f"(~{prod_before:.0f}s→~{prod_after:.1f}s on a free host, "
-                    f"~{prod_saved:.0f}s saved/load) for +{pct_increase:.0f}% size — "
-                    f"the load win clearly outweighs the size cost.")}
+                    f"~{prod_saved:.0f}s saved/load) for a {pct_increase:+.0f}% size "
+                    f"change — the load win clearly outweighs the size cost.")}
     return {"recommendation": "skip",
             "rationale": (
                 f"Skip. Load is already fast ({load_before:.2f}s, "
                 f"~{prod_before:.1f}s on a free host); baking saves only "
-                f"{saved:.2f}s but grows the file +{pct_increase:.0f}%. "
-                f"Not worth the size unless the target host is very constrained.")}
+                f"{saved:.2f}s for a {pct_increase:+.0f}% size change. "
+                f"Not worth it unless the target host is very constrained.")}
 
 
 def _derive_step_graph(step):
@@ -280,6 +280,44 @@ def _fmt_bytes(n):
     return f"{n / 1024:.1f} KB" if abs(n) >= 1024 else f"{n} B"
 
 
+def _has_nested_container(obj):
+    """True if ``obj`` (dict/list) holds any value that is itself a non-empty
+    dict or list — i.e. it is NOT a leaf container."""
+    vals = obj.values() if isinstance(obj, dict) else obj
+    return any(isinstance(v, (dict, list)) and v for v in vals)
+
+
+def _dumps_compact_leaves(obj, indent=2, level=0):
+    """Pretty-print JSON, but collapse *leaf* containers — dicts/lists whose
+    values are all scalars (or empty) — onto a single line.
+
+    Keeps the scene hierarchy (scenes → proof → steps → graph) readable while
+    shrinking the dozens of tiny graph node/edge objects from ~5 lines each to
+    one. All scalar/leaf serialization is delegated to ``json.dumps``, so string
+    escaping and number formatting are identical to a normal dump; only
+    container indentation is custom. Round-trips to the same data as
+    ``json.dumps`` (the caller asserts this before writing)."""
+    if isinstance(obj, (dict, list)) and obj and not _has_nested_container(obj):
+        return json.dumps(obj, ensure_ascii=False)  # leaf container → one line
+    pad = " " * (indent * (level + 1))
+    end = " " * (indent * level)
+    if isinstance(obj, dict):
+        if not obj:
+            return "{}"
+        items = [
+            f"{pad}{json.dumps(str(k), ensure_ascii=False)}: "
+            f"{_dumps_compact_leaves(v, indent, level + 1)}"
+            for k, v in obj.items()
+        ]
+        return "{\n" + ",\n".join(items) + "\n" + end + "}"
+    if isinstance(obj, list):
+        if not obj:
+            return "[]"
+        items = [f"{pad}{_dumps_compact_leaves(v, indent, level + 1)}" for v in obj]
+        return "[\n" + ",\n".join(items) + "\n" + end + "]"
+    return json.dumps(obj, ensure_ascii=False)  # scalar
+
+
 def _print_human(report, path):
     icon = {"valid": "✅", "stale": "♻️ ", "missing": "➕", "error": "⚠️ "}
     print(f"📄 {path}  —  {report['title'] or '(untitled)'}")
@@ -356,7 +394,14 @@ def main():
     # Serialize once so we can measure the final size (and write it if real).
     orig_size = len(original_text.encode("utf-8"))
     if result["baked"] > 0:
-        new_text = json.dumps(spec, indent=2, ensure_ascii=False) + "\n"
+        # Compact-leaves: structure stays indented; tiny node/edge objects
+        # collapse to one line (~3x fewer lines than indent=2).
+        new_text = _dumps_compact_leaves(spec) + "\n"
+        # Safety net: the custom writer must round-trip to the exact same data.
+        if json.loads(new_text) != spec:
+            print("error: compact serialization altered the data — aborting write",
+                  file=sys.stderr)
+            return 1
         if not args.dry_run:
             path.write_text(new_text, encoding="utf-8")
         final_size = len(new_text.encode("utf-8"))

--- a/scripts/prebake_semantic_graphs.py
+++ b/scripts/prebake_semantic_graphs.py
@@ -24,7 +24,11 @@ Modes (exactly one is required)
               are missing/stale graphs.
   --write     Bake graphs into the file. By default only missing+stale steps
               are (re)written, keeping the diff minimal; pass --all to rewrite
-              every derivable step.
+              every derivable step. Reports the before/after server load time
+              (simulating a real scene load — parse-if-missing), the
+              before/after file size + % growth, and a recommended strategy
+              (prebake / skip / noop) weighing that load win against the size
+              cost. Use --dry-run to get the strategy without writing.
 
 Usage
 -----
@@ -42,6 +46,9 @@ Exit codes
 """
 
 import argparse
+import contextlib
+import copy
+import io
 import json
 import sys
 import time
@@ -56,7 +63,61 @@ from backend.server import (  # noqa: E402
     _extract_htmlclass_pairs,
     _strip_html_class,
     _apply_highlights_to_graph,
+    _autofill_semantic_graphs,
 )
+
+
+def _simulate_server_load(spec):
+    """Time a real scene load on a COPY of the spec.
+
+    Runs the server's `_autofill_semantic_graphs` — the same parse-if-missing
+    pass a live `/scenes/...` load performs — and returns the wall-clock
+    seconds. Operates on a deep copy (autofill mutates) with stdout muted
+    (autofill prints a progress line). This is what baking actually speeds up:
+    before baking it derives every missing graph; after baking it skips them
+    and only the unparseable (error) steps still cost anything.
+    """
+    clone = copy.deepcopy(spec)
+    t = time.perf_counter()
+    with contextlib.redirect_stdout(io.StringIO()):
+        _autofill_semantic_graphs(clone)
+    return time.perf_counter() - t
+
+
+# A free Render instance ran the atmospheric lesson's ~5s local parse in ~61s,
+# so server load is roughly this much slower than a dev machine. Used only to
+# estimate the real-world (deployed) load win in the strategy rationale.
+FREE_HOST_SLOWDOWN = 12
+
+# Local load saved (seconds) above which prebaking is clearly worth the size
+# growth (~3.6s on a free host at the slowdown above).
+WORTH_IT_SAVED_SECONDS = 0.3
+
+
+def _propose_strategy(load_before, load_after, pct_increase, baked):
+    """Weigh the measured load-time win against the size growth and recommend
+    a strategy: ``prebake`` (worth it), ``skip`` (win too small for the size
+    cost), or ``noop`` (nothing to bake)."""
+    saved = load_before - load_after
+    prod_before = load_before * FREE_HOST_SLOWDOWN
+    prod_after = load_after * FREE_HOST_SLOWDOWN
+    prod_saved = saved * FREE_HOST_SLOWDOWN
+    if baked == 0:
+        return {"recommendation": "noop",
+                "rationale": "Already fully baked — no graphs to add."}
+    if saved >= WORTH_IT_SAVED_SECONDS:
+        return {"recommendation": "prebake",
+                "rationale": (
+                    f"Prebake. Load {load_before:.2f}s→{load_after:.2f}s locally "
+                    f"(~{prod_before:.0f}s→~{prod_after:.1f}s on a free host, "
+                    f"~{prod_saved:.0f}s saved/load) for +{pct_increase:.0f}% size — "
+                    f"the load win clearly outweighs the size cost.")}
+    return {"recommendation": "skip",
+            "rationale": (
+                f"Skip. Load is already fast ({load_before:.2f}s, "
+                f"~{prod_before:.1f}s on a free host); baking saves only "
+                f"{saved:.2f}s but grows the file +{pct_increase:.0f}%. "
+                f"Not worth the size unless the target host is very constrained.")}
 
 
 def _derive_step_graph(step):
@@ -206,6 +267,11 @@ def bake(spec, *, only_all=False):
     return {"baked": baked, "skippedValid": skipped_valid, "errors": errors, "changed": changed}
 
 
+def _fmt_bytes(n):
+    """Human-friendly byte count (KB above 1 KiB), sign-preserving."""
+    return f"{n / 1024:.1f} KB" if abs(n) >= 1024 else f"{n} B"
+
+
 def _print_human(report, path):
     icon = {"valid": "✅", "stale": "♻️ ", "missing": "➕", "error": "⚠️ "}
     print(f"📄 {path}  —  {report['title'] or '(untitled)'}")
@@ -244,39 +310,82 @@ def main():
         print(f"error: file not found: {path}", file=sys.stderr)
         return 1
     try:
-        spec = json.loads(path.read_text())
+        original_text = path.read_text()
+        spec = json.loads(original_text)
     except json.JSONDecodeError as e:
         print(f"error: invalid JSON in {path}: {e}", file=sys.stderr)
         return 1
 
-    # Always analyze first — both modes report the same classification.
-    report = analyze(spec)
-
     if args.validate:
+        report = analyze(spec)
         if args.json:
             print(json.dumps(report, indent=2))
         else:
             _print_human(report, path)
         return 2 if report["needsPrebake"] > 0 else 0
 
-    # write mode
+    # ---- write mode ----
+    # Measure a real scene load (server parse-if-missing) before and after
+    # baking, so the report shows the actual load-time win — not just the
+    # derive cost. "before" derives every missing graph (what users pay now);
+    # "after" skips the baked ones, leaving only the unparseable error steps.
+    title = spec.get("title") if isinstance(spec, dict) else None
+    load_before = _simulate_server_load(spec)
     result = bake(spec, only_all=args.all)
     if args.dry_run:
         result["dryRun"] = True
-    elif result["baked"] > 0:
-        with open(path, "w") as f:
-            json.dump(spec, f, indent=2, ensure_ascii=False)
-            f.write("\n")
+    load_after = _simulate_server_load(spec)  # spec is now baked in-memory
+    speedup = (load_before / load_after) if load_after > 0 else None
+    load = {
+        "beforeSeconds": round(load_before, 3),
+        "afterSeconds": round(load_after, 3),
+        "speedup": round(speedup, 1) if speedup else None,
+    }
 
-    out = {"mode": "write", "file": str(path), "validateBefore": report, "result": result}
+    # Serialize once so we can measure the final size (and write it if real).
+    orig_size = len(original_text.encode("utf-8"))
+    if result["baked"] > 0:
+        new_text = json.dumps(spec, indent=2, ensure_ascii=False) + "\n"
+        if not args.dry_run:
+            path.write_text(new_text)
+        final_size = len(new_text.encode("utf-8"))
+    else:
+        final_size = orig_size  # nothing baked → file unchanged
+    delta = final_size - orig_size
+    pct = (delta / orig_size * 100) if orig_size else 0.0
+    sizes = {
+        "originalBytes": orig_size,
+        "finalBytes": final_size,
+        "deltaBytes": delta,
+        "pctIncrease": round(pct, 1),
+    }
+
+    # Recommend a strategy from the measured load win vs. size growth.
+    strategy = _propose_strategy(load_before, load_after, pct, result["baked"])
+
+    out = {"mode": "write", "file": str(path), "load": load, "sizes": sizes,
+           "strategy": strategy, "result": result}
     if args.json:
         print(json.dumps(out, indent=2))
     else:
         verb = "would bake" if args.dry_run else "baked"
-        print(f"📄 {path}  —  {report['title'] or '(untitled)'}")
+        print(f"📄 {path}  —  {title or '(untitled)'}")
         print(f"   {verb} {result['baked']} graph(s); "
               f"left {result['skippedValid']} valid untouched; "
               f"{result['errors']} not derivable.")
+        # Only call out a speedup when baking actually changed something —
+        # otherwise before/after time the same spec and any delta is noise.
+        # When the after-time is negligible the ratio explodes into a silly
+        # number, so say "near-instant" instead.
+        speed_txt = ""
+        if result["baked"] > 0 and speedup and speedup >= 1.05:
+            speed_txt = ("  (near-instant)" if load_after < 0.02 or speedup >= 100
+                         else f"  ({speedup:.0f}× faster)")
+        print(f"   load (server parse):  {load_before:.2f}s → {load_after:.2f}s{speed_txt}")
+        size_verb = "size (would grow)" if args.dry_run else "size"
+        print(f"   {size_verb}:  {_fmt_bytes(orig_size)} → {_fmt_bytes(final_size)} "
+              f"({pct:+.1f}%, {_fmt_bytes(delta)})")
+        print(f"   → strategy: {strategy['recommendation'].upper()} — {strategy['rationale']}")
         if not args.dry_run and result["baked"] > 0:
             print(f"   ✅ wrote {path}")
     return 0

--- a/scripts/prebake_semantic_graphs.py
+++ b/scripts/prebake_semantic_graphs.py
@@ -249,7 +249,18 @@ def analyze(spec):
     # differently now (stale) or no longer derives at all (broken). This is the
     # CI gate: it means a shipped lesson's graph is out of sync with its math.
     out_of_sync = counts["stale"] + counts["errorBroken"]
-    recommend = needs > 0
+    # Suggest prebaking only when there are missing/stale graphs AND deriving
+    # them costs enough to matter (cheap parses aren't worth the file growth) —
+    # mirrors the --write strategy's prebake/skip threshold.
+    recommend = needs > 0 and runtime_derive >= WORTH_IT_SAVED_SECONDS
+    if needs == 0:
+        reason = f"all derivable graphs are baked; runtime derives ~{runtime_derive:.2f}s"
+    elif recommend:
+        reason = (f"{needs} graph(s) missing/stale costing ~{runtime_derive:.2f}s/load "
+                  f"(~{runtime_derive * FREE_HOST_SLOWDOWN:.0f}s on a free host) — prebake worthwhile")
+    else:
+        reason = (f"{needs} graph(s) missing/stale but deriving them is cheap "
+                  f"(~{runtime_derive:.2f}s) — prebaking optional")
     return {
         "title": spec.get("title") if isinstance(spec, dict) else None,
         "stepsWithMath": len(steps_report),
@@ -259,11 +270,7 @@ def analyze(spec):
         "deriveSeconds": round(total_derive, 2),
         "runtimeDeriveSeconds": round(runtime_derive, 2),
         "recommendPrebake": recommend,
-        "recommendReason": (
-            f"{needs} graph(s) missing or stale — ~{runtime_derive:.2f}s derived on every load until baked"
-            if needs > 0
-            else f"all derivable graphs are baked; runtime derives ~{runtime_derive:.2f}s"
-        ),
+        "recommendReason": reason,
         "steps": steps_report,
     }
 


### PR DESCRIPTION
## Why

At runtime the server derives a semantic graph for **every proof step that has `math` but no `semanticGraph`** (`_autofill_semantic_graphs`). For a large lesson that's dozens of derivations on every load — ~5s locally, **~61s on a free Render instance** (measured on staging). Prebaking runs those derivations once, offline, and inlines the graph blocks so the server skips them.

**Validated on staging:** the atmospheric lesson went **~61s → ~0.84s** warm load (~70× faster) on the real free-tier host.

## What

### `scripts/prebake_semantic_graphs.py`
Reuses the backend's exact derive + highlight pipeline, so baked graphs are byte-identical to server output (baking changes *when* the work happens, never the result).

- **Explicit, required mode:** `--validate` (read-only) | `--write` (mutually exclusive).
- **`--validate`** classifies every step: `valid` / `stale` / `missing` / `errorBroken` (a committed graph the parser can no longer reproduce) / `errorUnbaked` (unsupported LaTeX, never baked).
- **`--write`** bakes missing+stale (or `--all`), with `--dry-run`. Round-trip-asserted before saving.
- **Resilient:** any single-step failure degrades to a counted error — never aborts the batch.
- **Reports the trade-off:** server load time before→after (real scene-load simulation), file size before→after + % growth, and a recommended **strategy** (`prebake` / `skip` / `noop`) weighing load win vs size cost (~12× free-host estimate). All under `--dry-run` too.
- **Compact-leaves serialization:** structure stays indented, leaf objects/arrays (graph nodes/edges) collapse to one line — ~3× fewer lines than `indent=2`.
- **`--fail-on-stale`:** CI gate — exits non-zero **only** when a committed graph is out of sync (`stale` + `errorBroken`); `missing`/`errorUnbaked` never fail.
- **Threshold-aware `recommendPrebake`:** suggested only when un-baked graphs cost ≥ `WORTH_IT_SAVED_SECONDS` (0.3s local ≈ 3.6s free-host) to derive.

### `scripts/ci_validate_prebaked.py`
CI aggregator: runs `analyze()` over many scenes, emits one compact Markdown report — overall verdict, a per-scene table **with a TOTAL row**, and non-blocking **prebake suggestions** for un-baked scenes above the threshold. Exits 1 iff a committed graph is out of sync.

### `.github/workflows/validate-prebaked-graphs.yml` — "Validate Prebaked Graphs"
Triggers on changed scenes **and** graph-parser/script changes (re-checks all baked scenes then, since a parser change can stale any of them). Runs the aggregator (full deps via `run.sh`), posts the compact PR comment, and **fails only** on out-of-sync committed graphs. Closes the one gap prebaking introduces: a baked graph silently drifting from its `math` (edited expression not re-baked, or a parser change).

### `.agents/skills/algebench-prebake-graphs` (relative symlink into `.claude/skills/`)
Orchestrates: validate → dry-run for the strategy → present it → `AskUserQuestion` before any write → bake → re-validate.

### `scenes/atmospheric-entry-physics.json`
Prebaked: 74 graphs inlined (5 steps unparseable, left for the fast-failing runtime path), compact-leaves format. Server autofill: 4.82s → 0.18s locally.

### `fix(skills)`: relative symlinks
`algebench-prebake-graphs`, `deploy-to-render`, `issue-triage` symlinks made relative (`../../.agents/skills/<name>`) so they resolve on any clone.

## Notes for reviewer
- The atmospheric scene diff is the inlined graphs (now ~5.1k lines after compact-leaves, down from ~15.7k). Cosmetic float reformatting (`0.00007292115` → `7.292115e-05`) is a harmless `json` round-trip artifact; values are identical (round-trip-asserted).
- `quantum-states.json` is intentionally **not** in this PR (verdict was PREBAKE, kept separate).
- The "Validate Prebaked Graphs" check is green; its comment shows totals + prebake suggestions for the un-baked lessons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)