### PR TITLE
perf(scene): prebake semantic graphs for artemis-ii and quantum-states

### DIFF
--- a/scenes/artemis-ii-mission-simulation.json
+++ b/scenes/artemis-ii-mission-simulation.json
@@ -1,8 +1,6 @@
 {
   "title": "Artemis II Mission Simulation",
-  "import": [
-    "cislunar-dynamics"
-  ],
+  "import": ["cislunar-dynamics"],
   "scenes": [
     {
       "title": "The Earth-Moon Stage",
@@ -10,112 +8,47 @@
       "markdown": "# The Earth-Moon System\n\n## Scale of the System\n\nIn this scene, **1 unit = 10,000 km**. The key distances are:\n\n$$d_{\\text{Earth-Moon}} = 384{,}400 \\text{ km} \\approx 38.4 \\text{ units}$$\n\n$$R_{\\oplus} = 6{,}371 \\text{ km} \\approx 0.64 \\text{ units}$$\n\n$$R_{\\text{Moon}} = 1{,}737 \\text{ km} \\approx 0.17 \\text{ units}$$\n\n## Size Comparison\n\nThe Moon is only about **27%** of Earth's radius — and at the correct scale of 384,400 km separation, the Moon appears tiny.\n\n$$\\frac{R_{\\text{Moon}}}{R_{\\oplus}} = \\frac{1{,}737}{6{,}371} \\approx 0.273$$\n\n## How Far Is the Moon?\n\nThe Earth-Moon distance is approximately **30 Earth diameters**:\n\n$$\\frac{d_{\\text{Earth-Moon}}}{2R_{\\oplus}} = \\frac{384{,}400}{12{,}742} \\approx 30.2$$\n\nFor comparison, familiar orbital altitudes:\n\n| Orbit | Altitude | Model distance from Earth center |\n|---|---|---|\n| ISS | 400 km | 0.04 units above surface |\n| GPS | 20,200 km | 2.02 + 0.64 = 2.66 units |\n| Geostationary | 35,786 km | 3.58 + 0.64 = 4.22 units |\n| Moon | 384,400 km | 38.4 units |\n\n## Travel Time\n\nAt typical spacecraft speeds (~1 km/s average over coast phase), the journey takes:\n\n$$t = \\frac{384{,}400 \\text{ km}}{1 \\text{ km/s}} \\approx 384{,}400 \\text{ s} \\approx 4.4 \\text{ days}$$\n\nArtemis II is planned as a **~10-day mission** — fly out, loop around the Moon on a free-return trajectory, and return to Earth.\n\n## The Free-Return Trajectory\n\nA free-return trajectory is a figure-eight path that uses the Moon's gravity to redirect the spacecraft back toward Earth — no engine burn required at the Moon. It was used by Apollo and is the safety backbone of Artemis II.\n\n## Citations\n\n- NASA Moon Fact Sheet: https://nssdc.gsfc.nasa.gov/planetary/factsheet/moonfact.html\n- NASA Earth Fact Sheet: https://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html\n- Wikipedia: Earth-Moon system — https://en.wikipedia.org/wiki/Moon\n- Artemis II mission overview: https://www.nasa.gov/artemis-ii/",
       "prompt": "Guide students to appreciate the vastness of cislunar space. Use the scale model to build intuition: the ISS orbit is barely a hair's width above Earth's surface at this scale, while the Moon is 38 units away. Encourage exploration: What if the Moon were closer — how would that change orbital mechanics and travel time? Compare the Earth-Moon distance to everyday experiences — it's like traveling around Earth's equator about 9.5 times. Ask students to estimate how long it would take to drive to the Moon at highway speed (~100 km/h): about 160 days!",
       "range": [
-        [
-          -5,
-          45
-        ],
-        [
-          -25,
-          25
-        ],
-        [
-          -25,
-          25
-        ]
+        [-5, 45],
+        [-25, 25],
+        [-25, 25]
       ],
       "camera": {
-        "position": [
-          19,
-          5,
-          25
-        ],
-        "target": [
-          19,
-          0,
-          0
-        ]
+        "position": [19, 5, 25],
+        "target": [19, 0, 0]
       },
-      "starfield": {
-        "enabled": true,
-        "count": 1200,
-        "size": 1.8,
-        "opacity": 0.85,
-        "twinkle": 0
-      },
+      "starfield": {"enabled": true, "count": 1200, "size": 1.8, "opacity": 0.85, "twinkle": 0},
       "views": [
         {
           "name": "Overview",
           "description": "See both Earth and Moon together at full scale",
-          "position": [
-            19,
-            8,
-            30
-          ],
-          "target": [
-            19,
-            0,
-            0
-          ]
+          "position": [19, 8, 30],
+          "target": [19, 0, 0]
         },
         {
           "name": "Earth Close",
           "description": "Close-up of Earth and nearby orbital shells",
-          "position": [
-            0,
-            1,
-            3
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ]
+          "position": [0, 1, 3],
+          "target": [0, 0, 0]
         },
         {
           "name": "Moon Close",
           "description": "Close-up of the Moon at scale",
-          "position": [
-            38.4,
-            0.5,
-            2
-          ],
-          "target": [
-            38.4,
-            0,
-            0
-          ]
+          "position": [38.4, 0.5, 2],
+          "target": [38.4, 0, 0]
         },
         {
           "name": "Top Down",
           "description": "Top-down view of the entire Earth-Moon system",
-          "position": [
-            19,
-            30,
-            0.1
-          ],
-          "target": [
-            19,
-            0,
-            0
-          ]
+          "position": [19, 30, 0.1],
+          "target": [19, 0, 0]
         }
       ],
       "elements": [
-        {
-          "id": "_mathbox_init_0",
-          "type": "grid",
-          "plane": "xz",
-          "opacity": 0,
-          "divisions": 1
-        },
+        {"id": "_mathbox_init_0", "type": "grid", "plane": "xz", "opacity": 0, "divisions": 1},
         {
           "id": "earth",
           "type": "sphere",
-          "center": [
-            0,
-            0,
-            0
-          ],
+          "center": [0, 0, 0],
           "radius": 0.637,
           "color": "#3a7bd5",
           "emissive": "#112244",
@@ -125,21 +58,13 @@
           "id": "earth_label",
           "type": "text",
           "text": "Earth",
-          "position": [
-            0,
-            1.2,
-            0
-          ],
+          "position": [0, 1.2, 0],
           "color": "#ffffff"
         },
         {
           "id": "moon",
           "type": "sphere",
-          "center": [
-            38.4,
-            0,
-            0
-          ],
+          "center": [38.4, 0, 0],
           "radius": 0.17,
           "color": "#aaaaaa",
           "emissive": "#444444",
@@ -149,11 +74,7 @@
           "id": "moon_label",
           "type": "text",
           "text": "Moon",
-          "position": [
-            38.4,
-            0.6,
-            0
-          ],
+          "position": [38.4, 0.6, 0],
           "color": "#dddddd"
         }
       ],
@@ -162,31 +83,15 @@
           "title": "How Far Is the Moon?",
           "description": "The Moon is 384,400 km away — about 30 Earth diameters. Let's see it.",
           "camera": {
-            "position": [
-              19,
-              5,
-              25
-            ],
-            "target": [
-              19,
-              0,
-              0
-            ]
+            "position": [19, 5, 25],
+            "target": [19, 0, 0]
           },
           "add": [
             {
               "id": "distance_line",
               "type": "line",
-              "from": [
-                0,
-                0,
-                0
-              ],
-              "to": [
-                38.4,
-                0,
-                0
-              ],
+              "from": [0, 0, 0],
+              "to": [38.4, 0, 0],
               "color": "#555555",
               "opacity": 0.7,
               "width": 1
@@ -195,11 +100,7 @@
               "id": "distance_label",
               "type": "text",
               "text": "384,400 km",
-              "position": [
-                19,
-                1,
-                0
-              ],
+              "position": [19, 1, 0],
               "color": "#aaaaaa"
             }
           ],
@@ -209,26 +110,14 @@
           "title": "Scale Comparisons",
           "description": "For comparison: the ISS orbits just 400 km up — barely a speck at this scale. GPS satellites orbit at 20,200 km, and geostationary orbit is at 35,786 km.",
           "camera": {
-            "position": [
-              8,
-              4,
-              15
-            ],
-            "target": [
-              4,
-              0,
-              0
-            ]
+            "position": [8, 4, 15],
+            "target": [4, 0, 0]
           },
           "add": [
             {
               "id": "iss_pt",
               "type": "point",
-              "position": [
-                0.68,
-                0,
-                0
-              ],
+              "position": [0.68, 0, 0],
               "color": "#88ff88",
               "size": 5
             },
@@ -236,21 +125,13 @@
               "id": "iss_label",
               "type": "text",
               "text": "ISS orbit: 400 km",
-              "position": [
-                0.42,
-                -0.7,
-                0
-              ],
+              "position": [0.42, -0.7, 0],
               "color": "#88ff88"
             },
             {
               "id": "gps_pt",
               "type": "point",
-              "position": [
-                2.66,
-                0,
-                0
-              ],
+              "position": [2.66, 0, 0],
               "color": "#ffdd44",
               "size": 5
             },
@@ -258,21 +139,13 @@
               "id": "gps_label",
               "type": "text",
               "text": "GPS: 20,200 km",
-              "position": [
-                1.85,
-                -0.8,
-                0
-              ],
+              "position": [1.85, -0.8, 0],
               "color": "#ffdd44"
             },
             {
               "id": "geo_pt",
               "type": "point",
-              "position": [
-                4.22,
-                0,
-                0
-              ],
+              "position": [4.22, 0, 0],
               "color": "#ff8844",
               "size": 5
             },
@@ -280,11 +153,7 @@
               "id": "geo_label",
               "type": "text",
               "text": "Geostationary: 35,786 km",
-              "position": [
-                3,
-                -1.15,
-                0
-              ],
+              "position": [3, -1.15, 0],
               "color": "#ff8844"
             }
           ],
@@ -294,16 +163,8 @@
           "title": "The Journey Preview",
           "description": "This preview now uses the same mission construction as the simulation lesson: two Earth setup orbits from the departure sequence, then the nominal translunar coast, far-side flyby, and free-return leg. The path is frozen at the modeled closest-approach geometry so the flyby stays aligned with the fixed Moon marker in this scale view. Moon SOI entry marks where Orion enters the Moon's sphere of influence — the region where lunar gravity starts to dominate the flyby geometry.",
           "camera": {
-            "position": [
-              19,
-              10,
-              28
-            ],
-            "target": [
-              19,
-              0,
-              0
-            ]
+            "position": [19, 10, 28],
+            "target": [19, 0, 0]
           },
           "add": [
             {
@@ -312,10 +173,7 @@
               "x": "38.44 * cos(t)",
               "y": "38.44 * sin(t)",
               "z": "0",
-              "range": [
-                -0.2618,
-                0.2618
-              ],
+              "range": [-0.2618, 0.2618],
               "samples": 120,
               "color": "#9aa4b2",
               "opacity": 0.35,
@@ -324,11 +182,7 @@
             {
               "id": "marker_earth_apogee",
               "type": "point",
-              "position": [
-                7.719,
-                0.814,
-                0
-              ],
+              "position": [7.719, 0.814, 0],
               "color": "#ffd166",
               "size": 4
             },
@@ -336,21 +190,13 @@
               "id": "label_earth_apogee",
               "type": "text",
               "text": "Earth apogee",
-              "position": [
-                8.1,
-                1.15,
-                0
-              ],
+              "position": [8.1, 1.15, 0],
               "color": "#ffd166"
             },
             {
               "id": "marker_tli",
               "type": "point",
-              "position": [
-                0.275,
-                -1.394,
-                0
-              ],
+              "position": [0.275, -1.394, 0],
               "color": "#ff6b3d",
               "size": 4
             },
@@ -358,21 +204,13 @@
               "id": "label_tli",
               "type": "text",
               "text": "TLI burn",
-              "position": [
-                -1.15,
-                -2.15,
-                0
-              ],
+              "position": [-1.15, -2.15, 0],
               "color": "#ff6b3d"
             },
             {
               "id": "marker_moon_soi_entry",
               "type": "point",
-              "position": [
-                36.951,
-                -0.043,
-                0
-              ],
+              "position": [36.951, -0.043, 0],
               "color": "#a0c4ff",
               "size": 4
             },
@@ -380,32 +218,20 @@
               "id": "label_moon_soi_entry",
               "type": "text",
               "text": "Moon SOI entry",
-              "position": [
-                34.9,
-                -0.95,
-                0
-              ],
+              "position": [34.9, -0.95, 0],
               "color": "#a0c4ff"
             },
             {
               "id": "label_four_days_to_moon",
               "type": "text",
               "text": "4 days to Moon",
-              "position": [
-                31.9,
-                -1.95,
-                0
-              ],
+              "position": [31.9, -1.95, 0],
               "color": "#cbd5e1"
             },
             {
               "id": "marker_closest_lunar_approach",
               "type": "point",
-              "position": [
-                38.367,
-                0.259,
-                0
-              ],
+              "position": [38.367, 0.259, 0],
               "color": "#ff9f1c",
               "size": 4
             },
@@ -413,11 +239,7 @@
               "id": "label_closest_lunar_approach",
               "type": "text",
               "text": "Closest lunar approach",
-              "position": [
-                40.15,
-                0.95,
-                0
-              ],
+              "position": [40.15, 0.95, 0],
               "color": "#ff9f1c"
             },
             {
@@ -426,10 +248,7 @@
               "x": "missionX(t, 4050) * cos(moonTheta(4.945395, 4050)) + missionY(t, 4050) * sin(moonTheta(4.945395, 4050)) - 0.04",
               "y": "-missionX(t, 4050) * sin(moonTheta(4.945395, 4050)) + missionY(t, 4050) * cos(moonTheta(4.945395, 4050))",
               "z": "0",
-              "range": [
-                0,
-                1.0673611111111112
-              ],
+              "range": [0, 1.0673611111111112],
               "samples": 1200,
               "color": "#ff6644",
               "opacity": 0.3,
@@ -441,10 +260,7 @@
               "x": "missionX(t, 4050) * cos(moonTheta(4.945395, 4050)) + missionY(t, 4050) * sin(moonTheta(4.945395, 4050)) - 0.04",
               "y": "-missionX(t, 4050) * sin(moonTheta(4.945395, 4050)) + missionY(t, 4050) * cos(moonTheta(4.945395, 4050))",
               "z": "0",
-              "range": [
-                1.0673611111111112,
-                9
-              ],
+              "range": [1.0673611111111112, 9],
               "samples": 3600,
               "color": "#ff6644",
               "opacity": 0.6,
@@ -457,26 +273,14 @@
           "title": "Explore the Scale",
           "description": "The entire Artemis II mission takes about 10 days. Orbit the view to explore the scale of this incredible journey.",
           "camera": {
-            "position": [
-              19,
-              8,
-              30
-            ],
-            "target": [
-              19,
-              0,
-              0
-            ]
+            "position": [19, 8, 30],
+            "target": [19, 0, 0]
           },
           "add": [
             {
               "id": "you_are_here_pt",
               "type": "point",
-              "position": [
-                0.68,
-                0.2,
-                0
-              ],
+              "position": [0.68, 0.2, 0],
               "color": "#ffffff",
               "size": 7,
               "label": "You Are Here"
@@ -485,11 +289,7 @@
               "id": "mission_time_label",
               "type": "text",
               "text": "~4 days to return",
-              "position": [
-                10,
-                3,
-                0
-              ],
+              "position": [10, 3, 0],
               "color": "#aaaaaa"
             }
           ],
@@ -502,192 +302,89 @@
       "description": "SLS Block 1 and Orion — stages, mass ratios, and why staging is necessary",
       "prompt": "You are teaching about the SLS rocket and staging concept. The key insight: rockets must carry their own fuel, and fuel has mass, which requires more fuel — the tyranny of the rocket equation. Staging solves this by dropping empty tanks. Compare the 98m SLS to familiar structures (taller than the Statue of Liberty). Each stage has a specific job: SRBs for raw power at liftoff, core stage for sustained acceleration to orbit, ICPS for precision orbit adjustment. The crew of four sits at the very top in Orion — the only part that comes home.",
       "range": [
-        [
-          -6.5,
-          6.5
-        ],
-        [
-          -1,
-          12
-        ],
-        [
-          -6.5,
-          6.5
-        ]
+        [-6.5, 6.5],
+        [-1, 12],
+        [-6.5, 6.5]
       ],
       "camera": {
-        "position": [
-          8,
-          5,
-          8
-        ],
-        "target": [
-          0,
-          5,
-          0
-        ]
+        "position": [8, 5, 8],
+        "target": [0, 5, 0]
       },
       "views": [
         {
           "name": "Full Rocket",
-          "position": [
-            8,
-            5,
-            8
-          ],
-          "target": [
-            0,
-            5,
-            0
-          ],
+          "position": [8, 5, 8],
+          "target": [0, 5, 0],
           "description": "Full stack isometric view"
         },
         {
           "name": "Close-up Top",
-          "position": [
-            2,
-            9,
-            3
-          ],
-          "target": [
-            0,
-            9,
-            0
-          ],
+          "position": [2, 9, 3],
+          "target": [0, 9, 0],
           "description": "Orion and ICPS detail"
         },
         {
           "name": "Close-up Base",
-          "position": [
-            3,
-            0.5,
-            3
-          ],
-          "target": [
-            0,
-            0.5,
-            0
-          ],
+          "position": [3, 0.5, 3],
+          "target": [0, 0.5, 0],
           "description": "Launch pad and booster base"
         },
         {
           "name": "Side View",
-          "position": [
-            10,
-            5,
-            0
-          ],
-          "target": [
-            0,
-            5,
-            0
-          ],
+          "position": [10, 5, 0],
+          "target": [0, 5, 0],
           "description": "Profile view from the right"
         }
       ],
       "elements": [
-        {
-          "id": "_mathbox_init_1",
-          "type": "grid",
-          "plane": "xz",
-          "opacity": 0,
-          "divisions": 1
-        }
+        {"id": "_mathbox_init_1", "type": "grid", "plane": "xz", "opacity": 0, "divisions": 1}
       ],
       "steps": [
         {
           "title": "The Full Stack",
           "description": "The Space Launch System is the most powerful rocket ever flown. Standing 98 meters tall — taller than the Statue of Liberty — it generates 39 meganewtons of thrust at liftoff.",
           "camera": {
-            "position": [
-              8,
-              5,
-              8
-            ],
-            "target": [
-              0,
-              5,
-              0
-            ]
+            "position": [8, 5, 8],
+            "target": [0, 5, 0]
           },
           "add": [
             {
               "id": "srb_left",
               "type": "cylinder",
-              "from": [
-                -0.6,
-                0,
-                0
-              ],
-              "to": [
-                -0.6,
-                5.4,
-                0
-              ],
+              "from": [-0.6, 0, 0],
+              "to": [-0.6, 5.4, 0],
               "radius": 0.185,
               "color": "#ff4444"
             },
             {
               "id": "srb_right",
               "type": "cylinder",
-              "from": [
-                0.6,
-                0,
-                0
-              ],
-              "to": [
-                0.6,
-                5.4,
-                0
-              ],
+              "from": [0.6, 0, 0],
+              "to": [0.6, 5.4, 0],
               "radius": 0.185,
               "color": "#ff4444"
             },
             {
               "id": "core_stage",
               "type": "cylinder",
-              "from": [
-                0,
-                0,
-                0
-              ],
-              "to": [
-                0,
-                6.46,
-                0
-              ],
+              "from": [0, 0, 0],
+              "to": [0, 6.46, 0],
               "radius": 0.42,
               "color": "#ff8844"
             },
             {
               "id": "icps",
               "type": "cylinder",
-              "from": [
-                0,
-                6.46,
-                0
-              ],
-              "to": [
-                0,
-                7.86,
-                0
-              ],
+              "from": [0, 6.46, 0],
+              "to": [0, 7.86, 0],
               "radius": 0.26,
               "color": "#44aaff"
             },
             {
               "id": "orion",
               "type": "cylinder",
-              "from": [
-                0,
-                7.86,
-                0
-              ],
-              "to": [
-                0,
-                9.86,
-                0
-              ],
+              "from": [0, 7.86, 0],
+              "to": [0, 9.86, 0],
               "radius": 0.25,
               "color": "#ffffff"
             },
@@ -695,22 +392,14 @@
               "id": "label_sls",
               "type": "text",
               "text": "SLS Block 1",
-              "position": [
-                2,
-                5,
-                0
-              ],
+              "position": [2, 5, 0],
               "color": "#ffffff"
             },
             {
               "id": "label_height",
               "type": "text",
               "text": "98 meters tall",
-              "position": [
-                2,
-                4,
-                0
-              ],
+              "position": [2, 4, 0],
               "color": "#cccccc"
             }
           ]
@@ -723,33 +412,21 @@
               "id": "label_srb",
               "type": "text",
               "text": "2× SRBs",
-              "position": [
-                -1.5,
-                2.7,
-                0
-              ],
+              "position": [-1.5, 2.7, 0],
               "color": "#ff6666"
             },
             {
               "id": "label_srb_thrust",
               "type": "text",
               "text": "16 MN thrust each",
-              "position": [
-                -1.5,
-                2,
-                0
-              ],
+              "position": [-1.5, 2, 0],
               "color": "#ffaaaa"
             },
             {
               "id": "label_srb_burn",
               "type": "text",
               "text": "126 seconds burn",
-              "position": [
-                -1.5,
-                1.3,
-                0
-              ],
+              "position": [-1.5, 1.3, 0],
               "color": "#ffaaaa"
             }
           ]
@@ -762,33 +439,21 @@
               "id": "label_core",
               "type": "text",
               "text": "Core Stage",
-              "position": [
-                1.5,
-                3.2,
-                0
-              ],
+              "position": [1.5, 3.2, 0],
               "color": "#ffaa66"
             },
             {
               "id": "label_core_engines",
               "type": "text",
               "text": "4× RS-25 engines",
-              "position": [
-                1.5,
-                0.5,
-                0
-              ],
+              "position": [1.5, 0.5, 0],
               "color": "#ffcc99"
             },
             {
               "id": "label_core_prop",
               "type": "text",
               "text": "Liquid H₂ + O₂",
-              "position": [
-                1.5,
-                1.5,
-                0
-              ],
+              "position": [1.5, 1.5, 0],
               "color": "#ffcc99"
             }
           ]
@@ -801,22 +466,14 @@
               "id": "label_icps",
               "type": "text",
               "text": "ICPS",
-              "position": [
-                1.5,
-                7.2,
-                0
-              ],
+              "position": [1.5, 7.2, 0],
               "color": "#88ccff"
             },
             {
               "id": "label_icps_engine",
               "type": "text",
               "text": "RL10 engine",
-              "position": [
-                1.5,
-                6.6,
-                0
-              ],
+              "position": [1.5, 6.6, 0],
               "color": "#aaddff"
             }
           ]
@@ -825,38 +482,22 @@
           "title": "Orion Spacecraft",
           "description": "At the top sits Orion — carrying four astronauts: Reid Wiseman, Victor Glover, Christina Koch, and Jeremy Hansen. Its European Service Module provides propulsion for the lunar journey.",
           "camera": {
-            "position": [
-              2,
-              9,
-              3
-            ],
-            "target": [
-              0,
-              9,
-              0
-            ]
+            "position": [2, 9, 3],
+            "target": [0, 9, 0]
           },
           "add": [
             {
               "id": "label_orion",
               "type": "text",
               "text": "Orion",
-              "position": [
-                1.5,
-                9,
-                0
-              ],
+              "position": [1.5, 9, 0],
               "color": "#ffffff"
             },
             {
               "id": "label_orion_crew",
               "type": "text",
               "text": "4 crew",
-              "position": [
-                1.5,
-                8.4,
-                0
-              ],
+              "position": [1.5, 8.4, 0],
               "color": "#dddddd"
             }
           ]
@@ -865,46 +506,23 @@
           "title": "Why Staging?",
           "description": "About 85% of the rocket's 2.6 million kg liftoff mass is propellant. Staging works by discarding empty tanks — each stage falls away once its fuel is spent, leaving less mass for the next stage to push.",
           "camera": {
-            "position": [
-              8,
-              5,
-              8
-            ],
-            "target": [
-              0,
-              5,
-              0
-            ]
+            "position": [8, 5, 8],
+            "target": [0, 5, 0]
           },
           "add": [
             {
               "id": "label_mass_pct",
               "type": "text",
               "text": "~85% of launch mass is fuel",
-              "position": [
-                0,
-                -0.5,
-                0
-              ],
+              "position": [0, -0.5, 0],
               "color": "#ffdd88"
             }
           ],
           "sliders": [
-            {
-              "id": "massRatio",
-              "label": "Propellant fraction",
-              "min": 0,
-              "max": 1,
-              "step": 0.01,
-              "default": 0.85
-            }
+            {"id": "massRatio", "label": "Propellant fraction", "min": 0, "max": 1, "step": 0.01, "default": 0.85}
           ],
           "info": [
-            {
-              "id": "massInfo",
-              "content": "**Mass Budget**\n\nPropellant: {{toFixed(massRatio * 2610000, 0)}} kg\n\nDry mass: {{toFixed((1 - massRatio) * 2610000, 0)}} kg\n\nTotal: 2,610,000 kg",
-              "position": "top-left"
-            }
+            {"id": "massInfo", "content": "**Mass Budget**\n\nPropellant: {{toFixed(massRatio * 2610000, 0)}} kg\n\nDry mass: {{toFixed((1 - massRatio) * 2610000, 0)}} kg\n\nTotal: 2,610,000 kg", "position": "top-left"}
           ]
         }
       ],
@@ -924,13 +542,23 @@
             "explanation": "A rocket engine works by expelling mass (hot gas) at high speed out the nozzle. By Newton's third law, the exhaust pushing backward creates an equal forward force on the rocket.",
             "sceneStep": 0,
             "highlights": {
-              "action": {
-                "color": "cyan",
-                "label": "Force on exhaust (backward)"
-              },
-              "reaction": {
-                "color": "orange",
-                "label": "Force on rocket (forward)"
+              "action": {"color": "cyan", "label": "Force on exhaust (backward)"},
+              "reaction": {"color": "orange", "label": "Force on rocket (forward)"}
+            },
+            "semanticGraph": {
+              "graph": {
+                "nodes": [
+                  {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\vec{F}_{\\text{action}} = -\\vec{F}_{\\text{reaction}}"},
+                  {"id": "F_{\\text{action}}", "type": "vector", "latex": "\\vec{F}_{\\text{action}}", "subexpr": "\\vec{F}_{\\text{action}}", "description": "Force on exhaust (backward)", "color": "cyan", "highlight": "action"},
+                  {"id": "__negation_2", "type": "operator", "op": "negation", "subexpr": "-\\vec{F}_{\\text{reaction}}"},
+                  {"id": "F_{\\text{reaction}}", "type": "vector", "latex": "\\vec{F}_{\\text{reaction}}", "subexpr": "\\vec{F}_{\\text{reaction}}", "description": "Force on rocket (forward)", "color": "orange", "highlight": "reaction"}
+                ],
+                "edges": [
+                  {"from": "F_{\\text{action}}", "to": "__equals_1"},
+                  {"from": "F_{\\text{reaction}}", "to": "__negation_2"},
+                  {"from": "__negation_2", "to": "__equals_1"}
+                ],
+                "classification": {"kind": "algebraic"}
               }
             }
           },
@@ -942,13 +570,34 @@
             "explanation": "For a rocket, both mass and velocity are changing: the rocket gets lighter as it burns fuel, and it accelerates. We need the momentum form, not just $F = ma$.",
             "sceneStep": 0,
             "highlights": {
-              "force": {
-                "color": "cyan",
-                "label": "Net force"
-              },
-              "momentum": {
-                "color": "yellow",
-                "label": "Momentum"
+              "force": {"color": "cyan", "label": "Net force"},
+              "momentum": {"color": "yellow", "label": "Momentum"}
+            },
+            "semanticGraph": {
+              "graph": {
+                "nodes": [
+                  {"id": "F", "type": "vector", "latex": "\\vec{F}", "subexpr": "\\vec{F}", "description": "Net force", "color": "cyan", "highlight": "force"},
+                  {"id": "p", "type": "vector", "latex": "\\vec{p}", "subexpr": "\\vec{p}", "description": "Momentum", "color": "yellow", "highlight": "momentum"},
+                  {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                  {"id": "s1___deriv_1", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\frac{d}{d t} \\vec{p}"},
+                  {"id": "s2___multiply_2", "type": "operator", "op": "multiply", "subexpr": "m \\vec{v}"},
+                  {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m"},
+                  {"id": "v", "type": "vector", "latex": "\\vec{v}", "subexpr": "\\vec{v}"},
+                  {"id": "s2___deriv_1", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\frac{d}{d t} (m \\vec{v})"},
+                  {"id": "__equals_1", "type": "operator", "op": "equals", "subexpr": "\\vec{F} = \\frac{d\\vec{p}}{dt} = \\frac{d(m\\vec{v})}{dt}"}
+                ],
+                "edges": [
+                  {"from": "p", "to": "s1___deriv_1"},
+                  {"from": "t", "to": "s1___deriv_1"},
+                  {"from": "m", "to": "s2___multiply_2"},
+                  {"from": "v", "to": "s2___multiply_2"},
+                  {"from": "s2___multiply_2", "to": "s2___deriv_1"},
+                  {"from": "t", "to": "s2___deriv_1"},
+                  {"from": "F", "to": "__equals_1"},
+                  {"from": "s1___deriv_1", "to": "__equals_1"},
+                  {"from": "s2___deriv_1", "to": "__equals_1"}
+                ],
+                "classification": {"kind": "algebraic"}
               }
             }
           },
@@ -960,13 +609,43 @@
             "explanation": "A key assumption: the exhaust velocity $v_e$ is approximately constant for a given engine — it depends on the propellant chemistry and nozzle geometry, not on the rocket's speed. This is what makes the equation simple: only the mass flow rate $\\dot{m}$ varies during a burn.",
             "sceneStep": 1,
             "highlights": {
-              "mdot": {
-                "color": "yellow",
-                "label": "Mass flow rate (kg/s)"
-              },
-              "ve": {
-                "color": "green",
-                "label": "Exhaust velocity (constant)"
+              "mdot": {"color": "yellow", "label": "Mass flow rate (kg/s)"},
+              "ve": {"color": "green", "label": "Exhaust velocity (constant)"}
+            },
+            "semanticGraph": {
+              "graph": {
+                "nodes": [
+                  {"id": "F_{\\text{exhaust}}", "type": "scalar", "latex": "F_{\\text{exhaust}}", "subexpr": "F_{\\text{exhaust}}"},
+                  {"id": "p", "type": "scalar", "latex": "p", "subexpr": "p"},
+                  {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                  {"id": "s1___deriv_1", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\frac{d}{d t} p"},
+                  {"id": "s2___multiply_1", "type": "operator", "op": "multiply", "subexpr": "\\frac{d}{d t} m_{\\text{exhaust}} \\cdot v_e"},
+                  {"id": "m_{\\text{exhaust}}", "type": "scalar", "latex": "m_{\\text{exhaust}}", "subexpr": "m_{\\text{exhaust}}"},
+                  {"id": "s2___deriv_2", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\frac{d}{d t} m_{\\text{exhaust}}"},
+                  {"id": "v_{e}", "type": "scalar", "latex": "v_{e}", "subexpr": "v_{e}", "description": "Exhaust velocity (constant)", "color": "green", "highlight": "ve"},
+                  {"id": "s3___multiply_1", "type": "operator", "op": "multiply", "subexpr": "\\dot{m} \\cdot v_e"},
+                  {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m", "description": "Mass flow rate (kg/s)", "color": "yellow", "highlight": "mdot"},
+                  {"id": "s3___deriv_2", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\dot{m}"},
+                  {"id": "__equals_1", "type": "operator", "op": "equals", "subexpr": "F_{\\text{exhaust}} = \\frac{dp}{dt} = \\frac{dm_{\\text{exhaust}}}{dt} \\cdot v_e = \\dot{m} \\cdot v_e"},
+                  {"id": "__annotation_0", "type": "annotation", "label": "v_e constant", "latex": "v_e \\text{ constant}"}
+                ],
+                "edges": [
+                  {"from": "p", "to": "s1___deriv_1"},
+                  {"from": "t", "to": "s1___deriv_1"},
+                  {"from": "m_{\\text{exhaust}}", "to": "s2___deriv_2"},
+                  {"from": "t", "to": "s2___deriv_2"},
+                  {"from": "s2___deriv_2", "to": "s2___multiply_1"},
+                  {"from": "v_{e}", "to": "s2___multiply_1"},
+                  {"from": "m", "to": "s3___deriv_2"},
+                  {"from": "t", "to": "s3___deriv_2"},
+                  {"from": "s3___deriv_2", "to": "s3___multiply_1"},
+                  {"from": "v_{e}", "to": "s3___multiply_1"},
+                  {"from": "F_{\\text{exhaust}}", "to": "__equals_1"},
+                  {"from": "s1___deriv_1", "to": "__equals_1"},
+                  {"from": "s2___multiply_1", "to": "__equals_1"},
+                  {"from": "s3___multiply_1", "to": "__equals_1"}
+                ],
+                "classification": {"kind": "algebraic"}
               }
             }
           },
@@ -977,20 +656,42 @@
             "justification": "The thrust $T$ equals the mass flow rate $\\dot{m}$ (kg/s of propellant expelled) times the exhaust velocity $v_e$ (speed of the gas leaving the nozzle).",
             "explanation": "Each second, $\\dot{m}$ kilograms of propellant leave the nozzle at speed $v_e$. The momentum carried away per second is $\\dot{m} v_e$, which by Newton's third law equals the thrust force on the rocket.",
             "highlights": {
-              "thrust": {
-                "color": "cyan",
-                "label": "Thrust force (N)"
-              },
-              "mdot": {
-                "color": "yellow",
-                "label": "Mass flow rate (kg/s)"
-              },
-              "ve": {
-                "color": "green",
-                "label": "Exhaust velocity (m/s)"
-              }
+              "thrust": {"color": "cyan", "label": "Thrust force (N)"},
+              "mdot": {"color": "yellow", "label": "Mass flow rate (kg/s)"},
+              "ve": {"color": "green", "label": "Exhaust velocity (m/s)"}
             },
-            "sceneStep": 1
+            "sceneStep": 1,
+            "semanticGraph": {
+              "graph": {
+                "nodes": [
+                  {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "T = \\dot{m} \\cdot v_e"},
+                  {"id": "T", "type": "scalar", "latex": "T", "subexpr": "T", "description": "Thrust force (N)", "color": "cyan", "highlight": "thrust"},
+                  {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\dot{m} v_{e}"},
+                  {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m", "description": "Mass flow rate (kg/s)", "color": "yellow", "highlight": "mdot"},
+                  {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                  {"id": "__deriv_3", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\dot{m}"},
+                  {"id": "v_{e}", "type": "scalar", "latex": "v_{e}", "subexpr": "v_{e}", "description": "Exhaust velocity (m/s)", "color": "green", "highlight": "ve"}
+                ],
+                "edges": [
+                  {"from": "T", "to": "__equals_1"},
+                  {"from": "m", "to": "__deriv_3"},
+                  {"from": "t", "to": "__deriv_3", "role": "wrt"},
+                  {"from": "__deriv_3", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                  {"from": "v_{e}", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                  {"from": "__multiply_2", "to": "__equals_1"}
+                ],
+                "classification": {
+                  "kind": "ODE",
+                  "order": 1,
+                  "dependent_variables": ["m"],
+                  "independent_variables": ["t"],
+                  "sympy_hints": ["factorable", "nth_algebraic", "separable", "1st_exact", "1st_linear", "Bernoulli", "1st_power_series", "lie_group", "nth_linear_constant_coeff_undetermined_coefficients", "nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients", "nth_linear_constant_coeff_variation_of_parameters", "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters"],
+                  "linear": true,
+                  "homogeneous": true,
+                  "constant_coefficients": true
+                }
+              }
+            }
           },
           {
             "type": "step",
@@ -1000,17 +701,43 @@
             "explanation": "Impulse measures the total \"push\" delivered over a burn. A longer burn or higher thrust both increase impulse. This tells us how much momentum the rocket gains from burning all its fuel.",
             "sceneStep": 1,
             "highlights": {
-              "impulse": {
-                "color": "cyan",
-                "label": "Total impulse (N·s)"
-              },
-              "mprop": {
-                "color": "yellow",
-                "label": "Total propellant mass (kg)"
-              },
-              "ve": {
-                "color": "green",
-                "label": "Exhaust velocity (m/s)"
+              "impulse": {"color": "cyan", "label": "Total impulse (N·s)"},
+              "mprop": {"color": "yellow", "label": "Total propellant mass (kg)"},
+              "ve": {"color": "green", "label": "Exhaust velocity (m/s)"}
+            },
+            "semanticGraph": {
+              "graph": {
+                "nodes": [
+                  {"id": "J", "type": "scalar", "latex": "J", "subexpr": "J", "description": "Total impulse (N·s)", "color": "cyan", "highlight": "impulse"},
+                  {"id": "s1___multiply_1", "type": "operator", "op": "multiply", "subexpr": "T \\cdot t"},
+                  {"id": "T", "type": "scalar", "latex": "T", "subexpr": "T"},
+                  {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                  {"id": "s2___multiply_1", "type": "operator", "op": "multiply", "subexpr": "\\dot{m} \\cdot v_e \\cdot t"},
+                  {"id": "s2___multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\dot{m} v_{e}"},
+                  {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m"},
+                  {"id": "s2___deriv_3", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\dot{m}"},
+                  {"id": "v_{e}", "type": "scalar", "latex": "v_{e}", "subexpr": "v_{e}", "description": "Exhaust velocity (m/s)", "color": "green", "highlight": "ve"},
+                  {"id": "s3___multiply_1", "type": "operator", "op": "multiply", "subexpr": "m_{\\text{prop}} \\cdot v_e"},
+                  {"id": "m_{\\text{prop}}", "type": "scalar", "latex": "m_{\\text{prop}}", "subexpr": "m_{\\text{prop}}", "description": "Total propellant mass (kg)", "color": "yellow", "highlight": "mprop"},
+                  {"id": "__equals_1", "type": "operator", "op": "equals", "subexpr": "J = T \\cdot t = \\dot{m} \\cdot v_e \\cdot t = m_{\\text{prop}} \\cdot v_e"}
+                ],
+                "edges": [
+                  {"from": "T", "to": "s1___multiply_1"},
+                  {"from": "t", "to": "s1___multiply_1"},
+                  {"from": "m", "to": "s2___deriv_3"},
+                  {"from": "t", "to": "s2___deriv_3"},
+                  {"from": "s2___deriv_3", "to": "s2___multiply_2"},
+                  {"from": "v_{e}", "to": "s2___multiply_2"},
+                  {"from": "s2___multiply_2", "to": "s2___multiply_1"},
+                  {"from": "t", "to": "s2___multiply_1"},
+                  {"from": "m_{\\text{prop}}", "to": "s3___multiply_1"},
+                  {"from": "v_{e}", "to": "s3___multiply_1"},
+                  {"from": "J", "to": "__equals_1"},
+                  {"from": "s1___multiply_1", "to": "__equals_1"},
+                  {"from": "s2___multiply_1", "to": "__equals_1"},
+                  {"from": "s3___multiply_1", "to": "__equals_1"}
+                ],
+                "classification": {"kind": "algebraic"}
               }
             }
           },
@@ -1022,21 +749,52 @@
             "explanation": "The word \"specific\" means \"per unit weight.\" We divide by weight (not mass) for historical reasons — it gives $I_{sp}$ units of seconds, which is the same in both metric and imperial systems. An $I_{sp}$ of 452 s means one kilogram of propellant produces 452 seconds of 9.81 N thrust.",
             "sceneStep": 2,
             "highlights": {
-              "isp": {
-                "color": "orange",
-                "label": "Specific impulse (s)"
-              },
-              "mprop": {
-                "color": "yellow",
-                "label": "Propellant mass (cancels)"
-              },
-              "ve": {
-                "color": "green",
-                "label": "Exhaust velocity (m/s)"
-              },
-              "g0": {
-                "color": "blue",
-                "label": "Standard gravity (9.81 m/s²)"
+              "isp": {"color": "orange", "label": "Specific impulse (s)"},
+              "mprop": {"color": "yellow", "label": "Propellant mass (cancels)"},
+              "ve": {"color": "green", "label": "Exhaust velocity (m/s)"},
+              "g0": {"color": "blue", "label": "Standard gravity (9.81 m/s²)"}
+            },
+            "semanticGraph": {
+              "graph": {
+                "nodes": [
+                  {"id": "I_{sp}", "type": "scalar", "latex": "I_{sp}", "subexpr": "I_{sp}", "description": "Specific impulse (s)", "color": "orange", "highlight": "isp"},
+                  {"id": "s1___multiply_1", "type": "operator", "op": "multiply", "subexpr": "\\frac{J}{m_{\\text{prop}} \\cdot g_0}"},
+                  {"id": "J", "type": "scalar", "latex": "J", "subexpr": "J"},
+                  {"id": "s1___power_2", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{m_{\\text{prop}} g_{0}}"},
+                  {"id": "s1___multiply_3", "type": "operator", "op": "multiply", "subexpr": "m_{\\text{prop}} g_{0}"},
+                  {"id": "m_{\\text{prop}}", "type": "scalar", "latex": "m_{\\text{prop}}", "subexpr": "m_{\\text{prop}}", "description": "Propellant mass (cancels)", "color": "yellow", "highlight": "mprop"},
+                  {"id": "g_{0}", "type": "scalar", "latex": "g_{0}", "subexpr": "g_{0}", "description": "Standard gravity (9.81 m/s²)", "color": "blue", "highlight": "g0"},
+                  {"id": "s2___multiply_1", "type": "operator", "op": "multiply", "subexpr": "\\frac{m_{\\text{prop}} \\cdot v_e}{m_{\\text{prop}} \\cdot g_0}"},
+                  {"id": "s2___multiply_2", "type": "operator", "op": "multiply", "subexpr": "m_{\\text{prop}} v_{e}"},
+                  {"id": "v_{e}", "type": "scalar", "latex": "v_{e}", "subexpr": "v_{e}", "description": "Exhaust velocity (m/s)", "color": "green", "highlight": "ve"},
+                  {"id": "s2___power_3", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{m_{\\text{prop}} g_{0}}"},
+                  {"id": "s2___multiply_4", "type": "operator", "op": "multiply", "subexpr": "m_{\\text{prop}} g_{0}"},
+                  {"id": "s3___multiply_1", "type": "operator", "op": "multiply", "subexpr": "\\frac{v_e}{g_0}"},
+                  {"id": "s3___power_2", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{g_{0}}"},
+                  {"id": "__equals_1", "type": "operator", "op": "equals", "subexpr": "I_{sp} = \\frac{J}{m_{\\text{prop}} \\cdot g_0} = \\frac{m_{\\text{prop}} \\cdot v_e}{m_{\\text{prop}} \\cdot g_0} = \\frac{v_e}{g_0}"}
+                ],
+                "edges": [
+                  {"from": "J", "to": "s1___multiply_1"},
+                  {"from": "m_{\\text{prop}}", "to": "s1___multiply_3"},
+                  {"from": "g_{0}", "to": "s1___multiply_3"},
+                  {"from": "s1___multiply_3", "to": "s1___power_2"},
+                  {"from": "s1___power_2", "to": "s1___multiply_1"},
+                  {"from": "m_{\\text{prop}}", "to": "s2___multiply_2"},
+                  {"from": "v_{e}", "to": "s2___multiply_2"},
+                  {"from": "s2___multiply_2", "to": "s2___multiply_1"},
+                  {"from": "m_{\\text{prop}}", "to": "s2___multiply_4"},
+                  {"from": "g_{0}", "to": "s2___multiply_4"},
+                  {"from": "s2___multiply_4", "to": "s2___power_3"},
+                  {"from": "s2___power_3", "to": "s2___multiply_1"},
+                  {"from": "v_{e}", "to": "s3___multiply_1"},
+                  {"from": "g_{0}", "to": "s3___power_2"},
+                  {"from": "s3___power_2", "to": "s3___multiply_1"},
+                  {"from": "I_{sp}", "to": "__equals_1"},
+                  {"from": "s1___multiply_1", "to": "__equals_1"},
+                  {"from": "s2___multiply_1", "to": "__equals_1"},
+                  {"from": "s3___multiply_1", "to": "__equals_1"}
+                ],
+                "classification": {"kind": "algebraic"}
               }
             }
           },
@@ -1048,21 +806,44 @@
             "explanation": "This form is useful because $I_{sp}$ is how engines are rated. It separates thrust into three factors: how much propellant leaves each second, how efficiently the engine converts propellant into exhaust speed, and the standard-gravity conversion factor built into the historical definition of specific impulse.",
             "sceneStep": 3,
             "highlights": {
-              "thrust": {
-                "color": "cyan",
-                "label": "Thrust force (N)"
-              },
-              "mdot": {
-                "color": "yellow",
-                "label": "Mass flow rate (kg/s)"
-              },
-              "isp": {
-                "color": "orange",
-                "label": "Specific impulse (s)"
-              },
-              "g0": {
-                "color": "blue",
-                "label": "Standard gravity (9.81 m/s²)"
+              "thrust": {"color": "cyan", "label": "Thrust force (N)"},
+              "mdot": {"color": "yellow", "label": "Mass flow rate (kg/s)"},
+              "isp": {"color": "orange", "label": "Specific impulse (s)"},
+              "g0": {"color": "blue", "label": "Standard gravity (9.81 m/s²)"}
+            },
+            "semanticGraph": {
+              "graph": {
+                "nodes": [
+                  {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "T = \\dot{m} \\cdot I_{sp} \\cdot g_0"},
+                  {"id": "T", "type": "scalar", "latex": "T", "subexpr": "T", "description": "Thrust force (N)", "color": "cyan", "highlight": "thrust"},
+                  {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "\\dot{m} I_{sp} g_{0}"},
+                  {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "\\dot{m} I_{sp}"},
+                  {"id": "m", "type": "scalar", "latex": "m", "subexpr": "m", "description": "Mass flow rate (kg/s)", "color": "yellow", "highlight": "mdot"},
+                  {"id": "t", "type": "scalar", "latex": "t", "subexpr": "t"},
+                  {"id": "__deriv_4", "type": "operator", "op": "derivative", "with_respect_to": "t", "subexpr": "\\dot{m}"},
+                  {"id": "I_{sp}", "type": "scalar", "latex": "I_{sp}", "subexpr": "I_{sp}", "description": "Specific impulse (s)", "color": "orange", "highlight": "isp"},
+                  {"id": "g_{0}", "type": "scalar", "latex": "g_{0}", "subexpr": "g_{0}", "description": "Standard gravity (9.81 m/s²)", "color": "blue", "highlight": "g0"}
+                ],
+                "edges": [
+                  {"from": "T", "to": "__equals_1"},
+                  {"from": "m", "to": "__deriv_4"},
+                  {"from": "t", "to": "__deriv_4", "role": "wrt"},
+                  {"from": "__deriv_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                  {"from": "I_{sp}", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                  {"from": "__multiply_3", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                  {"from": "g_{0}", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                  {"from": "__multiply_2", "to": "__equals_1"}
+                ],
+                "classification": {
+                  "kind": "ODE",
+                  "order": 1,
+                  "dependent_variables": ["m"],
+                  "independent_variables": ["t"],
+                  "sympy_hints": ["factorable", "nth_algebraic", "separable", "1st_exact", "1st_linear", "Bernoulli", "1st_power_series", "lie_group", "nth_linear_constant_coeff_undetermined_coefficients", "nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients", "nth_linear_constant_coeff_variation_of_parameters", "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters"],
+                  "linear": true,
+                  "homogeneous": true,
+                  "constant_coefficients": true
+                }
               }
             }
           }
@@ -1074,133 +855,56 @@
       "description": "A uniform-scale Earth-Moon map with a time-controlled nominal Artemis II route and a dynamically moving Moon.",
       "markdown": "# Cislunar Scale and Nominal Route\n\nThis lesson uses a **uniform distance scale** in every direction:\n\n$$1\\text{ unit} = 10{,}000\\text{ km}$$\n\nSo the key mission distances become:\n\n$$R_{\\oplus} = 6371\\text{ km} \\approx 0.6371\\text{ units}$$\n$$R_{\\text{Moon}} = 1737\\text{ km} \\approx 0.1737\\text{ units}$$\n$$d_{\\oplus\\text{-Moon}} = 384{,}400\\text{ km} \\approx 38.44\\text{ units}$$\n\nThe route shown here is a **nominal reference trajectory** based on NASA SVS record **5610** and the Artemis II press kit. NASA explicitly notes that the actual trajectory may vary with final launch timing.\n\nThe Moon is also **dynamically simulated** rather than pinned in place. In this lesson, the Moon moves on a circular cislunar orbit with mean angular rate\n\n$$\\omega_{\\text{Moon}} = \\frac{2\\pi}{27.321661\\text{ days}} \\approx 0.23\\text{ rad/day}$$\n\nand the Artemis II path is timed so the flyby occurs when Orion reaches the moving Moon near mission day 5.\n\nA key mission fact is that Artemis II does **two Earth orbits before translunar injection**. So the route near Earth is not an accidental loop: it represents the planned Earth-orbit setup before Orion heads for the Moon.\n\nThat departure is **not** an Earth gravity assist. Orion must execute a real **translunar injection burn** with the service module after the Earth-orbit setup. The gravity-assist style turn happens later at the Moon during the free-return flyby.\n\n## Mission anchors used in this scene\n\n- mission duration: about **10 days**\n- closest approach above the Moon: about **4,000 to 6,000 miles**\n- communications blackout: about **30 to 50 minutes**\n- two Earth orbits before translunar injection\n- a thrust-driven translunar injection burn\n- free-return path back to Earth\n\n## Sources\n\n- NASA Artemis II press kit: https://www.nasa.gov/artemis-ii-press-kit/\n- NASA Artemis II mission page: https://www.nasa.gov/mission/artemis-ii/\n- NASA SVS API record 5610: https://svs.gsfc.nasa.gov/api/5610",
       "prompt": "Start with scale honesty. The student should immediately see that the Moon is far away, the high-Earth orbit is still close to Earth compared with lunar distance, and that Artemis II intentionally makes two Earth orbits before translunar injection. Make clear that Earth departure requires a real translunar injection burn, while the gravity-assist style turn belongs to the lunar flyby. The route is a nominal NASA-guided free-return model rather than a hand-drawn sketch.",
-      "scale": [
-        25,
-        12,
-        4
-      ],
+      "scale": [25, 12, 4],
       "range": [
-        [
-          -5,
-          45
-        ],
-        [
-          -12,
-          12
-        ],
-        [
-          -4,
-          4
-        ]
+        [-5, 45],
+        [-12, 12],
+        [-4, 4]
       ],
       "camera": {
-        "position": [
-          19,
-          8,
-          30
-        ],
-        "target": [
-          19,
-          0,
-          0
-        ],
-        "up": [
-          0,
-          0,
-          1
-        ]
+        "position": [19, 8, 30],
+        "target": [19, 0, 0],
+        "up": [0, 0, 1]
       },
       "views": [
         {
           "name": "Overview",
           "description": "See Earth, Moon, and the whole nominal route",
-          "position": [
-            19,
-            8,
-            30
-          ],
-          "target": [
-            19,
-            0,
-            0
-          ]
+          "position": [19, 8, 30],
+          "target": [19, 0, 0]
         },
         {
           "name": "Earth Close",
           "description": "Focus on Earth and the high-Earth orbit region",
-          "position": [
-            0,
-            1.5,
-            7
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ]
+          "position": [0, 1.5, 7],
+          "target": [0, 0, 0],
+          "up": [0, 0, 1]
         },
         {
           "name": "Moon Close",
           "description": "Focus on the far-side flyby region",
-          "position": [
-            38.44,
-            1.5,
-            7
-          ],
-          "target": [
-            38.44,
-            0,
-            0
-          ]
+          "position": [38.44, 1.5, 7],
+          "target": [38.44, 0, 0]
         },
         {
           "name": "Ride Along",
           "description": "Camera follows Orion along the route",
           "follow": "s1_orion",
-          "angleLockVector": [
-            "s1_orion"
-          ],
-          "offset": [
-            0,
-            2.5,
-            6
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ]
+          "angleLockVector": ["s1_orion"],
+          "offset": [0, 2.5, 6],
+          "up": [0, 0, 1]
         }
       ],
-      "starfield": {
-        "enabled": true,
-        "count": 1400,
-        "size": 1.7,
-        "opacity": 0.86,
-        "twinkle": 0
-      },
+      "starfield": {"enabled": true, "count": 1400, "size": 1.7, "opacity": 0.86, "twinkle": 0},
       "elements": [
         {
           "id": "s1_earth",
           "type": "sphere",
-          "center": [
-            0,
-            0,
-            0
-          ],
+          "center": [0, 0, 0],
           "radius": 0.6371,
           "color": "#3a7bd5",
           "label": "Earth",
-          "shader": {
-            "type": "phong",
-            "emissive": "#112244",
-            "shininess": 30
-          }
+          "shader": {"type": "phong", "emissive": "#112244", "shininess": 30}
         },
         {
           "id": "s1_moon_orbit",
@@ -1208,10 +912,7 @@
           "x": "38.44 * cos(t)",
           "y": "38.44 * sin(t)",
           "z": "0",
-          "range": [
-            0,
-            6.2832
-          ],
+          "range": [0, 6.2832],
           "color": "#6c7a89",
           "width": 1.1,
           "opacity": 0.32,
@@ -1220,32 +921,16 @@
         {
           "id": "s1_moon",
           "type": "sphere",
-          "centerExpr": [
-            "moonX(day)",
-            "moonY(day)",
-            "0"
-          ],
+          "centerExpr": ["moonX(day)", "moonY(day)", "0"],
           "radius": 0.1737,
           "color": "#b0b0b0",
-          "shader": {
-            "type": "phong",
-            "emissive": "#404040",
-            "shininess": 10
-          }
+          "shader": {"type": "phong", "emissive": "#404040", "shininess": 10}
         },
         {
           "id": "s1_em_vec",
           "type": "animated_vector",
-          "from": [
-            0,
-            0,
-            0
-          ],
-          "expr": [
-            "moonX(day)",
-            "moonY(day)",
-            "0"
-          ],
+          "from": [0, 0, 0],
+          "expr": ["moonX(day)", "moonY(day)", "0"],
           "color": "#e2e8f0",
           "opacity": 0.4,
           "width": 0.09,
@@ -1257,10 +942,7 @@
           "x": "missionX(t)",
           "y": "missionY(t)",
           "z": "0",
-          "range": [
-            0,
-            9.1
-          ],
+          "range": [0, 9.1],
           "color": "#ff6b3d",
           "label": "Nominal trajectory",
           "width": 2.4,
@@ -1269,41 +951,17 @@
         {
           "id": "s1_orion",
           "type": "animated_vector",
-          "fromExpr": [
-            "missionX(day) - 0.18 * missionVx(day) / max(0.001, sqrt(missionVx(day)^2 + missionVy(day)^2))",
-            "missionY(day) - 0.18 * missionVy(day) / max(0.001, sqrt(missionVx(day)^2 + missionVy(day)^2))",
-            "0"
-          ],
-          "expr": [
-            "missionX(day)",
-            "missionY(day)",
-            "0"
-          ],
+          "fromExpr": ["missionX(day) - 0.18 * missionVx(day) / max(0.001, sqrt(missionVx(day)^2 + missionVy(day)^2))", "missionY(day) - 0.18 * missionVy(day) / max(0.001, sqrt(missionVx(day)^2 + missionVy(day)^2))", "0"],
+          "expr": ["missionX(day)", "missionY(day)", "0"],
           "color": "#ffffff",
           "label": "Orion",
           "opacity": 1,
-          "shader": {
-            "emissive": "#cfd8e3",
-            "specular": "#ffffff",
-            "shininess": 140
-          },
-          "panels": {
-            "color": "#7dd3fc",
-            "opacity": 0.95,
-            "length": 0.11,
-            "width": 0.026,
-            "thickness": 0.008,
-            "gap": 0.014,
-            "segments": 2
-          },
+          "shader": {"emissive": "#cfd8e3", "specular": "#ffffff", "shininess": 140},
+          "panels": {"color": "#7dd3fc", "opacity": 0.95, "length": 0.11, "width": 0.026, "thickness": 0.008, "gap": 0.014, "segments": 2},
           "width": 1.4,
           "arrowScale": 3.6,
           "shaftScale": 20.7,
-          "labelOffset": [
-            0.16,
-            0.12,
-            0
-          ]
+          "labelOffset": [0.16, 0.12, 0]
         }
       ],
       "steps": [
@@ -1311,32 +969,11 @@
           "title": "Nominal Route",
           "description": "Move through the mission on a uniform-scale Earth-Moon map. The route is driven by mission day and flyby altitude.",
           "sliders": [
-            {
-              "id": "day",
-              "label": "Mission Day",
-              "min": 0,
-              "max": 9.1,
-              "default": 0.2,
-              "step": 0.001,
-              "animate": true,
-              "animateMode": "loop",
-              "duration": 24000
-            },
-            {
-              "id": "flyAlt",
-              "label": "Flyby Altitude (mi)",
-              "min": 4000,
-              "max": 6000,
-              "default": 4600,
-              "step": 50
-            }
+            {"id": "day", "label": "Mission Day", "min": 0, "max": 9.1, "default": 0.2, "step": 0.001, "animate": true, "animateMode": "loop", "duration": 24000},
+            {"id": "flyAlt", "label": "Flyby Altitude (mi)", "min": 4000, "max": 6000, "default": 4600, "step": 50}
           ],
           "info": [
-            {
-              "id": "s1_info",
-              "content": "**Phase:** {{missionPhase(day)}}\n\n**Distance from Earth center:** {{toFixed(distEarthKm(day), 0)}} km\n\n**Distance from Moon center:** {{toFixed(distMoonKm(day), 0)}} km\n\n**Moon angle:** {{toFixed(180 * moonTheta(day) / pi, 1)}} deg\n\n**Uniform scale:** 1 unit = 10,000 km",
-              "position": "top-left"
-            }
+            {"id": "s1_info", "content": "**Phase:** {{missionPhase(day)}}\n\n**Distance from Earth center:** {{toFixed(distEarthKm(day), 0)}} km\n\n**Distance from Moon center:** {{toFixed(distMoonKm(day), 0)}} km\n\n**Moon angle:** {{toFixed(180 * moonTheta(day) / pi, 1)}} deg\n\n**Uniform scale:** 1 unit = 10,000 km", "position": "top-left"}
           ],
           "add": []
         }
@@ -1347,107 +984,46 @@
       "description": "A closer look at the physically scaled high-Earth orbit and the departure phase.",
       "markdown": "# Earth-Orbit Setup and Departure Burns\n\nNASA's Artemis II profile keeps Orion close to Earth first. The stack enters early Earth orbit, the ICPS shapes the mission into a safe orbit and then a high Earth orbit, Orion separates, and only then does Orion perform the departure sequence.\n\nThe mission plan calls for **two Earth orbits before translunar injection**. In this scene, those loops are shown on purpose: they represent the real orbit-raising and departure setup sequence rather than wasted motion.\n\nThis part of the mission is **burn-driven**, not a gravity assist. The departure to the Moon happens because Orion performs a **translunar injection burn** after the Earth-orbit setup. In other words, Earth gravity holds the spacecraft in orbit until the burn program changes the orbit enough to send Orion onto the cislunar transfer.\n\n## What does the TLI burn look like?\n\nNASA's prelaunch press kit identified translunar injection as Orion's last major engine firing. Then, on **April 2, 2026**, NASA's Flight Day 2 update reported the actual TLI burn began at **7:49 p.m. EDT** and lasted **5 minutes 49 seconds** using Orion's main engine.\n\nThat makes the departure sequence easier to interpret pedagogically:\n\n- the long visible arcs near Earth are coast/orbit-setup phases\n- the decisive change in trajectory comes from a relatively short engine burn\n- after that burn, Orion enters the outbound coast toward the Moon\n\n## Scaled high-Earth orbit\n\nUsing the research brief values:\n\n- perigee radius from Earth center: \n$$r_p = \\frac{6371 + 185}{10{,}000} = 0.6556$$\n- apogee radius from Earth center:\n$$r_a = \\frac{6371 + 71{,}645}{10{,}000} = 7.8016$$\n\nThat gives a focus-centered ellipse with:\n$$a = \\frac{r_p + r_a}{2} = 4.2286, \\qquad c = a - r_p = 3.5730$$\n$$b = \\sqrt{a^2 - c^2} \\approx 2.2616$$\n\nThose are the numbers used directly in the orbit geometry below.\n\n## Mission stages highlighted here\n\n- ascent\n- first Earth orbit and safe-orbit shaping with ICPS\n- second Earth orbit and high-Earth-orbit departure setup\n- Orion separation from ICPS\n- Orion perigee raise burn\n- translunar injection burn\n\n## Sources\n\n- NASA Artemis II press kit: https://www.nasa.gov/artemis-ii-press-kit/\n- NASA Flight Day 2 update, April 2, 2026: https://www.nasa.gov/blogs/missions/2026/04/02/artemis-ii-flight-day-2-crew-houston-poll-go-for-translunar-injection-burn/",
       "prompt": "Use this scene to show that the route is not guessed. The high-Earth orbit is built from the actual perigee and apogee values in the research brief, and the departure sequence is a small number of discrete mission events. Make clear that translunar injection is a thrust-driven burn program, not an Earth gravity assist.",
-      "scale": [
-        10.5,
-        5,
-        3
-      ],
+      "scale": [10.5, 5, 3],
       "range": [
-        [
-          -9,
-          12
-        ],
-        [
-          -5,
-          5
-        ],
-        [
-          -3,
-          3
-        ]
+        [-9, 12],
+        [-5, 5],
+        [-3, 3]
       ],
       "camera": {
-        "position": [
-          0,
-          3,
-          12
-        ],
-        "target": [
-          0,
-          0,
-          0
-        ],
-        "up": [
-          0,
-          0,
-          1
-        ]
+        "position": [0, 3, 12],
+        "target": [0, 0, 0],
+        "up": [0, 0, 1]
       },
       "views": [
         {
           "name": "Orbit View",
           "description": "Earth-centered high-Earth orbit geometry",
-          "position": [
-            0,
-            3,
-            12
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ]
+          "position": [0, 3, 12],
+          "target": [0, 0, 0]
         },
         {
           "name": "Perigee Close",
           "description": "Focus on the low point where departure burns matter most",
-          "position": [
-            1.5,
-            1.2,
-            6
-          ],
-          "target": [
-            0.7,
-            0,
-            0
-          ]
+          "position": [1.5, 1.2, 6],
+          "target": [0.7, 0, 0]
         },
         {
           "name": "Departure View",
           "description": "See the route leaving Earth orbit",
-          "position": [
-            6,
-            4,
-            14
-          ],
-          "target": [
-            5,
-            0,
-            0
-          ]
+          "position": [6, 4, 14],
+          "target": [5, 0, 0]
         }
       ],
-      "starfield": {
-        "enabled": true,
-        "count": 900,
-        "size": 1.5,
-        "opacity": 0.82
-      },
+      "starfield": {"enabled": true, "count": 900, "size": 1.5, "opacity": 0.82},
       "elements": [
         {
           "id": "s2_earth",
           "type": "sphere",
-          "center": [
-            0,
-            0,
-            0
-          ],
+          "center": [0, 0, 0],
           "radius": 0.6371,
           "color": "#3a7bd5",
-          "shader": {
-            "type": "phong",
-            "emissive": "#112244"
-          }
+          "shader": {"type": "phong", "emissive": "#112244"}
         },
         {
           "id": "s2_route",
@@ -1455,10 +1031,7 @@
           "x": "missionX(t, 4600)",
           "y": "missionY(t, 4600)",
           "z": "0",
-          "range": [
-            0,
-            1.25
-          ],
+          "range": [0, 1.25],
           "color": "#ff6b3d",
           "width": 2.3,
           "samples": 500
@@ -1466,11 +1039,7 @@
         {
           "id": "s2_perigee",
           "type": "point",
-          "position": [
-            0.6556,
-            0,
-            0
-          ],
+          "position": [0.6556, 0, 0],
           "color": "#ffd166",
           "size": 8,
           "label": "Perigee"
@@ -1478,11 +1047,7 @@
         {
           "id": "s2_apogee",
           "type": "point",
-          "position": [
-            -7.8016,
-            0,
-            0
-          ],
+          "position": [-7.8016, 0, 0],
           "color": "#f5b041",
           "size": 8,
           "label": "Apogee"
@@ -1496,36 +1061,13 @@
             {
               "id": "s2_orion",
               "type": "animated_vector",
-              "fromExpr": [
-                "missionX(1.25 * tau, 4600) - 0.22 * missionVx(1.25 * tau, 4600) / max(0.001, sqrt(missionVx(1.25 * tau, 4600)^2 + missionVy(1.25 * tau, 4600)^2))",
-                "missionY(1.25 * tau, 4600) - 0.22 * missionVy(1.25 * tau, 4600) / max(0.001, sqrt(missionVx(1.25 * tau, 4600)^2 + missionVy(1.25 * tau, 4600)^2))",
-                "0.12"
-              ],
-              "expr": [
-                "missionX(1.25 * tau, 4600)",
-                "missionY(1.25 * tau, 4600)",
-                "0.12"
-              ],
+              "fromExpr": ["missionX(1.25 * tau, 4600) - 0.22 * missionVx(1.25 * tau, 4600) / max(0.001, sqrt(missionVx(1.25 * tau, 4600)^2 + missionVy(1.25 * tau, 4600)^2))", "missionY(1.25 * tau, 4600) - 0.22 * missionVy(1.25 * tau, 4600) / max(0.001, sqrt(missionVx(1.25 * tau, 4600)^2 + missionVy(1.25 * tau, 4600)^2))", "0.12"],
+              "expr": ["missionX(1.25 * tau, 4600)", "missionY(1.25 * tau, 4600)", "0.12"],
               "color": "#ffffff",
               "label": "Orion",
               "opacity": 1,
-              "shader": {
-                "emissive": "#cfd8e3",
-                "specular": "#ffffff",
-                "shininess": 140,
-                "depthTest": false,
-                "depthWrite": false
-              },
-              "panels": {
-                "color": "#7dd3fc",
-                "opacity": 0.95,
-                "length": 0.11,
-                "width": 0.026,
-                "thickness": 0.008,
-                "gap": 0.014,
-                "segments": 2,
-                "renderOrder": 49
-              },
+              "shader": {"emissive": "#cfd8e3", "specular": "#ffffff", "shininess": 140, "depthTest": false, "depthWrite": false},
+              "panels": {"color": "#7dd3fc", "opacity": 0.95, "length": 0.11, "width": 0.026, "thickness": 0.008, "gap": 0.014, "segments": 2, "renderOrder": 49},
               "renderOrder": 50,
               "width": 1.6,
               "arrowScale": 3.8,
@@ -1533,24 +1075,10 @@
             }
           ],
           "sliders": [
-            {
-              "id": "tau",
-              "label": "Early Mission Progress",
-              "min": 0,
-              "max": 1,
-              "default": 0.2,
-              "step": 0.001,
-              "animate": true,
-              "animateMode": "loop",
-              "duration": 9000
-            }
+            {"id": "tau", "label": "Early Mission Progress", "min": 0, "max": 1, "default": 0.2, "step": 0.001, "animate": true, "animateMode": "loop", "duration": 9000}
           ],
           "info": [
-            {
-              "id": "s2_info",
-              "content": "**Stage:** {{missionPhase(1.25 * tau, 4600)}}\n\n**Distance from Earth center:** {{toFixed(distEarthKm(1.25 * tau, 4600), 0)}} km\n\n**Milestone bucket:** {{missionMilestone(1.25 * tau)}}",
-              "position": "top-left"
-            }
+            {"id": "s2_info", "content": "**Stage:** {{missionPhase(1.25 * tau, 4600)}}\n\n**Distance from Earth center:** {{toFixed(distEarthKm(1.25 * tau, 4600), 0)}} km\n\n**Milestone bucket:** {{missionMilestone(1.25 * tau)}}", "position": "top-left"}
           ]
         }
       ]
@@ -1560,153 +1088,67 @@
       "description": "A Moon-centered simulation of the far-side pass and the Earth line-of-sight blackout.",
       "markdown": "# Moon Flyby and Blackout Geometry\n\nThis scene is centered on the Moon. Orion's route is shown in **Moon-centered coordinates** so the flyby and blackout geometry are easier to inspect.\n\n## What is modeled here?\n\n- launch-date-dependent closest approach between **4,000 and 6,000 miles** above the lunar surface\n- a far-side pass rather than lunar orbit insertion\n- the Earth-to-Orion line-of-sight test\n- a return route bent back toward Earth\n- a moving Earth direction in the Moon-centered frame because the Moon itself is orbiting Earth\n\n## Blackout physics\n\nThe blackout is geometric. If the straight line from Earth to Orion passes through the Moon, communications are blocked.\n\n## Sources\n\n- NASA Artemis II press kit: https://www.nasa.gov/artemis-ii-press-kit/\n- NASA SVS API record 5610: https://svs.gsfc.nasa.gov/api/5610",
       "prompt": "Teach the blackout as a line-of-sight problem and the free return as a flyby-geometry problem. Do not present the route as arbitrary or decorative.",
-      "scale": [
-        24,
-        12,
-        4
-      ],
+      "scale": [24, 12, 4],
       "range": [
-        [
-          -40,
-          8
-        ],
-        [
-          -12,
-          12
-        ],
-        [
-          -4,
-          4
-        ]
+        [-40, 8],
+        [-12, 12],
+        [-4, 4]
       ],
       "camera": {
-        "position": [
-          3.92,
-          1.99,
-          2.96
-        ],
-        "target": [
-          -38.18,
-          -0.01,
-          -3.07
-        ],
-        "up": [
-          0,
-          0,
-          1
-        ]
+        "position": [3.92, 1.99, 2.96],
+        "target": [-38.18, -0.01, -3.07],
+        "up": [0, 0, 1]
       },
       "views": [
         {
           "name": "Moon Centered",
           "description": "Moon-centered flyby view",
           "follow": "s3_moon",
-          "offset": [
-            -4,
-            1,
-            5
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ]
+          "offset": [-4, 1, 5],
+          "up": [0, 0, 1]
         },
         {
           "name": "Blackout View",
           "description": "View Earth hidden behind the Moon during blackout",
-          "position": [
-            1.72770706788452,
-            -0.1794360264324702,
-            0
-          ],
-          "target": [
-            -38.23434639578639,
-            3.970938892380054,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ]
+          "position": [1.72770706788452, -0.1794360264324702, 0],
+          "target": [-38.23434639578639, 3.970938892380054, 0],
+          "up": [0, 0, 1]
         },
         {
           "name": "Far Side",
           "description": "Focus on the blackout side of the Moon",
-          "position": [
-            3.73,
-            -2.85,
-            4
-          ],
-          "target": [
-            -38.09,
-            7.13,
-            -1.01
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ]
+          "position": [3.73, -2.85, 4],
+          "target": [-38.09, 7.13, -1.01],
+          "up": [0, 0, 1]
         },
         {
           "name": "Ride Along",
           "description": "Camera follows Orion through the flyby",
           "follow": "s3_orion",
-          "angleLockVector": [
-            "s3_orion"
-          ],
-          "offset": [
-            0,
-            2,
-            6
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ]
+          "angleLockVector": ["s3_orion"],
+          "offset": [0, 2, 6],
+          "up": [0, 0, 1]
         }
       ],
-      "starfield": {
-        "enabled": true,
-        "count": 1200,
-        "size": 1.6,
-        "opacity": 0.88
-      },
+      "starfield": {"enabled": true, "count": 1200, "size": 1.6, "opacity": 0.88},
       "elements": [
         {
           "id": "s3_moon",
           "type": "sphere",
-          "center": [
-            0,
-            0,
-            0
-          ],
+          "center": [0, 0, 0],
           "radius": 0.1737,
           "color": "#b0b0b0",
           "label": "Moon",
-          "shader": {
-            "type": "phong",
-            "emissive": "#404040"
-          }
+          "shader": {"type": "phong", "emissive": "#404040"}
         },
         {
           "id": "s3_earth",
           "type": "sphere",
-          "centerExpr": [
-            "-moonX(day)",
-            "-moonY(day)",
-            "0"
-          ],
+          "centerExpr": ["-moonX(day)", "-moonY(day)", "0"],
           "radius": 0.6371,
           "color": "#3a7bd5",
           "label": "Earth",
-          "shader": {
-            "type": "phong",
-            "emissive": "#112244"
-          }
+          "shader": {"type": "phong", "emissive": "#112244"}
         },
         {
           "id": "s3_flyby_path",
@@ -1714,10 +1156,7 @@
           "x": "missionX(t) - moonX(t)",
           "y": "missionY(t) - moonY(t)",
           "z": "0",
-          "range": [
-            4.6,
-            5.2
-          ],
+          "range": [4.6, 5.2],
           "color": "#ff6b3d",
           "label": "Flyby trajectory",
           "width": 1.2,
@@ -1733,36 +1172,13 @@
             {
               "id": "s3_orion",
               "type": "animated_vector",
-              "fromExpr": [
-                "missionX(day) - moonX(day) - 0.08 * missionVx(day) / max(0.001, sqrt(missionVx(day)^2 + missionVy(day)^2))",
-                "missionY(day) - moonY(day) - 0.08 * missionVy(day) / max(0.001, sqrt(missionVx(day)^2 + missionVy(day)^2))",
-                "0"
-              ],
-              "expr": [
-                "missionX(day) - moonX(day)",
-                "missionY(day) - moonY(day)",
-                "0"
-              ],
+              "fromExpr": ["missionX(day) - moonX(day) - 0.08 * missionVx(day) / max(0.001, sqrt(missionVx(day)^2 + missionVy(day)^2))", "missionY(day) - moonY(day) - 0.08 * missionVy(day) / max(0.001, sqrt(missionVx(day)^2 + missionVy(day)^2))", "0"],
+              "expr": ["missionX(day) - moonX(day)", "missionY(day) - moonY(day)", "0"],
               "color": "#ffffff",
               "label": "Orion",
               "opacity": 1,
-              "shader": {
-                "emissive": "#cfd8e3",
-                "specular": "#ffffff",
-                "shininess": 140,
-                "depthTest": false,
-                "depthWrite": false
-              },
-              "panels": {
-                "color": "#7dd3fc",
-                "opacity": 0.95,
-                "length": 0.11,
-                "width": 0.026,
-                "thickness": 0.008,
-                "gap": 0.014,
-                "segments": 2,
-                "renderOrder": 49
-              },
+              "shader": {"emissive": "#cfd8e3", "specular": "#ffffff", "shininess": 140, "depthTest": false, "depthWrite": false},
+              "panels": {"color": "#7dd3fc", "opacity": 0.95, "length": 0.11, "width": 0.026, "thickness": 0.008, "gap": 0.014, "segments": 2, "renderOrder": 49},
               "renderOrder": 50,
               "width": 1.2,
               "arrowScale": 3.15,
@@ -1771,16 +1187,8 @@
             {
               "id": "s3_los",
               "type": "animated_vector",
-              "fromExpr": [
-                "-moonX(day)",
-                "-moonY(day)",
-                "0"
-              ],
-              "expr": [
-                "missionX(day) - moonX(day)",
-                "missionY(day) - moonY(day)",
-                "0"
-              ],
+              "fromExpr": ["-moonX(day)", "-moonY(day)", "0"],
+              "expr": ["missionX(day) - moonX(day)", "missionY(day) - moonY(day)", "0"],
               "color": "#7dd3fc",
               "opacity": 0.5,
               "width": 0.11,
@@ -1789,32 +1197,11 @@
             }
           ],
           "sliders": [
-            {
-              "id": "day",
-              "label": "Mission Day",
-              "min": 4.6,
-              "max": 5.2,
-              "default": 4.95,
-              "step": 0.0005,
-              "animate": true,
-              "animateMode": "once",
-              "duration": 9000
-            },
-            {
-              "id": "flyAlt",
-              "label": "Flyby Altitude (mi)",
-              "min": 4000,
-              "max": 6000,
-              "default": 4600,
-              "step": 50
-            }
+            {"id": "day", "label": "Mission Day", "min": 4.6, "max": 5.2, "default": 4.95, "step": 0.0005, "animate": true, "animateMode": "once", "duration": 9000},
+            {"id": "flyAlt", "label": "Flyby Altitude (mi)", "min": 4000, "max": 6000, "default": 4600, "step": 50}
           ],
           "info": [
-            {
-              "id": "s3_info",
-              "content": "**Mission day:** {{toFixed(day, 3)}}\n\n**Flyby altitude setting:** {{toFixed(flyAlt, 0)}} mi\n\n**Earth direction angle:** {{toFixed(180 * moonTheta(day) / pi, 1)}} deg\n\n**Comms status:** {{missionBlackout(day) > 0.5 ? \"Blackout: Moon blocks Earth line of sight\" : \"Line of sight to Earth available\"}}\n\n**Closest-approach window:** about 4,000 to 6,000 mi above the lunar surface",
-              "position": "top-left"
-            }
+            {"id": "s3_info", "content": "**Mission day:** {{toFixed(day, 3)}}\n\n**Flyby altitude setting:** {{toFixed(flyAlt, 0)}} mi\n\n**Earth direction angle:** {{toFixed(180 * moonTheta(day) / pi, 1)}} deg\n\n**Comms status:** {{missionBlackout(day) > 0.5 ? \"Blackout: Moon blocks Earth line of sight\" : \"Line of sight to Earth available\"}}\n\n**Closest-approach window:** about 4,000 to 6,000 mi above the lunar surface", "position": "top-left"}
           ]
         }
       ]
@@ -1824,184 +1211,77 @@
       "description": "A full nominal mission simulation with live route, moving Moon, phase labels, and return conditions.",
       "markdown": "# Full Mission Physics Simulator\n\nThis capstone scene runs the nominal reference route as one continuous simulation on the same **uniform 10,000 km scale** used in the rest of the lesson.\n\nThe Moon is not frozen in place. Its Earth-centered position is updated through the mission using a mean orbital angular rate, so the Earth-Moon geometry and the blackout condition evolve with mission time.\n\n## Mission phases represented\n\n1. ascent\n2. Earth-orbit setup\n3. outbound cislunar coast\n4. far-side lunar flyby\n5. return coast\n6. entry interface and splashdown\n\n## Burns versus gravity assist\n\nBefore leaving Earth, Artemis II performs **two Earth orbits** and then a real **translunar injection burn**. That means the Earth-departure leg is created by thrust, not by a slingshot around Earth.\n\nNASA's Flight Day 2 update on **April 2, 2026** reported the TLI burn lasted **5 minutes 49 seconds**, which is a useful teaching point: a short burn can reshape the entire large-scale route when it is applied at the right orbital point.\n\nLater, at the Moon, the trajectory bends through a **lunar flyby / gravity-assist style turn** that sends Orion onto the free-return path back toward Earth.\n\n## Mission facts shown in the overlays\n\n- mission day and current phase\n- distance from Earth and Moon\n- flyby-altitude setting\n- Moon orbital angle\n- blackout condition from line-of-sight geometry\n- reentry anchors: **25,000 mph** and **400,000 ft** entry interface\n\n## Source basis\n\n- NASA Artemis II press kit: https://www.nasa.gov/artemis-ii-press-kit/\n- NASA Artemis II mission page: https://www.nasa.gov/mission/artemis-ii/\n- NASA SVS API record 5610: https://svs.gsfc.nasa.gov/api/5610\n- NASA Flight Day 2 update, April 2, 2026: https://www.nasa.gov/blogs/missions/2026/04/02/artemis-ii-flight-day-2-crew-houston-poll-go-for-translunar-injection-burn/",
       "prompt": "This is the main simulation scene. Keep the emphasis on actual mission phases, the uniform scale, the fact that Artemis II intentionally performs two Earth orbits before translunar injection, and the difference between short burns and long coast intervals. Make clear that Earth departure is created by a thrust-driven translunar injection burn, while the gravity-assist style turn belongs to the lunar flyby.",
-      "scale": [
-        25,
-        12,
-        4
-      ],
+      "scale": [25, 12, 4],
       "range": [
-        [
-          -5,
-          45
-        ],
-        [
-          -12,
-          12
-        ],
-        [
-          -4,
-          4
-        ]
+        [-5, 45],
+        [-12, 12],
+        [-4, 4]
       ],
       "camera": {
-        "position": [
-          -2.303000000000001,
-          22.19375,
-          71.38125
-        ],
-        "target": [
-          11.209,
-          -2.39375,
-          2.54375
-        ],
-        "up": [
-          -0.35,
-          0.126,
-          0.928
-        ]
+        "position": [-2.303000000000001, 22.19375, 71.38125],
+        "target": [11.209, -2.39375, 2.54375],
+        "up": [-0.35, 0.126, 0.928]
       },
       "views": [
         {
           "name": "Overview",
           "description": "Whole mission route",
-          "position": [
-            -2.303000000000001,
-            22.19375,
-            71.38125
-          ],
-          "target": [
-            11.209,
-            -2.39375,
-            2.54375
-          ],
-          "up": [
-            -0.35,
-            0.126,
-            0.928
-          ]
+          "position": [-2.303000000000001, 22.19375, 71.38125],
+          "target": [11.209, -2.39375, 2.54375],
+          "up": [-0.35, 0.126, 0.928]
         },
         {
           "name": "Moon Flyby",
           "description": "Focus on the lunar encounter",
-          "position": [
-            40.067,
-            -5.81,
-            2.956
-          ],
-          "target": [
-            38.717,
-            -7.138,
-            -0.006
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ]
+          "position": [40.067, -5.81, 2.956],
+          "target": [38.717, -7.138, -0.006],
+          "up": [0, 0, 1]
         },
         {
           "name": "Gravity Assist Plan View",
           "description": "Plan-view camera for inspecting the lunar gravity assist geometry",
-          "position": [
-            38.134,
-            -3.1333333333333333,
-            37.5
-          ],
-          "target": [
-            38.134,
-            -8.341666666666667,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ]
+          "position": [38.134, -3.1333333333333333, 37.5],
+          "target": [38.134, -8.341666666666667, 0],
+          "up": [0, 0, 1]
         },
         {
           "name": "Follow Moon",
           "description": "Follow the moving Moon with a helper anchor near the flyby",
           "follow": "s4_flyby_anchor",
-          "offset": [
-            2.1,
-            1.2,
-            3.1
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ]
+          "offset": [2.1, 1.2, 3.1],
+          "up": [0, 0, 1]
         },
         {
           "name": "Earth Return",
           "description": "Focus on Earth entry and splashdown",
-          "position": [
-            -1.7420000000000009,
-            2.2375,
-            4.41875
-          ],
-          "target": [
-            0.13899999999999935,
-            0.5833333333333334,
-            0.7125
-          ],
-          "up": [
-            -0.345,
-            0.099,
-            0.933
-          ]
+          "position": [-1.7420000000000009, 2.2375, 4.41875],
+          "target": [0.13899999999999935, 0.5833333333333334, 0.7125],
+          "up": [-0.345, 0.099, 0.933]
         },
         {
           "name": "Ride Along",
           "description": "Follow Orion through the mission",
           "follow": "s4_orion",
-          "angleLockVector": [
-            "s4_orion"
-          ],
-          "offset": [
-            0,
-            2.5,
-            6
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ]
+          "angleLockVector": ["s4_orion"],
+          "offset": [0, 2.5, 6],
+          "up": [0, 0, 1]
         }
       ],
-      "starfield": {
-        "enabled": true,
-        "count": 1500,
-        "size": 1.7,
-        "opacity": 0.88
-      },
+      "starfield": {"enabled": true, "count": 1500, "size": 1.7, "opacity": 0.88},
       "elements": [
         {
           "id": "s4_earth",
           "type": "sphere",
-          "center": [
-            0,
-            0,
-            0
-          ],
+          "center": [0, 0, 0],
           "radius": 0.6371,
           "color": "#3a7bd5",
           "label": "Earth",
-          "shader": {
-            "type": "phong",
-            "emissive": "#112244"
-          }
+          "shader": {"type": "phong", "emissive": "#112244"}
         },
         {
           "id": "s4_atmo",
           "type": "sphere",
-          "center": [
-            0,
-            0,
-            0
-          ],
+          "center": [0, 0, 0],
           "radius": 0.6493,
           "color": "#66b3ff",
           "opacity": 0.08
@@ -2012,10 +1292,7 @@
           "x": "38.44 * cos(t)",
           "y": "38.44 * sin(t)",
           "z": "0",
-          "range": [
-            0,
-            6.2832
-          ],
+          "range": [0, 6.2832],
           "color": "#8ecae6",
           "label": "Moon trajectory",
           "width": 2,
@@ -2025,27 +1302,16 @@
         {
           "id": "s4_moon",
           "type": "sphere",
-          "centerExpr": [
-            "moonX(day)",
-            "moonY(day)",
-            "0"
-          ],
+          "centerExpr": ["moonX(day)", "moonY(day)", "0"],
           "radius": 0.1737,
           "color": "#b0b0b0",
           "label": "Moon",
-          "shader": {
-            "type": "phong",
-            "emissive": "#404040"
-          }
+          "shader": {"type": "phong", "emissive": "#404040"}
         },
         {
           "id": "s4_flyby_anchor",
           "type": "animated_point",
-          "expr": [
-            "moonX(day)",
-            "moonY(day)",
-            "0"
-          ],
+          "expr": ["moonX(day)", "moonY(day)", "0"],
           "visibleExpr": "0",
           "opacity": 0,
           "size": 1
@@ -2056,10 +1322,7 @@
           "x": "missionX(t)",
           "y": "missionY(t)",
           "z": "0",
-          "range": [
-            0,
-            9.1
-          ],
+          "range": [0, 9.1],
           "color": "#ff6b3d",
           "label": "Mission trajectory",
           "width": 2.4,
@@ -2070,22 +1333,14 @@
           "id": "s4_free_return_label",
           "type": "text",
           "label": "Free Return Trajectory",
-          "positionExpr": [
-            "missionX(6.2) + 1.2",
-            "missionY(6.2) - 0.7",
-            "0.2"
-          ],
+          "positionExpr": ["missionX(6.2) + 1.2", "missionY(6.2) - 0.7", "0.2"],
           "text": "Free Return Trajectory",
           "color": "#ff8a65"
         },
         {
           "id": "s4_tli_label",
           "type": "text",
-          "positionExpr": [
-            "missionX(1.0673611111111112) + 1.1 * missionX(1.0673611111111112) / max(0.001, sqrt(missionX(1.0673611111111112)^2 + missionY(1.0673611111111112)^2))",
-            "missionY(1.0673611111111112) + 1.1 * missionY(1.0673611111111112) / max(0.001, sqrt(missionX(1.0673611111111112)^2 + missionY(1.0673611111111112)^2))",
-            "0.2"
-          ],
+          "positionExpr": ["missionX(1.0673611111111112) + 1.1 * missionX(1.0673611111111112) / max(0.001, sqrt(missionX(1.0673611111111112)^2 + missionY(1.0673611111111112)^2))", "missionY(1.0673611111111112) + 1.1 * missionY(1.0673611111111112) / max(0.001, sqrt(missionX(1.0673611111111112)^2 + missionY(1.0673611111111112)^2))", "0.2"],
           "text": "Translunar Injection",
           "color": "#ffb38a"
         },
@@ -2093,11 +1348,7 @@
           "id": "s4_day1_label",
           "type": "text",
           "label": "Mission day markers",
-          "positionExpr": [
-            "missionX(1)",
-            "missionY(1)",
-            "0.2"
-          ],
+          "positionExpr": ["missionX(1)", "missionY(1)", "0.2"],
           "text": "Day 1",
           "color": "#ffd7cc"
         },
@@ -2105,11 +1356,7 @@
           "id": "s4_day2_label",
           "type": "text",
           "label": "Mission day markers",
-          "positionExpr": [
-            "missionX(2)",
-            "missionY(2)",
-            "0.2"
-          ],
+          "positionExpr": ["missionX(2)", "missionY(2)", "0.2"],
           "text": "Day 2",
           "color": "#ffd7cc"
         },
@@ -2117,11 +1364,7 @@
           "id": "s4_day3_label",
           "type": "text",
           "label": "Mission day markers",
-          "positionExpr": [
-            "missionX(3)",
-            "missionY(3)",
-            "0.2"
-          ],
+          "positionExpr": ["missionX(3)", "missionY(3)", "0.2"],
           "text": "Day 3",
           "color": "#ffd7cc"
         },
@@ -2129,11 +1372,7 @@
           "id": "s4_day4_label",
           "type": "text",
           "label": "Mission day markers",
-          "positionExpr": [
-            "missionX(4)",
-            "missionY(4)",
-            "0.2"
-          ],
+          "positionExpr": ["missionX(4)", "missionY(4)", "0.2"],
           "text": "Day 4",
           "color": "#ffd7cc"
         },
@@ -2141,11 +1380,7 @@
           "id": "s4_day5_label",
           "type": "text",
           "label": "Mission day markers",
-          "positionExpr": [
-            "missionX(5)",
-            "missionY(5)",
-            "0.2"
-          ],
+          "positionExpr": ["missionX(5)", "missionY(5)", "0.2"],
           "text": "Day 5",
           "color": "#ffd7cc"
         },
@@ -2153,11 +1388,7 @@
           "id": "s4_day6_label",
           "type": "text",
           "label": "Mission day markers",
-          "positionExpr": [
-            "missionX(6)",
-            "missionY(6)",
-            "0.2"
-          ],
+          "positionExpr": ["missionX(6)", "missionY(6)", "0.2"],
           "text": "Day 6",
           "color": "#ffd7cc"
         },
@@ -2165,11 +1396,7 @@
           "id": "s4_day7_label",
           "type": "text",
           "label": "Mission day markers",
-          "positionExpr": [
-            "missionX(7)",
-            "missionY(7)",
-            "0.2"
-          ],
+          "positionExpr": ["missionX(7)", "missionY(7)", "0.2"],
           "text": "Day 7",
           "color": "#ffd7cc"
         },
@@ -2177,11 +1404,7 @@
           "id": "s4_day8_label",
           "type": "text",
           "label": "Mission day markers",
-          "positionExpr": [
-            "missionX(8)",
-            "missionY(8)",
-            "0.2"
-          ],
+          "positionExpr": ["missionX(8)", "missionY(8)", "0.2"],
           "text": "Day 8",
           "color": "#ffd7cc"
         },
@@ -2189,11 +1412,7 @@
           "id": "s4_day9_label",
           "type": "text",
           "label": "Mission day markers",
-          "positionExpr": [
-            "missionX(8.85)",
-            "missionY(8.85)",
-            "0.2"
-          ],
+          "positionExpr": ["missionX(8.85)", "missionY(8.85)", "0.2"],
           "text": "Day 9",
           "color": "#ffd7cc"
         }
@@ -2206,75 +1425,26 @@
             {
               "id": "s4_orion",
               "type": "animated_vector",
-              "fromExpr": [
-                "missionX(day) - 0.078 * missionVx(day) / max(0.001, sqrt(missionVx(day)^2 + missionVy(day)^2))",
-                "missionY(day) - 0.078 * missionVy(day) / max(0.001, sqrt(missionVx(day)^2 + missionVy(day)^2))",
-                "0"
-              ],
-              "expr": [
-                "missionX(day)",
-                "missionY(day)",
-                "0"
-              ],
+              "fromExpr": ["missionX(day) - 0.078 * missionVx(day) / max(0.001, sqrt(missionVx(day)^2 + missionVy(day)^2))", "missionY(day) - 0.078 * missionVy(day) / max(0.001, sqrt(missionVx(day)^2 + missionVy(day)^2))", "0"],
+              "expr": ["missionX(day)", "missionY(day)", "0"],
               "color": "#88bbff",
               "label": "Orion",
               "opacity": 1,
-              "shader": {
-                "emissive": "#224466",
-                "specular": "#aaddff",
-                "shininess": 120
-              },
-              "panels": {
-                "color": "#7dd3fc",
-                "opacity": 0.95,
-                "length": 0.11,
-                "width": 0.026,
-                "thickness": 0.008,
-                "gap": 0.014,
-                "segments": 2
-              },
+              "shader": {"emissive": "#224466", "specular": "#aaddff", "shininess": 120},
+              "panels": {"color": "#7dd3fc", "opacity": 0.95, "length": 0.11, "width": 0.026, "thickness": 0.008, "gap": 0.014, "segments": 2},
               "width": 0.8,
               "arrowScale": 0.4,
               "shaftScale": 12
             }
           ],
           "sliders": [
-            {
-              "id": "day",
-              "label": "Mission Day",
-              "min": 0,
-              "max": 9.1,
-              "default": 0,
-              "step": 0.001,
-              "animate": true,
-              "animateMode": "loop",
-              "duration": 36000
-            },
-            {
-              "id": "flyAlt",
-              "label": "Flyby Altitude (mi)",
-              "min": 4000,
-              "max": 6000,
-              "default": 4600,
-              "step": 50
-            }
+            {"id": "day", "label": "Mission Day", "min": 0, "max": 9.1, "default": 0, "step": 0.001, "animate": true, "animateMode": "loop", "duration": 36000},
+            {"id": "flyAlt", "label": "Flyby Altitude (mi)", "min": 4000, "max": 6000, "default": 4600, "step": 50}
           ],
           "info": [
-            {
-              "id": "s4_info",
-              "content": "**Phase:** {{missionPhase(day)}}\n\n**Mission day:** {{toFixed(day, 2)}}\n\n**Distance from Earth center:** {{toFixed(distEarthKm(day), 0)}} km\n\n**Distance from Moon center:** {{toFixed(distMoonKm(day), 0)}} km\n\n**Moon angle:** {{toFixed(180 * moonTheta(day) / pi, 1)}} deg\n\n**Playback:** looping nominal mission; use **Moon Flyby** view to inspect closest approach",
-              "position": "top-left"
-            },
-            {
-              "id": "s4_status_info",
-              "content": "**Milestone bucket:** {{missionMilestone(day)}}\n\n**Comms blackout:** {{missionBlackout(day) > 0.5 ? \"Yes\" : \"No\"}}",
-              "position": "top-right"
-            },
-            {
-              "id": "s4_return_info",
-              "content": "**Return anchors:** about 25,000 mph at entry interface, about 400,000 ft altitude at atmospheric entry",
-              "position": "bottom-right"
-            }
+            {"id": "s4_info", "content": "**Phase:** {{missionPhase(day)}}\n\n**Mission day:** {{toFixed(day, 2)}}\n\n**Distance from Earth center:** {{toFixed(distEarthKm(day), 0)}} km\n\n**Distance from Moon center:** {{toFixed(distMoonKm(day), 0)}} km\n\n**Moon angle:** {{toFixed(180 * moonTheta(day) / pi, 1)}} deg\n\n**Playback:** looping nominal mission; use **Moon Flyby** view to inspect closest approach", "position": "top-left"},
+            {"id": "s4_status_info", "content": "**Milestone bucket:** {{missionMilestone(day)}}\n\n**Comms blackout:** {{missionBlackout(day) > 0.5 ? \"Yes\" : \"No\"}}", "position": "top-right"},
+            {"id": "s4_return_info", "content": "**Return anchors:** about 25,000 mph at entry interface, about 400,000 ft altitude at atmospheric entry", "position": "bottom-right"}
           ]
         }
       ]

--- a/scenes/quantum-states.json
+++ b/scenes/quantum-states.json
@@ -7,58 +7,25 @@
       "markdown": "# A Qubit Lives in $\\mathbb{C}^2$\n\nConsider an electron passing through a Stern–Gerlach magnet. The beam splits into exactly **two** spots: spin-up and spin-down. Before measurement, the electron is in a superposition\n\n$$|\\psi\\rangle = \\alpha|{\\uparrow}\\rangle + \\beta|{\\downarrow}\\rangle$$\n\nwhere $\\alpha$ and $\\beta$ are **complex numbers** satisfying $|\\alpha|^2+|\\beta|^2=1$.\n\nThe same math describes photon polarization ($|H\\rangle, |V\\rangle$), superconducting qubits ($|0\\rangle, |1\\rangle$), and any other two-level quantum system.\n\n## Same qubit, different hardware\n\nOnce a basis is chosen, the symbols mean the same mathematical thing in every platform, but their physical interpretation changes:\n\n| System | Basis states | $\\alpha, \\beta$ encode | $\\theta$ encodes | $\\phi$ encodes |\n|--------|--------------|-------------------------|-------------------|-----------------|\n| Electron spin | $|\\uparrow_z\\rangle, |\\downarrow_z\\rangle$ | Spin-up / spin-down amplitudes in the $z$ basis | Tilt away from the $+z$ axis, which sets the spin-up vs spin-down population balance | Azimuth of the spin direction; affects $x$- and $y$-basis measurements |\n| Photon polarization | $|H\\rangle, |V\\rangle$ | Horizontal / vertical field amplitudes | How much of the state is in $H$ versus $V$ | Phase delay between $H$ and $V$, setting linear vs elliptical/circular polarization |\n| Two-level atom | $|g\\rangle, |e\\rangle$ | Ground / excited-state amplitudes | Population balance between $|g\\rangle$ and $|e\\rangle$ | Phase of the atomic coherence (dipole oscillation) |\n| Superconducting qubit | $|0\\rangle, |1\\rangle$ | Amplitudes of the two logical energy eigenstates | Ground-versus-excited occupation | Relative phase seen in coherent control and Ramsey interference |\n| Interferometer path qubit | $|A\\rangle, |B\\rangle$ | Probability amplitudes for the two paths | How strongly the state favors path $A$ or path $B$ | Optical phase difference accumulated between the paths |\n\nAcross all of these examples, $\\alpha$ and $\\beta$ are the raw complex amplitudes in the chosen basis. After imposing normalization and discarding global phase, the same state can always be written with two real angles:\n\n$$|\\psi\\rangle = \\cos\\left(\\frac{\\theta}{2}\\right)|0\\rangle + e^{i\\phi}\\sin\\left(\\frac{\\theta}{2}\\right)|1\\rangle.$$\n\nHere $\\theta$ determines the population balance in the chosen basis, while $\\phi$ determines the relative phase that shows up in interference and in measurements away from that basis.\n\n## From four real numbers to two\n\nTwo complex numbers have **four** real parameters. But:\n1. **Normalization** ($|\\alpha|^2+|\\beta|^2=1$) removes one.\n2. **Global phase** ($e^{i\\gamma}|\\psi\\rangle$ is the same state as $|\\psi\\rangle$) removes another.\n\nTwo real parameters remain — just enough to specify a point on a **sphere**.",
       "prompt": "Start from a physical example (electron spin in Stern-Gerlach). Build the connection: physical system → two complex amplitudes → normalization constraint → global phase invariance → two real parameters → sphere. Keep the colors consistent: cyan for alpha/|0>, coral for beta/|1>, gold for the state, green for the normalization circle.",
       "range": [
-        [
-          -1.3,
-          1.3
-        ],
-        [
-          -1.3,
-          1.3
-        ],
-        [
-          -1.3,
-          1.3
-        ]
+        [-1.3, 1.3],
+        [-1.3, 1.3],
+        [-1.3, 1.3]
       ],
       "camera": {
-        "position": [
-          0,
-          0,
-          5
-        ],
-        "target": [
-          0,
-          0,
-          0
-        ]
+        "position": [0, 0, 5],
+        "target": [0, 0, 0]
       },
       "views": [
         {
           "name": "Face On",
-          "position": [
-            0,
-            0,
-            5
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
+          "position": [0, 0, 5],
+          "target": [0, 0, 0],
           "description": "Complex plane view"
         },
         {
           "name": "Iso",
-          "position": [
-            3,
-            2,
-            3
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
+          "position": [3, 2, 3],
+          "target": [0, 0, 0],
           "description": "Three-dimensional perspective"
         }
       ],
@@ -67,10 +34,7 @@
           "id": "s0_axis_re",
           "type": "axis",
           "axis": "x",
-          "range": [
-            -1.2,
-            1.2
-          ],
+          "range": [-1.2, 1.2],
           "color": "#ff4444",
           "width": 1.2,
           "label": "$\\text{Re}$"
@@ -79,10 +43,7 @@
           "id": "s0_axis_im",
           "type": "axis",
           "axis": "y",
-          "range": [
-            -1.2,
-            1.2
-          ],
+          "range": [-1.2, 1.2],
           "color": "#4488ff",
           "width": 1.2,
           "label": "$\\text{Im}$"
@@ -91,15 +52,8 @@
           "id": "s0_grid",
           "type": "grid",
           "plane": "xy",
-          "range": [
-            -1.2,
-            1.2
-          ],
-          "color": [
-            0.28,
-            0.28,
-            0.45
-          ],
+          "range": [-1.2, 1.2],
+          "color": [0.28, 0.28, 0.45],
           "opacity": 0.15,
           "divisions": 12
         }
@@ -113,16 +67,8 @@
             {
               "id": "s0_alpha_vec",
               "type": "vector",
-              "from": [
-                0,
-                0,
-                0
-              ],
-              "to": [
-                1,
-                0,
-                0
-              ],
+              "from": [0, 0, 0],
+              "to": [1, 0, 0],
               "color": "#66d9ff",
               "width": 4,
               "label": "$\\alpha$"
@@ -130,32 +76,16 @@
             {
               "id": "s0_beta_vec",
               "type": "vector",
-              "from": [
-                0,
-                0,
-                0
-              ],
-              "to": [
-                0,
-                0.4,
-                0
-              ],
+              "from": [0, 0, 0],
+              "to": [0, 0.4, 0],
               "color": "#ff7b72",
               "width": 4,
               "label": "$\\beta$",
-              "labelOffset": [
-                -0.25,
-                0.05,
-                0
-              ]
+              "labelOffset": [-0.25, 0.05, 0]
             }
           ],
           "info": [
-            {
-              "id": "s0_state_info",
-              "position": "top-right",
-              "content": "$$\\lvert\\psi\\rangle = \\alpha\\lvert{\\uparrow}\\rangle + \\beta\\lvert{\\downarrow}\\rangle$$\n$$\\alpha, \\beta \\in \\mathbb{C} \\quad\\text{(each a complex number)}$$\n$$(\\alpha, \\beta) \\in \\mathbb{C}^2 \\;\\text{— four real dimensions}$$"
-            }
+            {"id": "s0_state_info", "position": "top-right", "content": "$$\\lvert\\psi\\rangle = \\alpha\\lvert{\\uparrow}\\rangle + \\beta\\lvert{\\downarrow}\\rangle$$\n$$\\alpha, \\beta \\in \\mathbb{C} \\quad\\text{(each a complex number)}$$\n$$(\\alpha, \\beta) \\in \\mathbb{C}^2 \\;\\text{— four real dimensions}$$"}
           ]
         },
         {
@@ -163,16 +93,10 @@
           "description": "A photon passing through a polarizer also has two outcomes: horizontal $|H\\rangle$ or vertical $|V\\rangle$. Before measurement, $|\\psi\\rangle = \\alpha|H\\rangle + \\beta|V\\rangle$ — the same two complex amplitudes.",
           "prompt": "Show that photon polarization is exactly the same math. The cyan vector is the H amplitude, the coral vector is the V amplitude. Mention that diagonal polarization is an equal superposition, and circular polarization is when beta has a phase of pi/2.",
           "remove": [
-            {
-              "id": "s0_state_info"
-            }
+            {"id": "s0_state_info"}
           ],
           "info": [
-            {
-              "id": "s0_photon_info",
-              "position": "top-right",
-              "content": "**Photon polarization**\n$$\\lvert\\psi\\rangle = \\alpha\\lvert H\\rangle + \\beta\\lvert V\\rangle$$\n$\\alpha = 1, \\beta = 0$ → horizontal\n$\\alpha = 0, \\beta = 1$ → vertical\n$\\alpha = \\beta = 1/\\sqrt{2}$ → diagonal"
-            }
+            {"id": "s0_photon_info", "position": "top-right", "content": "**Photon polarization**\n$$\\lvert\\psi\\rangle = \\alpha\\lvert H\\rangle + \\beta\\lvert V\\rangle$$\n$\\alpha = 1, \\beta = 0$ → horizontal\n$\\alpha = 0, \\beta = 1$ → vertical\n$\\alpha = \\beta = 1/\\sqrt{2}$ → diagonal"}
           ]
         },
         {
@@ -180,23 +104,13 @@
           "description": "Superconducting circuits, trapped ions, nitrogen-vacancy centers — every two-level quantum system maps to the same $\\alpha|0\\rangle + \\beta|1\\rangle$.",
           "prompt": "Drive home the universality: electron spin, photon polarization, superconducting transmon, trapped ion, NV center — all are the same two-complex-number problem. This is why the qubit abstraction is so powerful. Use the standard |0>, |1> labels from here on.",
           "remove": [
-            {
-              "id": "s0_photon_info"
-            }
+            {"id": "s0_photon_info"}
           ],
           "info": [
-            {
-              "id": "s0_universal_info",
-              "position": "top-right",
-              "content": "**The qubit abstraction**\n$$\\lvert\\psi\\rangle = \\alpha\\lvert 0\\rangle + \\beta\\lvert 1\\rangle$$\n\n| System | $\\lvert 0\\rangle$ | $\\lvert 1\\rangle$ |\n|--------|-----------|----------|\n| Electron spin | $\\lvert{\\uparrow}\\rangle$ | $\\lvert{\\downarrow}\\rangle$ |\n| Photon | $\\lvert H\\rangle$ | $\\lvert V\\rangle$ |\n| Transmon | ground | excited |\n| Trapped ion | $S_{1/2}$ | $D_{5/2}$ |"
-            }
+            {"id": "s0_universal_info", "position": "top-right", "content": "**The qubit abstraction**\n$$\\lvert\\psi\\rangle = \\alpha\\lvert 0\\rangle + \\beta\\lvert 1\\rangle$$\n\n| System | $\\lvert 0\\rangle$ | $\\lvert 1\\rangle$ |\n|--------|-----------|----------|\n| Electron spin | $\\lvert{\\uparrow}\\rangle$ | $\\lvert{\\downarrow}\\rangle$ |\n| Photon | $\\lvert H\\rangle$ | $\\lvert V\\rangle$ |\n| Transmon | ground | excited |\n| Trapped ion | $S_{1/2}$ | $D_{5/2}$ |"}
           ]
         },
-        {
-          "title": "Global phase — fixing the gauge",
-          "description": "If you rotate both $\\alpha$ and $\\beta$ by the exact same angle (a 'global phase'), nothing physical changes — no measurement can tell the difference. Because of this, we can always rotate our perspective until $\\alpha$ lands on the real axis. Physicists call this choice **gauge fixing**: picking one representative from a family of physically identical states. It doesn't lose any information; it just strips away the one dimension that the universe doesn't care about.",
-          "prompt": "Explain global phase intuitively: multiplying the whole state by e^{i gamma} is like rotating both arrows by the same angle — all relative relationships stay the same, so no experiment can detect it. We exploit this by choosing gamma so that alpha lands on the positive real axis. Introduce the term 'gauge fixing' — choosing a convention to eliminate redundancy. This removes one of our four real parameters, leaving three. The next step (normalization) will remove one more."
-        },
+        {"title": "Global phase — fixing the gauge", "description": "If you rotate both $\\alpha$ and $\\beta$ by the exact same angle (a 'global phase'), nothing physical changes — no measurement can tell the difference. Because of this, we can always rotate our perspective until $\\alpha$ lands on the real axis. Physicists call this choice **gauge fixing**: picking one representative from a family of physically identical states. It doesn't lose any information; it just strips away the one dimension that the universe doesn't care about.", "prompt": "Explain global phase intuitively: multiplying the whole state by e^{i gamma} is like rotating both arrows by the same angle — all relative relationships stay the same, so no experiment can detect it. We exploit this by choosing gamma so that alpha lands on the positive real axis. Introduce the term 'gauge fixing' — choosing a convention to eliminate redundancy. This removes one of our four real parameters, leaving three. The next step (normalization) will remove one more."},
         {
           "title": "Normalization",
           "description": "The total probability must be 1, so $|\\alpha|^2 + |\\beta|^2 = 1$. With global phase already removed, this constraint reduces our three remaining parameters to two — just enough for a point on a sphere.",
@@ -208,10 +122,7 @@
               "x": "cos(t)",
               "y": "sin(t)",
               "z": "0",
-              "range": [
-                0,
-                6.283185307179586
-              ],
+              "range": [0, 6.283185307179586],
               "samples": 120,
               "color": "#7bd389",
               "width": 2,
@@ -219,32 +130,15 @@
             }
           ],
           "remove": [
-            {
-              "id": "s0_alpha_vec"
-            },
-            {
-              "id": "s0_beta_vec"
-            },
-            {
-              "id": "s0_state_info"
-            }
+            {"id": "s0_alpha_vec"},
+            {"id": "s0_beta_vec"},
+            {"id": "s0_state_info"}
           ],
           "sliders": [
-            {
-              "id": "s0_theta",
-              "label": "$\\theta$",
-              "min": 0,
-              "max": 3.141592653589793,
-              "step": 0.01,
-              "default": 0.8
-            }
+            {"id": "s0_theta", "label": "$\\theta$", "min": 0, "max": 3.141592653589793, "step": 0.01, "default": 0.8}
           ],
           "info": [
-            {
-              "id": "s0_norm_info",
-              "position": "top-right",
-              "content": "$$\\lvert\\alpha\\rvert^2 + \\lvert\\beta\\rvert^2 = 1 \\;\\text{(defines } S^3 \\text{ in } \\mathbb{C}^2\\text{)}$$\n$$\\text{Gauge fix: choose } \\alpha \\text{ real} \\geq 0$$\n$$\\alpha = \\cos\\left(\\frac{\\theta}{2}\\right) = {{toFixed(cos(s0_theta/2),3)}}$$\n$$\\lvert\\beta\\rvert = \\sin\\left(\\frac{\\theta}{2}\\right) = {{toFixed(sin(s0_theta/2),3)}}$$\n$$p(0) = \\cos^2(\\theta/2) = {{toFixed(cos(s0_theta/2)^2,3)}},\\; p(1) = \\sin^2(\\theta/2) = {{toFixed(sin(s0_theta/2)^2,3)}}$$"
-            }
+            {"id": "s0_norm_info", "position": "top-right", "content": "$$\\lvert\\alpha\\rvert^2 + \\lvert\\beta\\rvert^2 = 1 \\;\\text{(defines } S^3 \\text{ in } \\mathbb{C}^2\\text{)}$$\n$$\\text{Gauge fix: choose } \\alpha \\text{ real} \\geq 0$$\n$$\\alpha = \\cos\\left(\\frac{\\theta}{2}\\right) = {{toFixed(cos(s0_theta/2),3)}}$$\n$$\\lvert\\beta\\rvert = \\sin\\left(\\frac{\\theta}{2}\\right) = {{toFixed(sin(s0_theta/2),3)}}$$\n$$p(0) = \\cos^2(\\theta/2) = {{toFixed(cos(s0_theta/2)^2,3)}},\\; p(1) = \\sin^2(\\theta/2) = {{toFixed(sin(s0_theta/2)^2,3)}}$$"}
           ]
         },
         {
@@ -255,16 +149,8 @@
             {
               "id": "s0_alpha_anim",
               "type": "animated_vector",
-              "from": [
-                0,
-                0,
-                0
-              ],
-              "expr": [
-                "cos(s0_theta/2)",
-                "0",
-                "0"
-              ],
+              "from": [0, 0, 0],
+              "expr": ["cos(s0_theta/2)", "0", "0"],
               "color": "#66d9ff",
               "width": 2,
               "label": "$\\alpha = \\cos(\\theta/2)$"
@@ -272,16 +158,8 @@
             {
               "id": "s0_beta_anim",
               "type": "animated_vector",
-              "from": [
-                0,
-                0,
-                0
-              ],
-              "expr": [
-                "0",
-                "sin(s0_theta/2)",
-                "0"
-              ],
+              "from": [0, 0, 0],
+              "expr": ["0", "sin(s0_theta/2)", "0"],
               "color": "#ff7b72",
               "width": 2,
               "label": "$\\beta = \\sin(\\theta/2)$"
@@ -293,34 +171,17 @@
           "description": "Now let $\\beta$ become complex: $\\beta = e^{i\\phi}\\sin(\\theta/2)$. The phase $\\phi$ rotates $\\beta$ in its own complex plane without changing its magnitude. Because $\\alpha$ is gauge-fixed real, this is the **relative** phase between the two amplitudes — the only phase with physical meaning.",
           "prompt": "Add the phi slider. Show that phi rotates the beta vector in its own complex plane without changing its length. The normalization circle stays the same. Emphasize this is a relative phase — it matters because alpha has been fixed real, so all the physically meaningful phase lives in beta. This is the second and final real parameter.",
           "remove": [
-            {
-              "id": "s0_beta_anim"
-            }
+            {"id": "s0_beta_anim"}
           ],
           "sliders": [
-            {
-              "id": "s0_phi",
-              "label": "$\\phi$",
-              "min": 0,
-              "max": 6.283185307179586,
-              "step": 0.01,
-              "default": 0.7
-            }
+            {"id": "s0_phi", "label": "$\\phi$", "min": 0, "max": 6.283185307179586, "step": 0.01, "default": 0.7}
           ],
           "add": [
             {
               "id": "s0_beta_phase",
               "type": "animated_vector",
-              "from": [
-                0,
-                0,
-                0
-              ],
-              "expr": [
-                "sin(s0_theta/2)*cos(s0_phi)",
-                "sin(s0_theta/2)*sin(s0_phi)",
-                "0"
-              ],
+              "from": [0, 0, 0],
+              "expr": ["sin(s0_theta/2)*cos(s0_phi)", "sin(s0_theta/2)*sin(s0_phi)", "0"],
               "color": "#ff7b72",
               "width": 2,
               "label": "$\\beta = e^{i\\phi}\\sin(\\theta/2)$"
@@ -331,10 +192,7 @@
               "x": "sin(s0_theta/2)*cos(t)",
               "y": "sin(s0_theta/2)*sin(t)",
               "z": "0",
-              "range": [
-                0,
-                6.283185307179586
-              ],
+              "range": [0, 6.283185307179586],
               "samples": 80,
               "color": "#c77dff",
               "width": 1.5,
@@ -342,11 +200,7 @@
             }
           ],
           "info": [
-            {
-              "id": "s0_phase_info",
-              "position": "top-right",
-              "content": "$$\\alpha = \\cos\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(cos(s0_theta/2),3)}}$$\n$$\\beta = e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)$$\n$$\\lvert\\beta\\rvert = {{toFixed(sin(s0_theta/2),3)}}, \\quad \\phi = {{toFixed(s0_phi,2)}}$$"
-            }
+            {"id": "s0_phase_info", "position": "top-right", "content": "$$\\alpha = \\cos\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(cos(s0_theta/2),3)}}$$\n$$\\beta = e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)$$\n$$\\lvert\\beta\\rvert = {{toFixed(sin(s0_theta/2),3)}}, \\quad \\phi = {{toFixed(s0_phi,2)}}$$"}
           ]
         },
         {
@@ -354,11 +208,7 @@
           "description": "Two real numbers $\\theta \\in [0,\\pi]$ and $\\phi \\in [0,2\\pi)$ specify every pure qubit state. These are exactly the polar and azimuthal angles of a sphere — the **Bloch sphere**.",
           "prompt": "This is the first bridge. Summarize: we started with 4 real parameters, removed 2 (normalization + global phase), and arrived at theta and phi. The next scene puts the physical electron beside its Hilbert-space description; the scene after that turns those same parameters into the Bloch sphere.",
           "info": [
-            {
-              "id": "s0_summary",
-              "position": "top-right",
-              "content": "$$\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle$$\n$$\\theta = {{toFixed(s0_theta,2)}}, \\quad \\phi = {{toFixed(s0_phi,2)}}$$\n$$\\text{Two angles} \\longrightarrow \\text{one sphere}$$"
-            }
+            {"id": "s0_summary", "position": "top-right", "content": "$$\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle$$\n$$\\theta = {{toFixed(s0_theta,2)}}, \\quad \\phi = {{toFixed(s0_phi,2)}}$$\n$$\\text{Two angles} \\longrightarrow \\text{one sphere}$$"}
           ]
         }
       ]
@@ -369,111 +219,42 @@
       "markdown": "# From Electron Spin to Hilbert Space\n\nA Stern-Gerlach experiment asks a concrete physical question: if we measure spin along the $z$ axis, do we get **up** or **down**?\n\nThat laboratory question defines a basis:\n\n$$\\lvert\\uparrow_z\\rangle, \\qquad \\lvert\\downarrow_z\\rangle.$$\n\nOnce that basis is chosen, we represent the **same physical electron** by a vector in a two-dimensional complex Hilbert space:\n\n$$\\lvert\\psi\\rangle = \\alpha\\lvert\\uparrow_z\\rangle + \\beta\\lvert\\downarrow_z\\rangle.$$\n\nThe left panel shows the laboratory picture. The right panel shows the Hilbert-space coordinates. Those coordinates are **not** a position in ordinary space; they are amplitudes that encode measurement probabilities and relative phase.\n\nFor a pure qubit, normalization and the irrelevance of global phase reduce the description to two real parameters. That reduction is what makes the Bloch-sphere picture possible in the next scene.",
       "prompt": "Teach this as the conceptual bridge the lesson needs. Left panel: real laboratory system and the chosen z-basis measurement. Right panel: the same state written in Hilbert-space coordinates. Be explicit that Hilbert space is not physical space; it is the abstract state space used to predict outcomes. Use cyan for the up basis component, coral for the down basis component, gold for the state, and magenta for relative phase.",
       "range": [
-        [
-          -5.2,
-          5.2
-        ],
-        [
-          -5.2,
-          5.2
-        ],
-        [
-          -5.2,
-          5.2
-        ]
+        [-5.2, 5.2],
+        [-5.2, 5.2],
+        [-5.2, 5.2]
       ],
       "camera": {
-        "position": [
-          0,
-          -8,
-          0.8
-        ],
-        "target": [
-          0,
-          0,
-          0
-        ],
-        "up": [
-          0,
-          0,
-          1
-        ]
+        "position": [0, -8, 0.8],
+        "target": [0, 0, 0],
+        "up": [0, 0, 1]
       },
       "views": [
         {
           "name": "Side By Side",
-          "position": [
-            0,
-            -8,
-            0.8
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [0, -8, 0.8],
+          "target": [0, 0, 0],
+          "up": [0, 0, 1],
           "description": "Compare the physical system and the Hilbert-space picture"
         },
         {
           "name": "Physical",
-          "position": [
-            -3.2,
-            -5.2,
-            0.8
-          ],
-          "target": [
-            -3.2,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [-3.2, -5.2, 0.8],
+          "target": [-3.2, 0, 0],
+          "up": [0, 0, 1],
           "description": "Focus on the electron and the measurement axis"
         },
         {
           "name": "Hilbert",
-          "position": [
-            2.6,
-            -5.2,
-            0.6
-          ],
-          "target": [
-            2.6,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [2.6, -5.2, 0.6],
+          "target": [2.6, 0, 0],
+          "up": [0, 0, 1],
           "description": "Focus on the ket and its amplitudes"
         },
         {
           "name": "Top",
-          "position": [
-            0,
-            0,
-            6
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            1,
-            0
-          ],
+          "position": [0, 0, 6],
+          "target": [0, 0, 0],
+          "up": [0, 1, 0],
           "description": "See the azimuthal phase rotation in the Hilbert-space panel"
         }
       ],
@@ -481,16 +262,8 @@
         {
           "id": "hs_divider",
           "type": "line",
-          "from": [
-            0,
-            0,
-            -1.9
-          ],
-          "to": [
-            0,
-            0,
-            1.9
-          ],
+          "from": [0, 0, -1.9],
+          "to": [0, 0, 1.9],
           "color": "#5c667a",
           "width": 1.2,
           "opacity": 0.6
@@ -498,11 +271,7 @@
         {
           "id": "hs_left_title",
           "type": "text",
-          "position": [
-            -3.2,
-            0,
-            1.95
-          ],
+          "position": [-3.2, 0, 1.95],
           "text": "Physical system",
           "color": "#ffd166",
           "size": 13
@@ -510,11 +279,7 @@
         {
           "id": "hs_right_title",
           "type": "text",
-          "position": [
-            2.6,
-            0,
-            1.95
-          ],
+          "position": [2.6, 0, 1.95],
           "text": "Hilbert-space state",
           "color": "#a6c8ff",
           "size": 13
@@ -529,38 +294,22 @@
             {
               "id": "hs_lab_axis",
               "type": "line",
-              "from": [
-                -3.2,
-                0,
-                -1.35
-              ],
-              "to": [
-                -3.2,
-                0,
-                1.35
-              ],
+              "from": [-3.2, 0, -1.35],
+              "to": [-3.2, 0, 1.35],
               "color": "#4488ff",
               "width": 1.6
             },
             {
               "id": "hs_up_state",
               "type": "point",
-              "position": [
-                -3.2,
-                0,
-                1.2
-              ],
+              "position": [-3.2, 0, 1.2],
               "color": "#66d9ff",
               "size": 9
             },
             {
               "id": "hs_up_label",
               "type": "text",
-              "position": [
-                -3.55,
-                0,
-                1.05
-              ],
+              "position": [-3.55, 0, 1.05],
               "text": "$\\lvert\\uparrow_z\\rangle$",
               "color": "#66d9ff",
               "size": 11
@@ -568,22 +317,14 @@
             {
               "id": "hs_down_state",
               "type": "point",
-              "position": [
-                -3.2,
-                0,
-                -1.2
-              ],
+              "position": [-3.2, 0, -1.2],
               "color": "#ff7b72",
               "size": 9
             },
             {
               "id": "hs_down_label",
               "type": "text",
-              "position": [
-                -3.62,
-                0,
-                -1.05
-              ],
+              "position": [-3.62, 0, -1.05],
               "text": "$\\lvert\\downarrow_z\\rangle$",
               "color": "#ff7b72",
               "size": 11
@@ -591,49 +332,29 @@
             {
               "id": "hs_electron",
               "type": "point",
-              "position": [
-                -3.2,
-                0,
-                0
-              ],
+              "position": [-3.2, 0, 0],
               "color": "#ffd166",
               "size": 10
             },
             {
               "id": "hs_spin_fixed",
               "type": "vector",
-              "from": [
-                -3.2,
-                0,
-                0
-              ],
-              "to": [
-                -2.35,
-                0,
-                0.92
-              ],
+              "from": [-3.2, 0, 0],
+              "to": [-2.35, 0, 0.92],
               "color": "#ffd166",
               "width": 1
             },
             {
               "id": "hs_spin_fixed_label",
               "type": "text",
-              "position": [
-                -2.35,
-                0,
-                0.18
-              ],
+              "position": [-2.35, 0, 0.18],
               "text": "spin state",
               "color": "#ffd166",
               "size": 11
             }
           ],
           "info": [
-            {
-              "id": "hs_lab_info",
-              "position": "top-right",
-              "content": "**Laboratory question**\n$$\\text{Measure spin along } z$$\n$$\\text{Possible outcomes: } \\lvert\\uparrow_z\\rangle,\\ \\lvert\\downarrow_z\\rangle$$"
-            }
+            {"id": "hs_lab_info", "position": "top-right", "content": "**Laboratory question**\n$$\\text{Measure spin along } z$$\n$$\\text{Possible outcomes: } \\lvert\\uparrow_z\\rangle,\\ \\lvert\\downarrow_z\\rangle$$"}
           ]
         },
         {
@@ -644,43 +365,23 @@
             {
               "id": "hs_top_slot",
               "type": "line",
-              "from": [
-                1.8,
-                0,
-                0.8
-              ],
-              "to": [
-                3.9,
-                0,
-                0.8
-              ],
+              "from": [1.8, 0, 0.8],
+              "to": [3.9, 0, 0.8],
               "color": "#66d9ff44",
               "width": 3
             },
             {
               "id": "hs_bottom_slot",
               "type": "line",
-              "from": [
-                1.8,
-                0,
-                -0.8
-              ],
-              "to": [
-                3.9,
-                0,
-                -0.8
-              ],
+              "from": [1.8, 0, -0.8],
+              "to": [3.9, 0, -0.8],
               "color": "#ff7b7244",
               "width": 3
             },
             {
               "id": "hs_top_basis",
               "type": "text",
-              "position": [
-                0.7,
-                0,
-                0.92
-              ],
+              "position": [0.7, 0, 0.92],
               "text": "up basis",
               "color": "#66d9ff",
               "size": 11
@@ -688,11 +389,7 @@
             {
               "id": "hs_bottom_basis",
               "type": "text",
-              "position": [
-                0.7,
-                0,
-                -0.68
-              ],
+              "position": [0.7, 0, -0.68],
               "text": "down basis",
               "color": "#ff7b72",
               "size": 11
@@ -700,27 +397,15 @@
             {
               "id": "hs_alpha_fixed",
               "type": "vector",
-              "from": [
-                1.8,
-                0,
-                0.8
-              ],
-              "to": [
-                3.6165,
-                0,
-                0.8
-              ],
+              "from": [1.8, 0, 0.8],
+              "to": [3.6165, 0, 0.8],
               "color": "#66d9ff",
               "width": 1.5
             },
             {
               "id": "hs_alpha_fixed_label",
               "type": "text",
-              "position": [
-                2.62,
-                0,
-                1.02
-              ],
+              "position": [2.62, 0, 1.02],
               "text": "$\\alpha$",
               "color": "#66d9ff",
               "size": 12
@@ -728,38 +413,22 @@
             {
               "id": "hs_beta_fixed",
               "type": "vector",
-              "from": [
-                1.8,
-                0,
-                -0.8
-              ],
-              "to": [
-                2.852,
-                0,
-                -0.8
-              ],
+              "from": [1.8, 0, -0.8],
+              "to": [2.852, 0, -0.8],
               "color": "#ff7b72",
               "width": 1.5
             },
             {
               "id": "hs_beta_fixed_label",
               "type": "text",
-              "position": [
-                2.18,
-                0,
-                -0.58
-              ],
+              "position": [2.18, 0, -0.58],
               "text": "$\\beta$",
               "color": "#ff7b72",
               "size": 12
             }
           ],
           "info": [
-            {
-              "id": "hs_ket_info",
-              "position": "top-right",
-              "content": "$$\\lvert\\psi\\rangle = \\alpha\\lvert\\uparrow_z\\rangle + \\beta\\lvert\\downarrow_z\\rangle$$\n$$\\alpha,\\beta\\in\\mathbb{C}, \\qquad |\\alpha|^2 + |\\beta|^2 = 1$$\n$$\\text{Right panel = abstract Hilbert-space coordinates}$$"
-            }
+            {"id": "hs_ket_info", "position": "top-right", "content": "$$\\lvert\\psi\\rangle = \\alpha\\lvert\\uparrow_z\\rangle + \\beta\\lvert\\downarrow_z\\rangle$$\n$$\\alpha,\\beta\\in\\mathbb{C}, \\qquad |\\alpha|^2 + |\\beta|^2 = 1$$\n$$\\text{Right panel = abstract Hilbert-space coordinates}$$"}
           ]
         },
         {
@@ -767,60 +436,29 @@
           "description": "Changing the state on the left changes the amplitudes on the right. The physical electron and the Hilbert-space ket are two views of the same state, not two different systems.",
           "prompt": "Add theta as the bridge parameter. As the physical spin tilts, the Hilbert-space amplitudes change in lockstep. Emphasize that theta sets the population balance in the chosen z basis.",
           "remove": [
-            {
-              "id": "hs_spin_fixed"
-            },
-            {
-              "id": "hs_spin_fixed_label"
-            },
-            {
-              "id": "hs_alpha_fixed"
-            },
-            {
-              "id": "hs_alpha_fixed_label"
-            },
-            {
-              "id": "hs_beta_fixed"
-            },
-            {
-              "id": "hs_beta_fixed_label"
-            }
+            {"id": "hs_spin_fixed"},
+            {"id": "hs_spin_fixed_label"},
+            {"id": "hs_alpha_fixed"},
+            {"id": "hs_alpha_fixed_label"},
+            {"id": "hs_beta_fixed"},
+            {"id": "hs_beta_fixed_label"}
           ],
           "sliders": [
-            {
-              "id": "hs_theta",
-              "label": "$\\theta$",
-              "min": 0,
-              "max": 3.141592653589793,
-              "step": 0.01,
-              "default": 1.05
-            }
+            {"id": "hs_theta", "label": "$\\theta$", "min": 0, "max": 3.141592653589793, "step": 0.01, "default": 1.05}
           ],
           "add": [
             {
               "id": "hs_spin_theta",
               "type": "animated_vector",
-              "from": [
-                -3.2,
-                0,
-                0
-              ],
-              "expr": [
-                "-3.2 + 1.05*sin(hs_theta)",
-                "0",
-                "1.05*cos(hs_theta)"
-              ],
+              "from": [-3.2, 0, 0],
+              "expr": ["-3.2 + 1.05*sin(hs_theta)", "0", "1.05*cos(hs_theta)"],
               "color": "#ffd166",
               "width": 1
             },
             {
               "id": "hs_spin_theta_label",
               "type": "text",
-              "positionExpr": [
-                "-2.3 + 0.55*sin(hs_theta)",
-                "0",
-                "0.18 + 0.25*cos(hs_theta)"
-              ],
+              "positionExpr": ["-2.3 + 0.55*sin(hs_theta)", "0", "0.18 + 0.25*cos(hs_theta)"],
               "text": "same state",
               "color": "#ffd166",
               "size": 11
@@ -828,27 +466,15 @@
             {
               "id": "hs_alpha_bar",
               "type": "animated_vector",
-              "from": [
-                1.8,
-                0,
-                0.8
-              ],
-              "expr": [
-                "1.8 + 2.1*cos(hs_theta/2)",
-                "0",
-                "0.8"
-              ],
+              "from": [1.8, 0, 0.8],
+              "expr": ["1.8 + 2.1*cos(hs_theta/2)", "0", "0.8"],
               "color": "#66d9ff",
               "width": 1.5
             },
             {
               "id": "hs_alpha_bar_label",
               "type": "text",
-              "positionExpr": [
-                "2.05 + 1.0*cos(hs_theta/2)",
-                "0",
-                "1.02"
-              ],
+              "positionExpr": ["2.05 + 1.0*cos(hs_theta/2)", "0", "1.02"],
               "text": "$\\alpha$",
               "color": "#66d9ff",
               "size": 12
@@ -856,38 +482,22 @@
             {
               "id": "hs_beta_bar",
               "type": "animated_vector",
-              "from": [
-                1.8,
-                0,
-                -0.8
-              ],
-              "expr": [
-                "1.8 + 2.1*sin(hs_theta/2)",
-                "0",
-                "-0.8"
-              ],
+              "from": [1.8, 0, -0.8],
+              "expr": ["1.8 + 2.1*sin(hs_theta/2)", "0", "-0.8"],
               "color": "#ff7b72",
               "width": 1.5
             },
             {
               "id": "hs_beta_bar_label",
               "type": "text",
-              "positionExpr": [
-                "2.05 + 1.0*sin(hs_theta/2)",
-                "0",
-                "-0.58"
-              ],
+              "positionExpr": ["2.05 + 1.0*sin(hs_theta/2)", "0", "-0.58"],
               "text": "$|\\beta|$",
               "color": "#ff7b72",
               "size": 12
             }
           ],
           "info": [
-            {
-              "id": "hs_theta_info",
-              "position": "top-right",
-              "content": "$$\\alpha = \\cos\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(cos(hs_theta/2), 3)}}$$\n$$|\\beta| = \\sin\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(sin(hs_theta/2), 3)}}$$\n$$\\theta = {{toFixed(hs_theta, 2)}}\\ \\text{controls the up/down balance}$$\n$$p(0) = \\cos^2(\\theta/2) = {{toFixed(cos(hs_theta/2)^2,3)}},\\; p(1) = \\sin^2(\\theta/2) = {{toFixed(sin(hs_theta/2)^2,3)}}$$"
-            }
+            {"id": "hs_theta_info", "position": "top-right", "content": "$$\\alpha = \\cos\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(cos(hs_theta/2), 3)}}$$\n$$|\\beta| = \\sin\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(sin(hs_theta/2), 3)}}$$\n$$\\theta = {{toFixed(hs_theta, 2)}}\\ \\text{controls the up/down balance}$$\n$$p(0) = \\cos^2(\\theta/2) = {{toFixed(cos(hs_theta/2)^2,3)}},\\; p(1) = \\sin^2(\\theta/2) = {{toFixed(sin(hs_theta/2)^2,3)}}$$"}
           ]
         },
         {
@@ -895,48 +505,25 @@
           "description": "The amplitudes are complex, so magnitude is not the whole story. The relative phase $\\phi$ lives naturally in Hilbert space and, for electron spin, also changes the spin direction in a physically meaningful way.",
           "prompt": "Add phi carefully. The right panel should make clear that beta is complex, not just a positive length. Since this is electron spin, you can also let the left arrow rotate with phi and point out that this direct geometric reading is special to some systems.",
           "remove": [
-            {
-              "id": "hs_spin_theta"
-            },
-            {
-              "id": "hs_spin_theta_label"
-            }
+            {"id": "hs_spin_theta"},
+            {"id": "hs_spin_theta_label"}
           ],
           "sliders": [
-            {
-              "id": "hs_phi",
-              "label": "$\\phi$",
-              "min": 0,
-              "max": 6.283185307179586,
-              "step": 0.01,
-              "default": 0.9
-            }
+            {"id": "hs_phi", "label": "$\\phi$", "min": 0, "max": 6.283185307179586, "step": 0.01, "default": 0.9}
           ],
           "add": [
             {
               "id": "hs_spin_full",
               "type": "animated_vector",
-              "from": [
-                -3.2,
-                0,
-                0
-              ],
-              "expr": [
-                "-3.2 + 1.05*sin(hs_theta)*cos(hs_phi)",
-                "1.05*sin(hs_theta)*sin(hs_phi)",
-                "1.05*cos(hs_theta)"
-              ],
+              "from": [-3.2, 0, 0],
+              "expr": ["-3.2 + 1.05*sin(hs_theta)*cos(hs_phi)", "1.05*sin(hs_theta)*sin(hs_phi)", "1.05*cos(hs_theta)"],
               "color": "#ffd166",
               "width": 1
             },
             {
               "id": "hs_spin_full_label",
               "type": "text",
-              "positionExpr": [
-                "-2.3 + 0.55*sin(hs_theta)*cos(hs_phi)",
-                "0",
-                "0.18 + 0.25*cos(hs_theta)"
-              ],
+              "positionExpr": ["-2.3 + 0.55*sin(hs_theta)*cos(hs_phi)", "0", "0.18 + 0.25*cos(hs_theta)"],
               "text": "spin direction",
               "color": "#ffd166",
               "size": 11
@@ -947,10 +534,7 @@
               "x": "1.8 + 2.1*sin(hs_theta/2)",
               "y": "0.32*cos(t)",
               "z": "-0.8 + 0.32*sin(t)",
-              "range": [
-                0,
-                6.283185307179586
-              ],
+              "range": [0, 6.283185307179586],
               "samples": 80,
               "color": "#c77dff",
               "width": 1.5,
@@ -959,38 +543,22 @@
             {
               "id": "hs_beta_phase",
               "type": "animated_vector",
-              "fromExpr": [
-                "1.8 + 2.1*sin(hs_theta/2)",
-                "0",
-                "-0.8"
-              ],
-              "expr": [
-                "1.8 + 2.1*sin(hs_theta/2)",
-                "0.32*cos(hs_phi)",
-                "-0.8 + 0.32*sin(hs_phi)"
-              ],
+              "fromExpr": ["1.8 + 2.1*sin(hs_theta/2)", "0", "-0.8"],
+              "expr": ["1.8 + 2.1*sin(hs_theta/2)", "0.32*cos(hs_phi)", "-0.8 + 0.32*sin(hs_phi)"],
               "color": "#c77dff",
               "width": 2
             },
             {
               "id": "hs_beta_phase_label",
               "type": "text",
-              "positionExpr": [
-                "1.8 + 2.1*sin(hs_theta/2)",
-                "0.32*cos(hs_phi)",
-                "-0.8 + 0.32*sin(hs_phi)"
-              ],
+              "positionExpr": ["1.8 + 2.1*sin(hs_theta/2)", "0.32*cos(hs_phi)", "-0.8 + 0.32*sin(hs_phi)"],
               "text": "$\\phi$",
               "color": "#c77dff",
               "size": 12
             }
           ],
           "info": [
-            {
-              "id": "hs_phase_info",
-              "position": "top-right",
-              "content": "$$\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert\\uparrow_z\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert\\downarrow_z\\rangle$$\n$$\\theta = {{toFixed(hs_theta, 2)}},\\qquad \\phi = {{toFixed(hs_phi, 2)}}$$\n$$\\text{Hilbert space keeps track of both population balance and relative phase}$$"
-            }
+            {"id": "hs_phase_info", "position": "top-right", "content": "$$\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert\\uparrow_z\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert\\downarrow_z\\rangle$$\n$$\\theta = {{toFixed(hs_theta, 2)}},\\qquad \\phi = {{toFixed(hs_phi, 2)}}$$\n$$\\text{Hilbert space keeps track of both population balance and relative phase}$$"}
           ]
         }
       ]
@@ -1001,111 +569,42 @@
       "markdown": "# From Hilbert Space to the Bloch Sphere\n\nOn the left, a pure qubit is written in Hilbert space as\n\n$$\\lvert\\psi\\rangle = \\alpha\\lvert 0\\rangle + \\beta\\lvert 1\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle.$$\n\nOn the right, the **same state** is represented by a Bloch vector\n\n$$\\vec r = (\\sin\\theta\\cos\\phi,\\; \\sin\\theta\\sin\\phi,\\; \\cos\\theta).$$\n\nThis is not a change of physics; it is a change of coordinates.\n\n- In the Hilbert-space picture, $\\alpha$ and $\\beta$ are complex amplitudes.\n- In the Bloch-sphere picture, the same information is compressed into a point on the unit sphere.\n- $\\theta$ controls the balance between $\\lvert 0\\rangle$ and $\\lvert 1\\rangle$.\n- $\\phi$ controls the relative phase.\n\nSo the Bloch sphere is a geometric summary of the pure-state Hilbert-space data for one qubit.",
       "prompt": "Teach this as a true coordinate-change scene. Left panel: Hilbert-space amplitudes. Right panel: Bloch-sphere geometry. Keep saying 'same state, different representation.' Use cyan for the |0>/alpha channel, coral for the |1>/beta channel, gold for the state, green for latitude/z information, and magenta for phase/azimuth.",
       "range": [
-        [
-          -5.2,
-          5.2
-        ],
-        [
-          -5.2,
-          5.2
-        ],
-        [
-          -5.2,
-          5.2
-        ]
+        [-5.2, 5.2],
+        [-5.2, 5.2],
+        [-5.2, 5.2]
       ],
       "camera": {
-        "position": [
-          0,
-          -8,
-          0.8
-        ],
-        "target": [
-          0,
-          0,
-          0
-        ],
-        "up": [
-          0,
-          0,
-          1
-        ]
+        "position": [0, -8, 0.8],
+        "target": [0, 0, 0],
+        "up": [0, 0, 1]
       },
       "views": [
         {
           "name": "Side By Side",
-          "position": [
-            0,
-            -8,
-            0.8
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [0, -8, 0.8],
+          "target": [0, 0, 0],
+          "up": [0, 0, 1],
           "description": "Compare Hilbert amplitudes and the Bloch vector"
         },
         {
           "name": "Hilbert",
-          "position": [
-            -2.6,
-            -5.5,
-            0.6
-          ],
-          "target": [
-            -2.6,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [-2.6, -5.5, 0.6],
+          "target": [-2.6, 0, 0],
+          "up": [0, 0, 1],
           "description": "Focus on the amplitude picture"
         },
         {
           "name": "Bloch",
-          "position": [
-            2.6,
-            -5.5,
-            0.6
-          ],
-          "target": [
-            2.6,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [2.6, -5.5, 0.6],
+          "target": [2.6, 0, 0],
+          "up": [0, 0, 1],
           "description": "Focus on the sphere picture"
         },
         {
           "name": "Top",
-          "position": [
-            2.6,
-            0,
-            6
-          ],
-          "target": [
-            2.6,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            1,
-            0
-          ],
+          "position": [2.6, 0, 6],
+          "target": [2.6, 0, 0],
+          "up": [0, 1, 0],
           "description": "Look down the Bloch z-axis to see azimuth"
         }
       ],
@@ -1113,16 +612,8 @@
         {
           "id": "hb_divider",
           "type": "line",
-          "from": [
-            0,
-            0,
-            -2.0
-          ],
-          "to": [
-            0,
-            0,
-            2.0
-          ],
+          "from": [0, 0, -2.0],
+          "to": [0, 0, 2.0],
           "color": "#5c667a",
           "width": 1.2,
           "opacity": 0.6
@@ -1130,11 +621,7 @@
         {
           "id": "hb_left_title",
           "type": "text",
-          "position": [
-            -2.6,
-            0,
-            1.95
-          ],
+          "position": [-2.6, 0, 1.95],
           "text": "Hilbert-space coordinates",
           "color": "#a6c8ff",
           "size": 13
@@ -1142,11 +629,7 @@
         {
           "id": "hb_right_title",
           "type": "text",
-          "position": [
-            2.6,
-            0,
-            1.95
-          ],
+          "position": [2.6, 0, 1.95],
           "text": "Bloch-sphere picture",
           "color": "#ffd166",
           "size": 13
@@ -1161,43 +644,23 @@
             {
               "id": "hb_top_slot",
               "type": "line",
-              "from": [
-                -3.8,
-                0,
-                0.8
-              ],
-              "to": [
-                -1.7,
-                0,
-                0.8
-              ],
+              "from": [-3.8, 0, 0.8],
+              "to": [-1.7, 0, 0.8],
               "color": "#66d9ff44",
               "width": 3
             },
             {
               "id": "hb_bottom_slot",
               "type": "line",
-              "from": [
-                -3.8,
-                0,
-                -0.8
-              ],
-              "to": [
-                -1.7,
-                0,
-                -0.8
-              ],
+              "from": [-3.8, 0, -0.8],
+              "to": [-1.7, 0, -0.8],
               "color": "#ff7b7244",
               "width": 3
             },
             {
               "id": "hb_top_basis",
               "type": "text",
-              "position": [
-                -4.9,
-                0,
-                0.92
-              ],
+              "position": [-4.9, 0, 0.92],
               "text": "|0> channel",
               "color": "#66d9ff",
               "size": 11
@@ -1205,11 +668,7 @@
             {
               "id": "hb_bottom_basis",
               "type": "text",
-              "position": [
-                -4.95,
-                0,
-                -0.68
-              ],
+              "position": [-4.95, 0, -0.68],
               "text": "|1> channel",
               "color": "#ff7b72",
               "size": 11
@@ -1217,27 +676,15 @@
             {
               "id": "hb_alpha_fixed",
               "type": "vector",
-              "from": [
-                -3.8,
-                0,
-                0.8
-              ],
-              "to": [
-                -1.98,
-                0,
-                0.8
-              ],
+              "from": [-3.8, 0, 0.8],
+              "to": [-1.98, 0, 0.8],
               "color": "#66d9ff",
               "width": 1.5
             },
             {
               "id": "hb_alpha_fixed_label",
               "type": "text",
-              "position": [
-                -2.95,
-                0,
-                1.03
-              ],
+              "position": [-2.95, 0, 1.03],
               "text": "$\\alpha$",
               "color": "#66d9ff",
               "size": 12
@@ -1245,27 +692,15 @@
             {
               "id": "hb_beta_fixed",
               "type": "vector",
-              "from": [
-                -3.8,
-                0,
-                -0.8
-              ],
-              "to": [
-                -2.75,
-                0,
-                -0.8
-              ],
+              "from": [-3.8, 0, -0.8],
+              "to": [-2.75, 0, -0.8],
               "color": "#ff7b72",
               "width": 1.5
             },
             {
               "id": "hb_beta_fixed_label",
               "type": "text",
-              "position": [
-                -3.38,
-                0,
-                -0.58
-              ],
+              "position": [-3.38, 0, -0.58],
               "text": "$\\beta$",
               "color": "#ff7b72",
               "size": 12
@@ -1273,38 +708,22 @@
             {
               "id": "hb_bloch_axis",
               "type": "line",
-              "from": [
-                2.6,
-                0,
-                -1.2
-              ],
-              "to": [
-                2.6,
-                0,
-                1.2
-              ],
+              "from": [2.6, 0, -1.2],
+              "to": [2.6, 0, 1.2],
               "color": "#4488ff",
               "width": 1.4
             },
             {
               "id": "hb_ket0",
               "type": "point",
-              "position": [
-                2.6,
-                0,
-                1.0
-              ],
+              "position": [2.6, 0, 1.0],
               "color": "#66d9ff",
               "size": 8
             },
             {
               "id": "hb_ket0_label",
               "type": "text",
-              "position": [
-                2.95,
-                0,
-                1.0
-              ],
+              "position": [2.95, 0, 1.0],
               "text": "$|0\\rangle$",
               "color": "#66d9ff",
               "size": 11
@@ -1312,22 +731,14 @@
             {
               "id": "hb_ket1",
               "type": "point",
-              "position": [
-                2.6,
-                0,
-                -1.0
-              ],
+              "position": [2.6, 0, -1.0],
               "color": "#ff7b72",
               "size": 8
             },
             {
               "id": "hb_ket1_label",
               "type": "text",
-              "position": [
-                2.95,
-                0,
-                -1.0
-              ],
+              "position": [2.95, 0, -1.0],
               "text": "$|1\\rangle$",
               "color": "#ff7b72",
               "size": 11
@@ -1335,38 +746,22 @@
             {
               "id": "hb_state_fixed",
               "type": "vector",
-              "from": [
-                2.6,
-                0,
-                0
-              ],
-              "to": [
-                3.47,
-                0,
-                0.5
-              ],
+              "from": [2.6, 0, 0],
+              "to": [3.47, 0, 0.5],
               "color": "#ffd166",
               "width": 1.2
             },
             {
               "id": "hb_state_fixed_label",
               "type": "text",
-              "position": [
-                3.05,
-                0,
-                0.18
-              ],
+              "position": [3.05, 0, 0.18],
               "text": "same state",
               "color": "#ffd166",
               "size": 11
             }
           ],
           "info": [
-            {
-              "id": "hb_intro_info",
-              "position": "top-right",
-              "content": "$$\\lvert\\psi\\rangle = \\alpha\\lvert 0\\rangle + \\beta\\lvert 1\\rangle$$\n$$\\alpha = \\cos\\!\\left(\\frac{\\theta}{2}\\right), \\qquad \\beta = e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)$$"
-            }
+            {"id": "hb_intro_info", "position": "top-right", "content": "$$\\lvert\\psi\\rangle = \\alpha\\lvert 0\\rangle + \\beta\\lvert 1\\rangle$$\n$$\\alpha = \\cos\\!\\left(\\frac{\\theta}{2}\\right), \\qquad \\beta = e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)$$"}
           ]
         },
         {
@@ -1374,60 +769,29 @@
           "description": "The magnitudes of $\\alpha$ and $\\beta$ determine how far up or down the Bloch vector sits. As $\\theta$ changes, the Hilbert-space bars and the Bloch latitude move together.",
           "prompt": "Make theta the first visible bridge. On the left, alpha shrinks while beta grows. On the right, the Bloch vector slides from north pole to south pole.",
           "remove": [
-            {
-              "id": "hb_alpha_fixed"
-            },
-            {
-              "id": "hb_alpha_fixed_label"
-            },
-            {
-              "id": "hb_beta_fixed"
-            },
-            {
-              "id": "hb_beta_fixed_label"
-            },
-            {
-              "id": "hb_state_fixed"
-            },
-            {
-              "id": "hb_state_fixed_label"
-            }
+            {"id": "hb_alpha_fixed"},
+            {"id": "hb_alpha_fixed_label"},
+            {"id": "hb_beta_fixed"},
+            {"id": "hb_beta_fixed_label"},
+            {"id": "hb_state_fixed"},
+            {"id": "hb_state_fixed_label"}
           ],
           "sliders": [
-            {
-              "id": "hb_theta",
-              "label": "$\\theta$",
-              "min": 0,
-              "max": 3.141592653589793,
-              "step": 0.01,
-              "default": 1.05
-            }
+            {"id": "hb_theta", "label": "$\\theta$", "min": 0, "max": 3.141592653589793, "step": 0.01, "default": 1.05}
           ],
           "add": [
             {
               "id": "hb_alpha_bar",
               "type": "animated_vector",
-              "from": [
-                -3.8,
-                0,
-                0.8
-              ],
-              "expr": [
-                "-3.8 + 2.1*cos(hb_theta/2)",
-                "0",
-                "0.8"
-              ],
+              "from": [-3.8, 0, 0.8],
+              "expr": ["-3.8 + 2.1*cos(hb_theta/2)", "0", "0.8"],
               "color": "#66d9ff",
               "width": 1.5
             },
             {
               "id": "hb_alpha_bar_label",
               "type": "text",
-              "positionExpr": [
-                "-3.55 + 1.0*cos(hb_theta/2)",
-                "0",
-                "1.03"
-              ],
+              "positionExpr": ["-3.55 + 1.0*cos(hb_theta/2)", "0", "1.03"],
               "text": "$\\alpha$",
               "color": "#66d9ff",
               "size": 12
@@ -1435,27 +799,15 @@
             {
               "id": "hb_beta_bar",
               "type": "animated_vector",
-              "from": [
-                -3.8,
-                0,
-                -0.8
-              ],
-              "expr": [
-                "-3.8 + 2.1*sin(hb_theta/2)",
-                "0",
-                "-0.8"
-              ],
+              "from": [-3.8, 0, -0.8],
+              "expr": ["-3.8 + 2.1*sin(hb_theta/2)", "0", "-0.8"],
               "color": "#ff7b72",
               "width": 1.5
             },
             {
               "id": "hb_beta_bar_label",
               "type": "text",
-              "positionExpr": [
-                "-3.55 + 1.0*sin(hb_theta/2)",
-                "0",
-                "-0.58"
-              ],
+              "positionExpr": ["-3.55 + 1.0*sin(hb_theta/2)", "0", "-0.58"],
               "text": "$|\\beta|$",
               "color": "#ff7b72",
               "size": 12
@@ -1463,19 +815,13 @@
             {
               "id": "hb_sphere",
               "type": "sphere",
-              "center": [
-                2.6,
-                0,
-                0
-              ],
+              "center": [2.6, 0, 0],
               "radius": 1,
               "color": "#334466",
               "opacity": 0.15,
               "segments": 64,
               "rings": 48,
-              "shader": {
-                "depthWrite": false
-              }
+              "shader": {"depthWrite": false}
             },
             {
               "id": "hb_meridian",
@@ -1483,10 +829,7 @@
               "x": "2.6 + sin(t)",
               "y": "0",
               "z": "cos(t)",
-              "range": [
-                0,
-                3.141592653589793
-              ],
+              "range": [0, 3.141592653589793],
               "samples": 80,
               "color": "#7bd389",
               "width": 2,
@@ -1495,27 +838,15 @@
             {
               "id": "hb_state_theta",
               "type": "animated_vector",
-              "from": [
-                2.6,
-                0,
-                0
-              ],
-              "expr": [
-                "2.6 + sin(hb_theta)",
-                "0",
-                "cos(hb_theta)"
-              ],
+              "from": [2.6, 0, 0],
+              "expr": ["2.6 + sin(hb_theta)", "0", "cos(hb_theta)"],
               "color": "#ffd166",
               "width": 1.2
             },
             {
               "id": "hb_state_theta_label",
               "type": "text",
-              "positionExpr": [
-                "3.0 + 0.45*sin(hb_theta)",
-                "0",
-                "0.18 + 0.25*cos(hb_theta)"
-              ],
+              "positionExpr": ["3.0 + 0.45*sin(hb_theta)", "0", "0.18 + 0.25*cos(hb_theta)"],
               "text": "same state",
               "color": "#ffd166",
               "size": 11
@@ -1523,27 +854,15 @@
             {
               "id": "hb_zproj",
               "type": "animated_vector",
-              "from": [
-                2.6,
-                0,
-                0
-              ],
-              "expr": [
-                "2.6",
-                "0",
-                "cos(hb_theta)"
-              ],
+              "from": [2.6, 0, 0],
+              "expr": ["2.6", "0", "cos(hb_theta)"],
               "color": "#7bd389",
               "width": 1.5,
               "opacity": 0.5
             }
           ],
           "info": [
-            {
-              "id": "hb_theta_info",
-              "position": "top-right",
-              "content": "$$\\alpha = \\cos\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(cos(hb_theta/2), 3)}}$$\n$$|\\beta| = \\sin\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(sin(hb_theta/2), 3)}}$$\n$$z = \\cos\\theta = {{toFixed(cos(hb_theta), 3)}}$$\n$$p(0) = \\cos^2(\\theta/2) = {{toFixed(cos(hb_theta/2)^2,3)}},\\; p(1) = \\sin^2(\\theta/2) = {{toFixed(sin(hb_theta/2)^2,3)}}$$"
-            }
+            {"id": "hb_theta_info", "position": "top-right", "content": "$$\\alpha = \\cos\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(cos(hb_theta/2), 3)}}$$\n$$|\\beta| = \\sin\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(sin(hb_theta/2), 3)}}$$\n$$z = \\cos\\theta = {{toFixed(cos(hb_theta), 3)}}$$\n$$p(0) = \\cos^2(\\theta/2) = {{toFixed(cos(hb_theta/2)^2,3)}},\\; p(1) = \\sin^2(\\theta/2) = {{toFixed(sin(hb_theta/2)^2,3)}}$$"}
           ]
         },
         {
@@ -1551,25 +870,12 @@
           "description": "The relative phase rotates the state around the Bloch z-axis. On the left it is the phase of the lower amplitude; on the right it is the azimuthal angle of the Bloch vector.",
           "prompt": "Add phi as the second bridge. Left panel: beta carries phase around a small phase circle. Right panel: the Bloch vector sweeps around the sphere at fixed latitude.",
           "remove": [
-            {
-              "id": "hb_state_theta"
-            },
-            {
-              "id": "hb_state_theta_label"
-            },
-            {
-              "id": "hb_zproj"
-            }
+            {"id": "hb_state_theta"},
+            {"id": "hb_state_theta_label"},
+            {"id": "hb_zproj"}
           ],
           "sliders": [
-            {
-              "id": "hb_phi",
-              "label": "$\\phi$",
-              "min": 0,
-              "max": 6.283185307179586,
-              "step": 0.01,
-              "default": 0.9
-            }
+            {"id": "hb_phi", "label": "$\\phi$", "min": 0, "max": 6.283185307179586, "step": 0.01, "default": 0.9}
           ],
           "add": [
             {
@@ -1578,10 +884,7 @@
               "x": "-3.8 + 2.1*sin(hb_theta/2)",
               "y": "0.32*cos(t)",
               "z": "-0.8 + 0.32*sin(t)",
-              "range": [
-                0,
-                6.283185307179586
-              ],
+              "range": [0, 6.283185307179586],
               "samples": 80,
               "color": "#c77dff",
               "width": 1.5,
@@ -1590,27 +893,15 @@
             {
               "id": "hb_beta_phase",
               "type": "animated_vector",
-              "fromExpr": [
-                "-3.8 + 2.1*sin(hb_theta/2)",
-                "0",
-                "-0.8"
-              ],
-              "expr": [
-                "-3.8 + 2.1*sin(hb_theta/2)",
-                "0.32*cos(hb_phi)",
-                "-0.8 + 0.32*sin(hb_phi)"
-              ],
+              "fromExpr": ["-3.8 + 2.1*sin(hb_theta/2)", "0", "-0.8"],
+              "expr": ["-3.8 + 2.1*sin(hb_theta/2)", "0.32*cos(hb_phi)", "-0.8 + 0.32*sin(hb_phi)"],
               "color": "#c77dff",
               "width": 2
             },
             {
               "id": "hb_beta_phase_label",
               "type": "text",
-              "positionExpr": [
-                "-3.8 + 2.1*sin(hb_theta/2)",
-                "0.32*cos(hb_phi)",
-                "-0.8 + 0.32*sin(hb_phi)"
-              ],
+              "positionExpr": ["-3.8 + 2.1*sin(hb_theta/2)", "0.32*cos(hb_phi)", "-0.8 + 0.32*sin(hb_phi)"],
               "text": "$\\phi$",
               "color": "#c77dff",
               "size": 12
@@ -1621,10 +912,7 @@
               "x": "2.6 + cos(t)",
               "y": "sin(t)",
               "z": "0",
-              "range": [
-                0,
-                6.283185307179586
-              ],
+              "range": [0, 6.283185307179586],
               "samples": 120,
               "color": "#c77dff",
               "width": 2,
@@ -1633,27 +921,15 @@
             {
               "id": "hb_state_full",
               "type": "animated_vector",
-              "from": [
-                2.6,
-                0,
-                0
-              ],
-              "expr": [
-                "2.6 + sin(hb_theta)*cos(hb_phi)",
-                "sin(hb_theta)*sin(hb_phi)",
-                "cos(hb_theta)"
-              ],
+              "from": [2.6, 0, 0],
+              "expr": ["2.6 + sin(hb_theta)*cos(hb_phi)", "sin(hb_theta)*sin(hb_phi)", "cos(hb_theta)"],
               "color": "#ffd166",
               "width": 1.2
             },
             {
               "id": "hb_state_full_label",
               "type": "text",
-              "positionExpr": [
-                "3.0 + 0.42*sin(hb_theta)*cos(hb_phi)",
-                "0",
-                "0.18 + 0.25*cos(hb_theta)"
-              ],
+              "positionExpr": ["3.0 + 0.42*sin(hb_theta)*cos(hb_phi)", "0", "0.18 + 0.25*cos(hb_theta)"],
               "text": "same state",
               "color": "#ffd166",
               "size": 11
@@ -1664,10 +940,7 @@
               "x": "2.6 + sin(hb_theta)*cos(t)",
               "y": "sin(hb_theta)*sin(t)",
               "z": "cos(hb_theta)",
-              "range": [
-                0,
-                6.283185307179586
-              ],
+              "range": [0, 6.283185307179586],
               "samples": 80,
               "color": "#c77dff",
               "width": 1.5,
@@ -1675,11 +948,7 @@
             }
           ],
           "info": [
-            {
-              "id": "hb_phi_info",
-              "position": "top-right",
-              "content": "$$\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle$$\n$$\\vec r = (\\sin\\theta\\cos\\phi,\\; \\sin\\theta\\sin\\phi,\\; \\cos\\theta)$$\n$$\\phi = {{toFixed(hb_phi, 2)}}\\ \\text{is phase on the left and azimuth on the right}$$"
-            }
+            {"id": "hb_phi_info", "position": "top-right", "content": "$$\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle$$\n$$\\vec r = (\\sin\\theta\\cos\\phi,\\; \\sin\\theta\\sin\\phi,\\; \\cos\\theta)$$\n$$\\phi = {{toFixed(hb_phi, 2)}}\\ \\text{is phase on the left and azimuth on the right}$$"}
           ]
         },
         {
@@ -1687,11 +956,7 @@
           "description": "For a pure qubit, the Hilbert-space amplitudes and the Bloch vector contain exactly the same physical information. The next scene will zoom in on the Bloch sphere alone.",
           "prompt": "Close the bridge clearly: Hilbert space and the Bloch sphere are two coordinate systems for the same pure state. The next scene can now focus purely on the sphere geometry.",
           "info": [
-            {
-              "id": "hb_summary",
-              "position": "top-right",
-              "content": "**Same pure qubit state**\n$$\\alpha,\\beta \\quad \\Longleftrightarrow \\quad (\\theta,\\phi) \\quad \\Longleftrightarrow \\quad \\vec r \\in S^2$$\n$$\\text{Hilbert-space data} \\longleftrightarrow \\text{Bloch-sphere geometry}$$"
-            }
+            {"id": "hb_summary", "position": "top-right", "content": "**Same pure qubit state**\n$$\\alpha,\\beta \\quad \\Longleftrightarrow \\quad (\\theta,\\phi) \\quad \\Longleftrightarrow \\quad \\vec r \\in S^2$$\n$$\\text{Hilbert-space data} \\longleftrightarrow \\text{Bloch-sphere geometry}$$"}
           ]
         }
       ]
@@ -1702,92 +967,35 @@
       "markdown": "# From Amplitudes to Probabilities\n\nA pure qubit written in Hilbert space has the form\n\n$$\\lvert\\psi\\rangle = \\alpha\\lvert 0\\rangle + \\beta\\lvert 1\\rangle.$$\n\nThe numbers $\\alpha$ and $\\beta$ are **probability amplitudes**, not probabilities themselves. The actual measurement probabilities are given by **Born's rule**:\n\n$$p(0)=|\\alpha|^2, \\qquad p(1)=|\\beta|^2.$$\n\nFor the Bloch-sphere parameterization,\n\n$$\\alpha = \\cos\\!\\left(\\frac{\\theta}{2}\\right), \\qquad \\beta = e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right),$$\n\nso the probabilities become\n\n$$p(0)=\\cos^2\\!\\left(\\frac{\\theta}{2}\\right), \\qquad p(1)=\\sin^2\\!\\left(\\frac{\\theta}{2}\\right).$$\n\nThe phase $\\phi$ changes interference in other bases, but it does **not** affect these computational-basis probabilities.",
       "prompt": "Teach this as the Born's-rule bridge. Left panel: amplitudes in Hilbert space. Right panel: actual measurement probabilities. Be explicit that amplitudes are not probabilities; magnitudes squared are. Use cyan for alpha / p(0), coral for beta / p(1), and magenta only to show that phi does not change the computational-basis probabilities.",
       "range": [
-        [
-          -5.2,
-          5.2
-        ],
-        [
-          -5.2,
-          5.2
-        ],
-        [
-          -5.2,
-          5.2
-        ]
+        [-5.2, 5.2],
+        [-5.2, 5.2],
+        [-5.2, 5.2]
       ],
       "camera": {
-        "position": [
-          0,
-          -8,
-          0.8
-        ],
-        "target": [
-          0,
-          0,
-          0
-        ],
-        "up": [
-          0,
-          0,
-          1
-        ]
+        "position": [0, -8, 0.8],
+        "target": [0, 0, 0],
+        "up": [0, 0, 1]
       },
       "views": [
         {
           "name": "Side By Side",
-          "position": [
-            0,
-            -8,
-            0.8
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [0, -8, 0.8],
+          "target": [0, 0, 0],
+          "up": [0, 0, 1],
           "description": "Compare amplitudes and probabilities"
         },
         {
           "name": "Amplitudes",
-          "position": [
-            -2.6,
-            -5.6,
-            0.7
-          ],
-          "target": [
-            -2.6,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [-2.6, -5.6, 0.7],
+          "target": [-2.6, 0, 0],
+          "up": [0, 0, 1],
           "description": "Focus on the Hilbert amplitudes"
         },
         {
           "name": "Probabilities",
-          "position": [
-            2.6,
-            -5.6,
-            0.7
-          ],
-          "target": [
-            2.6,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [2.6, -5.6, 0.7],
+          "target": [2.6, 0, 0],
+          "up": [0, 0, 1],
           "description": "Focus on the measurable probabilities"
         }
       ],
@@ -1795,16 +1003,8 @@
         {
           "id": "ap_divider",
           "type": "line",
-          "from": [
-            0,
-            0,
-            -2.0
-          ],
-          "to": [
-            0,
-            0,
-            2.0
-          ],
+          "from": [0, 0, -2.0],
+          "to": [0, 0, 2.0],
           "color": "#5c667a",
           "width": 1.2,
           "opacity": 0.6
@@ -1812,11 +1012,7 @@
         {
           "id": "ap_left_title",
           "type": "text",
-          "position": [
-            -2.6,
-            0,
-            1.95
-          ],
+          "position": [-2.6, 0, 1.95],
           "text": "Hilbert amplitudes",
           "color": "#a6c8ff",
           "size": 13
@@ -1824,11 +1020,7 @@
         {
           "id": "ap_right_title",
           "type": "text",
-          "position": [
-            2.6,
-            0,
-            1.95
-          ],
+          "position": [2.6, 0, 1.95],
           "text": "Measurement probabilities",
           "color": "#ffd166",
           "size": 13
@@ -1843,75 +1035,39 @@
             {
               "id": "ap_amp_top_slot",
               "type": "line",
-              "from": [
-                -3.8,
-                0,
-                0.8
-              ],
-              "to": [
-                -1.7,
-                0,
-                0.8
-              ],
+              "from": [-3.8, 0, 0.8],
+              "to": [-1.7, 0, 0.8],
               "color": "#66d9ff44",
               "width": 3
             },
             {
               "id": "ap_amp_bottom_slot",
               "type": "line",
-              "from": [
-                -3.8,
-                0,
-                -0.8
-              ],
-              "to": [
-                -1.7,
-                0,
-                -0.8
-              ],
+              "from": [-3.8, 0, -0.8],
+              "to": [-1.7, 0, -0.8],
               "color": "#ff7b7244",
               "width": 3
             },
             {
               "id": "ap_prob_top_slot",
               "type": "line",
-              "from": [
-                1.5,
-                0,
-                0.8
-              ],
-              "to": [
-                3.6,
-                0,
-                0.8
-              ],
+              "from": [1.5, 0, 0.8],
+              "to": [3.6, 0, 0.8],
               "color": "#66d9ff44",
               "width": 3
             },
             {
               "id": "ap_prob_bottom_slot",
               "type": "line",
-              "from": [
-                1.5,
-                0,
-                -0.8
-              ],
-              "to": [
-                3.6,
-                0,
-                -0.8
-              ],
+              "from": [1.5, 0, -0.8],
+              "to": [3.6, 0, -0.8],
               "color": "#ff7b7244",
               "width": 3
             },
             {
               "id": "ap_amp_top_text",
               "type": "text",
-              "position": [
-                -4.9,
-                0,
-                0.92
-              ],
+              "position": [-4.9, 0, 0.92],
               "text": "$|0\\rangle$ amplitude",
               "color": "#66d9ff",
               "size": 11
@@ -1919,11 +1075,7 @@
             {
               "id": "ap_amp_bottom_text",
               "type": "text",
-              "position": [
-                -4.9,
-                0,
-                -0.68
-              ],
+              "position": [-4.9, 0, -0.68],
               "text": "$|1\\rangle$ amplitude",
               "color": "#ff7b72",
               "size": 11
@@ -1931,11 +1083,7 @@
             {
               "id": "ap_prob_top_text",
               "type": "text",
-              "position": [
-                0.55,
-                0,
-                0.92
-              ],
+              "position": [0.55, 0, 0.92],
               "text": "$p(0)$",
               "color": "#66d9ff",
               "size": 11
@@ -1943,11 +1091,7 @@
             {
               "id": "ap_prob_bottom_text",
               "type": "text",
-              "position": [
-                0.55,
-                0,
-                -0.68
-              ],
+              "position": [0.55, 0, -0.68],
               "text": "$p(1)$",
               "color": "#ff7b72",
               "size": 11
@@ -1955,27 +1099,15 @@
             {
               "id": "ap_alpha_fixed",
               "type": "vector",
-              "from": [
-                -3.8,
-                0,
-                0.8
-              ],
-              "to": [
-                -1.98,
-                0,
-                0.8
-              ],
+              "from": [-3.8, 0, 0.8],
+              "to": [-1.98, 0, 0.8],
               "color": "#66d9ff",
               "width": 1.5
             },
             {
               "id": "ap_alpha_fixed_label",
               "type": "text",
-              "position": [
-                -2.95,
-                0,
-                1.03
-              ],
+              "position": [-2.95, 0, 1.03],
               "text": "$|\\alpha|$",
               "color": "#66d9ff",
               "size": 12
@@ -1983,27 +1115,15 @@
             {
               "id": "ap_beta_fixed",
               "type": "vector",
-              "from": [
-                -3.8,
-                0,
-                -0.8
-              ],
-              "to": [
-                -2.75,
-                0,
-                -0.8
-              ],
+              "from": [-3.8, 0, -0.8],
+              "to": [-2.75, 0, -0.8],
               "color": "#ff7b72",
               "width": 1.5
             },
             {
               "id": "ap_beta_fixed_label",
               "type": "text",
-              "position": [
-                -3.38,
-                0,
-                -0.58
-              ],
+              "position": [-3.38, 0, -0.58],
               "text": "$|\\beta|$",
               "color": "#ff7b72",
               "size": 12
@@ -2011,27 +1131,15 @@
             {
               "id": "ap_p0_fixed",
               "type": "vector",
-              "from": [
-                1.5,
-                0,
-                0.8
-              ],
-              "to": [
-                3.075,
-                0,
-                0.8
-              ],
+              "from": [1.5, 0, 0.8],
+              "to": [3.075, 0, 0.8],
               "color": "#66d9ff",
               "width": 1.5
             },
             {
               "id": "ap_p0_fixed_label",
               "type": "text",
-              "position": [
-                2.18,
-                0,
-                1.03
-              ],
+              "position": [2.18, 0, 1.03],
               "text": "$|\\alpha|^2$",
               "color": "#66d9ff",
               "size": 12
@@ -2039,38 +1147,22 @@
             {
               "id": "ap_p1_fixed",
               "type": "vector",
-              "from": [
-                1.5,
-                0,
-                -0.8
-              ],
-              "to": [
-                2.025,
-                0,
-                -0.8
-              ],
+              "from": [1.5, 0, -0.8],
+              "to": [2.025, 0, -0.8],
               "color": "#ff7b72",
               "width": 1.5
             },
             {
               "id": "ap_p1_fixed_label",
               "type": "text",
-              "position": [
-                1.72,
-                0,
-                -0.58
-              ],
+              "position": [1.72, 0, -0.58],
               "text": "$|\\beta|^2$",
               "color": "#ff7b72",
               "size": 12
             }
           ],
           "info": [
-            {
-              "id": "ap_intro_info",
-              "position": "top-right",
-              "content": "$$\\lvert\\psi\\rangle = \\alpha\\lvert 0\\rangle + \\beta\\lvert 1\\rangle$$\n$$p(0)=|\\alpha|^2, \\qquad p(1)=|\\beta|^2$$"
-            }
+            {"id": "ap_intro_info", "position": "top-right", "content": "$$\\lvert\\psi\\rangle = \\alpha\\lvert 0\\rangle + \\beta\\lvert 1\\rangle$$\n$$p(0)=|\\alpha|^2, \\qquad p(1)=|\\beta|^2$$"}
           ]
         },
         {
@@ -2078,55 +1170,24 @@
           "description": "As $\\theta$ changes, the amplitudes change on the left and the probabilities change on the right. The right panel always shows the squared magnitudes of the left panel.",
           "prompt": "Make the squaring relationship visible. Students should see that shortening an amplitude bar by a little can shorten the corresponding probability bar by more.",
           "remove": [
-            {
-              "id": "ap_alpha_fixed"
-            },
-            {
-              "id": "ap_alpha_fixed_label"
-            },
-            {
-              "id": "ap_beta_fixed"
-            },
-            {
-              "id": "ap_beta_fixed_label"
-            },
-            {
-              "id": "ap_p0_fixed"
-            },
-            {
-              "id": "ap_p0_fixed_label"
-            },
-            {
-              "id": "ap_p1_fixed"
-            },
-            {
-              "id": "ap_p1_fixed_label"
-            }
+            {"id": "ap_alpha_fixed"},
+            {"id": "ap_alpha_fixed_label"},
+            {"id": "ap_beta_fixed"},
+            {"id": "ap_beta_fixed_label"},
+            {"id": "ap_p0_fixed"},
+            {"id": "ap_p0_fixed_label"},
+            {"id": "ap_p1_fixed"},
+            {"id": "ap_p1_fixed_label"}
           ],
           "sliders": [
-            {
-              "id": "ap_theta",
-              "label": "$\\theta$",
-              "min": 0,
-              "max": 3.141592653589793,
-              "step": 0.01,
-              "default": 1.05
-            }
+            {"id": "ap_theta", "label": "$\\theta$", "min": 0, "max": 3.141592653589793, "step": 0.01, "default": 1.05}
           ],
           "add": [
             {
               "id": "ap_plot_x_axis",
               "type": "line",
-              "from": [
-                -0.8,
-                0,
-                -0.8
-              ],
-              "to": [
-                0.8,
-                0,
-                -0.8
-              ],
+              "from": [-0.8, 0, -0.8],
+              "to": [0.8, 0, -0.8],
               "color": "#5c667a",
               "width": 1.0,
               "opacity": 0.7
@@ -2134,16 +1195,8 @@
             {
               "id": "ap_plot_z_axis",
               "type": "line",
-              "from": [
-                -0.8,
-                0,
-                -0.8
-              ],
-              "to": [
-                -0.8,
-                0,
-                0.8
-              ],
+              "from": [-0.8, 0, -0.8],
+              "to": [-0.8, 0, 0.8],
               "color": "#5c667a",
               "width": 1.0,
               "opacity": 0.7
@@ -2151,11 +1204,7 @@
             {
               "id": "ap_plot_x_label",
               "type": "text",
-              "position": [
-                0.0,
-                0,
-                -1.1
-              ],
+              "position": [0.0, 0, -1.1],
               "text": "$m$",
               "color": "#8899aa",
               "size": 11
@@ -2163,11 +1212,7 @@
             {
               "id": "ap_plot_z_label",
               "type": "text",
-              "position": [
-                -1.15,
-                0,
-                0.0
-              ],
+              "position": [-1.15, 0, 0.0],
               "text": "$p$",
               "color": "#8899aa",
               "size": 11
@@ -2175,11 +1220,7 @@
             {
               "id": "ap_plot_tick_m1",
               "type": "text",
-              "position": [
-                0.8,
-                0,
-                -1.0
-              ],
+              "position": [0.8, 0, -1.0],
               "text": "1",
               "color": "#5c667a",
               "size": 9
@@ -2187,11 +1228,7 @@
             {
               "id": "ap_plot_tick_p1",
               "type": "text",
-              "position": [
-                -1.0,
-                0,
-                0.8
-              ],
+              "position": [-1.0, 0, 0.8],
               "text": "1",
               "color": "#5c667a",
               "size": 9
@@ -2199,26 +1236,15 @@
             {
               "id": "ap_linear_line",
               "type": "line",
-              "from": [
-                -0.8,
-                0,
-                -0.8
-              ],
-              "to": [
-                0.8,
-                0,
-                0.8
-              ],
+              "from": [-0.8, 0, -0.8],
+              "to": [0.8, 0, 0.8],
               "color": "#5c667a44",
               "width": 1.0
             },
             {
               "id": "ap_squaring_curve",
               "type": "parametric_curve",
-              "range": [
-                0,
-                1
-              ],
+              "range": [0, 1],
               "color": "#ffd166",
               "width": 2.5,
               "samples": 64,
@@ -2229,33 +1255,21 @@
             {
               "id": "ap_track_alpha",
               "type": "animated_point",
-              "expr": [
-                "-0.8 + 1.6*cos(ap_theta/2)",
-                "0",
-                "-0.8 + 1.6*cos(ap_theta/2)^2"
-              ],
+              "expr": ["-0.8 + 1.6*cos(ap_theta/2)", "0", "-0.8 + 1.6*cos(ap_theta/2)^2"],
               "color": "#66d9ff",
               "size": 6
             },
             {
               "id": "ap_track_beta",
               "type": "animated_point",
-              "expr": [
-                "-0.8 + 1.6*sin(ap_theta/2)",
-                "0",
-                "-0.8 + 1.6*sin(ap_theta/2)^2"
-              ],
+              "expr": ["-0.8 + 1.6*sin(ap_theta/2)", "0", "-0.8 + 1.6*sin(ap_theta/2)^2"],
               "color": "#ff7b72",
               "size": 6
             },
             {
               "id": "ap_plot_title",
               "type": "text",
-              "position": [
-                0.0,
-                0,
-                1.1
-              ],
+              "position": [0.0, 0, 1.1],
               "text": "$p = m^2$",
               "color": "#ffd166",
               "size": 12
@@ -2263,27 +1277,15 @@
             {
               "id": "ap_alpha_bar",
               "type": "animated_vector",
-              "from": [
-                -3.8,
-                0,
-                0.8
-              ],
-              "expr": [
-                "-3.8 + 2.1*cos(ap_theta/2)",
-                "0",
-                "0.8"
-              ],
+              "from": [-3.8, 0, 0.8],
+              "expr": ["-3.8 + 2.1*cos(ap_theta/2)", "0", "0.8"],
               "color": "#66d9ff",
               "width": 1.5
             },
             {
               "id": "ap_alpha_bar_label",
               "type": "text",
-              "positionExpr": [
-                "-3.55 + 1.0*cos(ap_theta/2)",
-                "0",
-                "1.03"
-              ],
+              "positionExpr": ["-3.55 + 1.0*cos(ap_theta/2)", "0", "1.03"],
               "text": "$|\\alpha|$",
               "color": "#66d9ff",
               "size": 12
@@ -2291,27 +1293,15 @@
             {
               "id": "ap_beta_bar",
               "type": "animated_vector",
-              "from": [
-                -3.8,
-                0,
-                -0.8
-              ],
-              "expr": [
-                "-3.8 + 2.1*sin(ap_theta/2)",
-                "0",
-                "-0.8"
-              ],
+              "from": [-3.8, 0, -0.8],
+              "expr": ["-3.8 + 2.1*sin(ap_theta/2)", "0", "-0.8"],
               "color": "#ff7b72",
               "width": 1.5
             },
             {
               "id": "ap_beta_bar_label",
               "type": "text",
-              "positionExpr": [
-                "-3.55 + 1.0*sin(ap_theta/2)",
-                "0",
-                "-0.58"
-              ],
+              "positionExpr": ["-3.55 + 1.0*sin(ap_theta/2)", "0", "-0.58"],
               "text": "$|\\beta|$",
               "color": "#ff7b72",
               "size": 12
@@ -2319,27 +1309,15 @@
             {
               "id": "ap_p0_bar",
               "type": "animated_vector",
-              "from": [
-                1.5,
-                0,
-                0.8
-              ],
-              "expr": [
-                "1.5 + 2.1*cos(ap_theta/2)^2",
-                "0",
-                "0.8"
-              ],
+              "from": [1.5, 0, 0.8],
+              "expr": ["1.5 + 2.1*cos(ap_theta/2)^2", "0", "0.8"],
               "color": "#66d9ff",
               "width": 1.5
             },
             {
               "id": "ap_p0_bar_label",
               "type": "text",
-              "positionExpr": [
-                "1.78 + 1.0*cos(ap_theta/2)^2",
-                "0",
-                "1.03"
-              ],
+              "positionExpr": ["1.78 + 1.0*cos(ap_theta/2)^2", "0", "1.03"],
               "text": "$p(0)$",
               "color": "#66d9ff",
               "size": 12
@@ -2347,38 +1325,22 @@
             {
               "id": "ap_p1_bar",
               "type": "animated_vector",
-              "from": [
-                1.5,
-                0,
-                -0.8
-              ],
-              "expr": [
-                "1.5 + 2.1*sin(ap_theta/2)^2",
-                "0",
-                "-0.8"
-              ],
+              "from": [1.5, 0, -0.8],
+              "expr": ["1.5 + 2.1*sin(ap_theta/2)^2", "0", "-0.8"],
               "color": "#ff7b72",
               "width": 1.5
             },
             {
               "id": "ap_p1_bar_label",
               "type": "text",
-              "positionExpr": [
-                "1.78 + 1.0*sin(ap_theta/2)^2",
-                "0",
-                "-0.58"
-              ],
+              "positionExpr": ["1.78 + 1.0*sin(ap_theta/2)^2", "0", "-0.58"],
               "text": "$p(1)$",
               "color": "#ff7b72",
               "size": 12
             }
           ],
           "info": [
-            {
-              "id": "ap_theta_info",
-              "position": "top-right",
-              "content": "$$|\\alpha| = \\cos\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(cos(ap_theta/2),3)}}$$\n$$|\\beta| = \\sin\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(sin(ap_theta/2),3)}}$$\n$$p(0)=|\\alpha|^2={{toFixed(cos(ap_theta/2)^2,3)}},\\quad p(1)=|\\beta|^2={{toFixed(sin(ap_theta/2)^2,3)}}$$"
-            }
+            {"id": "ap_theta_info", "position": "top-right", "content": "$$|\\alpha| = \\cos\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(cos(ap_theta/2),3)}}$$\n$$|\\beta| = \\sin\\!\\left(\\frac{\\theta}{2}\\right) = {{toFixed(sin(ap_theta/2),3)}}$$\n$$p(0)=|\\alpha|^2={{toFixed(cos(ap_theta/2)^2,3)}},\\quad p(1)=|\\beta|^2={{toFixed(sin(ap_theta/2)^2,3)}}$$"}
           ]
         },
         {
@@ -2386,14 +1348,7 @@
           "description": "Now add relative phase. The lower amplitude can rotate in Hilbert space, but the computational-basis probabilities stay fixed because only the magnitudes matter.",
           "prompt": "Use this step to separate amplitude phase from measurement probability. The left panel gains a phase wheel; the right panel does not move.",
           "sliders": [
-            {
-              "id": "ap_phi",
-              "label": "$\\phi$",
-              "min": 0,
-              "max": 6.283185307179586,
-              "step": 0.01,
-              "default": 0.9
-            }
+            {"id": "ap_phi", "label": "$\\phi$", "min": 0, "max": 6.283185307179586, "step": 0.01, "default": 0.9}
           ],
           "add": [
             {
@@ -2402,10 +1357,7 @@
               "x": "-3.8 + 2.1*sin(ap_theta/2)",
               "y": "0.32*cos(t)",
               "z": "-0.8 + 0.32*sin(t)",
-              "range": [
-                0,
-                6.283185307179586
-              ],
+              "range": [0, 6.283185307179586],
               "samples": 80,
               "color": "#c77dff",
               "width": 1.5,
@@ -2414,38 +1366,22 @@
             {
               "id": "ap_beta_phase",
               "type": "animated_vector",
-              "fromExpr": [
-                "-3.8 + 2.1*sin(ap_theta/2)",
-                "0",
-                "-0.8"
-              ],
-              "expr": [
-                "-3.8 + 2.1*sin(ap_theta/2)",
-                "0.32*cos(ap_phi)",
-                "-0.8 + 0.32*sin(ap_phi)"
-              ],
+              "fromExpr": ["-3.8 + 2.1*sin(ap_theta/2)", "0", "-0.8"],
+              "expr": ["-3.8 + 2.1*sin(ap_theta/2)", "0.32*cos(ap_phi)", "-0.8 + 0.32*sin(ap_phi)"],
               "color": "#c77dff",
               "width": 2
             },
             {
               "id": "ap_beta_phase_label",
               "type": "text",
-              "positionExpr": [
-                "-3.8 + 2.1*sin(ap_theta/2)",
-                "0.32*cos(ap_phi)",
-                "-0.8 + 0.32*sin(ap_phi)"
-              ],
+              "positionExpr": ["-3.8 + 2.1*sin(ap_theta/2)", "0.32*cos(ap_phi)", "-0.8 + 0.32*sin(ap_phi)"],
               "text": "$\\phi$",
               "color": "#c77dff",
               "size": 12
             }
           ],
           "info": [
-            {
-              "id": "ap_phase_info",
-              "position": "top-right",
-              "content": "$$\\beta = e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)$$\n$$|\\beta| = \\sin\\!\\left(\\frac{\\theta}{2}\\right),\\qquad |\\beta|^2 = {{toFixed(sin(ap_theta/2)^2,3)}}$$\n$$\\text{Changing } \\phi \\text{ leaves } p(0),p(1) \\text{ unchanged.}$$"
-            }
+            {"id": "ap_phase_info", "position": "top-right", "content": "$$\\beta = e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)$$\n$$|\\beta| = \\sin\\!\\left(\\frac{\\theta}{2}\\right),\\qquad |\\beta|^2 = {{toFixed(sin(ap_theta/2)^2,3)}}$$\n$$\\text{Changing } \\phi \\text{ leaves } p(0),p(1) \\text{ unchanged.}$$"}
           ]
         }
       ]
@@ -2456,92 +1392,35 @@
       "markdown": "# From Amplitudes to a Sphere\n\nIn the previous scene we matched the Hilbert-space amplitudes to their Bloch-sphere image. Now we zoom in on the sphere itself.\n\nFor a pure qubit,\n\n$$\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle$$\n\nmaps to the **Bloch vector**\n\n$$\\vec{r} = (\\sin\\theta\\cos\\phi,\\; \\sin\\theta\\sin\\phi,\\; \\cos\\theta).$$\n\nThis is a unit vector in $\\mathbb{R}^3$ — a point on a sphere.\n\n- **$\\theta$** is the polar angle from the north pole. It controls the balance between $\\lvert 0\\rangle$ and $\\lvert 1\\rangle$.\n- **$\\phi$** is the azimuthal angle around the equator. It controls the relative phase.\n- **$z = \\cos\\theta$** directly gives the measurement probabilities: $p(0) = (1+z)/2$.",
       "prompt": "This scene is now a zoom-in on the Bloch sphere after the side-by-side bridge. Focus on the sphere geometry itself rather than re-explaining the full coordinate change. Keep colors consistent: cyan for |0>/alpha, coral for |1>/beta, gold for the state vector, green for z-projection/meridian, magenta for equator/phase.",
       "range": [
-        [
-          -1.35,
-          1.35
-        ],
-        [
-          -1.35,
-          1.35
-        ],
-        [
-          -1.35,
-          1.35
-        ]
+        [-1.35, 1.35],
+        [-1.35, 1.35],
+        [-1.35, 1.35]
       ],
       "camera": {
-        "position": [
-          2.8,
-          -2.4,
-          1.8
-        ],
-        "target": [
-          0,
-          0,
-          0
-        ],
-        "up": [
-          0,
-          0,
-          1
-        ]
+        "position": [2.8, -2.4, 1.8],
+        "target": [0, 0, 0],
+        "up": [0, 0, 1]
       },
       "views": [
         {
           "name": "Iso",
-          "position": [
-            2.8,
-            -2.4,
-            1.8
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [2.8, -2.4, 1.8],
+          "target": [0, 0, 0],
+          "up": [0, 0, 1],
           "description": "See the full sphere and the state vector"
         },
         {
           "name": "North Pole",
-          "position": [
-            0,
-            0,
-            4
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            1,
-            0
-          ],
+          "position": [0, 0, 4],
+          "target": [0, 0, 0],
+          "up": [0, 1, 0],
           "description": "Top-down view — see the azimuthal angle $\\phi$"
         },
         {
           "name": "Equator",
-          "position": [
-            3.2,
-            0,
-            0
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [3.2, 0, 0],
+          "target": [0, 0, 0],
+          "up": [0, 0, 1],
           "description": "Side view — see the polar angle $\\theta$"
         }
       ],
@@ -2550,10 +1429,7 @@
           "id": "sb_axis_x",
           "type": "axis",
           "axis": "x",
-          "range": [
-            -1.2,
-            1.2
-          ],
+          "range": [-1.2, 1.2],
           "color": "#ff4444",
           "width": 1.2,
           "label": "$x$"
@@ -2562,10 +1438,7 @@
           "id": "sb_axis_y",
           "type": "axis",
           "axis": "y",
-          "range": [
-            -1.2,
-            1.2
-          ],
+          "range": [-1.2, 1.2],
           "color": "#44cc44",
           "width": 1.2,
           "label": "$y$"
@@ -2574,10 +1447,7 @@
           "id": "sb_axis_z",
           "type": "axis",
           "axis": "z",
-          "range": [
-            -1.2,
-            1.2
-          ],
+          "range": [-1.2, 1.2],
           "color": "#4488ff",
           "width": 1.2,
           "label": "$z$"
@@ -2586,15 +1456,8 @@
           "id": "sb_grid",
           "type": "grid",
           "plane": "xy",
-          "range": [
-            -1.2,
-            1.2
-          ],
-          "color": [
-            0.28,
-            0.28,
-            0.45
-          ],
+          "range": [-1.2, 1.2],
+          "color": [0.28, 0.28, 0.45],
           "opacity": 0.15,
           "divisions": 12
         }
@@ -2608,11 +1471,7 @@
             {
               "id": "sb_ket0",
               "type": "point",
-              "position": [
-                0,
-                0,
-                1
-              ],
+              "position": [0, 0, 1],
               "color": "#66d9ff",
               "size": 10,
               "label": "$\\lvert 0\\rangle$"
@@ -2620,22 +1479,14 @@
             {
               "id": "sb_ket1",
               "type": "point",
-              "position": [
-                0,
-                0,
-                -1
-              ],
+              "position": [0, 0, -1],
               "color": "#ff7b72",
               "size": 10,
               "label": "$\\lvert 1\\rangle$"
             }
           ],
           "info": [
-            {
-              "id": "sb_recap_info",
-              "position": "top-right",
-              "content": "$$\\lvert\\psi\\rangle = \\underbrace{\\cos\\!\\left(\\frac{\\theta}{2}\\right)}_{\\alpha}\\lvert 0\\rangle + \\underbrace{e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)}_{\\beta}\\lvert 1\\rangle$$\n$$\\text{Two real parameters: } \\theta, \\phi$$"
-            }
+            {"id": "sb_recap_info", "position": "top-right", "content": "$$\\lvert\\psi\\rangle = \\underbrace{\\cos\\!\\left(\\frac{\\theta}{2}\\right)}_{\\alpha}\\lvert 0\\rangle + \\underbrace{e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)}_{\\beta}\\lvert 1\\rangle$$\n$$\\text{Two real parameters: } \\theta, \\phi$$"}
           ]
         },
         {
@@ -2643,14 +1494,7 @@
           "description": "The polar angle $\\theta$ sweeps from $\\lvert 0\\rangle$ at the north pole ($\\theta = 0$) to $\\lvert 1\\rangle$ at the south pole ($\\theta = \\pi$). Halfway ($\\theta = \\pi/2$) is an equal superposition.",
           "prompt": "Show the meridian and let the student sweep theta. Connect it explicitly: theta=0 means alpha=1 beta=0, theta=pi means alpha=0 beta=1. The z-coordinate is cos(theta).",
           "sliders": [
-            {
-              "id": "sb_theta",
-              "label": "$\\theta$",
-              "min": 0,
-              "max": 3.141592653589793,
-              "step": 0.01,
-              "default": 1.05
-            }
+            {"id": "sb_theta", "label": "$\\theta$", "min": 0, "max": 3.141592653589793, "step": 0.01, "default": 1.05}
           ],
           "add": [
             {
@@ -2659,10 +1503,7 @@
               "x": "sin(t)",
               "y": "0",
               "z": "cos(t)",
-              "range": [
-                0,
-                3.141592653589793
-              ],
+              "range": [0, 3.141592653589793],
               "samples": 80,
               "color": "#7bd389",
               "width": 2,
@@ -2671,16 +1512,8 @@
             {
               "id": "sb_state_vec",
               "type": "animated_vector",
-              "from": [
-                0,
-                0,
-                0
-              ],
-              "expr": [
-                "sin(sb_theta)",
-                "0",
-                "cos(sb_theta)"
-              ],
+              "from": [0, 0, 0],
+              "expr": ["sin(sb_theta)", "0", "cos(sb_theta)"],
               "color": "#ffd166",
               "width": 2,
               "label": "$\\lvert\\psi\\rangle$"
@@ -2688,27 +1521,15 @@
             {
               "id": "sb_zproj",
               "type": "animated_vector",
-              "from": [
-                0,
-                0,
-                0
-              ],
-              "expr": [
-                "0",
-                "0",
-                "cos(sb_theta)"
-              ],
+              "from": [0, 0, 0],
+              "expr": ["0", "0", "cos(sb_theta)"],
               "color": "#7bd389",
               "width": 2,
               "opacity": 0.6
             }
           ],
           "info": [
-            {
-              "id": "sb_theta_info",
-              "position": "top-right",
-              "content": "$$\\theta = {{toFixed(sb_theta, 2)}}$$\n$$\\alpha = \\cos(\\theta/2) = {{toFixed(cos(sb_theta/2), 3)}}$$\n$$\\lvert\\beta\\rvert = \\sin(\\theta/2) = {{toFixed(sin(sb_theta/2), 3)}}$$\n$$z = \\cos\\theta = {{toFixed(cos(sb_theta), 3)}}$$\n$$p(0) = \\cos^2(\\theta/2) = {{toFixed(cos(sb_theta/2)^2,3)}},\\; p(1) = \\sin^2(\\theta/2) = {{toFixed(sin(sb_theta/2)^2,3)}}$$"
-            }
+            {"id": "sb_theta_info", "position": "top-right", "content": "$$\\theta = {{toFixed(sb_theta, 2)}}$$\n$$\\alpha = \\cos(\\theta/2) = {{toFixed(cos(sb_theta/2), 3)}}$$\n$$\\lvert\\beta\\rvert = \\sin(\\theta/2) = {{toFixed(sin(sb_theta/2), 3)}}$$\n$$z = \\cos\\theta = {{toFixed(cos(sb_theta), 3)}}$$\n$$p(0) = \\cos^2(\\theta/2) = {{toFixed(cos(sb_theta/2)^2,3)}},\\; p(1) = \\sin^2(\\theta/2) = {{toFixed(sin(sb_theta/2)^2,3)}}$$"}
           ]
         },
         {
@@ -2719,19 +1540,13 @@
             {
               "id": "sb_sphere",
               "type": "sphere",
-              "center": [
-                0,
-                0,
-                0
-              ],
+              "center": [0, 0, 0],
               "radius": 1,
               "color": "#334466",
               "opacity": 0.15,
               "segments": 64,
               "rings": 48,
-              "shader": {
-                "depthWrite": false
-              }
+              "shader": {"depthWrite": false}
             },
             {
               "id": "sb_equator",
@@ -2739,10 +1554,7 @@
               "x": "cos(t)",
               "y": "sin(t)",
               "z": "0",
-              "range": [
-                0,
-                6.283185307179586
-              ],
+              "range": [0, 6.283185307179586],
               "samples": 120,
               "color": "#c77dff",
               "width": 2,
@@ -2755,37 +1567,18 @@
           "description": "The relative phase $\\phi$ rotates the state around the z-axis. It sweeps out the equator and every latitude circle — this is the Bloch sphere.",
           "prompt": "Add the phi slider. Now the state can reach any point on the sphere. Connect back to the amplitude picture: theta controlled |alpha| vs |beta|, phi controls the complex phase of beta. Together they cover every pure state.",
           "remove": [
-            {
-              "id": "sb_state_vec"
-            },
-            {
-              "id": "sb_zproj"
-            }
+            {"id": "sb_state_vec"},
+            {"id": "sb_zproj"}
           ],
           "sliders": [
-            {
-              "id": "sb_phi",
-              "label": "$\\phi$",
-              "min": 0,
-              "max": 6.283185307179586,
-              "step": 0.01,
-              "default": 0.7
-            }
+            {"id": "sb_phi", "label": "$\\phi$", "min": 0, "max": 6.283185307179586, "step": 0.01, "default": 0.7}
           ],
           "add": [
             {
               "id": "sb_state_full",
               "type": "animated_vector",
-              "from": [
-                0,
-                0,
-                0
-              ],
-              "expr": [
-                "sin(sb_theta)*cos(sb_phi)",
-                "sin(sb_theta)*sin(sb_phi)",
-                "cos(sb_theta)"
-              ],
+              "from": [0, 0, 0],
+              "expr": ["sin(sb_theta)*cos(sb_phi)", "sin(sb_theta)*sin(sb_phi)", "cos(sb_theta)"],
               "color": "#ffd166",
               "width": 2,
               "label": "$\\lvert\\psi\\rangle$"
@@ -2793,16 +1586,8 @@
             {
               "id": "sb_zproj_full",
               "type": "animated_vector",
-              "from": [
-                0,
-                0,
-                0
-              ],
-              "expr": [
-                "0",
-                "0",
-                "cos(sb_theta)"
-              ],
+              "from": [0, 0, 0],
+              "expr": ["0", "0", "cos(sb_theta)"],
               "color": "#7bd389",
               "width": 2,
               "opacity": 0.5
@@ -2813,10 +1598,7 @@
               "x": "sin(sb_theta)*cos(t)",
               "y": "sin(sb_theta)*sin(t)",
               "z": "cos(sb_theta)",
-              "range": [
-                0,
-                6.283185307179586
-              ],
+              "range": [0, 6.283185307179586],
               "samples": 80,
               "color": "#c77dff",
               "width": 1.5,
@@ -2824,11 +1606,7 @@
             }
           ],
           "info": [
-            {
-              "id": "sb_full_info",
-              "position": "top-right",
-              "content": "$$\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle$$\n$$\\theta = {{toFixed(sb_theta, 2)}}, \\quad \\phi = {{toFixed(sb_phi, 2)}}$$\n$$\\vec{r} = ({{toFixed(sin(sb_theta)*cos(sb_phi),2)}},\\; {{toFixed(sin(sb_theta)*sin(sb_phi),2)}},\\; {{toFixed(cos(sb_theta),2)}})$$"
-            }
+            {"id": "sb_full_info", "position": "top-right", "content": "$$\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle$$\n$$\\theta = {{toFixed(sb_theta, 2)}}, \\quad \\phi = {{toFixed(sb_phi, 2)}}$$\n$$\\vec{r} = ({{toFixed(sin(sb_theta)*cos(sb_phi),2)}},\\; {{toFixed(sin(sb_theta)*sin(sb_phi),2)}},\\; {{toFixed(cos(sb_theta),2)}})$$"}
           ]
         },
         {
@@ -2836,11 +1614,7 @@
           "description": "Every pure qubit state is a point on this sphere. The amplitudes $\\alpha$ and $\\beta$ from the Hilbert space map one-to-one to the angles $\\theta$ and $\\phi$ on the Bloch sphere.",
           "prompt": "Wrap up the bridge. The student now knows: ℂ² amplitudes → two angles → Bloch sphere. Every subsequent scene will work directly on the sphere. Mention that mixed states (statistical mixtures) live inside the sphere, but this lesson stays on the surface.",
           "info": [
-            {
-              "id": "sb_summary",
-              "position": "top-right",
-              "content": "**The Bloch sphere map**\n$$\\mathbb{C}^2 \\longrightarrow S^2$$\n$\\alpha, \\beta$ (complex amplitudes)\n$\\quad\\downarrow$ normalization + global phase\n$\\theta, \\phi$ (two real angles)\n$\\quad\\downarrow$ spherical coordinates\nOne point on the Bloch sphere"
-            }
+            {"id": "sb_summary", "position": "top-right", "content": "**The Bloch sphere map**\n$$\\mathbb{C}^2 \\longrightarrow S^2$$\n$\\alpha, \\beta$ (complex amplitudes)\n$\\quad\\downarrow$ normalization + global phase\n$\\theta, \\phi$ (two real angles)\n$\\quad\\downarrow$ spherical coordinates\nOne point on the Bloch sphere"}
           ]
         }
       ]
@@ -2851,111 +1625,42 @@
       "markdown": "# From Bit to Bloch Sphere\n\nA classical bit has two pure states: $0$ and $1$. A **qubit** has basis states $|0\\rangle$ and $|1\\rangle$, but any normalized superposition\n\n$$|\\psi\\rangle = \\alpha |0\\rangle + \\beta |1\\rangle, \\qquad |\\alpha|^2 + |\\beta|^2 = 1$$\n\nis also a valid pure state.\n\nFor a single qubit, global phase does not affect measurements, so every pure state can be represented by a point on the **Bloch sphere**. The north pole is $|0\\rangle$, the south pole is $|1\\rangle$, and intermediate points represent superpositions.\n\nThis draft lesson focuses on **pure one-qubit states** because they admit a clean 3D picture. Mixed states live inside the sphere rather than on its surface.",
       "prompt": "Teach this scene as the jump from classical states to pure qubit states. Gold is always the current state, cyan is |0>, coral is |1>, and magenta is reserved for phase-related circles. Emphasize that the Bloch sphere visualizes pure states of a two-level system, not all quantum states in full generality.",
       "range": [
-        [
-          -1.35,
-          1.35
-        ],
-        [
-          -1.35,
-          1.35
-        ],
-        [
-          -1.35,
-          1.35
-        ]
+        [-1.35, 1.35],
+        [-1.35, 1.35],
+        [-1.35, 1.35]
       ],
       "camera": {
-        "position": [
-          2.7,
-          -2.7,
-          1.8
-        ],
-        "target": [
-          0,
-          0,
-          0
-        ],
-        "up": [
-          0,
-          0,
-          1
-        ]
+        "position": [2.7, -2.7, 1.8],
+        "target": [0, 0, 0],
+        "up": [0, 0, 1]
       },
       "views": [
         {
           "name": "Iso",
-          "position": [
-            2.7,
-            -2.7,
-            1.8
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [2.7, -2.7, 1.8],
+          "target": [0, 0, 0],
+          "up": [0, 0, 1],
           "description": "Three-dimensional view of the Bloch sphere"
         },
         {
           "name": "Face On",
-          "position": [
-            0,
-            -4,
-            0
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [0, -4, 0],
+          "target": [0, 0, 0],
+          "up": [0, 0, 1],
           "description": "Look directly at the x-z cross-section"
         },
         {
           "name": "North Pole",
-          "position": [
-            0,
-            0,
-            4
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            1,
-            0
-          ],
+          "position": [0, 0, 4],
+          "target": [0, 0, 0],
+          "up": [0, 1, 0],
           "description": "Focus on the $|0\\rangle$ pole"
         },
         {
           "name": "Equator",
-          "position": [
-            3.2,
-            0,
-            0
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [3.2, 0, 0],
+          "target": [0, 0, 0],
+          "up": [0, 0, 1],
           "description": "Side view of equatorial superpositions"
         }
       ],
@@ -2963,11 +1668,7 @@
         {
           "id": "s1_sphere",
           "type": "sphere",
-          "center": [
-            0,
-            0,
-            0
-          ],
+          "center": [0, 0, 0],
           "radius": 1,
           "color": "#5c7cfa",
           "opacity": 0.12,
@@ -2978,10 +1679,7 @@
           "id": "s1_axis_x",
           "type": "axis",
           "axis": "x",
-          "range": [
-            -1.2,
-            1.2
-          ],
+          "range": [-1.2, 1.2],
           "color": "#ff4444",
           "width": 1.2,
           "label": "$x$"
@@ -2990,10 +1688,7 @@
           "id": "s1_axis_y",
           "type": "axis",
           "axis": "y",
-          "range": [
-            -1.2,
-            1.2
-          ],
+          "range": [-1.2, 1.2],
           "color": "#44cc44",
           "width": 1.2,
           "label": "$y$"
@@ -3002,10 +1697,7 @@
           "id": "s1_axis_z",
           "type": "axis",
           "axis": "z",
-          "range": [
-            -1.2,
-            1.2
-          ],
+          "range": [-1.2, 1.2],
           "color": "#4488ff",
           "width": 1.2,
           "label": "$z$"
@@ -3014,15 +1706,8 @@
           "id": "s1_grid_xy",
           "type": "grid",
           "plane": "xy",
-          "range": [
-            -1.2,
-            1.2
-          ],
-          "color": [
-            0.28,
-            0.28,
-            0.45
-          ],
+          "range": [-1.2, 1.2],
+          "color": [0.28, 0.28, 0.45],
           "opacity": 0.12,
           "divisions": 8
         }
@@ -3036,11 +1721,7 @@
             {
               "id": "s1_ket0",
               "type": "point",
-              "position": [
-                0,
-                0,
-                1
-              ],
+              "position": [0, 0, 1],
               "color": "#66d9ff",
               "size": 10,
               "label": "$|0\\rangle$"
@@ -3048,11 +1729,7 @@
             {
               "id": "s1_ket1",
               "type": "point",
-              "position": [
-                0,
-                0,
-                -1
-              ],
+              "position": [0, 0, -1],
               "color": "#ff7b72",
               "size": 10,
               "label": "$|1\\rangle$"
@@ -3067,16 +1744,8 @@
             {
               "id": "s1_plusx_vec",
               "type": "vector",
-              "from": [
-                0,
-                0,
-                0
-              ],
-              "to": [
-                1,
-                0,
-                0
-              ],
+              "from": [0, 0, 0],
+              "to": [1, 0, 0],
               "color": "#ffd166",
               "width": 4,
               "label": "$|+x\\rangle$"
@@ -3084,11 +1753,7 @@
             {
               "id": "s1_plusx_pt",
               "type": "point",
-              "position": [
-                1,
-                0,
-                0
-              ],
+              "position": [1, 0, 0],
               "color": "#ffd166",
               "size": 8
             }
@@ -3099,27 +1764,15 @@
           "description": "A general pure qubit can point anywhere on the sphere. This sample state has both a latitude and an azimuth, so it needs more than a single 'probability of 1' number to describe it.",
           "prompt": "Introduce the idea that one angle sets the balance between |0> and |1>, while another controls relative phase. Keep it qualitative here and save formulas for the next scene.",
           "remove": [
-            {
-              "id": "s1_plusx_vec"
-            },
-            {
-              "id": "s1_plusx_pt"
-            }
+            {"id": "s1_plusx_vec"},
+            {"id": "s1_plusx_pt"}
           ],
           "add": [
             {
               "id": "s1_generic_vec",
               "type": "vector",
-              "from": [
-                0,
-                0,
-                0
-              ],
-              "to": [
-                0.612,
-                0.612,
-                0.5
-              ],
+              "from": [0, 0, 0],
+              "to": [0.612, 0.612, 0.5],
               "color": "#ffd166",
               "width": 4,
               "label": "$|\\psi\\rangle$"
@@ -3127,11 +1780,7 @@
             {
               "id": "s1_generic_pt",
               "type": "point",
-              "position": [
-                0.612,
-                0.612,
-                0.5
-              ],
+              "position": [0.612, 0.612, 0.5],
               "color": "#ffd166",
               "size": 8
             }
@@ -3148,10 +1797,7 @@
               "x": "cos(t)",
               "y": "sin(t)",
               "z": "0",
-              "range": [
-                0,
-                6.283185307179586
-              ],
+              "range": [0, 6.283185307179586],
               "samples": 180,
               "color": "#c77dff",
               "width": 2,
@@ -3163,10 +1809,7 @@
               "x": "sin(t)",
               "y": "0",
               "z": "cos(t)",
-              "range": [
-                0,
-                3.141592653589793
-              ],
+              "range": [0, 3.141592653589793],
               "samples": 120,
               "color": "#7bd389",
               "width": 2,
@@ -3182,92 +1825,35 @@
       "markdown": "# Angles Encode Amplitudes\n\nFor a pure one-qubit state, the Bloch sphere coordinates are usually written as\n\n$$|\\psi\\rangle = \\cos\\left(\\frac{\\theta}{2}\\right)|0\\rangle + e^{i\\phi}\\sin\\left(\\frac{\\theta}{2}\\right)|1\\rangle.$$\n\nThe Bloch point has coordinates\n\n$$r=(x,y,z)=\\bigl(\\sin\\theta\\cos\\phi,\\;\\sin\\theta\\sin\\phi,\\;\\cos\\theta\\bigr).$$\n\nSo:\n\n- $\\theta$ controls the **latitude** and therefore the balance between $|0\\rangle$ and $|1\\rangle$.\n- $\\phi$ controls the **azimuth** and therefore the **relative phase** between those basis states.\n\nThis is the standard pure-state parameterization for qubits; it is the geometric version of the normalized state-vector description.",
       "prompt": "Teach this scene as the algebra-geometry bridge. Keep gold for the active state, cyan for |0>, coral for |1>, green for the meridian, and magenta for azimuth/equator cues. Emphasize that theta controls amplitude magnitudes while phi controls relative phase.",
       "range": [
-        [
-          -1.35,
-          1.35
-        ],
-        [
-          -1.35,
-          1.35
-        ],
-        [
-          -1.35,
-          1.35
-        ]
+        [-1.35, 1.35],
+        [-1.35, 1.35],
+        [-1.35, 1.35]
       ],
       "camera": {
-        "position": [
-          2.9,
-          -2.4,
-          1.7
-        ],
-        "target": [
-          0,
-          0,
-          0
-        ],
-        "up": [
-          0,
-          0,
-          1
-        ]
+        "position": [2.9, -2.4, 1.7],
+        "target": [0, 0, 0],
+        "up": [0, 0, 1]
       },
       "views": [
         {
           "name": "Iso",
-          "position": [
-            2.9,
-            -2.4,
-            1.7
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [2.9, -2.4, 1.7],
+          "target": [0, 0, 0],
+          "up": [0, 0, 1],
           "description": "See both latitude and azimuth"
         },
         {
           "name": "Meridian",
-          "position": [
-            0,
-            -4,
-            0
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [0, -4, 0],
+          "target": [0, 0, 0],
+          "up": [0, 0, 1],
           "description": "Best view for changing $\\theta$ at fixed $\\phi=0$"
         },
         {
           "name": "Top Down",
-          "position": [
-            0,
-            0,
-            4
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            1,
-            0
-          ],
+          "position": [0, 0, 4],
+          "target": [0, 0, 0],
+          "up": [0, 1, 0],
           "description": "Look straight down to see the azimuth angle $\\phi$"
         }
       ],
@@ -3275,11 +1861,7 @@
         {
           "id": "s2_sphere",
           "type": "sphere",
-          "center": [
-            0,
-            0,
-            0
-          ],
+          "center": [0, 0, 0],
           "radius": 1,
           "color": "#5c7cfa",
           "opacity": 0.12,
@@ -3290,10 +1872,7 @@
           "id": "s2_axis_x",
           "type": "axis",
           "axis": "x",
-          "range": [
-            -1.2,
-            1.2
-          ],
+          "range": [-1.2, 1.2],
           "color": "#ff4444",
           "width": 1.2,
           "label": "$x$"
@@ -3302,10 +1881,7 @@
           "id": "s2_axis_y",
           "type": "axis",
           "axis": "y",
-          "range": [
-            -1.2,
-            1.2
-          ],
+          "range": [-1.2, 1.2],
           "color": "#44cc44",
           "width": 1.2,
           "label": "$y$"
@@ -3314,10 +1890,7 @@
           "id": "s2_axis_z",
           "type": "axis",
           "axis": "z",
-          "range": [
-            -1.2,
-            1.2
-          ],
+          "range": [-1.2, 1.2],
           "color": "#4488ff",
           "width": 1.2,
           "label": "$z$"
@@ -3326,26 +1899,15 @@
           "id": "s2_grid_xy",
           "type": "grid",
           "plane": "xy",
-          "range": [
-            -1.2,
-            1.2
-          ],
-          "color": [
-            0.28,
-            0.28,
-            0.45
-          ],
+          "range": [-1.2, 1.2],
+          "color": [0.28, 0.28, 0.45],
           "opacity": 0.12,
           "divisions": 8
         },
         {
           "id": "s2_ket0",
           "type": "point",
-          "position": [
-            0,
-            0,
-            1
-          ],
+          "position": [0, 0, 1],
           "color": "#66d9ff",
           "size": 10,
           "label": "$|0\\rangle$"
@@ -3353,11 +1915,7 @@
         {
           "id": "s2_ket1",
           "type": "point",
-          "position": [
-            0,
-            0,
-            -1
-          ],
+          "position": [0, 0, -1],
           "color": "#ff7b72",
           "size": 10,
           "label": "$|1\\rangle$"
@@ -3369,14 +1927,7 @@
           "description": "Start on a single meridian with $\\phi=0$. As $\\theta$ increases from 0 to $\\pi$, the state slides from $|0\\rangle$ down to $|1\\rangle$.",
           "prompt": "Connect theta to north-versus-south balance. Point out that theta alone already tells the student how much of |0> and |1> appears in the amplitudes.",
           "sliders": [
-            {
-              "id": "q2_theta",
-              "label": "$\\theta$",
-              "min": 0,
-              "max": 3.141592653589793,
-              "step": 0.01,
-              "default": 1.05
-            }
+            {"id": "q2_theta", "label": "$\\theta$", "min": 0, "max": 3.141592653589793, "step": 0.01, "default": 1.05}
           ],
           "add": [
             {
@@ -3385,10 +1936,7 @@
               "x": "sin(t)",
               "y": "0",
               "z": "cos(t)",
-              "range": [
-                0,
-                3.141592653589793
-              ],
+              "range": [0, 3.141592653589793],
               "samples": 120,
               "color": "#7bd389",
               "width": 2,
@@ -3397,16 +1945,8 @@
             {
               "id": "s2_theta_vec",
               "type": "animated_vector",
-              "from": [
-                0,
-                0,
-                0
-              ],
-              "expr": [
-                "sin(q2_theta)",
-                "0",
-                "cos(q2_theta)"
-              ],
+              "from": [0, 0, 0],
+              "expr": ["sin(q2_theta)", "0", "cos(q2_theta)"],
               "color": "#ffd166",
               "width": 2.0,
               "label": "$|\\psi(\\theta)\\rangle$"
@@ -3414,21 +1954,13 @@
             {
               "id": "s2_theta_pt",
               "type": "animated_point",
-              "expr": [
-                "sin(q2_theta)",
-                "0",
-                "cos(q2_theta)"
-              ],
+              "expr": ["sin(q2_theta)", "0", "cos(q2_theta)"],
               "color": "#ffd166",
               "size": 1.0
             }
           ],
           "info": [
-            {
-              "id": "s2_theta_info",
-              "position": "top-right",
-              "content": "$$\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + \\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle$$\n$$\\theta={{toFixed(q2_theta,2)}}\\ \\text{rad},\\quad z=\\cos\\theta={{toFixed(cos(q2_theta),2)}}$$\n$$p(0) = \\cos^2(\\theta/2) = {{toFixed(cos(q2_theta/2)^2,3)}},\\; p(1) = \\sin^2(\\theta/2) = {{toFixed(sin(q2_theta/2)^2,3)}}$$"
-            }
+            {"id": "s2_theta_info", "position": "top-right", "content": "$$\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + \\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle$$\n$$\\theta={{toFixed(q2_theta,2)}}\\ \\text{rad},\\quad z=\\cos\\theta={{toFixed(cos(q2_theta),2)}}$$\n$$p(0) = \\cos^2(\\theta/2) = {{toFixed(cos(q2_theta/2)^2,3)}},\\; p(1) = \\sin^2(\\theta/2) = {{toFixed(sin(q2_theta/2)^2,3)}}$$"}
           ]
         },
         {
@@ -3436,37 +1968,18 @@
           "description": "Now let the state swing around the sphere. Changing $\\phi$ rotates the state around the z-axis while keeping the latitude fixed.",
           "prompt": "Name phi as the azimuth angle and the source of relative phase. Do not claim that phi changes z-basis probabilities; save that comparison for later.",
           "remove": [
-            {
-              "id": "s2_theta_vec"
-            },
-            {
-              "id": "s2_theta_pt"
-            }
+            {"id": "s2_theta_vec"},
+            {"id": "s2_theta_pt"}
           ],
           "sliders": [
-            {
-              "id": "q2_phi",
-              "label": "$\\phi$",
-              "min": 0,
-              "max": 6.283185307179586,
-              "step": 0.01,
-              "default": 0.79
-            }
+            {"id": "q2_phi", "label": "$\\phi$", "min": 0, "max": 6.283185307179586, "step": 0.01, "default": 0.79}
           ],
           "add": [
             {
               "id": "s2_full_vec",
               "type": "animated_vector",
-              "from": [
-                0,
-                0,
-                0
-              ],
-              "expr": [
-                "sin(q2_theta)*cos(q2_phi)",
-                "sin(q2_theta)*sin(q2_phi)",
-                "cos(q2_theta)"
-              ],
+              "from": [0, 0, 0],
+              "expr": ["sin(q2_theta)*cos(q2_phi)", "sin(q2_theta)*sin(q2_phi)", "cos(q2_theta)"],
               "color": "#ffd166",
               "width": 2.0,
               "label": "$|\\psi(\\theta,\\phi)\\rangle$"
@@ -3474,11 +1987,7 @@
             {
               "id": "s2_full_pt",
               "type": "animated_point",
-              "expr": [
-                "sin(q2_theta)*cos(q2_phi)",
-                "sin(q2_theta)*sin(q2_phi)",
-                "cos(q2_theta)"
-              ],
+              "expr": ["sin(q2_theta)*cos(q2_phi)", "sin(q2_theta)*sin(q2_phi)", "cos(q2_theta)"],
               "color": "#ffd166",
               "size": 1.0
             }
@@ -3495,10 +2004,7 @@
               "x": "cos(t)",
               "y": "sin(t)",
               "z": "0",
-              "range": [
-                0,
-                6.283185307179586
-              ],
+              "range": [0, 6.283185307179586],
               "samples": 180,
               "color": "#c77dff",
               "width": 2,
@@ -3506,11 +2012,7 @@
             }
           ],
           "info": [
-            {
-              "id": "s2_formula",
-              "position": "top-right",
-              "content": "$$\\lvert\\psi\\rangle = \\alpha\\lvert 0\\rangle + \\beta\\lvert 1\\rangle,\\qquad \\alpha=\\cos\\!\\left(\\frac{\\theta}{2}\\right),\\ \\beta=e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)$$\n$$\\lvert\\alpha\\rvert^2={{toFixed(cos(q2_theta/2)^2,3)}},\\qquad \\lvert\\beta\\rvert^2={{toFixed(sin(q2_theta/2)^2,3)}}$$"
-            }
+            {"id": "s2_formula", "position": "top-right", "content": "$$\\lvert\\psi\\rangle = \\alpha\\lvert 0\\rangle + \\beta\\lvert 1\\rangle,\\qquad \\alpha=\\cos\\!\\left(\\frac{\\theta}{2}\\right),\\ \\beta=e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)$$\n$$\\lvert\\alpha\\rvert^2={{toFixed(cos(q2_theta/2)^2,3)}},\\qquad \\lvert\\beta\\rvert^2={{toFixed(sin(q2_theta/2)^2,3)}}$$"}
           ]
         }
       ],
@@ -3529,83 +2031,342 @@
               "label": "Start with a general qubit",
               "math": "\\htmlClass{hl-gen}{\\lvert\\psi\\rangle = \\alpha\\lvert 0\\rangle + \\beta\\lvert 1\\rangle}, \\quad \\alpha,\\beta\\in\\mathbb{C}, \\quad \\lvert\\alpha\\rvert^2 + \\lvert\\beta\\rvert^2 = 1",
               "highlights": {
-                "gen": {
-                  "color": "cyan",
-                  "label": "Any normalized two-component complex vector"
-                }
+                "gen": {"color": "cyan", "label": "Any normalized two-component complex vector"}
               },
               "justification": "A qubit lives in $\\mathbb{C}^2$ with unit norm.",
               "explanation": "Two complex numbers give four real parameters, but normalization removes one.",
               "prompt": "Emphasize the count: 4 real parameters minus 1 normalization = 3, but we will lose one more to global phase.",
-              "sceneStep": 0
+              "sceneStep": 0,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {"id": "c0___equals_1", "type": "relation", "op": "equals", "subexpr": "|\\psi\\rangle = \\alpha| 0\\rangle + \\beta| 1\\rangle"},
+                    {"id": "c0___ket_2", "type": "ket", "latex": "\\left|\\psi\\right\\rangle", "subexpr": "\\left|\\psi\\right\\rangle"},
+                    {"id": "c0___add_3", "type": "operator", "op": "add", "subexpr": "\\alpha {\\left|0\\right\\rangle } + \\beta {\\left|1\\right\\rangle }"},
+                    {"id": "c0___multiply_4", "type": "operator", "op": "multiply", "subexpr": "\\alpha {\\left|0\\right\\rangle }"},
+                    {"id": "alpha", "type": "scalar", "latex": "\\alpha", "subexpr": "\\alpha"},
+                    {"id": "c0___ket_5", "type": "ket", "latex": "\\left|0\\right\\rangle", "subexpr": "\\left|0\\right\\rangle"},
+                    {"id": "c0___multiply_6", "type": "operator", "op": "multiply", "subexpr": "\\beta {\\left|1\\right\\rangle }"},
+                    {"id": "beta", "type": "scalar", "latex": "\\beta", "subexpr": "\\beta"},
+                    {"id": "c0___ket_7", "type": "ket", "latex": "\\left|1\\right\\rangle", "subexpr": "\\left|1\\right\\rangle"},
+                    {"id": "c1___and_1", "type": "operator", "label": "and", "emoji": ",", "op": "and", "subexpr": "\\alpha,\\beta"},
+                    {"id": "C", "type": "scalar", "latex": "\\mathbb{C}", "subexpr": "{C}"},
+                    {"id": "c1___element_of_2", "type": "relation", "label": "element of", "emoji": "∈", "op": "element_of", "subexpr": "\\alpha,\\beta\\in\\mathbb{C}"},
+                    {"id": "c2___equals_1", "type": "relation", "op": "equals", "subexpr": "|\\alpha|^2 + |\\beta|^2 = 1"},
+                    {"id": "c2___add_2", "type": "operator", "op": "add", "subexpr": "\\left|{\\alpha}\\right|^{2} + \\left|{\\beta}\\right|^{2}"},
+                    {"id": "c2___power_3", "type": "operator", "op": "power", "exponent": "2", "subexpr": "\\left|{\\alpha}\\right|^{2}"},
+                    {"id": "c2___abs_4", "type": "function", "op": "abs", "subexpr": "\\left|{\\alpha}\\right|"},
+                    {"id": "c2___power_5", "type": "operator", "op": "power", "exponent": "2", "subexpr": "\\left|{\\beta}\\right|^{2}"},
+                    {"id": "c2___abs_6", "type": "function", "op": "abs", "subexpr": "\\left|{\\beta}\\right|"},
+                    {"id": "c2___num_7", "type": "number", "label": "1", "subexpr": "1"}
+                  ],
+                  "edges": [
+                    {"from": "c0___ket_2", "to": "c0___equals_1"},
+                    {"from": "alpha", "to": "c0___multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "c0___ket_5", "to": "c0___multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "c0___multiply_4", "to": "c0___add_3"},
+                    {"from": "beta", "to": "c0___multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "c0___ket_7", "to": "c0___multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "c0___multiply_6", "to": "c0___add_3"},
+                    {"from": "c0___add_3", "to": "c0___equals_1"},
+                    {"from": "alpha", "to": "c1___and_1"},
+                    {"from": "beta", "to": "c1___and_1"},
+                    {"from": "c1___and_1", "to": "c1___element_of_2", "role": "lhs"},
+                    {"from": "C", "to": "c1___element_of_2", "role": "rhs"},
+                    {"from": "alpha", "to": "c2___abs_4"},
+                    {"from": "c2___abs_4", "to": "c2___power_3"},
+                    {"from": "c2___power_3", "to": "c2___add_2"},
+                    {"from": "beta", "to": "c2___abs_6"},
+                    {"from": "c2___abs_6", "to": "c2___power_5"},
+                    {"from": "c2___power_5", "to": "c2___add_2"},
+                    {"from": "c2___add_2", "to": "c2___equals_1"},
+                    {"from": "c2___num_7", "to": "c2___equals_1"}
+                  ],
+                  "classification": {
+                    "kind": "statements",
+                    "count": 3,
+                    "clauses": [
+                      {"kind": "algebraic"},
+                      {"kind": "algebraic"},
+                      {"kind": "algebraic"}
+                    ]
+                  }
+                }
+              }
             },
             {
               "type": "step",
               "label": "Write amplitudes in polar form",
               "math": "\\alpha = \\htmlClass{hl-ra}{r_\\alpha\\, e^{i\\gamma_\\alpha}}, \\quad \\beta = \\htmlClass{hl-rb}{r_\\beta\\, e^{i\\gamma_\\beta}}, \\quad r_\\alpha^2 + r_\\beta^2 = 1",
               "highlights": {
-                "ra": {
-                  "color": "green",
-                  "label": "Magnitude and phase of $\\alpha$"
-                },
-                "rb": {
-                  "color": "orange",
-                  "label": "Magnitude and phase of $\\beta$"
-                }
+                "ra": {"color": "green", "label": "Magnitude and phase of $\\alpha$"},
+                "rb": {"color": "orange", "label": "Magnitude and phase of $\\beta$"}
               },
               "justification": "Every complex number $z$ can be written as $|z|e^{i\\arg z}$.",
               "explanation": "Now we have two magnitudes ($r_\\alpha, r_\\beta$) and two phases ($\\gamma_\\alpha, \\gamma_\\beta$). Normalization constrains the magnitudes.",
               "prompt": "Point out that the magnitudes are non-negative and live on a unit circle in the $(r_\\alpha, r_\\beta)$ plane.",
-              "sceneStep": 0
+              "sceneStep": 0,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {"id": "c0___equals_1", "type": "relation", "op": "equals", "subexpr": "\\alpha = r_\\alpha\\, e^{i\\gamma_\\alpha}"},
+                    {"id": "alpha", "type": "scalar", "latex": "\\alpha", "subexpr": "\\alpha"},
+                    {"id": "c0___multiply_2", "type": "operator", "op": "multiply", "subexpr": "e^{\\gamma_{\\alpha} i} r_{\\alpha}"},
+                    {"id": "c0_r_{\\alpha}", "type": "scalar", "latex": "r_{\\alpha}", "subexpr": "r_{\\alpha}"},
+                    {"id": "c0___power_3", "type": "operator", "op": "power", "subexpr": "e^{\\gamma_{\\alpha} i}"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "c0___multiply_4", "type": "operator", "op": "multiply", "subexpr": "i \\gamma_{\\alpha}"},
+                    {"id": "i", "type": "scalar", "latex": "i", "subexpr": "i"},
+                    {"id": "c0_\\gamma_{\\alpha}", "type": "scalar", "latex": "\\gamma_{\\alpha}", "subexpr": "\\gamma_{\\alpha}"},
+                    {"id": "c1___equals_1", "type": "relation", "op": "equals", "subexpr": "\\beta = r_\\beta\\, e^{i\\gamma_\\beta}"},
+                    {"id": "beta", "type": "scalar", "latex": "\\beta", "subexpr": "\\beta"},
+                    {"id": "c1___multiply_2", "type": "operator", "op": "multiply", "subexpr": "e^{\\gamma_{\\beta} i} r_{\\beta}"},
+                    {"id": "c1_r_{\\beta}", "type": "scalar", "latex": "r_{\\beta}", "subexpr": "r_{\\beta}"},
+                    {"id": "c1___power_3", "type": "operator", "op": "power", "subexpr": "e^{\\gamma_{\\beta} i}"},
+                    {"id": "c1___multiply_4", "type": "operator", "op": "multiply", "subexpr": "i \\gamma_{\\beta}"},
+                    {"id": "c1_\\gamma_{\\beta}", "type": "scalar", "latex": "\\gamma_{\\beta}", "subexpr": "\\gamma_{\\beta}"},
+                    {"id": "c2___equals_1", "type": "relation", "op": "equals", "subexpr": "r_\\alpha^2 + r_\\beta^2 = 1"},
+                    {"id": "c2___add_2", "type": "operator", "op": "add", "subexpr": "r_{\\alpha}^{2} + r_{\\beta}^{2}"},
+                    {"id": "c2___power_3", "type": "operator", "op": "power", "exponent": "2", "subexpr": "r_{\\alpha}^{2}"},
+                    {"id": "c2_r_{\\alpha}", "type": "scalar", "latex": "r_{\\alpha}", "subexpr": "r_{\\alpha}"},
+                    {"id": "c2___power_4", "type": "operator", "op": "power", "exponent": "2", "subexpr": "r_{\\beta}^{2}"},
+                    {"id": "c2_r_{\\beta}", "type": "scalar", "latex": "r_{\\beta}", "subexpr": "r_{\\beta}"},
+                    {"id": "c2___num_5", "type": "number", "label": "1", "subexpr": "1"}
+                  ],
+                  "edges": [
+                    {"from": "alpha", "to": "c0___equals_1"},
+                    {"from": "c0_r_{\\alpha}", "to": "c0___multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "e", "to": "c0___power_3"},
+                    {"from": "i", "to": "c0___multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "c0_\\gamma_{\\alpha}", "to": "c0___multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "c0___multiply_4", "to": "c0___power_3", "role": "exp"},
+                    {"from": "c0___power_3", "to": "c0___multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "c0___multiply_2", "to": "c0___equals_1"},
+                    {"from": "beta", "to": "c1___equals_1"},
+                    {"from": "c1_r_{\\beta}", "to": "c1___multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "e", "to": "c1___power_3"},
+                    {"from": "i", "to": "c1___multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "c1_\\gamma_{\\beta}", "to": "c1___multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "c1___multiply_4", "to": "c1___power_3", "role": "exp"},
+                    {"from": "c1___power_3", "to": "c1___multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "c1___multiply_2", "to": "c1___equals_1"},
+                    {"from": "c2_r_{\\alpha}", "to": "c2___power_3"},
+                    {"from": "c2___power_3", "to": "c2___add_2"},
+                    {"from": "c2_r_{\\beta}", "to": "c2___power_4"},
+                    {"from": "c2___power_4", "to": "c2___add_2"},
+                    {"from": "c2___add_2", "to": "c2___equals_1"},
+                    {"from": "c2___num_5", "to": "c2___equals_1"}
+                  ],
+                  "classification": {
+                    "kind": "statements",
+                    "count": 3,
+                    "clauses": [
+                      {"kind": "algebraic"},
+                      {"kind": "algebraic"},
+                      {"kind": "algebraic"}
+                    ]
+                  }
+                }
+              }
             },
             {
               "type": "step",
               "label": "Factor out the global phase",
               "math": "\\lvert\\psi\\rangle = \\htmlClass{hl-global}{e^{i\\gamma_\\alpha}} \\bigl( r_\\alpha\\lvert 0\\rangle + r_\\beta\\, e^{i(\\gamma_\\beta - \\gamma_\\alpha)}\\lvert 1\\rangle \\bigr)",
               "highlights": {
-                "global": {
-                  "color": "gray",
-                  "label": "Global phase — physically unobservable"
-                }
+                "global": {"color": "gray", "label": "Global phase — physically unobservable"}
               },
               "justification": "Pull $e^{i\\gamma_\\alpha}$ out of both terms.",
               "explanation": "Global phase has no effect on any measurement outcome, so we drop it. Only the relative phase $\\phi = \\gamma_\\beta - \\gamma_\\alpha$ matters.",
               "prompt": "This is the key physical insight: two states that differ only by a global phase are the same state. That removes one more parameter: 3 → 2.",
-              "sceneStep": 1
+              "sceneStep": 1,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "|\\psi\\rangle = e^{i\\gamma_\\alpha} \\bigl( r_\\alpha| 0\\rangle + r_\\beta\\, e^{i(\\gamma_\\beta - \\gamma_\\alpha)}| 1\\rangle \\bigr)"},
+                    {"id": "__ket_2", "type": "ket", "latex": "\\left|\\psi\\right\\rangle", "subexpr": "\\left|\\psi\\right\\rangle"},
+                    {"id": "__multiply_3", "type": "operator", "op": "multiply", "subexpr": "e^{\\gamma_{\\alpha} i} \\operatorname{bigl}{\\left(r_{\\alpha} {\\left|0\\right\\rangle } + r_{\\beta} e^{i{\\left(- \\gamma_{\\alpha} + \\gamma_{\\beta} \\right)}} {\\left|1\\right\\rangle } \\bigr \\right)}"},
+                    {"id": "__power_4", "type": "operator", "op": "power", "subexpr": "e^{\\gamma_{\\alpha} i}"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "i \\gamma_{\\alpha}"},
+                    {"id": "i", "type": "scalar", "latex": "i", "subexpr": "i"},
+                    {"id": "\\gamma_{\\alpha}", "type": "scalar", "latex": "\\gamma_{\\alpha}", "subexpr": "\\gamma_{\\alpha}"},
+                    {"id": "__bigl_6", "type": "function", "latex": "\\bigl", "op": "bigl", "subexpr": "\\operatorname{bigl}{\\left(r_{\\alpha} {\\left|0\\right\\rangle } + r_{\\beta} e^{i{\\left(- \\gamma_{\\alpha} + \\gamma_{\\beta} \\right)}} {\\left|1\\right\\rangle } \\bigr \\right)}"},
+                    {"id": "__add_7", "type": "operator", "op": "add", "subexpr": "r_{\\alpha} {\\left|0\\right\\rangle } + r_{\\beta} e^{i{\\left(- \\gamma_{\\alpha} + \\gamma_{\\beta} \\right)}} \\bigr {\\left|1\\right\\rangle }"},
+                    {"id": "__multiply_8", "type": "operator", "op": "multiply", "subexpr": "r_{\\alpha} {\\left|0\\right\\rangle }"},
+                    {"id": "r_{\\alpha}", "type": "scalar", "latex": "r_{\\alpha}", "subexpr": "r_{\\alpha}"},
+                    {"id": "__ket_9", "type": "ket", "latex": "\\left|0\\right\\rangle", "subexpr": "\\left|0\\right\\rangle"},
+                    {"id": "__multiply_10", "type": "operator", "op": "multiply", "subexpr": "r_{\\beta} e^{i{\\left(- \\gamma_{\\alpha} + \\gamma_{\\beta} \\right)}} \\bigr {\\left|1\\right\\rangle }"},
+                    {"id": "r_{\\beta}", "type": "scalar", "latex": "r_{\\beta}", "subexpr": "r_{\\beta}"},
+                    {"id": "__multiply_11", "type": "operator", "op": "multiply", "subexpr": "e^{i{\\left(- \\gamma_{\\alpha} + \\gamma_{\\beta} \\right)}} \\bigr {\\left|1\\right\\rangle }"},
+                    {"id": "__power_12", "type": "operator", "op": "power", "subexpr": "e^{i{\\left(- \\gamma_{\\alpha} + \\gamma_{\\beta} \\right)}}"},
+                    {"id": "__i_13", "type": "function", "op": "i", "subexpr": "i{\\left(- \\gamma_{\\alpha} + \\gamma_{\\beta} \\right)}"},
+                    {"id": "__add_14", "type": "operator", "op": "add", "subexpr": "-\\gamma_{\\alpha} + \\gamma_{\\beta}"},
+                    {"id": "\\gamma_{\\beta}", "type": "scalar", "latex": "\\gamma_{\\beta}", "subexpr": "\\gamma_{\\beta}"},
+                    {"id": "__negation_15", "type": "operator", "op": "negation", "subexpr": "-\\gamma_{\\alpha}"},
+                    {"id": "__multiply_16", "type": "operator", "op": "multiply", "subexpr": "\\bigr {\\left|1\\right\\rangle }"},
+                    {"id": "__ket_17", "type": "ket", "latex": "\\left|1\\right\\rangle", "subexpr": "\\left|1\\right\\rangle"},
+                    {"id": "bigr", "type": "scalar", "latex": "\\bigr", "subexpr": "\\bigr"}
+                  ],
+                  "edges": [
+                    {"from": "__ket_2", "to": "__equals_1"},
+                    {"from": "e", "to": "__power_4"},
+                    {"from": "i", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "\\gamma_{\\alpha}", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_5", "to": "__power_4", "role": "exp"},
+                    {"from": "__power_4", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "r_{\\alpha}", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "__ket_9", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_8", "to": "__add_7"},
+                    {"from": "r_{\\beta}", "to": "__multiply_10", "semantic": "direct", "weight": 1.0},
+                    {"from": "e", "to": "__power_12"},
+                    {"from": "\\gamma_{\\beta}", "to": "__add_14"},
+                    {"from": "\\gamma_{\\alpha}", "to": "__negation_15"},
+                    {"from": "__negation_15", "to": "__add_14"},
+                    {"from": "__add_14", "to": "__i_13"},
+                    {"from": "__i_13", "to": "__power_12", "role": "exp"},
+                    {"from": "__power_12", "to": "__multiply_11", "semantic": "direct", "weight": 1.0},
+                    {"from": "__ket_17", "to": "__multiply_16", "semantic": "direct", "weight": 1.0},
+                    {"from": "bigr", "to": "__multiply_16", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_16", "to": "__multiply_11", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_11", "to": "__multiply_10", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_10", "to": "__add_7"},
+                    {"from": "__add_7", "to": "__bigl_6"},
+                    {"from": "__bigl_6", "to": "__multiply_3", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_3", "to": "__equals_1"}
+                  ],
+                  "classification": {"kind": "algebraic"}
+                }
+              }
             },
             {
               "type": "step",
               "label": "Parameterize the magnitudes",
               "math": "r_\\alpha^2 + r_\\beta^2 = 1 \\;\\Longrightarrow\\; r_\\alpha = \\htmlClass{hl-cosH}{\\cos\\!\\left(\\frac{\\theta}{2}\\right)}, \\; r_\\beta = \\htmlClass{hl-sinH}{\\sin\\!\\left(\\frac{\\theta}{2}\\right)}",
               "highlights": {
-                "cosH": {
-                  "color": "green",
-                  "label": "$r_\\alpha$ as cosine of half-angle"
-                },
-                "sinH": {
-                  "color": "orange",
-                  "label": "$r_\\beta$ as sine of half-angle"
-                }
+                "cosH": {"color": "green", "label": "$r_\\alpha$ as cosine of half-angle"},
+                "sinH": {"color": "orange", "label": "$r_\\beta$ as sine of half-angle"}
               },
               "justification": "Any point on the unit circle $(r_\\alpha, r_\\beta)$ with $r_\\alpha, r_\\beta \\geq 0$ can be written as $(\\cos\\eta, \\sin\\eta)$ for $\\eta \\in [0, \\pi/2]$. Set $\\eta = \\theta/2$ so $\\theta$ ranges over $[0, \\pi]$.",
               "explanation": "The half-angle $\\theta/2$ is chosen so that $\\theta$ spans the full polar range of the sphere.",
               "prompt": "Explain why we use theta/2 instead of theta: we want theta in [0, pi] to cover north pole to south pole, so the half-angle lives in [0, pi/2] where both cos and sin are non-negative.",
-              "sceneStep": 1
+              "sceneStep": 1,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "r_{\\alpha}^2 + r_{\\beta}^2 = 1"},
+                    {"id": "__add_2", "type": "operator", "op": "add", "subexpr": "r_{\\alpha}^{2} + r_{\\beta}^{2}"},
+                    {"id": "__power_3", "type": "operator", "op": "power", "exponent": "2", "subexpr": "r_{\\alpha}^{2}"},
+                    {"id": "r_{\\alpha}", "type": "scalar", "latex": "r_{\\alpha}", "subexpr": "r_{\\alpha}"},
+                    {"id": "__power_4", "type": "operator", "op": "power", "exponent": "2", "subexpr": "r_{\\beta}^{2}"},
+                    {"id": "r_{\\beta}", "type": "scalar", "latex": "r_{\\beta}", "subexpr": "r_{\\beta}"},
+                    {"id": "__num_5", "type": "number", "label": "1", "subexpr": "1"},
+                    {"id": "__equals_6", "type": "relation", "op": "equals", "subexpr": "r_{\\alpha} = \\cos \\left(\\frac{\\theta}{2}\\right)"},
+                    {"id": "__cos_7", "type": "function", "latex": "\\cos", "op": "cos", "subexpr": "\\cos{\\left(\\frac{\\theta}{2} \\right)}"},
+                    {"id": "__multiply_8", "type": "operator", "op": "multiply", "subexpr": "\\theta \\frac{1}{2}"},
+                    {"id": "theta", "type": "scalar", "latex": "\\theta", "subexpr": "\\theta"},
+                    {"id": "__power_9", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__num_10", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__equals_11", "type": "relation", "op": "equals", "subexpr": "r_{\\beta} = \\sin \\left(\\frac{\\theta}{2}\\right)"},
+                    {"id": "__sin_12", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\frac{\\theta}{2} \\right)}"},
+                    {"id": "__multiply_13", "type": "operator", "op": "multiply", "subexpr": "\\theta \\frac{1}{2}"},
+                    {"id": "__power_14", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__num_15", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__and_16", "type": "operator", "label": "and", "emoji": ",", "op": "and", "subexpr": "r_{\\alpha} = \\cos \\left(\\frac{\\theta}{2}\\right),  r_{\\beta} = \\sin \\left(\\frac{\\theta}{2}\\right)"},
+                    {"id": "__implies_17", "type": "operator", "label": "implies", "emoji": "⟹", "op": "implies", "subexpr": "r_\\alpha^2 + r_\\beta^2 = 1 \\;\\Longrightarrow\\; r_\\alpha = \\cos\\!\\left(\\frac{\\theta}{2}\\right), \\; r_\\beta = \\sin\\!\\left(\\frac{\\theta}{2}\\right)"}
+                  ],
+                  "edges": [
+                    {"from": "r_{\\alpha}", "to": "__power_3"},
+                    {"from": "__power_3", "to": "__add_2"},
+                    {"from": "r_{\\beta}", "to": "__power_4"},
+                    {"from": "__power_4", "to": "__add_2"},
+                    {"from": "__add_2", "to": "__equals_1"},
+                    {"from": "__num_5", "to": "__equals_1"},
+                    {"from": "r_{\\alpha}", "to": "__equals_6"},
+                    {"from": "theta", "to": "__multiply_8", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_10", "to": "__power_9"},
+                    {"from": "__power_9", "to": "__multiply_8"},
+                    {"from": "__multiply_8", "to": "__cos_7"},
+                    {"from": "__cos_7", "to": "__equals_6"},
+                    {"from": "r_{\\beta}", "to": "__equals_11"},
+                    {"from": "theta", "to": "__multiply_13", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_15", "to": "__power_14"},
+                    {"from": "__power_14", "to": "__multiply_13"},
+                    {"from": "__multiply_13", "to": "__sin_12"},
+                    {"from": "__sin_12", "to": "__equals_11"},
+                    {"from": "__equals_6", "to": "__and_16"},
+                    {"from": "__equals_11", "to": "__and_16"},
+                    {"from": "__equals_1", "to": "__implies_17", "role": "lhs"},
+                    {"from": "__and_16", "to": "__implies_17", "role": "rhs"}
+                  ],
+                  "classification": {"kind": "algebraic"}
+                }
+              }
             },
             {
               "type": "conclusion",
               "label": "The Bloch parameterization",
               "math": "\\htmlClass{hl-final}{\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle}",
               "highlights": {
-                "final": {
-                  "color": "gold",
-                  "label": "Two real angles parameterize all pure qubit states"
-                }
+                "final": {"color": "gold", "label": "Two real angles parameterize all pure qubit states"}
               },
               "justification": "Substitute $r_\\alpha$, $r_\\beta$, and $\\phi = \\gamma_\\beta - \\gamma_\\alpha$ into the state.",
               "explanation": "Every pure qubit maps to a unique point $(\\theta, \\phi)$ on the unit sphere. The half-angle ensures the north pole ($\\theta=0$) is $\\lvert 0\\rangle$ and the south pole ($\\theta=\\pi$) is $\\lvert 1\\rangle$.",
               "prompt": "Tie back to the visualization: theta is the gold vector's polar angle, phi is its azimuth. Two angles, one sphere, all pure states.",
-              "sceneStep": 2
+              "sceneStep": 2,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "|\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)| 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)| 1\\rangle"},
+                    {"id": "__ket_2", "type": "ket", "latex": "\\left|\\psi\\right\\rangle", "subexpr": "\\left|\\psi\\right\\rangle"},
+                    {"id": "__add_3", "type": "operator", "op": "add", "subexpr": "e^{i \\phi} \\sin{\\left(\\frac{\\theta}{2} \\right)} {\\left|1\\right\\rangle } + \\cos{\\left(\\frac{\\theta}{2} \\right)} {\\left|0\\right\\rangle }"},
+                    {"id": "__multiply_4", "type": "operator", "op": "multiply", "subexpr": "\\cos{\\left(\\frac{\\theta}{2} \\right)} {\\left|0\\right\\rangle }"},
+                    {"id": "__cos_5", "type": "function", "latex": "\\cos", "op": "cos", "subexpr": "\\cos{\\left(\\frac{\\theta}{2} \\right)}"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "\\theta \\frac{1}{2}"},
+                    {"id": "theta", "type": "scalar", "latex": "\\theta", "subexpr": "\\theta"},
+                    {"id": "__power_7", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__num_8", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__ket_9", "type": "ket", "latex": "\\left|0\\right\\rangle", "subexpr": "\\left|0\\right\\rangle"},
+                    {"id": "__multiply_10", "type": "operator", "op": "multiply", "subexpr": "e^{i \\phi} \\sin{\\left(\\frac{\\theta}{2} \\right)} {\\left|1\\right\\rangle }"},
+                    {"id": "__power_11", "type": "operator", "op": "power", "subexpr": "e^{i \\phi}"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "__multiply_12", "type": "operator", "op": "multiply", "subexpr": "i \\phi"},
+                    {"id": "i", "type": "scalar", "latex": "i", "subexpr": "i"},
+                    {"id": "phi", "type": "scalar", "latex": "\\phi", "subexpr": "\\phi"},
+                    {"id": "__multiply_13", "type": "operator", "op": "multiply", "subexpr": "\\sin{\\left(\\frac{\\theta}{2} \\right)} {\\left|1\\right\\rangle }"},
+                    {"id": "__sin_14", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\frac{\\theta}{2} \\right)}"},
+                    {"id": "__multiply_15", "type": "operator", "op": "multiply", "subexpr": "\\theta \\frac{1}{2}"},
+                    {"id": "__power_16", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__num_17", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__ket_18", "type": "ket", "latex": "\\left|1\\right\\rangle", "subexpr": "\\left|1\\right\\rangle"}
+                  ],
+                  "edges": [
+                    {"from": "__ket_2", "to": "__equals_1"},
+                    {"from": "theta", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_8", "to": "__power_7"},
+                    {"from": "__power_7", "to": "__multiply_6"},
+                    {"from": "__multiply_6", "to": "__cos_5"},
+                    {"from": "__cos_5", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "__ket_9", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_4", "to": "__add_3"},
+                    {"from": "e", "to": "__power_11"},
+                    {"from": "i", "to": "__multiply_12", "semantic": "direct", "weight": 1.0},
+                    {"from": "phi", "to": "__multiply_12", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_12", "to": "__power_11", "role": "exp"},
+                    {"from": "__power_11", "to": "__multiply_10", "semantic": "direct", "weight": 1.0},
+                    {"from": "theta", "to": "__multiply_15", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_17", "to": "__power_16"},
+                    {"from": "__power_16", "to": "__multiply_15"},
+                    {"from": "__multiply_15", "to": "__sin_14"},
+                    {"from": "__sin_14", "to": "__multiply_13", "semantic": "direct", "weight": 1.0},
+                    {"from": "__ket_18", "to": "__multiply_13", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_13", "to": "__multiply_10", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_10", "to": "__add_3"},
+                    {"from": "__add_3", "to": "__equals_1"}
+                  ],
+                  "classification": {"kind": "algebraic"}
+                }
+              }
             }
           ]
         },
@@ -3622,25 +2383,72 @@
               "label": "Bloch parameterization",
               "math": "\\htmlClass{hl-ket}{\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle}",
               "highlights": {
-                "ket": {
-                  "color": "cyan",
-                  "label": "General pure qubit state"
-                }
+                "ket": {"color": "cyan", "label": "General pure qubit state"}
               },
               "justification": "Standard parameterization of a normalized single-qubit state.",
               "explanation": "This is the state whose Bloch coordinates we want to derive.",
               "prompt": "Remind the student that theta and phi are the polar and azimuthal angles on the sphere.",
-              "sceneStep": 0
+              "sceneStep": 0,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "|\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)| 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)| 1\\rangle"},
+                    {"id": "__ket_2", "type": "ket", "latex": "\\left|\\psi\\right\\rangle", "subexpr": "\\left|\\psi\\right\\rangle"},
+                    {"id": "__add_3", "type": "operator", "op": "add", "subexpr": "e^{i \\phi} \\sin{\\left(\\frac{\\theta}{2} \\right)} {\\left|1\\right\\rangle } + \\cos{\\left(\\frac{\\theta}{2} \\right)} {\\left|0\\right\\rangle }"},
+                    {"id": "__multiply_4", "type": "operator", "op": "multiply", "subexpr": "\\cos{\\left(\\frac{\\theta}{2} \\right)} {\\left|0\\right\\rangle }"},
+                    {"id": "__cos_5", "type": "function", "latex": "\\cos", "op": "cos", "subexpr": "\\cos{\\left(\\frac{\\theta}{2} \\right)}"},
+                    {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "\\theta \\frac{1}{2}"},
+                    {"id": "theta", "type": "scalar", "latex": "\\theta", "subexpr": "\\theta"},
+                    {"id": "__power_7", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__num_8", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__ket_9", "type": "ket", "latex": "\\left|0\\right\\rangle", "subexpr": "\\left|0\\right\\rangle"},
+                    {"id": "__multiply_10", "type": "operator", "op": "multiply", "subexpr": "e^{i \\phi} \\sin{\\left(\\frac{\\theta}{2} \\right)} {\\left|1\\right\\rangle }"},
+                    {"id": "__power_11", "type": "operator", "op": "power", "subexpr": "e^{i \\phi}"},
+                    {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                    {"id": "__multiply_12", "type": "operator", "op": "multiply", "subexpr": "i \\phi"},
+                    {"id": "i", "type": "scalar", "latex": "i", "subexpr": "i"},
+                    {"id": "phi", "type": "scalar", "latex": "\\phi", "subexpr": "\\phi"},
+                    {"id": "__multiply_13", "type": "operator", "op": "multiply", "subexpr": "\\sin{\\left(\\frac{\\theta}{2} \\right)} {\\left|1\\right\\rangle }"},
+                    {"id": "__sin_14", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\frac{\\theta}{2} \\right)}"},
+                    {"id": "__multiply_15", "type": "operator", "op": "multiply", "subexpr": "\\theta \\frac{1}{2}"},
+                    {"id": "__power_16", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__num_17", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__ket_18", "type": "ket", "latex": "\\left|1\\right\\rangle", "subexpr": "\\left|1\\right\\rangle"}
+                  ],
+                  "edges": [
+                    {"from": "__ket_2", "to": "__equals_1"},
+                    {"from": "theta", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_8", "to": "__power_7"},
+                    {"from": "__power_7", "to": "__multiply_6"},
+                    {"from": "__multiply_6", "to": "__cos_5"},
+                    {"from": "__cos_5", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "__ket_9", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_4", "to": "__add_3"},
+                    {"from": "e", "to": "__power_11"},
+                    {"from": "i", "to": "__multiply_12", "semantic": "direct", "weight": 1.0},
+                    {"from": "phi", "to": "__multiply_12", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_12", "to": "__power_11", "role": "exp"},
+                    {"from": "__power_11", "to": "__multiply_10", "semantic": "direct", "weight": 1.0},
+                    {"from": "theta", "to": "__multiply_15", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_17", "to": "__power_16"},
+                    {"from": "__power_16", "to": "__multiply_15"},
+                    {"from": "__multiply_15", "to": "__sin_14"},
+                    {"from": "__sin_14", "to": "__multiply_13", "semantic": "direct", "weight": 1.0},
+                    {"from": "__ket_18", "to": "__multiply_13", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_13", "to": "__multiply_10", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_10", "to": "__add_3"},
+                    {"from": "__add_3", "to": "__equals_1"}
+                  ],
+                  "classification": {"kind": "algebraic"}
+                }
+              }
             },
             {
               "type": "step",
               "label": "Recall the Pauli Z operator",
               "math": "\\htmlClass{hl-Z}{Z} = \\begin{pmatrix} 1 & 0 \\\\ 0 & -1 \\end{pmatrix}, \\quad Z\\lvert 0\\rangle = \\lvert 0\\rangle,\\; Z\\lvert 1\\rangle = -\\lvert 1\\rangle",
               "highlights": {
-                "Z": {
-                  "color": "blue",
-                  "label": "Pauli Z matrix"
-                }
+                "Z": {"color": "blue", "label": "Pauli Z matrix"}
               },
               "justification": "Z is diagonal in the computational basis with eigenvalues +1 and −1.",
               "explanation": "The eigenstates of Z are exactly the north and south poles of the Bloch sphere.",
@@ -3652,49 +2460,156 @@
               "label": "Compute the expectation value",
               "math": "\\langle\\psi\\lvert Z\\rvert\\psi\\rangle = \\htmlClass{hl-cos2}{\\cos^2\\!\\left(\\frac{\\theta}{2}\\right)} \\cdot(+1) + \\htmlClass{hl-sin2}{\\sin^2\\!\\left(\\frac{\\theta}{2}\\right)} \\cdot(-1)",
               "highlights": {
-                "cos2": {
-                  "color": "green",
-                  "label": "Probability of $\\lvert 0\\rangle$ (eigenvalue +1)"
-                },
-                "sin2": {
-                  "color": "orange",
-                  "label": "Probability of $\\lvert 1\\rangle$ (eigenvalue −1)"
-                }
+                "cos2": {"color": "green", "label": "Probability of $\\lvert 0\\rangle$ (eigenvalue +1)"},
+                "sin2": {"color": "orange", "label": "Probability of $\\lvert 1\\rangle$ (eigenvalue −1)"}
               },
               "justification": "The expectation value of Z is the weighted sum of its eigenvalues, weighted by the Born-rule probabilities.",
               "explanation": "The phase $e^{i\\phi}$ drops out because $\\lvert e^{i\\phi}\\rvert^2 = 1$.",
               "prompt": "Point out that this is the same Born's rule calculation as in the next scene, but framed as an expectation value.",
-              "sceneStep": 1
+              "sceneStep": 1,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\langle\\psi| Z|\\psi\\rangle = \\cos^2\\!\\left(\\frac{\\theta}{2}\\right) \\cdot(+1) + \\sin^2\\!\\left(\\frac{\\theta}{2}\\right) \\cdot(-1)"},
+                    {"id": "__multiply_2", "type": "operator", "op": "multiply", "subexpr": "{\\left\\langle \\psi\\right|} Z {\\left|\\psi\\right\\rangle }"},
+                    {"id": "__bra_3", "type": "bra", "latex": "\\left\\langle \\psi\\right|", "subexpr": "\\left\\langle \\psi\\right|"},
+                    {"id": "__multiply_4", "type": "operator", "op": "multiply", "subexpr": "Z {\\left|\\psi\\right\\rangle }"},
+                    {"id": "Z", "type": "scalar", "latex": "Z", "subexpr": "Z"},
+                    {"id": "__ket_5", "type": "ket", "latex": "\\left|\\psi\\right\\rangle", "subexpr": "\\left|\\psi\\right\\rangle"},
+                    {"id": "__add_6", "type": "operator", "op": "add", "subexpr": "\\sin^{2}{\\left(\\frac{\\theta}{2} \\right)} -1 + \\cos^{2}{\\left(\\frac{\\theta}{2} \\right)} 1"},
+                    {"id": "__multiply_7", "type": "operator", "op": "multiply", "subexpr": "\\cos^{2}{\\left(\\frac{\\theta}{2} \\right)} 1"},
+                    {"id": "__power_8", "type": "operator", "op": "power", "exponent": "2", "subexpr": "\\cos^{2}{\\left(\\frac{\\theta}{2} \\right)}"},
+                    {"id": "__cos_9", "type": "function", "latex": "\\cos", "op": "cos", "subexpr": "\\cos{\\left(\\frac{\\theta}{2} \\right)}"},
+                    {"id": "__multiply_10", "type": "operator", "op": "multiply", "subexpr": "\\theta \\frac{1}{2}"},
+                    {"id": "theta", "type": "scalar", "latex": "\\theta", "subexpr": "\\theta"},
+                    {"id": "__power_11", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__num_12", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__num_13", "type": "number", "label": "1", "subexpr": "1"},
+                    {"id": "__multiply_14", "type": "operator", "op": "multiply", "subexpr": "\\sin^{2}{\\left(\\frac{\\theta}{2} \\right)} -1"},
+                    {"id": "__power_15", "type": "operator", "op": "power", "exponent": "2", "subexpr": "\\sin^{2}{\\left(\\frac{\\theta}{2} \\right)}"},
+                    {"id": "__sin_16", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\frac{\\theta}{2} \\right)}"},
+                    {"id": "__multiply_17", "type": "operator", "op": "multiply", "subexpr": "\\theta \\frac{1}{2}"},
+                    {"id": "__power_18", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__num_19", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__num_20", "type": "number", "label": "-1", "subexpr": "-1"}
+                  ],
+                  "edges": [
+                    {"from": "__bra_3", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "Z", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "__ket_5", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_4", "to": "__multiply_2", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_2", "to": "__equals_1"},
+                    {"from": "theta", "to": "__multiply_10", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_12", "to": "__power_11"},
+                    {"from": "__power_11", "to": "__multiply_10"},
+                    {"from": "__multiply_10", "to": "__cos_9"},
+                    {"from": "__cos_9", "to": "__power_8"},
+                    {"from": "__power_8", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_13", "to": "__multiply_7", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_7", "to": "__add_6"},
+                    {"from": "theta", "to": "__multiply_17", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_19", "to": "__power_18"},
+                    {"from": "__power_18", "to": "__multiply_17"},
+                    {"from": "__multiply_17", "to": "__sin_16"},
+                    {"from": "__sin_16", "to": "__power_15"},
+                    {"from": "__power_15", "to": "__multiply_14", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_20", "to": "__multiply_14", "semantic": "direct", "weight": 1.0},
+                    {"from": "__multiply_14", "to": "__add_6"},
+                    {"from": "__add_6", "to": "__equals_1"}
+                  ],
+                  "classification": {"kind": "algebraic"}
+                }
+              }
             },
             {
               "type": "step",
               "label": "Apply the double-angle identity",
               "math": "\\cos^2\\!\\left(\\frac{\\theta}{2}\\right) - \\sin^2\\!\\left(\\frac{\\theta}{2}\\right) = \\htmlClass{hl-costheta}{\\cos\\theta}",
               "highlights": {
-                "costheta": {
-                  "color": "blue",
-                  "label": "The familiar cosine double-angle formula"
-                }
+                "costheta": {"color": "blue", "label": "The familiar cosine double-angle formula"}
               },
               "justification": "Use $\\cos^2(\\alpha) - \\sin^2(\\alpha) = \\cos(2\\alpha)$ with $\\alpha = \\theta/2$.",
               "explanation": "This collapses two terms into a single trigonometric function of the polar angle.",
               "prompt": "Emphasize that this is why the parameterization uses theta/2 — so that the Bloch z-coordinate comes out as simply cos(theta).",
-              "sceneStep": 1
+              "sceneStep": 1,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "\\cos^2\\!\\left(\\frac{\\theta}{2}\\right) - \\sin^2\\!\\left(\\frac{\\theta}{2}\\right) = \\cos\\theta"},
+                    {"id": "__add_2", "type": "operator", "op": "add", "subexpr": "-\\sin^{2}{\\left(\\frac{\\theta}{2} \\right)} + \\cos^{2}{\\left(\\frac{\\theta}{2} \\right)}"},
+                    {"id": "__power_3", "type": "operator", "op": "power", "exponent": "2", "subexpr": "\\cos^{2}{\\left(\\frac{\\theta}{2} \\right)}"},
+                    {"id": "__cos_4", "type": "function", "latex": "\\cos", "op": "cos", "subexpr": "\\cos{\\left(\\frac{\\theta}{2} \\right)}"},
+                    {"id": "__multiply_5", "type": "operator", "op": "multiply", "subexpr": "\\theta \\frac{1}{2}"},
+                    {"id": "theta", "type": "scalar", "latex": "\\theta", "subexpr": "\\theta"},
+                    {"id": "__power_6", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__num_7", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__negation_8", "type": "operator", "op": "negation", "subexpr": "-\\sin^{2}{\\left(\\frac{\\theta}{2} \\right)}"},
+                    {"id": "__power_9", "type": "operator", "op": "power", "exponent": "2", "subexpr": "\\sin^{2}{\\left(\\frac{\\theta}{2} \\right)}"},
+                    {"id": "__sin_10", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\frac{\\theta}{2} \\right)}"},
+                    {"id": "__multiply_11", "type": "operator", "op": "multiply", "subexpr": "\\theta \\frac{1}{2}"},
+                    {"id": "__power_12", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                    {"id": "__num_13", "type": "number", "label": "2", "subexpr": "2"},
+                    {"id": "__cos_14", "type": "function", "latex": "\\cos", "op": "cos", "subexpr": "\\cos{\\left(\\theta \\right)}"}
+                  ],
+                  "edges": [
+                    {"from": "theta", "to": "__multiply_5", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_7", "to": "__power_6"},
+                    {"from": "__power_6", "to": "__multiply_5"},
+                    {"from": "__multiply_5", "to": "__cos_4"},
+                    {"from": "__cos_4", "to": "__power_3"},
+                    {"from": "__power_3", "to": "__add_2"},
+                    {"from": "theta", "to": "__multiply_11", "semantic": "direct", "weight": 1.0},
+                    {"from": "__num_13", "to": "__power_12"},
+                    {"from": "__power_12", "to": "__multiply_11"},
+                    {"from": "__multiply_11", "to": "__sin_10"},
+                    {"from": "__sin_10", "to": "__power_9"},
+                    {"from": "__power_9", "to": "__negation_8"},
+                    {"from": "__negation_8", "to": "__add_2"},
+                    {"from": "__add_2", "to": "__equals_1"},
+                    {"from": "theta", "to": "__cos_14"},
+                    {"from": "__cos_14", "to": "__equals_1"}
+                  ],
+                  "classification": {"kind": "algebraic"}
+                }
+              }
             },
             {
               "type": "conclusion",
               "label": "The z-coordinate is an expectation value",
               "math": "\\htmlClass{hl-result}{z = \\langle\\psi\\lvert Z\\rvert\\psi\\rangle = \\cos\\theta}",
               "highlights": {
-                "result": {
-                  "color": "green",
-                  "label": "Height on the Bloch sphere = expectation of Pauli Z"
-                }
+                "result": {"color": "green", "label": "Height on the Bloch sphere = expectation of Pauli Z"}
               },
               "justification": "Combining the previous steps.",
               "explanation": "The Bloch z-coordinate is not an arbitrary label — it is the physical expectation value of the Z measurement. The same logic gives $x = \\langle X\\rangle$ and $y = \\langle Y\\rangle$.",
               "prompt": "Close by noting that all three Bloch coordinates come from Pauli expectation values: x from X, y from Y, z from Z. This is why the Bloch sphere is physically meaningful.",
-              "sceneStep": 2
+              "sceneStep": 2,
+              "semanticGraph": {
+                "graph": {
+                  "nodes": [
+                    {"id": "z", "type": "scalar", "latex": "z", "subexpr": "z"},
+                    {"id": "s1___multiply_1", "type": "operator", "op": "multiply", "subexpr": "\\langle\\psi| Z|\\psi\\rangle"},
+                    {"id": "s1___bra_2", "type": "bra", "latex": "\\left\\langle \\psi\\right|", "subexpr": "\\left\\langle \\psi\\right|"},
+                    {"id": "s1___multiply_3", "type": "operator", "op": "multiply", "subexpr": "Z {\\left|\\psi\\right\\rangle }"},
+                    {"id": "Z", "type": "scalar", "latex": "Z", "subexpr": "Z"},
+                    {"id": "s1___ket_4", "type": "ket", "latex": "\\left|\\psi\\right\\rangle", "subexpr": "\\left|\\psi\\right\\rangle"},
+                    {"id": "s2___cos_1", "type": "function", "latex": "\\cos", "op": "cos", "subexpr": "\\cos\\theta"},
+                    {"id": "theta", "type": "scalar", "latex": "\\theta", "subexpr": "\\theta"},
+                    {"id": "__equals_1", "type": "operator", "op": "equals", "subexpr": "z = \\langle\\psi\\lvert Z\\rvert\\psi\\rangle = \\cos\\theta", "description": "Height on the Bloch sphere = expectation of Pauli Z", "color": "green", "highlight": "result"}
+                  ],
+                  "edges": [
+                    {"from": "s1___bra_2", "to": "s1___multiply_1"},
+                    {"from": "Z", "to": "s1___multiply_3"},
+                    {"from": "s1___ket_4", "to": "s1___multiply_3"},
+                    {"from": "s1___multiply_3", "to": "s1___multiply_1"},
+                    {"from": "theta", "to": "s2___cos_1"},
+                    {"from": "z", "to": "__equals_1"},
+                    {"from": "s1___multiply_1", "to": "__equals_1"},
+                    {"from": "s2___cos_1", "to": "__equals_1"}
+                  ],
+                  "classification": {"kind": "algebraic"}
+                }
+              }
             }
           ]
         }
@@ -3706,73 +2621,28 @@
       "markdown": "# Measurement Reads Latitude\n\nFor the Bloch-sphere parameterization\n\n$$|\\psi\\rangle = \\cos\\left(\\frac{\\theta}{2}\\right)|0\\rangle + e^{i\\phi}\\sin\\left(\\frac{\\theta}{2}\\right)|1\\rangle,$$\n\nBorn's rule gives\n\n$$p(0)=|\\langle 0|\\psi\\rangle|^2 = \\cos^2\\left(\\frac{\\theta}{2}\\right),\\qquad p(1)=|\\langle 1|\\psi\\rangle|^2 = \\sin^2\\left(\\frac{\\theta}{2}\\right).$$\n\nBecause the Bloch z-coordinate is $z=\\cos\\theta$, the half-angle identities turn those into\n\n$$p(0)=\\frac{1+z}{2},\\qquad p(1)=\\frac{1-z}{2}.$$\n\nSo a computational-basis measurement only reads the state's **height** on the sphere. The azimuth $\\phi$ matters for other measurement bases, but not for this one.",
       "prompt": "Teach this scene as the first real predictive payoff of the Bloch sphere. Green is the z projection, gold is the state, and magenta is the horizontal gap between the state and its projection. Emphasize that phi is irrelevant for computational-basis measurement.",
       "range": [
-        [
-          -1.35,
-          1.35
-        ],
-        [
-          -1.35,
-          1.35
-        ],
-        [
-          -1.35,
-          1.35
-        ]
+        [-1.35, 1.35],
+        [-1.35, 1.35],
+        [-1.35, 1.35]
       ],
       "camera": {
-        "position": [
-          2.8,
-          -2.4,
-          1.8
-        ],
-        "target": [
-          0,
-          0,
-          0
-        ],
-        "up": [
-          0,
-          0,
-          1
-        ]
+        "position": [2.8, -2.4, 1.8],
+        "target": [0, 0, 0],
+        "up": [0, 0, 1]
       },
       "views": [
         {
           "name": "Iso",
-          "position": [
-            2.8,
-            -2.4,
-            1.8
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [2.8, -2.4, 1.8],
+          "target": [0, 0, 0],
+          "up": [0, 0, 1],
           "description": "See the full state and its projection"
         },
         {
           "name": "Meridian",
-          "position": [
-            0,
-            -4,
-            0
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [0, -4, 0],
+          "target": [0, 0, 0],
+          "up": [0, 0, 1],
           "description": "Look directly at the x-z plane"
         }
       ],
@@ -3780,11 +2650,7 @@
         {
           "id": "s3_sphere",
           "type": "sphere",
-          "center": [
-            0,
-            0,
-            0
-          ],
+          "center": [0, 0, 0],
           "radius": 1,
           "color": "#5c7cfa",
           "opacity": 0.12,
@@ -3795,10 +2661,7 @@
           "id": "s3_axis_x",
           "type": "axis",
           "axis": "x",
-          "range": [
-            -1.2,
-            1.2
-          ],
+          "range": [-1.2, 1.2],
           "color": "#ff4444",
           "width": 1.2,
           "label": "$x$"
@@ -3807,10 +2670,7 @@
           "id": "s3_axis_y",
           "type": "axis",
           "axis": "y",
-          "range": [
-            -1.2,
-            1.2
-          ],
+          "range": [-1.2, 1.2],
           "color": "#44cc44",
           "width": 1.2,
           "label": "$y$"
@@ -3819,10 +2679,7 @@
           "id": "s3_axis_z",
           "type": "axis",
           "axis": "z",
-          "range": [
-            -1.2,
-            1.2
-          ],
+          "range": [-1.2, 1.2],
           "color": "#4488ff",
           "width": 1.2,
           "label": "$z$"
@@ -3831,26 +2688,15 @@
           "id": "s3_grid_xy",
           "type": "grid",
           "plane": "xy",
-          "range": [
-            -1.2,
-            1.2
-          ],
-          "color": [
-            0.28,
-            0.28,
-            0.45
-          ],
+          "range": [-1.2, 1.2],
+          "color": [0.28, 0.28, 0.45],
           "opacity": 0.12,
           "divisions": 8
         },
         {
           "id": "s3_ket0",
           "type": "point",
-          "position": [
-            0,
-            0,
-            1
-          ],
+          "position": [0, 0, 1],
           "color": "#66d9ff",
           "size": 10,
           "label": "$|0\\rangle$"
@@ -3858,11 +2704,7 @@
         {
           "id": "s3_ket1",
           "type": "point",
-          "position": [
-            0,
-            0,
-            -1
-          ],
+          "position": [0, 0, -1],
           "color": "#ff7b72",
           "size": 10,
           "label": "$|1\\rangle$"
@@ -3874,29 +2716,14 @@
           "description": "Choose a state on the x-z meridian. Sliding $\\theta$ changes the state's height and therefore its computational-basis bias.",
           "prompt": "Make the student track height first. Explain that we are freezing phi because computational-basis measurement only cares about the z coordinate.",
           "sliders": [
-            {
-              "id": "q3_theta",
-              "label": "$\\theta$",
-              "min": 0,
-              "max": 3.141592653589793,
-              "step": 0.01,
-              "default": 1.2
-            }
+            {"id": "q3_theta", "label": "$\\theta$", "min": 0, "max": 3.141592653589793, "step": 0.01, "default": 1.2}
           ],
           "add": [
             {
               "id": "s3_state_vec",
               "type": "animated_vector",
-              "from": [
-                0,
-                0,
-                0
-              ],
-              "expr": [
-                "sin(q3_theta)",
-                "0",
-                "cos(q3_theta)"
-              ],
+              "from": [0, 0, 0],
+              "expr": ["sin(q3_theta)", "0", "cos(q3_theta)"],
               "color": "#ffd166",
               "width": 2.0,
               "label": "$|\\psi\\rangle$"
@@ -3904,11 +2731,7 @@
             {
               "id": "s3_state_pt",
               "type": "animated_point",
-              "expr": [
-                "sin(q3_theta)",
-                "0",
-                "cos(q3_theta)"
-              ],
+              "expr": ["sin(q3_theta)", "0", "cos(q3_theta)"],
               "color": "#ffd166",
               "size": 1.0
             }
@@ -3922,16 +2745,8 @@
             {
               "id": "s3_zproj_vec",
               "type": "animated_vector",
-              "from": [
-                0,
-                0,
-                0
-              ],
-              "expr": [
-                "0",
-                "0",
-                "cos(q3_theta)"
-              ],
+              "from": [0, 0, 0],
+              "expr": ["0", "0", "cos(q3_theta)"],
               "color": "#7bd389",
               "width": 2.0,
               "label": "$z$"
@@ -3939,16 +2754,8 @@
             {
               "id": "s3_gap_vec",
               "type": "animated_vector",
-              "fromExpr": [
-                "0",
-                "0",
-                "cos(q3_theta)"
-              ],
-              "expr": [
-                "sin(q3_theta)",
-                "0",
-                "cos(q3_theta)"
-              ],
+              "fromExpr": ["0", "0", "cos(q3_theta)"],
+              "expr": ["sin(q3_theta)", "0", "cos(q3_theta)"],
               "color": "#c77dff",
               "width": 1.0,
               "opacity": 0.5,
@@ -3956,11 +2763,7 @@
             }
           ],
           "info": [
-            {
-              "id": "s3_probs",
-              "position": "top-right",
-              "content": "$$z=\\cos\\theta={{toFixed(cos(q3_theta),3)}}$$\n$$p(0)=\\cos^2\\left(\\frac{\\theta}{2}\\right)={{toFixed(cos(q3_theta/2)^2,3)}}$$\n$$p(1)=\\sin^2\\left(\\frac{\\theta}{2}\\right)={{toFixed(sin(q3_theta/2)^2,3)}}$$"
-            }
+            {"id": "s3_probs", "position": "top-right", "content": "$$z=\\cos\\theta={{toFixed(cos(q3_theta),3)}}$$\n$$p(0)=\\cos^2\\left(\\frac{\\theta}{2}\\right)={{toFixed(cos(q3_theta/2)^2,3)}}$$\n$$p(1)=\\sin^2\\left(\\frac{\\theta}{2}\\right)={{toFixed(sin(q3_theta/2)^2,3)}}$$"}
           ]
         },
         {
@@ -3968,11 +2771,7 @@
           "description": "Using the half-angle identities, the probabilities become linear in the Bloch z-coordinate. That is why a computational-basis measurement can be read directly from the state's height.",
           "prompt": "Tie the algebra back to the picture. The goal is not just to manipulate identities, but to see why latitude predicts measurement.",
           "info": [
-            {
-              "id": "s3_linear",
-              "position": "top-right",
-              "content": "$$p(0)=\\frac{1+z}{2}={{toFixed((1+cos(q3_theta))/2,3)}},\\qquad p(1)=\\frac{1-z}{2}={{toFixed((1-cos(q3_theta))/2,3)}}$$"
-            }
+            {"id": "s3_linear", "position": "top-right", "content": "$$p(0)=\\frac{1+z}{2}={{toFixed((1+cos(q3_theta))/2,3)}},\\qquad p(1)=\\frac{1-z}{2}={{toFixed((1-cos(q3_theta))/2,3)}}$$"}
           ]
         }
       ],
@@ -3990,67 +2789,232 @@
             "label": "Start from the Bloch parameterization",
             "math": "\\htmlClass{hl-state}{\\lvert\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)\\lvert 1\\rangle}",
             "highlights": {
-              "state": {
-                "color": "cyan",
-                "label": "A general pure qubit state"
-              }
+              "state": {"color": "cyan", "label": "A general pure qubit state"}
             },
             "justification": "Use the standard parameterization of a pure qubit on the Bloch sphere.",
             "explanation": "The coefficients already tell us the amplitudes for the computational basis states.",
             "prompt": "Remind the student that the north and south poles correspond to pure |0> and |1>.",
-            "sceneStep": 0
+            "sceneStep": 0,
+            "semanticGraph": {
+              "graph": {
+                "nodes": [
+                  {"id": "__equals_1", "type": "relation", "op": "equals", "subexpr": "|\\psi\\rangle = \\cos\\!\\left(\\frac{\\theta}{2}\\right)| 0\\rangle + e^{i\\phi}\\sin\\!\\left(\\frac{\\theta}{2}\\right)| 1\\rangle"},
+                  {"id": "__ket_2", "type": "ket", "latex": "\\left|\\psi\\right\\rangle", "subexpr": "\\left|\\psi\\right\\rangle"},
+                  {"id": "__add_3", "type": "operator", "op": "add", "subexpr": "e^{i \\phi} \\sin{\\left(\\frac{\\theta}{2} \\right)} {\\left|1\\right\\rangle } + \\cos{\\left(\\frac{\\theta}{2} \\right)} {\\left|0\\right\\rangle }"},
+                  {"id": "__multiply_4", "type": "operator", "op": "multiply", "subexpr": "\\cos{\\left(\\frac{\\theta}{2} \\right)} {\\left|0\\right\\rangle }"},
+                  {"id": "__cos_5", "type": "function", "latex": "\\cos", "op": "cos", "subexpr": "\\cos{\\left(\\frac{\\theta}{2} \\right)}"},
+                  {"id": "__multiply_6", "type": "operator", "op": "multiply", "subexpr": "\\theta \\frac{1}{2}"},
+                  {"id": "theta", "type": "scalar", "latex": "\\theta", "subexpr": "\\theta"},
+                  {"id": "__power_7", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                  {"id": "__num_8", "type": "number", "label": "2", "subexpr": "2"},
+                  {"id": "__ket_9", "type": "ket", "latex": "\\left|0\\right\\rangle", "subexpr": "\\left|0\\right\\rangle"},
+                  {"id": "__multiply_10", "type": "operator", "op": "multiply", "subexpr": "e^{i \\phi} \\sin{\\left(\\frac{\\theta}{2} \\right)} {\\left|1\\right\\rangle }"},
+                  {"id": "__power_11", "type": "operator", "op": "power", "subexpr": "e^{i \\phi}"},
+                  {"id": "e", "type": "scalar", "latex": "e", "subexpr": "e"},
+                  {"id": "__multiply_12", "type": "operator", "op": "multiply", "subexpr": "i \\phi"},
+                  {"id": "i", "type": "scalar", "latex": "i", "subexpr": "i"},
+                  {"id": "phi", "type": "scalar", "latex": "\\phi", "subexpr": "\\phi"},
+                  {"id": "__multiply_13", "type": "operator", "op": "multiply", "subexpr": "\\sin{\\left(\\frac{\\theta}{2} \\right)} {\\left|1\\right\\rangle }"},
+                  {"id": "__sin_14", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\frac{\\theta}{2} \\right)}"},
+                  {"id": "__multiply_15", "type": "operator", "op": "multiply", "subexpr": "\\theta \\frac{1}{2}"},
+                  {"id": "__power_16", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                  {"id": "__num_17", "type": "number", "label": "2", "subexpr": "2"},
+                  {"id": "__ket_18", "type": "ket", "latex": "\\left|1\\right\\rangle", "subexpr": "\\left|1\\right\\rangle"}
+                ],
+                "edges": [
+                  {"from": "__ket_2", "to": "__equals_1"},
+                  {"from": "theta", "to": "__multiply_6", "semantic": "direct", "weight": 1.0},
+                  {"from": "__num_8", "to": "__power_7"},
+                  {"from": "__power_7", "to": "__multiply_6"},
+                  {"from": "__multiply_6", "to": "__cos_5"},
+                  {"from": "__cos_5", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                  {"from": "__ket_9", "to": "__multiply_4", "semantic": "direct", "weight": 1.0},
+                  {"from": "__multiply_4", "to": "__add_3"},
+                  {"from": "e", "to": "__power_11"},
+                  {"from": "i", "to": "__multiply_12", "semantic": "direct", "weight": 1.0},
+                  {"from": "phi", "to": "__multiply_12", "semantic": "direct", "weight": 1.0},
+                  {"from": "__multiply_12", "to": "__power_11", "role": "exp"},
+                  {"from": "__power_11", "to": "__multiply_10", "semantic": "direct", "weight": 1.0},
+                  {"from": "theta", "to": "__multiply_15", "semantic": "direct", "weight": 1.0},
+                  {"from": "__num_17", "to": "__power_16"},
+                  {"from": "__power_16", "to": "__multiply_15"},
+                  {"from": "__multiply_15", "to": "__sin_14"},
+                  {"from": "__sin_14", "to": "__multiply_13", "semantic": "direct", "weight": 1.0},
+                  {"from": "__ket_18", "to": "__multiply_13", "semantic": "direct", "weight": 1.0},
+                  {"from": "__multiply_13", "to": "__multiply_10", "semantic": "direct", "weight": 1.0},
+                  {"from": "__multiply_10", "to": "__add_3"},
+                  {"from": "__add_3", "to": "__equals_1"}
+                ],
+                "classification": {"kind": "algebraic"}
+              }
+            }
           },
           {
             "type": "step",
             "label": "Apply Born's rule",
             "math": "p(0)=\\lvert\\langle 0\\vert\\psi\\rangle\\rvert^2=\\htmlClass{hl-p0}{\\cos^2\\!\\left(\\frac{\\theta}{2}\\right)} \\\\ p(1)=\\lvert\\langle 1\\vert\\psi\\rangle\\rvert^2=\\htmlClass{hl-p1}{\\sin^2\\!\\left(\\frac{\\theta}{2}\\right)}",
             "highlights": {
-              "p0": {
-                "color": "green",
-                "label": "$|0\\rangle$ probability"
-              },
-              "p1": {
-                "color": "orange",
-                "label": "$|1\\rangle$ probability"
-              }
+              "p0": {"color": "green", "label": "$|0\\rangle$ probability"},
+              "p1": {"color": "orange", "label": "$|1\\rangle$ probability"}
             },
             "justification": "Project the state onto each basis vector and square the magnitude of the amplitude.",
             "explanation": "The phase factor $e^{i\\phi}$ disappears from the magnitude, so $\\phi$ does not affect this measurement basis.",
             "prompt": "Point out explicitly that the global magnitude of the complex phase is 1, so it drops out of the probabilities.",
-            "sceneStep": 1
+            "sceneStep": 1,
+            "semanticGraph": {
+              "graph": {
+                "nodes": [
+                  {"id": "c0___p_1", "type": "function", "op": "p", "subexpr": "p(0)"},
+                  {"id": "c0___num_2", "type": "number", "label": "0", "subexpr": "0"},
+                  {"id": "c0___power_3", "type": "operator", "op": "power", "exponent": "2", "subexpr": "|{\\langle 0|\\psi\\rangle}|^2"},
+                  {"id": "c0___abs_4", "type": "function", "op": "abs", "subexpr": "\\left|{{\\langle 0|\\psi\\rangle}}\\right|"},
+                  {"id": "c0_Phi_{0}", "type": "operator", "latex": "\\langle 0\\,|\\,\\cdot\\rangle", "op": "inner_product", "subexpr": "\\langle 0|\\psi\\rangle"},
+                  {"id": "psi", "type": "scalar", "latex": "\\psi", "subexpr": "\\psi"},
+                  {"id": "c0___power_5", "type": "operator", "op": "power", "exponent": "2", "subexpr": "\\cos^2 \\left(\\frac{\\theta}{2}\\right)"},
+                  {"id": "c0___cos_6", "type": "function", "latex": "\\cos", "op": "cos", "subexpr": "\\cos{\\left(\\frac{\\theta}{2} \\right)}"},
+                  {"id": "c0___multiply_7", "type": "operator", "op": "multiply", "subexpr": "\\theta \\frac{1}{2}"},
+                  {"id": "theta", "type": "scalar", "latex": "\\theta", "subexpr": "\\theta"},
+                  {"id": "c0___power_8", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                  {"id": "c0___num_9", "type": "number", "label": "2", "subexpr": "2"},
+                  {"id": "c0___equals_10", "type": "relation", "label": "equals", "emoji": "=", "op": "equals", "subexpr": "p(0)=|\\langle 0|\\psi\\rangle|^2=\\cos^2\\!\\left(\\frac{\\theta}{2}\\right)"},
+                  {"id": "c1___p_1", "type": "function", "op": "p", "subexpr": "p(1)"},
+                  {"id": "c1___num_2", "type": "number", "label": "1", "subexpr": "1"},
+                  {"id": "c1___power_3", "type": "operator", "op": "power", "exponent": "2", "subexpr": "|{\\langle 1|\\psi\\rangle}|^2"},
+                  {"id": "c1___abs_4", "type": "function", "op": "abs", "subexpr": "\\left|{{\\langle 1|\\psi\\rangle}}\\right|"},
+                  {"id": "c1_Phi_{0}", "type": "operator", "latex": "\\langle 1\\,|\\,\\cdot\\rangle", "op": "inner_product", "subexpr": "\\langle 1|\\psi\\rangle"},
+                  {"id": "c1___power_5", "type": "operator", "op": "power", "exponent": "2", "subexpr": "\\sin^2 \\left(\\frac{\\theta}{2}\\right)"},
+                  {"id": "c1___sin_6", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\frac{\\theta}{2} \\right)}"},
+                  {"id": "c1___multiply_7", "type": "operator", "op": "multiply", "subexpr": "\\theta \\frac{1}{2}"},
+                  {"id": "c1___power_8", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                  {"id": "c1___num_9", "type": "number", "label": "2", "subexpr": "2"},
+                  {"id": "c1___equals_10", "type": "relation", "label": "equals", "emoji": "=", "op": "equals", "subexpr": "p(1)=|\\langle 1|\\psi\\rangle|^2=\\sin^2\\!\\left(\\frac{\\theta}{2}\\right)"}
+                ],
+                "edges": [
+                  {"from": "c0___num_2", "to": "c0___p_1"},
+                  {"from": "psi", "to": "c0_Phi_{0}", "role": "rhs"},
+                  {"from": "c0_Phi_{0}", "to": "c0___abs_4"},
+                  {"from": "c0___abs_4", "to": "c0___power_3"},
+                  {"from": "theta", "to": "c0___multiply_7", "semantic": "direct", "weight": 1.0},
+                  {"from": "c0___num_9", "to": "c0___power_8"},
+                  {"from": "c0___power_8", "to": "c0___multiply_7"},
+                  {"from": "c0___multiply_7", "to": "c0___cos_6"},
+                  {"from": "c0___cos_6", "to": "c0___power_5"},
+                  {"from": "c0___p_1", "to": "c0___equals_10"},
+                  {"from": "c0___power_3", "to": "c0___equals_10"},
+                  {"from": "c0___power_5", "to": "c0___equals_10"},
+                  {"from": "c1___num_2", "to": "c1___p_1"},
+                  {"from": "psi", "to": "c1_Phi_{0}", "role": "rhs"},
+                  {"from": "c1_Phi_{0}", "to": "c1___abs_4"},
+                  {"from": "c1___abs_4", "to": "c1___power_3"},
+                  {"from": "theta", "to": "c1___multiply_7", "semantic": "direct", "weight": 1.0},
+                  {"from": "c1___num_9", "to": "c1___power_8"},
+                  {"from": "c1___power_8", "to": "c1___multiply_7"},
+                  {"from": "c1___multiply_7", "to": "c1___sin_6"},
+                  {"from": "c1___sin_6", "to": "c1___power_5"},
+                  {"from": "c1___p_1", "to": "c1___equals_10"},
+                  {"from": "c1___power_3", "to": "c1___equals_10"},
+                  {"from": "c1___power_5", "to": "c1___equals_10"}
+                ],
+                "classification": {
+                  "kind": "statements",
+                  "count": 2,
+                  "clauses": [
+                    {"kind": "algebraic"},
+                    {"kind": "algebraic"}
+                  ]
+                }
+              }
+            }
           },
           {
             "type": "step",
             "label": "Use the half-angle identities",
             "math": "\\cos^2\\left(\\frac{\\theta}{2}\\right)=\\frac{1+\\htmlClass{hl-z}{\\cos\\theta}}{2},\\qquad \\sin^2\\left(\\frac{\\theta}{2}\\right)=\\frac{1-\\htmlClass{hl-z2}{\\cos\\theta}}{2}",
             "highlights": {
-              "z": {
-                "color": "blue",
-                "label": "$\\cos\\theta$ becomes the Bloch z-coordinate"
-              },
-              "z2": {
-                "color": "blue",
-                "label": "Same z-coordinate in the second probability"
-              }
+              "z": {"color": "blue", "label": "$\\cos\\theta$ becomes the Bloch z-coordinate"},
+              "z2": {"color": "blue", "label": "Same z-coordinate in the second probability"}
             },
             "justification": "Use $\\cos^2(\\theta/2)=(1+\\cos\\theta)/2$ and $\\sin^2(\\theta/2)=(1-\\cos\\theta)/2$.",
             "explanation": "This is the algebraic bridge from amplitudes to geometry.",
             "prompt": "Make the phrase 'height on the sphere' explicit when you replace cos theta by z.",
-            "sceneStep": 2
+            "sceneStep": 2,
+            "semanticGraph": {
+              "graph": {
+                "nodes": [
+                  {"id": "c0___equals_1", "type": "relation", "op": "equals", "subexpr": "\\cos^2\\left(\\frac{\\theta}{2}\\right)=\\frac{1+\\cos\\theta}{2}"},
+                  {"id": "c0___power_2", "type": "operator", "op": "power", "exponent": "2", "subexpr": "\\cos^{2}{\\left(\\frac{\\theta}{2} \\right)}"},
+                  {"id": "c0___cos_3", "type": "function", "latex": "\\cos", "op": "cos", "subexpr": "\\cos{\\left(\\frac{\\theta}{2} \\right)}"},
+                  {"id": "c0___multiply_4", "type": "operator", "op": "multiply", "subexpr": "\\theta \\frac{1}{2}"},
+                  {"id": "theta", "type": "scalar", "latex": "\\theta", "subexpr": "\\theta"},
+                  {"id": "c0___power_5", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                  {"id": "c0___num_6", "type": "number", "label": "2", "subexpr": "2"},
+                  {"id": "c0___multiply_7", "type": "operator", "op": "multiply", "subexpr": "\\left(\\cos{\\left(\\theta \\right)} + 1\\right) \\frac{1}{2}"},
+                  {"id": "c0___add_8", "type": "operator", "op": "add", "subexpr": "\\cos{\\left(\\theta \\right)} + 1"},
+                  {"id": "c0___num_9", "type": "number", "label": "1", "subexpr": "1"},
+                  {"id": "c0___cos_10", "type": "function", "latex": "\\cos", "op": "cos", "subexpr": "\\cos{\\left(\\theta \\right)}"},
+                  {"id": "c0___power_11", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                  {"id": "c0___num_12", "type": "number", "label": "2", "subexpr": "2"},
+                  {"id": "c1___equals_1", "type": "relation", "op": "equals", "subexpr": "\\sin^2\\left(\\frac{\\theta}{2}\\right)=\\frac{1-\\cos\\theta}{2}"},
+                  {"id": "c1___power_2", "type": "operator", "op": "power", "exponent": "2", "subexpr": "\\sin^{2}{\\left(\\frac{\\theta}{2} \\right)}"},
+                  {"id": "c1___sin_3", "type": "function", "latex": "\\sin", "op": "sin", "subexpr": "\\sin{\\left(\\frac{\\theta}{2} \\right)}"},
+                  {"id": "c1___multiply_4", "type": "operator", "op": "multiply", "subexpr": "\\theta \\frac{1}{2}"},
+                  {"id": "c1___power_5", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                  {"id": "c1___num_6", "type": "number", "label": "2", "subexpr": "2"},
+                  {"id": "c1___multiply_7", "type": "operator", "op": "multiply", "subexpr": "\\left(1 - \\cos{\\left(\\theta \\right)}\\right) \\frac{1}{2}"},
+                  {"id": "c1___add_8", "type": "operator", "op": "add", "subexpr": "1 - \\cos{\\left(\\theta \\right)}"},
+                  {"id": "c1___num_9", "type": "number", "label": "1", "subexpr": "1"},
+                  {"id": "c1___negation_10", "type": "operator", "op": "negation", "subexpr": "-\\cos{\\left(\\theta \\right)}"},
+                  {"id": "c1___cos_11", "type": "function", "latex": "\\cos", "op": "cos", "subexpr": "\\cos{\\left(\\theta \\right)}"},
+                  {"id": "c1___power_12", "type": "operator", "latex": "\\dfrac{1}{(\\cdot)}", "op": "power", "exponent": "-1", "subexpr": "\\frac{1}{2}"},
+                  {"id": "c1___num_13", "type": "number", "label": "2", "subexpr": "2"}
+                ],
+                "edges": [
+                  {"from": "theta", "to": "c0___multiply_4", "semantic": "direct", "weight": 1.0},
+                  {"from": "c0___num_6", "to": "c0___power_5"},
+                  {"from": "c0___power_5", "to": "c0___multiply_4"},
+                  {"from": "c0___multiply_4", "to": "c0___cos_3"},
+                  {"from": "c0___cos_3", "to": "c0___power_2"},
+                  {"from": "c0___power_2", "to": "c0___equals_1"},
+                  {"from": "c0___num_9", "to": "c0___add_8"},
+                  {"from": "theta", "to": "c0___cos_10"},
+                  {"from": "c0___cos_10", "to": "c0___add_8"},
+                  {"from": "c0___add_8", "to": "c0___multiply_7", "semantic": "direct", "weight": 1.0},
+                  {"from": "c0___num_12", "to": "c0___power_11"},
+                  {"from": "c0___power_11", "to": "c0___multiply_7"},
+                  {"from": "c0___multiply_7", "to": "c0___equals_1"},
+                  {"from": "theta", "to": "c1___multiply_4", "semantic": "direct", "weight": 1.0},
+                  {"from": "c1___num_6", "to": "c1___power_5"},
+                  {"from": "c1___power_5", "to": "c1___multiply_4"},
+                  {"from": "c1___multiply_4", "to": "c1___sin_3"},
+                  {"from": "c1___sin_3", "to": "c1___power_2"},
+                  {"from": "c1___power_2", "to": "c1___equals_1"},
+                  {"from": "c1___num_9", "to": "c1___add_8"},
+                  {"from": "theta", "to": "c1___cos_11"},
+                  {"from": "c1___cos_11", "to": "c1___negation_10"},
+                  {"from": "c1___negation_10", "to": "c1___add_8"},
+                  {"from": "c1___add_8", "to": "c1___multiply_7", "semantic": "direct", "weight": 1.0},
+                  {"from": "c1___num_13", "to": "c1___power_12"},
+                  {"from": "c1___power_12", "to": "c1___multiply_7"},
+                  {"from": "c1___multiply_7", "to": "c1___equals_1"}
+                ],
+                "classification": {
+                  "kind": "statements",
+                  "count": 2,
+                  "clauses": [
+                    {"kind": "algebraic"},
+                    {"kind": "algebraic"}
+                  ]
+                }
+              }
+            }
           },
           {
             "type": "conclusion",
             "label": "Read height as probability",
             "math": "z=\\cos\\theta\\ \\Longrightarrow\\ p(0)=\\frac{1+\\htmlClass{hl-zfinal}{z}}{2},\\qquad p(1)=\\frac{1-\\htmlClass{hl-zfinal2}{z}}{2}",
             "highlights": {
-              "zfinal": {
-                "color": "green",
-                "label": "Positive z favors $|0\\rangle$"
-              },
-              "zfinal2": {
-                "color": "orange",
-                "label": "Negative z favors $|1\\rangle$"
-              }
+              "zfinal": {"color": "green", "label": "Positive z favors $|0\\rangle$"},
+              "zfinal2": {"color": "orange", "label": "Negative z favors $|1\\rangle$"}
             },
             "justification": "Substitute the Bloch coordinate $z$ for $\\cos\\theta$.",
             "explanation": "A computational-basis measurement only needs the state's z-coordinate, so latitude alone predicts the outcome probabilities.",
@@ -4066,73 +3030,28 @@
       "markdown": "# Relative Phase Changes Other Measurements\n\nOn the equator of the Bloch sphere, $\\theta=\\pi/2$, so the state takes the form\n\n$$|\\psi(\\phi)\\rangle = \\frac{|0\\rangle + e^{i\\phi}|1\\rangle}{\\sqrt{2}}.$$\n\nEvery such state has\n\n$$p_z(0)=p_z(1)=\\frac{1}{2},$$\n\nso a computational-basis measurement cannot distinguish them.\n\nBut other bases can. For the x basis,\n\n$$p(+x)=\\frac{1+\\cos\\phi}{2},\\qquad p(-x)=\\frac{1-\\cos\\phi}{2},$$\n\nand for the y basis,\n\n$$p(+y)=\\frac{1+\\sin\\phi}{2},\\qquad p(-y)=\\frac{1-\\sin\\phi}{2}.$$\n\nThis is why **relative phase matters**. By contrast, multiplying the entire ket by $e^{i\\gamma}$ leaves the Bloch point unchanged, so **global phase is physically invisible** for a single qubit.",
       "prompt": "Teach this scene as the payoff for relative phase. The z-basis probabilities stay flat at one half, while x and y measurements change with phi. Keep the distinction between relative phase and global phase crisp and explicit.",
       "range": [
-        [
-          -1.35,
-          1.35
-        ],
-        [
-          -1.35,
-          1.35
-        ],
-        [
-          -1.35,
-          1.35
-        ]
+        [-1.35, 1.35],
+        [-1.35, 1.35],
+        [-1.35, 1.35]
       ],
       "camera": {
-        "position": [
-          2.8,
-          -2.4,
-          1.8
-        ],
-        "target": [
-          0,
-          0,
-          0
-        ],
-        "up": [
-          0,
-          0,
-          1
-        ]
+        "position": [2.8, -2.4, 1.8],
+        "target": [0, 0, 0],
+        "up": [0, 0, 1]
       },
       "views": [
         {
           "name": "Iso",
-          "position": [
-            2.8,
-            -2.4,
-            1.8
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            0,
-            1
-          ],
+          "position": [2.8, -2.4, 1.8],
+          "target": [0, 0, 0],
+          "up": [0, 0, 1],
           "description": "See the equator and the x, y, z axes together"
         },
         {
           "name": "Top Down",
-          "position": [
-            0,
-            0,
-            4
-          ],
-          "target": [
-            0,
-            0,
-            0
-          ],
-          "up": [
-            0,
-            1,
-            0
-          ],
+          "position": [0, 0, 4],
+          "target": [0, 0, 0],
+          "up": [0, 1, 0],
           "description": "Watch $\\phi$ sweep the equator from above"
         }
       ],
@@ -4140,11 +3059,7 @@
         {
           "id": "s4_sphere",
           "type": "sphere",
-          "center": [
-            0,
-            0,
-            0
-          ],
+          "center": [0, 0, 0],
           "radius": 1,
           "color": "#5c7cfa",
           "opacity": 0.12,
@@ -4155,10 +3070,7 @@
           "id": "s4_axis_x",
           "type": "axis",
           "axis": "x",
-          "range": [
-            -1.2,
-            1.2
-          ],
+          "range": [-1.2, 1.2],
           "color": "#ff4444",
           "width": 1.2,
           "label": "$x$"
@@ -4167,10 +3079,7 @@
           "id": "s4_axis_y",
           "type": "axis",
           "axis": "y",
-          "range": [
-            -1.2,
-            1.2
-          ],
+          "range": [-1.2, 1.2],
           "color": "#44cc44",
           "width": 1.2,
           "label": "$y$"
@@ -4179,10 +3088,7 @@
           "id": "s4_axis_z",
           "type": "axis",
           "axis": "z",
-          "range": [
-            -1.2,
-            1.2
-          ],
+          "range": [-1.2, 1.2],
           "color": "#4488ff",
           "width": 1.2,
           "label": "$z$"
@@ -4191,15 +3097,8 @@
           "id": "s4_grid_xy",
           "type": "grid",
           "plane": "xy",
-          "range": [
-            -1.2,
-            1.2
-          ],
-          "color": [
-            0.28,
-            0.28,
-            0.45
-          ],
+          "range": [-1.2, 1.2],
+          "color": [0.28, 0.28, 0.45],
           "opacity": 0.12,
           "divisions": 8
         }
@@ -4210,16 +3109,7 @@
           "description": "Set $\\theta=\\pi/2$ and change only $\\phi$. The state moves around the equator, but its z-coordinate stays at zero, so a z-basis measurement always gives 50%-50%.",
           "prompt": "Say explicitly that the equator means z equals zero. Use that to justify the flat z-basis probabilities before discussing any other basis.",
           "sliders": [
-            {
-              "id": "q4_phi",
-              "label": "$\\phi$",
-              "min": 0,
-              "max": 6.283185307179586,
-              "step": 0.01,
-              "default": 0,
-              "animate": true,
-              "duration": 5000
-            }
+            {"id": "q4_phi", "label": "$\\phi$", "min": 0, "max": 6.283185307179586, "step": 0.01, "default": 0, "animate": true, "duration": 5000}
           ],
           "add": [
             {
@@ -4228,10 +3118,7 @@
               "x": "cos(t)",
               "y": "sin(t)",
               "z": "0",
-              "range": [
-                0,
-                6.283185307179586
-              ],
+              "range": [0, 6.283185307179586],
               "samples": 180,
               "color": "#c77dff",
               "width": 2,
@@ -4240,16 +3127,8 @@
             {
               "id": "s4_state_vec",
               "type": "animated_vector",
-              "from": [
-                0,
-                0,
-                0
-              ],
-              "expr": [
-                "cos(q4_phi)",
-                "sin(q4_phi)",
-                "0"
-              ],
+              "from": [0, 0, 0],
+              "expr": ["cos(q4_phi)", "sin(q4_phi)", "0"],
               "color": "#ffd166",
               "width": 2.0,
               "label": "$|\\psi(\\phi)\\rangle$"
@@ -4257,21 +3136,13 @@
             {
               "id": "s4_state_pt",
               "type": "animated_point",
-              "expr": [
-                "cos(q4_phi)",
-                "sin(q4_phi)",
-                "0"
-              ],
+              "expr": ["cos(q4_phi)", "sin(q4_phi)", "0"],
               "color": "#ffd166",
               "size": 1.0
             }
           ],
           "info": [
-            {
-              "id": "s4_zflat",
-              "position": "top-right",
-              "content": "$$\\lvert\\psi(\\phi)\\rangle = \\frac{\\lvert 0\\rangle + e^{i\\phi}\\lvert 1\\rangle}{\\sqrt{2}}$$\n$$p_z(0)=p_z(1)=0.5$$"
-            }
+            {"id": "s4_zflat", "position": "top-right", "content": "$$\\lvert\\psi(\\phi)\\rangle = \\frac{\\lvert 0\\rangle + e^{i\\phi}\\lvert 1\\rangle}{\\sqrt{2}}$$\n$$p_z(0)=p_z(1)=0.5$$"}
           ]
         },
         {
@@ -4282,11 +3153,7 @@
             {
               "id": "s4_plusx",
               "type": "point",
-              "position": [
-                1,
-                0,
-                0
-              ],
+              "position": [1, 0, 0],
               "color": "#66d9ff",
               "size": 10,
               "label": "$|+x\\rangle$"
@@ -4294,22 +3161,14 @@
             {
               "id": "s4_minusx",
               "type": "point",
-              "position": [
-                -1,
-                0,
-                0
-              ],
+              "position": [-1, 0, 0],
               "color": "#ff7b72",
               "size": 10,
               "label": "$|-x\\rangle$"
             }
           ],
           "info": [
-            {
-              "id": "s4_xbasis",
-              "position": "top-right",
-              "content": "$$p(+x)=\\frac{1+\\cos\\phi}{2}={{toFixed((1+cos(q4_phi))/2,3)}}$$\n$$p(-x)=\\frac{1-\\cos\\phi}{2}={{toFixed((1-cos(q4_phi))/2,3)}}$$"
-            }
+            {"id": "s4_xbasis", "position": "top-right", "content": "$$p(+x)=\\frac{1+\\cos\\phi}{2}={{toFixed((1+cos(q4_phi))/2,3)}}$$\n$$p(-x)=\\frac{1-\\cos\\phi}{2}={{toFixed((1-cos(q4_phi))/2,3)}}$$"}
           ]
         },
         {
@@ -4320,11 +3179,7 @@
             {
               "id": "s4_plusy",
               "type": "point",
-              "position": [
-                0,
-                1,
-                0
-              ],
+              "position": [0, 1, 0],
               "color": "#7bd389",
               "size": 10,
               "label": "$|+y\\rangle$"
@@ -4332,22 +3187,14 @@
             {
               "id": "s4_minusy",
               "type": "point",
-              "position": [
-                0,
-                -1,
-                0
-              ],
+              "position": [0, -1, 0],
               "color": "#c77dff",
               "size": 10,
               "label": "$|-y\\rangle$"
             }
           ],
           "info": [
-            {
-              "id": "s4_ybasis",
-              "position": "top-right",
-              "content": "$$p(+y)=\\frac{1+\\sin\\phi}{2}={{toFixed((1+sin(q4_phi))/2,3)}}$$\n$$p(-y)=\\frac{1-\\sin\\phi}{2}={{toFixed((1-sin(q4_phi))/2,3)}}$$"
-            }
+            {"id": "s4_ybasis", "position": "top-right", "content": "$$p(+y)=\\frac{1+\\sin\\phi}{2}={{toFixed((1+sin(q4_phi))/2,3)}}$$\n$$p(-y)=\\frac{1-\\sin\\phi}{2}={{toFixed((1-sin(q4_phi))/2,3)}}$$"}
           ]
         },
         {
@@ -4355,11 +3202,7 @@
           "description": "Multiplying the entire ket by $e^{i\\gamma}$ does not move the Bloch point or change any measurement probability. Only the relative phase between the basis amplitudes changes the state geometry.",
           "prompt": "Students often confuse relative phase with global phase. State the distinction plainly: relative phase moves the Bloch point; global phase does not.",
           "info": [
-            {
-              "id": "s4_global_phase",
-              "position": "top-right",
-              "content": "$$e^{i\\gamma}\\lvert\\psi\\rangle\\ \\text{and}\\ \\lvert\\psi\\rangle\\ \\text{represent the same physical state}$$\n$$\\text{Only the relative phase }\\phi\\text{ changes the Bloch point.}$$"
-            }
+            {"id": "s4_global_phase", "position": "top-right", "content": "$$e^{i\\gamma}\\lvert\\psi\\rangle\\ \\text{and}\\ \\lvert\\psi\\rangle\\ \\text{represent the same physical state}$$\n$$\\text{Only the relative phase }\\phi\\text{ changes the Bloch point.}$$"}
           ]
         }
       ]


### PR DESCRIPTION
## What

Bakes the per-step semantic graphs into two production lessons so the server serves them directly instead of deriving them on **every** scene load via `_autofill_semantic_graphs` (`backend/server.py`).

| Lesson | Graphs baked | Server parse (load) | Size |
|---|---|---|---|
| `artemis-ii-mission-simulation.json` | 7 | 0.76s → ~0.00s | 75.4 KB → 79.0 KB (+4.7%) |
| `quantum-states.json` | 12 | 0.68s → 0.04s (~19× faster) | 140.5 KB → 170.5 KB (+21.4%) |

The load win is ~12× larger on a constrained free Render host (≈9s and ≈8s saved per load respectively).

## Why

Runtime graph derivation is CPU-heavy and runs on every load; prebaking moves that work offline so lessons load near-instantly. This is the same play as the recently-merged prebake of the atmospheric-entry lesson ([#350](https://github.com/ibenian/algebench/pull/350)).

## How

Generated with `scripts/prebake_semantic_graphs.py --write`, which reuses the backend's exact derivation + highlight pipeline — baked graphs are byte-identical to what the server would compute. Baking changes *when* the work happens, never the result.

## Reviewer notes

- **Large diff is mostly cosmetic.** `--write` re-serializes each file with the script's compact-leaves layout + canonical number formatting; it's round-trip-checked and data-identical. The substantive change is the inlined `{"graph": …}` blocks.
- **2 quantum steps left unbaked** (`errorUnbaked`): a Pauli-Z matrix (`\begin{pmatrix}…`) and a `\Longrightarrow` chain the parser can't derive. They fail-fast at runtime regardless — nothing to bake, not a regression (`errorBroken: 0`).
- **Validated clean** post-bake: `needsPrebake: 0`, `outOfSync: 0` on both — so the CI `validate-prebaked-graphs` gate passes.
- **Verified in preview**: both lessons render their baked graphs in the MATH panel with no console errors, and the server logs show **no `auto-derived` lines** on load — confirming baked graphs are served, not derived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)