### PR TITLE
fix: load CLI scene path via correct channel instead of 404ing

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -2013,7 +2013,19 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
 
     url = f"http://localhost:{port}/"
     if initial_scene_path:
-        url = f"{url}?scene={quote(str(initial_scene_path))}"
+        # The frontend's ?scene= load path goes through /api/scene_file, which
+        # confines reads to scenes/ and REJECTS absolute paths. So only emit
+        # ?scene= for files inside scenes/ (as a scenes/<name> relative path
+        # that round-trips through resolve_scene_path_safe + reload). For paths
+        # outside scenes/, open the bare URL: the frontend then falls back to
+        # /api/scene, which serves the pre-loaded current_spec from the
+        # (trusted) absolute path and keeps working across reloads.
+        try:
+            rel = "scenes/" + Path(initial_scene_path).resolve().relative_to(
+                scenes_dir.resolve()).as_posix()
+            url = f"{url}?scene={quote(rel)}"
+        except ValueError:
+            pass
 
     if json_output:
         result = {


### PR DESCRIPTION
## Problem

Launching `./algebench <scene>` from the CLI opened the browser at
`?scene=<absolute path>` (the path comes back absolute from
`resolve_scene_path`). The frontend loads `?scene=` through
`/api/scene_file`, which `resolve_scene_path_safe` confines to `scenes/`
and **rejects absolute paths** by design — so the request 404'd and the
UI silently fell back to a blank/default scene.

Loading the *same* file from the built-in scenes menu worked, because the
menu passes a relative `scenes/<name>` path that the safe resolver accepts.
That mismatch is why "loads from the menu but not from the CLI param".

## Fix

In `serve_and_open`, pick the right channel per case:

- **Inside `scenes/`** → emit `?scene=scenes/<name>` (relative). Round-trips
  through `resolve_scene_path_safe` and survives reload.
- **Outside `scenes/`** → open the bare URL. The frontend's
  `loadInitialSceneFromQuery()` finds no `?scene=` and falls back to
  `/api/scene`, which serves the pre-loaded `current_spec` from the
  **trusted** absolute path (and re-loads it on every reload).

So no CLI path is ignored: in-`scenes/` files round-trip via the URL, and
external files load through the trusted current-scene endpoint.

## Verification

| CLI invocation | Opened URL | Loads via |
|---|---|---|
| `./algebench scenes/atmospheric-entry-physics.json` | `…/?scene=scenes/atmospheric-entry-physics.json` | `/api/scene_file` → HTTP 200 ✅ |
| `./algebench /tmp/ext_scene.json` (outside `scenes/`) | `…/` (bare) | `/api/scene` → HTTP 200, correct scene ✅ |

Confirmed end-to-end against a running server (curl + actual opened-URL output).

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>