### PR TITLE
On-the-fly proof derivation animations on the semantic graph

### DIFF
--- a/backend/experts/__init__.py
+++ b/backend/experts/__init__.py
@@ -12,15 +12,18 @@ from __future__ import annotations
 
 from .registry import (  # re-exported for convenience
     EXPERT_REGISTRY,
+    HANDLER_REGISTRY,
     METRIC_REGISTRY,
     resolve_context_model,
 )
 
 
 def discover() -> None:
-    """Import every expert package so decorators populate the registries."""
+    """Import every expert + handler package so decorators populate the registries."""
     from .modules import discover_experts
     discover_experts()
+    from .handlers import discover_handlers
+    discover_handlers()
 
 
 def init_experts(configure_lm: bool = True) -> None:

--- a/backend/experts/handlers/README.md
+++ b/backend/experts/handlers/README.md
@@ -1,0 +1,49 @@
+# Expert handlers
+
+A **handler** wraps a registered expert with custom **pre/post-processing**,
+exposed through the single generic endpoint:
+
+```
+POST /api/expert/{name}
+```
+
+The DSPy expert itself lives under `../modules/` and stays pure (it only knows
+how to turn a typed context into typed outputs). The handler is the
+orchestration glue around one expert call:
+
+1. **pre** — parse a feature-shaped request, build the expert's context payload
+   (e.g. infer a missing input, parse LaTeX → semantic graphs);
+2. **call** — `backend.experts.service.invoke("<expert>", context_id, payload, …)`;
+3. **post** — turn the expert's typed outputs into the JSON the client needs
+   (e.g. render a trajectory into animation data).
+
+`service.run(name, body)` is the single dispatch point: if `name` has a handler
+it validates `body` against the handler's `request_model` and calls it; otherwise
+`name` is treated as a plain expert and `invoke` runs directly. Either way, **no
+new endpoint wiring** — experts and handlers self-register and are reachable by
+name.
+
+Concurrency/abuse is handled once, at the endpoint, by the shared per-IP
+`_agentic_rate_limit`. Handlers do **not** implement their own throttling.
+
+## Adding a handler
+
+1. Create `handlers/<name>/handler.py`:
+   ```python
+   from pydantic import BaseModel
+   from backend.experts.registry import register_handler
+   from backend.experts.service import invoke
+
+   class MyRequest(BaseModel):
+       ...
+
+   @register_handler("my_handler", request_model=MyRequest)
+   def my_handler(req: MyRequest) -> dict:
+       # pre … → invoke("some_expert", …) → post …
+       return {...}
+   ```
+2. Add `handlers/<name>/__init__.py` that imports `handler` so registration runs
+   on discovery.
+
+`discover_handlers()` (called by `init_experts()`) imports every subpackage here,
+so the decorator fires at startup.

--- a/backend/experts/handlers/__init__.py
+++ b/backend/experts/handlers/__init__.py
@@ -1,0 +1,22 @@
+"""Expert *handlers*. Each subpackage is one self-contained handler that
+self-registers (``@register_handler``) on import.
+
+A handler wraps a registered expert with custom pre/post-processing behind the
+generic ``POST /api/expert/{name}`` endpoint — see ``README.md``. Adding a
+handler = drop a package here; ``discover_handlers()`` imports it so the
+decorator runs.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+
+
+def discover_handlers() -> None:
+    """Import every handler subpackage so it self-registers."""
+    import backend.experts.handlers as pkg
+
+    for info in pkgutil.iter_modules(pkg.__path__):
+        if info.ispkg:  # only handler packages, not stray modules
+            importlib.import_module(f"{pkg.__name__}.{info.name}")

--- a/backend/experts/handlers/proof_animation/__init__.py
+++ b/backend/experts/handlers/proof_animation/__init__.py
@@ -1,0 +1,5 @@
+"""proof_animation handler — registers on import (via ``handler``)."""
+
+from __future__ import annotations
+
+from . import handler  # noqa: F401  (import side effect: @register_handler runs)

--- a/backend/experts/handlers/proof_animation/animation.py
+++ b/backend/experts/handlers/proof_animation/animation.py
@@ -152,17 +152,30 @@ def build(trajectory: ProofTrajectory, domain: str, title: str = "", *,
     working = None
     out = []
     for i, (operation, justification, ltx) in enumerate(chain):
-        g = svc.latex_to_graph(ltx, domain=domain)
-        if g is None:
-            raise ValueError(f"could not parse state {i}: {ltx!r}")
-        # rebase: keep g's authored structure, reuse stable ids for persisting parts
-        working = g if working is None else _rebase(working, g)
+        try:
+            g = svc.latex_to_graph(ltx, domain=domain)
+        except Exception:
+            g = None
+        # An ungroundable state — one that won't parse to a graph OR whose graph
+        # can't be re-rendered (e.g. an operator the renderer doesn't know) — is
+        # shown as raw LaTeX (no stable-id morphing) rather than failing the whole
+        # derivation. ``working`` only advances on a fully-rendered state, so the
+        # next good state rebases onto the last good one.
+        annotated = plain = ltx
+        if g is not None:
+            try:
+                cand = g if working is None else _rebase(working, g)
+                annotated = to_latex(cand, with_ids=True)   # annotated, stable ids
+                plain = to_latex(cand)                       # for labels/fallback
+                working = cand
+            except Exception:
+                annotated = plain = ltx
         out.append({
             "index": i,
             "operation": operation,
             "justification": justification,
-            "input_latex": ltx,                         # what was authored
-            "latex": to_latex(working, with_ids=True),  # annotated, stable ids
-            "plain": to_latex(working),                 # for labels/fallback
+            "input_latex": ltx,
+            "latex": annotated,
+            "plain": plain,
         })
     return {"title": title, "domain": domain, "steps": out}

--- a/backend/experts/handlers/proof_animation/animation.py
+++ b/backend/experts/handlers/proof_animation/animation.py
@@ -1,0 +1,168 @@
+"""Proof-animation CONVERSION library — a ProofTrajectory → animation data.
+
+Deterministic, no LM. Given the expert's output (a ``ProofTrajectory``: a start
+state + ordered ``DerivationStep``s), this threads the states so a sub-expression
+that persists keeps the SAME node id across states (GumTree-style rebase) and
+renders each state to **annotated LaTeX** (``\\htmlData{n=<id>}{...}``) with those
+stable ids. The JS engine FLIP-morphs between states keyed on ``data-n``.
+
+This module is the conversion core. The proof-animation *handler* (``handler.py``)
+calls ``build`` after running the ProofCompletionExpert; the offline tooling
+(``scripts/proof_animation/build.py``) re-imports ``build`` and wraps it with a
+``ProofAnimation`` display model.
+"""
+from __future__ import annotations
+
+import hashlib
+from collections import defaultdict
+
+from backend.semantic_graph.service import SemanticGraphService
+from backend.semantic_graph.latex_renderer import to_latex
+from backend.experts.modules.proof_completion.graph_ops import wl_colors, _content
+from backend.experts.modules.proof_completion.outputs import ProofTrajectory
+
+
+def _children(graph):
+    """node id -> [(role, child_id)] (operands = incoming edges)."""
+    ch = defaultdict(list)
+    for e in graph.edges:
+        ch[e.to].append((e.role, e.from_))
+    return ch
+
+
+def _subtree_sigs(graph):
+    """Per-node DOWNWARD subtree signature: identical subtrees share a sig,
+    wherever they sit. (content + sorted child sigs.) Returns (sig, children, nodes, size)."""
+    nodes = {n.id: n for n in graph.nodes}
+    ch = _children(graph)
+    sig, size = {}, {}
+
+    def walk(nid):
+        if nid in sig:
+            return
+        for _r, c in ch[nid]:
+            walk(c)
+        kids = tuple(sorted((r or "", sig[c]) for r, c in ch[nid]))
+        # deterministic, collision-resistant digest (not Python's salted hash())
+        sig[nid] = hashlib.blake2b(repr((_content(nodes[nid]), kids)).encode(),
+                                   digest_size=16).hexdigest()
+        size[nid] = 1 + sum(size[c] for _r, c in ch[nid])
+
+    for nid in nodes:
+        walk(nid)
+    return sig, ch, nodes, size
+
+
+def _rebase(prev, gnew):
+    """Relabel gnew so persisting sub-expressions keep prev's ids, preserving
+    gnew's OWN structure (authored side order) and **minimizing change**.
+
+    GumTree-style top-down match: anchor the LARGEST identical subtrees first
+    (by downward subtree signature), pairing each prev node with an unmatched new
+    node of the same signature and recursively aligning their (structurally
+    identical) descendants. This keeps repeated/unchanged pieces — e.g. the ``2``
+    in ``c^2`` — bound to the same id across states, so they neither move nor get
+    deleted-and-reinserted. Whatever is left over falls back to a content-only
+    (``diff``-style) match; genuinely new nodes get a fresh, collision-free id.
+    """
+    psig, pch, pnodes, psize = _subtree_sigs(prev)
+    nsig, nch, nnodes, _ = _subtree_sigs(gnew)
+
+    new_by_sig = defaultdict(list)
+    for nid in nnodes:
+        new_by_sig[nsig[nid]].append(nid)
+
+    new_to_prev, used_prev, matched_new = {}, set(), set()
+
+    def match_tree(pid, nid):
+        new_to_prev[nid] = pid
+        used_prev.add(pid)
+        matched_new.add(nid)
+        pc = sorted(pch[pid], key=lambda rc: (rc[0] or "", psig[rc[1]]))
+        nc = sorted(nch[nid], key=lambda rc: (rc[0] or "", nsig[rc[1]]))
+        for (_pr, pcid), (_nr, ncid) in zip(pc, nc):
+            match_tree(pcid, ncid)
+
+    # anchor largest identical subtrees first
+    for pid in sorted(pnodes, key=lambda i: -psize[i]):
+        if pid in used_prev:
+            continue
+        cand = next((c for c in new_by_sig.get(psig[pid], []) if c not in matched_new), None)
+        if cand is not None:
+            match_tree(pid, cand)
+
+    # content-only fallback for whatever's left (a changed node that still has a
+    # same-content counterpart, e.g. a coefficient that changed value)
+    cprev, cnew = wl_colors(prev, rounds=0), wl_colors(gnew, rounds=0)
+    rem_by_content = defaultdict(list)
+    for p in pnodes:
+        if p not in used_prev:
+            rem_by_content[cprev[p]].append(p)
+    for nid in nnodes:
+        if nid in matched_new:
+            continue
+        bucket = rem_by_content.get(cnew[nid])
+        if bucket:
+            new_to_prev[nid] = bucket.pop(0)
+            matched_new.add(nid)
+
+    # build the id map; new nodes keep their own id, deduped against taken ones
+    final, taken, k = {}, set(new_to_prev.values()), 0
+    for nid in nnodes:
+        if nid in new_to_prev:
+            final[nid] = new_to_prev[nid]
+        else:
+            tgt = nid
+            while tgt in taken:
+                k += 1
+                tgt = f"_r{k}_{nid}"
+            final[nid] = tgt
+            taken.add(tgt)
+
+    g = gnew.model_copy(deep=True)
+    for n in g.nodes:
+        n.id = final[n.id]
+    for e in g.edges:
+        e.from_, e.to = final[e.from_], final[e.to]
+    return g
+
+
+def build(trajectory: ProofTrajectory, domain: str, title: str = "", *,
+          start_operation: str = "Start",
+          start_justification: str = "the starting expression") -> dict:
+    """Render a ProofCompletionExpert ``ProofTrajectory`` into animation data.
+
+    The trajectory is the expert's output: ``start_latex`` plus ordered
+    ``DerivationStep``s (each a complete ``expr_latex`` reached by one
+    ``operation``). The animation chain is the start state followed by each step's
+    expression; we parse each, rebase onto the previous so persisting parts keep
+    stable ids, and emit id-annotated LaTeX for the FLIP engine. ``start_operation``
+    / ``start_justification`` caption the initial state (step 0).
+    """
+    # (operation, justification, latex) for every state, starting from the start.
+    chain: list[tuple[str, str, str]] = []
+    if trajectory.start_latex:
+        chain.append((start_operation, start_justification, trajectory.start_latex))
+    for s in trajectory.steps:
+        chain.append((s.operation, s.justification, s.expr_latex))
+    if not chain:
+        raise ValueError("trajectory has no states (need start_latex or steps)")
+
+    svc = SemanticGraphService()
+    working = None
+    out = []
+    for i, (operation, justification, ltx) in enumerate(chain):
+        g = svc.latex_to_graph(ltx, domain=domain)
+        if g is None:
+            raise ValueError(f"could not parse state {i}: {ltx!r}")
+        # rebase: keep g's authored structure, reuse stable ids for persisting parts
+        working = g if working is None else _rebase(working, g)
+        out.append({
+            "index": i,
+            "operation": operation,
+            "justification": justification,
+            "input_latex": ltx,                         # what was authored
+            "latex": to_latex(working, with_ids=True),  # annotated, stable ids
+            "plain": to_latex(working),                 # for labels/fallback
+        })
+    return {"title": title, "domain": domain, "steps": out}

--- a/backend/experts/handlers/proof_animation/handler.py
+++ b/backend/experts/handlers/proof_animation/handler.py
@@ -50,18 +50,61 @@ class DeriveProofRequest(BaseModel):
     # A human-readable name for the derivation (e.g. the proof title). Used as
     # the animation title; falls back to the LM/goal/"Derivation".
     title: Optional[str] = None
+    # Lesson/scene/proof context (same shape the enrichment endpoint receives) —
+    # threaded to the expert's `lesson_context` so it derives in context.
+    context: Optional[dict] = None
     # The proof's `given` step when available — skips start inference.
     start_latex: Optional[str] = None
     intent: Optional[str] = None
 
 
+def _format_lesson_context(ctx: Optional[dict]) -> str:
+    """Flatten the lesson/scene/proof context dict into the expert's
+    ``lesson_context`` string (same fields the enrichment endpoint sends)."""
+    if not ctx:
+        return ""
+    fields = [
+        ("lessonTitle", "Lesson"),
+        ("lessonDescription", None),
+        ("sceneTitle", "Scene"),
+        ("sceneDescription", None),
+        ("proofTitle", "Proof"),
+        ("proofGoal", "Goal"),
+        ("proofTechnique", "Technique"),
+    ]
+    lines = []
+    for key, label in fields:
+        val = ctx.get(key)
+        if not isinstance(val, str) or not val.strip():
+            continue
+        val = val.strip()
+        lines.append(f"{label}: {val}" if label else val)
+    return "\n".join(lines)
+
+
+# GraphTransition.intent is capped at 400 chars; keep the givens clause well
+# under that so the assembled intent always validates (some scenes carry many
+# givens). Real proofs have a handful; this just bounds pathological cases.
+_GIVENS_CLAUSE_MAX = 240
+_INTENT_MAX = 400
+# Retries when the (stochastic) expert returns an empty trajectory for an
+# otherwise-derivable pair. Total attempts, not extra retries.
+_DERIVE_ATTEMPTS = 2
+
+
 def _givens_clause(req: DeriveProofRequest) -> str:
-    """A short 'given …' clause from the goal + given expressions (may be empty)."""
+    """A short 'given …' clause from the goal + given expressions (may be empty).
+
+    Bounded to `_GIVENS_CLAUSE_MAX` chars so the assembled intent stays valid.
+    """
     parts: list[str] = []
     if req.goal:
         parts.append(req.goal.strip())
     parts.extend(g.math.strip() for g in req.givens if g.math.strip())
-    return "; ".join(p for p in parts if p)
+    clause = "; ".join(p for p in parts if p)
+    if len(clause) > _GIVENS_CLAUSE_MAX:
+        clause = clause[:_GIVENS_CLAUSE_MAX].rstrip(" ;,") + "…"
+    return clause
 
 
 @register_handler("proof_animation", request_model=DeriveProofRequest)
@@ -87,6 +130,8 @@ def derive_proof_animation(req: DeriveProofRequest) -> dict:
     intent = req.intent or (
         f"Derive {req.target_latex}" + (f" given {givens}" if givens else "")
     )
+    if len(intent) > _INTENT_MAX:        # GraphTransition.intent hard limit
+        intent = intent[:_INTENT_MAX].rstrip()
 
     # --- call: run the expert through the canonical invoke boundary -------------
     svc = SemanticGraphService()
@@ -97,21 +142,30 @@ def derive_proof_animation(req: DeriveProofRequest) -> dict:
         raise ValueError(f"could not parse {which} expression")
 
     payload = {"start": start_g, "target": target_g, "domain": domain, "intent": intent}
-    result = invoke(
-        "proof_completion",
-        build_context_id(scene="adhoc", semantic_graph=True),
-        payload,
-        instruction=intent,
-    )
-    traj = result.single()
-    if not traj.steps:
-        raise ValueError("the expert returned no derivation steps")
+    context_id = build_context_id(scene="adhoc", semantic_graph=True)
+    lesson_context = _format_lesson_context(req.context)
+
+    # The LM samples at temperature, so a derivable pair can occasionally come
+    # back empty — retry a couple of times before giving up. (A genuinely
+    # underivable pair, e.g. start == target, just costs the extra attempt.)
+    traj = None
+    for _attempt in range(_DERIVE_ATTEMPTS):
+        traj = invoke(
+            "proof_completion", context_id, payload,
+            instruction=intent, lesson_context=lesson_context,
+        ).single()
+        if traj.steps:
+            break
+    if not traj or not traj.steps:
+        raise ValueError(
+            f"No derivation found — couldn't get from ${start}$ to ${req.target_latex}$.")
 
     # --- post: render the trajectory into FLIP animation data -------------------
     # Prefer a human-readable title (proof title) over the raw goal expression.
     title = (req.title or lm_title or req.goal or "Derivation").strip()
     start_operation = given_label or f"Given ${start}$"
-    start_justification = start_note or req.goal or "the starting expression"
+    # A short caption for step 0 — never the goal formula (it renders as raw $…$).
+    start_justification = start_note or "the starting expression"
     return build(traj, domain, title,
                  start_operation=start_operation,
                  start_justification=start_justification)

--- a/backend/experts/handlers/proof_animation/handler.py
+++ b/backend/experts/handlers/proof_animation/handler.py
@@ -124,7 +124,7 @@ def derive_proof_animation(req: DeriveProofRequest) -> dict:
         start, _lm_target, lm_domain, lm_title, given_label, start_note = \
             endpoints_from_prompt(prompt)
         if not start:
-            raise ValueError("could not infer a starting expression for this derivation")
+            return {"error": "Couldn't infer a starting expression for this derivation."}
 
     domain = (req.domain or lm_domain or "algebra").strip()
     intent = req.intent or (
@@ -135,11 +135,14 @@ def derive_proof_animation(req: DeriveProofRequest) -> dict:
 
     # --- call: run the expert through the canonical invoke boundary -------------
     svc = SemanticGraphService()
-    start_g = svc.latex_to_graph(start, domain=domain)
-    target_g = svc.latex_to_graph(req.target_latex, domain=domain)
+    try:
+        start_g = svc.latex_to_graph(start, domain=domain)
+        target_g = svc.latex_to_graph(req.target_latex, domain=domain)
+    except Exception:
+        start_g = target_g = None
     if start_g is None or target_g is None:
         which = "start" if start_g is None else "target"
-        raise ValueError(f"could not parse {which} expression")
+        return {"error": f"Couldn't parse the {which} expression."}
 
     payload = {"start": start_g, "target": target_g, "domain": domain, "intent": intent}
     context_id = build_context_id(scene="adhoc", semantic_graph=True)
@@ -157,8 +160,7 @@ def derive_proof_animation(req: DeriveProofRequest) -> dict:
         if traj.steps:
             break
     if not traj or not traj.steps:
-        raise ValueError(
-            f"No derivation found — couldn't get from ${start}$ to ${req.target_latex}$.")
+        return {"error": f"No derivation found — couldn't get from ${start}$ to ${req.target_latex}$."}
 
     # --- post: render the trajectory into FLIP animation data -------------------
     # Prefer a human-readable title (proof title) over the raw goal expression.

--- a/backend/experts/handlers/proof_animation/handler.py
+++ b/backend/experts/handlers/proof_animation/handler.py
@@ -1,0 +1,117 @@
+"""``proof_animation`` handler — derive a docked proof animation on the fly.
+
+Wraps the ``proof_completion`` expert with the pre/post-processing the live app
+needs (see ``../README.md``):
+
+* **pre** — the client sends the clicked node's expression as ``target_latex``
+  plus the proof's givens/goal; the START is either supplied (a proof's
+  ``given`` step) or inferred from a prompt via :func:`endpoints_from_prompt`.
+* **call** — run ``proof_completion`` through ``service.invoke`` (never by
+  instantiating the expert directly).
+* **post** — render the returned ``ProofTrajectory`` into FLIP animation data
+  via :func:`build`.
+
+Exposed at ``POST /api/expert/proof_animation``. Requires DSPy configured
+(handled by the endpoint's ``_ensure_experts``).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from backend.experts.context_id import build as build_context_id
+from backend.experts.registry import register_handler
+from backend.experts.service import invoke
+from backend.semantic_graph.service import SemanticGraphService
+
+from .animation import build
+from .prompt_endpoints import endpoints_from_prompt
+
+
+class Given(BaseModel):
+    """One proof given — its LaTeX plus an optional human label."""
+
+    model_config = ConfigDict(extra="ignore")
+    math: str
+    label: Optional[str] = None
+
+
+class DeriveProofRequest(BaseModel):
+    """Request for ``POST /api/expert/proof_animation``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    target_latex: str = Field(min_length=1)
+    domain: Optional[str] = None
+    givens: list[Given] = Field(default_factory=list)
+    goal: Optional[str] = None
+    # A human-readable name for the derivation (e.g. the proof title). Used as
+    # the animation title; falls back to the LM/goal/"Derivation".
+    title: Optional[str] = None
+    # The proof's `given` step when available — skips start inference.
+    start_latex: Optional[str] = None
+    intent: Optional[str] = None
+
+
+def _givens_clause(req: DeriveProofRequest) -> str:
+    """A short 'given …' clause from the goal + given expressions (may be empty)."""
+    parts: list[str] = []
+    if req.goal:
+        parts.append(req.goal.strip())
+    parts.extend(g.math.strip() for g in req.givens if g.math.strip())
+    return "; ".join(p for p in parts if p)
+
+
+@register_handler("proof_animation", request_model=DeriveProofRequest)
+def derive_proof_animation(req: DeriveProofRequest) -> dict:
+    """Infer the start (if needed), run ``proof_completion``, render animation data."""
+    givens = _givens_clause(req)
+
+    # --- pre: resolve the START (and display captions) --------------------------
+    given_label = ""
+    start_note = ""
+    lm_domain = lm_title = ""
+    start = (req.start_latex or "").strip()
+    if not start:
+        prompt = f"Derive this expression: {req.target_latex}"
+        if givens:
+            prompt += f" given {givens}"
+        start, _lm_target, lm_domain, lm_title, given_label, start_note = \
+            endpoints_from_prompt(prompt)
+        if not start:
+            raise ValueError("could not infer a starting expression for this derivation")
+
+    domain = (req.domain or lm_domain or "algebra").strip()
+    intent = req.intent or (
+        f"Derive {req.target_latex}" + (f" given {givens}" if givens else "")
+    )
+
+    # --- call: run the expert through the canonical invoke boundary -------------
+    svc = SemanticGraphService()
+    start_g = svc.latex_to_graph(start, domain=domain)
+    target_g = svc.latex_to_graph(req.target_latex, domain=domain)
+    if start_g is None or target_g is None:
+        which = "start" if start_g is None else "target"
+        raise ValueError(f"could not parse {which} expression")
+
+    payload = {"start": start_g, "target": target_g, "domain": domain, "intent": intent}
+    result = invoke(
+        "proof_completion",
+        build_context_id(scene="adhoc", semantic_graph=True),
+        payload,
+        instruction=intent,
+    )
+    traj = result.single()
+    if not traj.steps:
+        raise ValueError("the expert returned no derivation steps")
+
+    # --- post: render the trajectory into FLIP animation data -------------------
+    # Prefer a human-readable title (proof title) over the raw goal expression.
+    title = (req.title or lm_title or req.goal or "Derivation").strip()
+    start_operation = given_label or f"Given ${start}$"
+    start_justification = start_note or req.goal or "the starting expression"
+    return build(traj, domain, title,
+                 start_operation=start_operation,
+                 start_justification=start_justification)

--- a/backend/experts/handlers/proof_animation/prompt_endpoints.py
+++ b/backend/experts/handlers/proof_animation/prompt_endpoints.py
@@ -1,0 +1,43 @@
+"""Prompt → derivation endpoints (reusable DSPy predict).
+
+Names the canonical START and TARGET expressions a short request asks to derive.
+Used by the proof-animation handler (to infer a START when the client doesn't
+supply one) and by the offline ``scripts/proof_animation/derive.py`` CLI.
+
+Requires DSPy to be configured first (``init_experts()`` / ``configure_dspy()``).
+"""
+
+from __future__ import annotations
+
+import dspy
+
+
+class ProofPromptSig(dspy.Signature):
+    """Name the exact start and target expressions a short request asks to derive.
+
+    Given a brief topic/request (e.g. "derive Lorentz time dilation"), output the
+    canonical STARTING expression and the canonical TARGET (result) expression of
+    that derivation, both as plain LaTeX, plus a math domain and a short title.
+    Both expressions must be complete, valid, parseable LaTeX — the actual
+    endpoints a textbook would prove between (not the intermediate steps).
+    """
+
+    prompt: str = dspy.InputField(desc="the request, e.g. 'derive Lorentz time dilation'")
+    start_latex: str = dspy.OutputField(desc="canonical starting expression, as LaTeX")
+    target_latex: str = dspy.OutputField(desc="canonical target/result expression, as LaTeX")
+    domain: str = dspy.OutputField(desc="math domain: algebra, calculus, etc.")
+    title: str = dspy.OutputField(desc="short display title for the derivation")
+    given_label: str = dspy.OutputField(
+        desc="a short 'Given …' label NAMING the starting expression, e.g. "
+             "'Given the quadratic equation', 'Given the energy–momentum relation'")
+    start_note: str = dspy.OutputField(
+        desc="one short line on the goal / what to do (e.g. 'solve for $x$'); "
+             "may use inline $…$ LaTeX")
+
+
+def endpoints_from_prompt(prompt: str) -> tuple[str, str, str, str, str, str]:
+    """LM-propose (start, target, domain, title, given_label, start_note) for a request."""
+    ep = dspy.Predict(ProofPromptSig)(prompt=prompt)
+    return (ep.start_latex.strip(), ep.target_latex.strip(),
+            (ep.domain or "").strip(), (ep.title or "").strip(),
+            (ep.given_label or "").strip(), (ep.start_note or "").strip())

--- a/backend/experts/registry.py
+++ b/backend/experts/registry.py
@@ -5,14 +5,20 @@ Everything extensible is a plain ``dict`` looked up by a string key — there is
 framework. Experts and metrics *self-register* via the decorators below, and
 ``discover_experts()`` imports the modules so registration happens on load.
 
-Three registries: ``EXPERT_REGISTRY`` (name → :class:`ExpertSpec`),
-``CONTEXT_MODELS`` (context_id terminal scope → default Pydantic model), and
-``METRIC_REGISTRY`` (name → DSPy metric). There is no output/handler registry —
-experts return typed ``Output`` objects directly and ``service.invoke`` wraps
-them in an :class:`~backend.experts.outputs.ExpertResult` (no dispatch layer).
+Four registries: ``EXPERT_REGISTRY`` (name → :class:`ExpertSpec`),
+``CONTEXT_MODELS`` (context_id terminal scope → default Pydantic model),
+``METRIC_REGISTRY`` (name → DSPy metric), and ``HANDLER_REGISTRY`` (name →
+:class:`HandlerSpec`). A *handler* wraps an expert call with custom
+pre/post-processing (parse a feature request, build the context payload, call
+``service.invoke``, post-process the outputs) behind the generic
+``POST /api/expert/{name}`` endpoint; experts with no handler are reached
+through the default ``invoke`` path. Experts still return typed ``Output``
+objects directly and ``service.invoke`` wraps them in an
+:class:`~backend.experts.outputs.ExpertResult`.
 
-Adding an expert = drop a self-registering module under ``modules/``. No
-core-loop edits, no config file.
+Adding an expert = drop a self-registering module under ``modules/``; adding a
+handler = drop a self-registering module under ``handlers/``. No core-loop
+edits, no config file.
 """
 
 from __future__ import annotations
@@ -41,12 +47,33 @@ class ExpertSpec:
     context_model: Optional[type] = None
 
 
+@dataclass(frozen=True)
+class HandlerSpec:
+    """A handler's registration record.
+
+    A handler is request→orchestration glue exposed at ``POST /api/expert/{name}``:
+    ``fn`` takes a validated ``request_model`` instance and returns a JSON-able
+    ``dict`` (it does the pre-processing, calls ``service.invoke`` for the actual
+    expert, and post-processes the outputs). ``requires_experts`` asks the
+    endpoint to ensure DSPy/experts are configured before the call (it almost
+    always does, since handlers run experts). Concurrency/abuse is handled by the
+    shared per-IP rate limiter at the endpoint, not here.
+    """
+
+    name: str
+    fn: Callable[[Any], dict]
+    request_model: type
+    requires_experts: bool = True
+
+
 # name -> ExpertSpec
 EXPERT_REGISTRY: dict[str, ExpertSpec] = {}
 # context_id terminal type -> default Pydantic context model
 CONTEXT_MODELS: dict[str, type] = {}
 # expert name -> DSPy metric callable
 METRIC_REGISTRY: dict[str, Callable[..., Any]] = {}
+# handler name -> HandlerSpec (custom pre/post wrapper around an expert call)
+HANDLER_REGISTRY: dict[str, HandlerSpec] = {}
 
 
 # --------------------------------------------------------------------------- #
@@ -75,6 +102,33 @@ def register_expert(
         cls.context_scope = context_scope  # type: ignore[attr-defined]
         cls.context_model = context_model  # type: ignore[attr-defined]
         return cls
+
+    return deco
+
+
+def register_handler(
+    name: str,
+    *,
+    request_model: type,
+    requires_experts: bool = True,
+) -> Callable[[Callable], Callable]:
+    """Decorator: register a function as a handler for ``POST /api/expert/{name}``.
+
+    The decorated ``fn(req)`` receives a validated ``request_model`` instance and
+    returns a JSON-able ``dict``. The handler name is independent of the expert
+    name(s) it calls — it decides which expert(s) to invoke.
+    """
+
+    def deco(fn: Callable) -> Callable:
+        if name in HANDLER_REGISTRY:
+            raise ValueError(f"handler {name!r} already registered")
+        HANDLER_REGISTRY[name] = HandlerSpec(
+            name=name,
+            fn=fn,
+            request_model=request_model,
+            requires_experts=requires_experts,
+        )
+        return fn
 
     return deco
 

--- a/backend/experts/registry.py
+++ b/backend/experts/registry.py
@@ -54,10 +54,13 @@ class HandlerSpec:
     A handler is request→orchestration glue exposed at ``POST /api/expert/{name}``:
     ``fn`` takes a validated ``request_model`` instance and returns a JSON-able
     ``dict`` (it does the pre-processing, calls ``service.invoke`` for the actual
-    expert, and post-processes the outputs). ``requires_experts`` asks the
-    endpoint to ensure DSPy/experts are configured before the call (it almost
-    always does, since handlers run experts). Concurrency/abuse is handled by the
+    expert, and post-processes the outputs). Concurrency/abuse is handled by the
     shared per-IP rate limiter at the endpoint, not here.
+
+    ``requires_experts`` is currently **informational**: the endpoint always
+    configures DSPy + discovers handlers/experts (discovery is what populates
+    this very registry, so it can't be skipped). The flag documents intent and is
+    reserved for a future split of discovery from LM configuration.
     """
 
     name: str

--- a/backend/experts/service.py
+++ b/backend/experts/service.py
@@ -18,6 +18,8 @@ between calls, and no ``Signature`` is constructed.
 
 from __future__ import annotations
 
+from pydantic import BaseModel, ConfigDict
+
 from .context_id import parse
 from .outputs import ExpertResult
 from .registry import EXPERT_REGISTRY, HANDLER_REGISTRY, resolve_context_model
@@ -25,6 +27,18 @@ from .registry import EXPERT_REGISTRY, HANDLER_REGISTRY, resolve_context_model
 
 class UnknownExpert(KeyError):
     """Raised by ``run`` when ``name`` is neither a handler nor a registered expert."""
+
+
+class _ExpertCall(BaseModel):
+    """Shape of a generic (non-handler) expert request body — validated so a
+    malformed body surfaces as a 422 (pydantic ValidationError) at the endpoint
+    rather than a 500 KeyError."""
+
+    model_config = ConfigDict(extra="ignore")
+    context_id: str
+    payload: dict
+    instruction: str = ""
+    lesson_context: str = ""
 
 
 def run(name: str, body: dict) -> dict:
@@ -48,12 +62,13 @@ def run(name: str, body: dict) -> dict:
         return spec.fn(req)
 
     if name in EXPERT_REGISTRY:
+        call = _ExpertCall.model_validate(body)   # ValidationError -> 422 (not KeyError/500)
         result = invoke(
             name,
-            body["context_id"],
-            body["payload"],
-            instruction=body.get("instruction", ""),
-            lesson_context=body.get("lesson_context", ""),
+            call.context_id,
+            call.payload,
+            instruction=call.instruction,
+            lesson_context=call.lesson_context,
         )
         return result.model_dump()
 

--- a/backend/experts/service.py
+++ b/backend/experts/service.py
@@ -20,7 +20,44 @@ from __future__ import annotations
 
 from .context_id import parse
 from .outputs import ExpertResult
-from .registry import EXPERT_REGISTRY, resolve_context_model
+from .registry import EXPERT_REGISTRY, HANDLER_REGISTRY, resolve_context_model
+
+
+class UnknownExpert(KeyError):
+    """Raised by ``run`` when ``name`` is neither a handler nor a registered expert."""
+
+
+def run(name: str, body: dict) -> dict:
+    """Turn one HTTP request body into an expert run, returning a JSON-able dict.
+
+    The single dispatch point behind ``POST /api/expert/{name}``:
+
+    * If ``name`` has a registered **handler**, validate ``body`` against the
+      handler's ``request_model`` and let the handler do its pre/post-processing
+      around ``invoke`` (it returns the dict verbatim).
+    * Otherwise treat ``name`` as a plain expert: ``body`` carries
+      ``context_id`` + ``payload`` (and optional ``instruction`` /
+      ``lesson_context``); ``invoke`` runs it and we serialize the
+      ``ExpertResult``.
+
+    Adding an expert or handler needs no new endpoint — it self-registers.
+    """
+    spec = HANDLER_REGISTRY.get(name)
+    if spec is not None:
+        req = spec.request_model.model_validate(body)
+        return spec.fn(req)
+
+    if name in EXPERT_REGISTRY:
+        result = invoke(
+            name,
+            body["context_id"],
+            body["payload"],
+            instruction=body.get("instruction", ""),
+            lesson_context=body.get("lesson_context", ""),
+        )
+        return result.model_dump()
+
+    raise UnknownExpert(name)
 
 
 def invoke(

--- a/backend/server.py
+++ b/backend/server.py
@@ -1719,24 +1719,26 @@ def create_app(initial_scene_path=None, debug=False,
         return Response(content=content, media_type=media_type,
                         headers={"Cache-Control": "no-cache, no-store, must-revalidate"})
 
+    # The FLIP animation engine's static assets — a fixed, known set. Serving
+    # only these (exact-match whitelist) makes path traversal impossible by
+    # construction (no user-controlled value ever reaches the filesystem path).
+    _PROOF_ANIM_ASSETS = {
+        "proof-animation.js": "application/javascript",
+        "proof-animation.css": "text/css",
+        "sg-proof.js": "application/javascript",
+        "dock-seq.js": "application/javascript",
+    }
+
     @fastapp.get("/proof-animation/{filename:path}")
     async def get_proof_animation_file(filename: str):
-        """Serve files from static/proof-animation/ (the FLIP animation engine).
-
-        Path traversal is confined by ``sanitize_path`` (resolve() +
-        is_relative_to), the same blessed helper every other static route uses.
-        """
-        path = sanitize_path(static_dir / "proof-animation", filename)
-        if not path or not path.is_file():
+        """Serve a known FLIP-engine asset from static/proof-animation/."""
+        media_type = _PROOF_ANIM_ASSETS.get(filename)
+        if media_type is None:
             return Response(status_code=404)
-        suffix = path.suffix
-        if suffix == '.js':
-            media_type = "application/javascript"
-        elif suffix == '.css':
-            media_type = "text/css"
-        else:
-            media_type = "application/octet-stream"
-        with open(path, 'rb') as f:
+        path = static_dir / "proof-animation" / filename
+        if not path.is_file():
+            return Response(status_code=404)
+        with open(path, "rb") as f:
             content = f.read()
         return Response(content=content, media_type=media_type,
                         headers={"Cache-Control": "no-cache, no-store, must-revalidate"})

--- a/backend/server.py
+++ b/backend/server.py
@@ -1719,20 +1719,24 @@ def create_app(initial_scene_path=None, debug=False,
         return Response(content=content, media_type=media_type,
                         headers={"Cache-Control": "no-cache, no-store, must-revalidate"})
 
-    @fastapp.get("/proof-animation/{filename}")
+    @fastapp.get("/proof-animation/{filename:path}")
     async def get_proof_animation_file(filename: str):
-        """Serve a .js/.css file from static/proof-animation/ (the FLIP engine).
+        """Serve files from static/proof-animation/ (the FLIP animation engine).
 
-        ``filename`` is constrained to a single flat ``<name>.js|.css`` segment —
-        no path separators, no ``..`` — so it can't escape the directory.
+        Path traversal is confined by ``sanitize_path`` (resolve() +
+        is_relative_to), the same blessed helper every other static route uses.
         """
-        if not re.fullmatch(r"[A-Za-z0-9_-]+\.(?:js|css)", filename or ""):
+        path = sanitize_path(static_dir / "proof-animation", filename)
+        if not path or not path.is_file():
             return Response(status_code=404)
-        path = static_dir / "proof-animation" / filename
-        if not path.is_file():
-            return Response(status_code=404)
-        media_type = "application/javascript" if path.suffix == ".js" else "text/css"
-        with open(path, "rb") as f:
+        suffix = path.suffix
+        if suffix == '.js':
+            media_type = "application/javascript"
+        elif suffix == '.css':
+            media_type = "text/css"
+        else:
+            media_type = "application/octet-stream"
+        with open(path, 'rb') as f:
             content = f.read()
         return Response(content=content, media_type=media_type,
                         headers={"Cache-Control": "no-cache, no-store, must-revalidate"})

--- a/backend/server.py
+++ b/backend/server.py
@@ -1512,17 +1512,23 @@ def create_app(initial_scene_path=None, debug=False,
         try:
             # The whole sync pipeline (validation + LM call + conversion) off-loop.
             result = await asyncio.to_thread(expert_service.run, name, body)
-            return JSONResponse(result)
         except ValidationError as e:
             print(f"   ⚠️  /api/expert/{name}: invalid request: {e.errors()}", flush=True)
             return JSONResponse({"error": "invalid request", "detail": e.errors()}, status_code=422)
-        except (ValueError, KeyError) as e:
-            print(f"   ⚠️  /api/expert/{name}: {e}", flush=True)
-            return JSONResponse({"error": str(e)}, status_code=400)
         except Exception as e:
+            # Never surface exception text to the client — log server-side, return
+            # a generic message.
             import traceback
-            print(f"   ❌ /api/expert/{name}: {e}\n{traceback.format_exc()}")
+            print(f"   ❌ /api/expert/{name}: {e}\n{traceback.format_exc()}", flush=True)
             return JSONResponse({"error": "internal error running expert"}, status_code=500)
+
+        # A handler reports an expected, user-facing failure as DATA — an
+        # ``{"error": <message>}`` dict with no ``steps`` — so the message is a
+        # controlled, handler-authored string, never an exception's str().
+        if isinstance(result, dict) and result.get("error") and "steps" not in result:
+            print(f"   ⚠️  /api/expert/{name}: {result['error']}", flush=True)
+            return JSONResponse({"error": result["error"]}, status_code=400)
+        return JSONResponse(result)
 
     class GraphEnrichRequest(BaseModel):
         graph: dict
@@ -1713,20 +1719,20 @@ def create_app(initial_scene_path=None, debug=False,
         return Response(content=content, media_type=media_type,
                         headers={"Cache-Control": "no-cache, no-store, must-revalidate"})
 
-    @fastapp.get("/proof-animation/{filename:path}")
+    @fastapp.get("/proof-animation/{filename}")
     async def get_proof_animation_file(filename: str):
-        """Serve files from static/proof-animation/ (the FLIP animation engine)."""
-        path = sanitize_path(static_dir / "proof-animation", filename)
-        if not path or not path.is_file():
+        """Serve a .js/.css file from static/proof-animation/ (the FLIP engine).
+
+        ``filename`` is constrained to a single flat ``<name>.js|.css`` segment —
+        no path separators, no ``..`` — so it can't escape the directory.
+        """
+        if not re.fullmatch(r"[A-Za-z0-9_-]+\.(?:js|css)", filename or ""):
             return Response(status_code=404)
-        suffix = path.suffix
-        if suffix == '.js':
-            media_type = "application/javascript"
-        elif suffix == '.css':
-            media_type = "text/css"
-        else:
-            media_type = "application/octet-stream"
-        with open(path, 'rb') as f:
+        path = static_dir / "proof-animation" / filename
+        if not path.is_file():
+            return Response(status_code=404)
+        media_type = "application/javascript" if path.suffix == ".js" else "text/css"
+        with open(path, "rb") as f:
             content = f.read()
         return Response(content=content, media_type=media_type,
                         headers={"Cache-Control": "no-cache, no-store, must-revalidate"})

--- a/backend/server.py
+++ b/backend/server.py
@@ -380,7 +380,34 @@ from backend.util import sanitize_path, limiter_from_env, rate_limit_dependency 
 # Gemini spend on a public, unauthenticated deployment; the app is otherwise open.
 _chat_rate_limit = rate_limit_dependency(limiter_from_env("ALGEBENCH_RATELIMIT_CHAT", 20, 60))
 _tts_rate_limit = rate_limit_dependency(limiter_from_env("ALGEBENCH_RATELIMIT_TTS", 20, 60))
-_enrich_rate_limit = rate_limit_dependency(limiter_from_env("ALGEBENCH_RATELIMIT_ENRICH", 60, 60))
+# One shared limiter for ALL agentic/LM work (graph enrichment + the generic
+# expert endpoint). The backend is shared by many clients, so this is per-IP,
+# never a global cap.
+_agentic_rate_limit = rate_limit_dependency(limiter_from_env("ALGEBENCH_RATELIMIT_AGENTIC", 60, 60))
+
+
+# --- Expert framework: lazy one-time DSPy config + registry discovery --------
+_experts_ready = False
+_experts_lock = threading.Lock()
+
+
+def _ensure_experts() -> None:
+    """Configure DSPy and discover experts/handlers exactly once (idempotent).
+
+    Lazy so a missing GEMINI key never breaks startup — the first
+    ``/api/expert`` request pays the one-time cost. Safe to call from a worker
+    thread; ``init_experts`` itself is import-cached, the lock just avoids a
+    redundant first-call race.
+    """
+    global _experts_ready
+    if _experts_ready:
+        return
+    with _experts_lock:
+        if _experts_ready:
+            return
+        from backend.experts import init_experts
+        init_experts()
+        _experts_ready = True
 
 
 def _safe_open_scene_path(source) -> Path:
@@ -1336,7 +1363,7 @@ def create_app(initial_scene_path=None, debug=False,
     _TOP_LEVEL_MODULES = {
         'state', 'expr', 'trust', 'coords', 'labels', 'follow-cam', 'camera',
         'sliders', 'overlay', 'context-browser', 'scene-loader', 'ui',
-        'json-browser', 'main', 'proof', 'graph-view',
+        'json-browser', 'main', 'proof', 'graph-view', 'expert-client',
     }
 
     @fastapp.get("/api/graph/themes")
@@ -1444,12 +1471,60 @@ def create_app(initial_scene_path=None, debug=False,
                 status_code=500,
             )
 
+    @fastapp.post("/api/expert/{name}")
+    async def run_expert(name: str, request: Request, _rl: None = Depends(_agentic_rate_limit)):
+        """Generic expert/handler entry point.
+
+        ``name`` selects a registered expert or a handler (a custom pre/post
+        wrapper around an expert call). Adding an expert or handler needs no new
+        route — they self-register and are reachable here by name. The shared
+        per-IP ``_agentic_rate_limit`` (above) is the only throttle.
+
+        Status codes: 404 unknown name, 422 bad request body, 400 derivation
+        error (unparseable expression / empty result), 500 otherwise.
+        """
+        from pydantic import ValidationError
+
+        from backend.experts import service as expert_service
+        from backend.experts.registry import EXPERT_REGISTRY, HANDLER_REGISTRY
+
+        try:
+            body = await request.json()
+        except Exception:
+            return JSONResponse({"error": "request body must be valid JSON"}, status_code=400)
+        if not isinstance(body, dict):
+            return JSONResponse({"error": "request body must be a JSON object"}, status_code=400)
+
+        try:
+            # One-time DSPy config + discovery (imports/configures — off the loop).
+            await asyncio.to_thread(_ensure_experts)
+        except Exception as e:
+            import traceback
+            print(f"   ❌ /api/expert/{name}: expert init failed: {e}\n{traceback.format_exc()}")
+            return JSONResponse({"error": "expert framework unavailable"}, status_code=503)
+
+        if name not in HANDLER_REGISTRY and name not in EXPERT_REGISTRY:
+            return JSONResponse({"error": f"unknown expert/handler: {name!r}"}, status_code=404)
+
+        try:
+            # The whole sync pipeline (validation + LM call + conversion) off-loop.
+            result = await asyncio.to_thread(expert_service.run, name, body)
+            return JSONResponse(result)
+        except ValidationError as e:
+            return JSONResponse({"error": "invalid request", "detail": e.errors()}, status_code=422)
+        except (ValueError, KeyError) as e:
+            return JSONResponse({"error": str(e)}, status_code=400)
+        except Exception as e:
+            import traceback
+            print(f"   ❌ /api/expert/{name}: {e}\n{traceback.format_exc()}")
+            return JSONResponse({"error": "internal error running expert"}, status_code=500)
+
     class GraphEnrichRequest(BaseModel):
         graph: dict
         context: dict | None = None
 
     @fastapp.post("/api/graph/enrich")
-    async def post_graph_enrich(req: GraphEnrichRequest, _rl: None = Depends(_enrich_rate_limit)):
+    async def post_graph_enrich(req: GraphEnrichRequest, _rl: None = Depends(_agentic_rate_limit)):
         """Enrich a semantic graph via Gemini (descriptions, emoji, color, corrections).
 
         Runtime in-memory cache keyed by ``sha256({graph, context})`` — the
@@ -1619,6 +1694,24 @@ def create_app(initial_scene_path=None, debug=False,
     async def get_graph_panel_file(filename: str):
         """Serve files from static/graph-panel/ subdirectory."""
         path = sanitize_path(static_dir / "graph-panel", filename)
+        if not path or not path.is_file():
+            return Response(status_code=404)
+        suffix = path.suffix
+        if suffix == '.js':
+            media_type = "application/javascript"
+        elif suffix == '.css':
+            media_type = "text/css"
+        else:
+            media_type = "application/octet-stream"
+        with open(path, 'rb') as f:
+            content = f.read()
+        return Response(content=content, media_type=media_type,
+                        headers={"Cache-Control": "no-cache, no-store, must-revalidate"})
+
+    @fastapp.get("/proof-animation/{filename:path}")
+    async def get_proof_animation_file(filename: str):
+        """Serve files from static/proof-animation/ (the FLIP animation engine)."""
+        path = sanitize_path(static_dir / "proof-animation", filename)
         if not path or not path.is_file():
             return Response(status_code=404)
         suffix = path.suffix

--- a/backend/server.py
+++ b/backend/server.py
@@ -1495,6 +1495,9 @@ def create_app(initial_scene_path=None, debug=False,
         if not isinstance(body, dict):
             return JSONResponse({"error": "request body must be a JSON object"}, status_code=400)
 
+        # One-line request log for observability.
+        print(f"   🧠 /api/expert/{name} {json.dumps(body, ensure_ascii=False)}", flush=True)
+
         try:
             # One-time DSPy config + discovery (imports/configures — off the loop).
             await asyncio.to_thread(_ensure_experts)
@@ -1511,8 +1514,10 @@ def create_app(initial_scene_path=None, debug=False,
             result = await asyncio.to_thread(expert_service.run, name, body)
             return JSONResponse(result)
         except ValidationError as e:
+            print(f"   ⚠️  /api/expert/{name}: invalid request: {e.errors()}", flush=True)
             return JSONResponse({"error": "invalid request", "detail": e.errors()}, status_code=422)
         except (ValueError, KeyError) as e:
+            print(f"   ⚠️  /api/expert/{name}: {e}", flush=True)
             return JSONResponse({"error": str(e)}, status_code=400)
         except Exception as e:
             import traceback

--- a/backend/server.py
+++ b/backend/server.py
@@ -1719,23 +1719,25 @@ def create_app(initial_scene_path=None, debug=False,
         return Response(content=content, media_type=media_type,
                         headers={"Cache-Control": "no-cache, no-store, must-revalidate"})
 
-    # The FLIP animation engine's static assets — a fixed, known set. Serving
-    # only these (exact-match whitelist) makes path traversal impossible by
-    # construction (no user-controlled value ever reaches the filesystem path).
+    # The FLIP animation engine's static assets — a fixed, known set. The request
+    # filename is only ever used to LOOK UP a constant (name, media_type); the
+    # filesystem path is built from the mapped constant ``name`` literal, so no
+    # user-controlled value reaches the path (no traversal possible).
     _PROOF_ANIM_ASSETS = {
-        "proof-animation.js": "application/javascript",
-        "proof-animation.css": "text/css",
-        "sg-proof.js": "application/javascript",
-        "dock-seq.js": "application/javascript",
+        "proof-animation.js": ("proof-animation.js", "application/javascript"),
+        "proof-animation.css": ("proof-animation.css", "text/css"),
+        "sg-proof.js": ("sg-proof.js", "application/javascript"),
+        "dock-seq.js": ("dock-seq.js", "application/javascript"),
     }
 
     @fastapp.get("/proof-animation/{filename:path}")
     async def get_proof_animation_file(filename: str):
         """Serve a known FLIP-engine asset from static/proof-animation/."""
-        media_type = _PROOF_ANIM_ASSETS.get(filename)
-        if media_type is None:
+        entry = _PROOF_ANIM_ASSETS.get(filename)
+        if entry is None:
             return Response(status_code=404)
-        path = static_dir / "proof-animation" / filename
+        name, media_type = entry                       # constants from the table
+        path = static_dir / "proof-animation" / name
         if not path.is_file():
             return Response(status_code=404)
         with open(path, "rb") as f:

--- a/backend/server.py
+++ b/backend/server.py
@@ -1495,15 +1495,19 @@ def create_app(initial_scene_path=None, debug=False,
         if not isinstance(body, dict):
             return JSONResponse({"error": "request body must be a JSON object"}, status_code=400)
 
-        # One-line request log for observability.
-        print(f"   🧠 /api/expert/{name} {json.dumps(body, ensure_ascii=False)}", flush=True)
+        # One-line request log — single line (newlines escaped) and length-capped
+        # so a large/arbitrary LaTeX body can't flood the logs.
+        _body_log = json.dumps(body, ensure_ascii=False).replace("\n", "\\n")
+        if len(_body_log) > 2000:
+            _body_log = _body_log[:2000] + f"…(+{len(_body_log) - 2000} chars)"
+        print(f"   🧠 /api/expert/{name} {_body_log}", flush=True)
 
         try:
             # One-time DSPy config + discovery (imports/configures — off the loop).
             await asyncio.to_thread(_ensure_experts)
         except Exception as e:
             import traceback
-            print(f"   ❌ /api/expert/{name}: expert init failed: {e}\n{traceback.format_exc()}")
+            print(f"   ❌ /api/expert/{name}: expert init failed: {e}\n{traceback.format_exc()}", flush=True)
             return JSONResponse({"error": "expert framework unavailable"}, status_code=503)
 
         if name not in HANDLER_REGISTRY and name not in EXPERT_REGISTRY:

--- a/scripts/proof_animation/build.py
+++ b/scripts/proof_animation/build.py
@@ -13,120 +13,17 @@ deriving a proof from a prompt is ``derive.py``.
 """
 from __future__ import annotations
 
-import hashlib
-from collections import defaultdict
-
 from pydantic import BaseModel, ConfigDict
 
-from backend.semantic_graph.service import SemanticGraphService
-from backend.semantic_graph.latex_renderer import to_latex
-from backend.experts.modules.proof_completion.graph_ops import wl_colors, _content
 from backend.experts.modules.proof_completion.outputs import ProofTrajectory
 
-
-def _children(graph):
-    """node id -> [(role, child_id)] (operands = incoming edges)."""
-    ch = defaultdict(list)
-    for e in graph.edges:
-        ch[e.to].append((e.role, e.from_))
-    return ch
-
-
-def _subtree_sigs(graph):
-    """Per-node DOWNWARD subtree signature: identical subtrees share a sig,
-    wherever they sit. (content + sorted child sigs.) Returns (sig, children, nodes, size)."""
-    nodes = {n.id: n for n in graph.nodes}
-    ch = _children(graph)
-    sig, size = {}, {}
-
-    def walk(nid):
-        if nid in sig:
-            return
-        for _r, c in ch[nid]:
-            walk(c)
-        kids = tuple(sorted((r or "", sig[c]) for r, c in ch[nid]))
-        # deterministic, collision-resistant digest (not Python's salted hash())
-        sig[nid] = hashlib.blake2b(repr((_content(nodes[nid]), kids)).encode(),
-                                   digest_size=16).hexdigest()
-        size[nid] = 1 + sum(size[c] for _r, c in ch[nid])
-
-    for nid in nodes:
-        walk(nid)
-    return sig, ch, nodes, size
-
-
-def _rebase(prev, gnew):
-    """Relabel gnew so persisting sub-expressions keep prev's ids, preserving
-    gnew's OWN structure (authored side order) and **minimizing change**.
-
-    GumTree-style top-down match: anchor the LARGEST identical subtrees first
-    (by downward subtree signature), pairing each prev node with an unmatched new
-    node of the same signature and recursively aligning their (structurally
-    identical) descendants. This keeps repeated/unchanged pieces — e.g. the ``2``
-    in ``c^2`` — bound to the same id across states, so they neither move nor get
-    deleted-and-reinserted. Whatever is left over falls back to a content-only
-    (``diff``-style) match; genuinely new nodes get a fresh, collision-free id.
-    """
-    psig, pch, pnodes, psize = _subtree_sigs(prev)
-    nsig, nch, nnodes, _ = _subtree_sigs(gnew)
-
-    new_by_sig = defaultdict(list)
-    for nid in nnodes:
-        new_by_sig[nsig[nid]].append(nid)
-
-    new_to_prev, used_prev, matched_new = {}, set(), set()
-
-    def match_tree(pid, nid):
-        new_to_prev[nid] = pid
-        used_prev.add(pid)
-        matched_new.add(nid)
-        pc = sorted(pch[pid], key=lambda rc: (rc[0] or "", psig[rc[1]]))
-        nc = sorted(nch[nid], key=lambda rc: (rc[0] or "", nsig[rc[1]]))
-        for (_pr, pcid), (_nr, ncid) in zip(pc, nc):
-            match_tree(pcid, ncid)
-
-    # anchor largest identical subtrees first
-    for pid in sorted(pnodes, key=lambda i: -psize[i]):
-        if pid in used_prev:
-            continue
-        cand = next((c for c in new_by_sig.get(psig[pid], []) if c not in matched_new), None)
-        if cand is not None:
-            match_tree(pid, cand)
-
-    # content-only fallback for whatever's left (a changed node that still has a
-    # same-content counterpart, e.g. a coefficient that changed value)
-    cprev, cnew = wl_colors(prev, rounds=0), wl_colors(gnew, rounds=0)
-    rem_by_content = defaultdict(list)
-    for p in pnodes:
-        if p not in used_prev:
-            rem_by_content[cprev[p]].append(p)
-    for nid in nnodes:
-        if nid in matched_new:
-            continue
-        bucket = rem_by_content.get(cnew[nid])
-        if bucket:
-            new_to_prev[nid] = bucket.pop(0)
-            matched_new.add(nid)
-
-    # build the id map; new nodes keep their own id, deduped against taken ones
-    final, taken, k = {}, set(new_to_prev.values()), 0
-    for nid in nnodes:
-        if nid in new_to_prev:
-            final[nid] = new_to_prev[nid]
-        else:
-            tgt = nid
-            while tgt in taken:
-                k += 1
-                tgt = f"_r{k}_{nid}"
-            final[nid] = tgt
-            taken.add(tgt)
-
-    g = gnew.model_copy(deep=True)
-    for n in g.nodes:
-        n.id = final[n.id]
-    for e in g.edges:
-        e.from_, e.to = final[e.from_], final[e.to]
-    return g
+# The conversion core now lives in the proof_animation handler package so the
+# live server can render animations too. Re-imported here (and kept available
+# under this module's name) so the offline tooling and the test suite keep
+# working unchanged.
+from backend.experts.handlers.proof_animation.animation import (  # noqa: F401
+    _children, _rebase, _subtree_sigs, build,
+)
 
 
 class ProofAnimation(BaseModel):

--- a/scripts/proof_animation/build.py
+++ b/scripts/proof_animation/build.py
@@ -46,47 +46,6 @@ class ProofAnimation(BaseModel):
     trajectory: ProofTrajectory
 
 
-def build(trajectory: ProofTrajectory, domain: str, title: str = "", *,
-          start_operation: str = "Start",
-          start_justification: str = "the starting expression") -> dict:
-    """Render a ProofCompletionExpert ``ProofTrajectory`` into animation data.
-
-    The trajectory is the expert's output: ``start_latex`` plus ordered
-    ``DerivationStep``s (each a complete ``expr_latex`` reached by one
-    ``operation``). The animation chain is the start state followed by each step's
-    expression; we parse each, rebase onto the previous so persisting parts keep
-    stable ids, and emit id-annotated LaTeX for the FLIP engine. ``start_operation``
-    / ``start_justification`` caption the initial state (step 0).
-    """
-    # (operation, justification, latex) for every state, starting from the start.
-    chain: list[tuple[str, str, str]] = []
-    if trajectory.start_latex:
-        chain.append((start_operation, start_justification, trajectory.start_latex))
-    for s in trajectory.steps:
-        chain.append((s.operation, s.justification, s.expr_latex))
-    if not chain:
-        raise ValueError("trajectory has no states (need start_latex or steps)")
-
-    svc = SemanticGraphService()
-    working = None
-    out = []
-    for i, (operation, justification, ltx) in enumerate(chain):
-        g = svc.latex_to_graph(ltx, domain=domain)
-        if g is None:
-            raise ValueError(f"could not parse state {i}: {ltx!r}")
-        # rebase: keep g's authored structure, reuse stable ids for persisting parts
-        working = g if working is None else _rebase(working, g)
-        out.append({
-            "index": i,
-            "operation": operation,
-            "justification": justification,
-            "input_latex": ltx,                         # what was authored
-            "latex": to_latex(working, with_ids=True),  # annotated, stable ids
-            "plain": to_latex(working),                 # for labels/fallback
-        })
-    return {"title": title, "domain": domain, "steps": out}
-
-
 def build_animation(anim: ProofAnimation) -> dict:
     """Build animation data from a ProofAnimation (carries the step-0 caption)."""
     return build(anim.trajectory, anim.domain, anim.title,

--- a/scripts/proof_animation/derive.py
+++ b/scripts/proof_animation/derive.py
@@ -28,42 +28,12 @@ from _pc_env import load_env_local
 
 load_env_local()
 
-import dspy  # noqa: E402
-
 from backend.experts import init_experts  # noqa: E402
+from backend.experts.handlers.proof_animation.prompt_endpoints import (  # noqa: E402
+    endpoints_from_prompt as _endpoints_from_prompt,
+)
 from proof_completion_derive import derive_trajectory  # noqa: E402  (top-level sibling)
 from proof_animation.build import ProofAnimation  # noqa: E402
-
-
-class _ProofPromptSig(dspy.Signature):
-    """Name the exact start and target expressions a short request asks to derive.
-
-    Given a brief topic/request (e.g. "derive Lorentz time dilation"), output the
-    canonical STARTING expression and the canonical TARGET (result) expression of
-    that derivation, both as plain LaTeX, plus a math domain and a short title.
-    Both expressions must be complete, valid, parseable LaTeX — the actual
-    endpoints a textbook would prove between (not the intermediate steps).
-    """
-
-    prompt: str = dspy.InputField(desc="the request, e.g. 'derive Lorentz time dilation'")
-    start_latex: str = dspy.OutputField(desc="canonical starting expression, as LaTeX")
-    target_latex: str = dspy.OutputField(desc="canonical target/result expression, as LaTeX")
-    domain: str = dspy.OutputField(desc="math domain: algebra, calculus, etc.")
-    title: str = dspy.OutputField(desc="short display title for the derivation")
-    given_label: str = dspy.OutputField(
-        desc="a short 'Given …' label NAMING the starting expression, e.g. "
-             "'Given the quadratic equation', 'Given the energy–momentum relation'")
-    start_note: str = dspy.OutputField(
-        desc="one short line on the goal / what to do (e.g. 'solve for $x$'); "
-             "may use inline $…$ LaTeX")
-
-
-def _endpoints_from_prompt(prompt: str) -> tuple[str, str, str, str, str, str]:
-    """LM-propose (start, target, domain, title, given_label, start_note) for a request."""
-    ep = dspy.Predict(_ProofPromptSig)(prompt=prompt)
-    return (ep.start_latex.strip(), ep.target_latex.strip(),
-            (ep.domain or "").strip(), (ep.title or "").strip(),
-            (ep.given_label or "").strip(), (ep.start_note or "").strip())
 
 
 def main() -> int:

--- a/static/expert-client.js
+++ b/static/expert-client.js
@@ -1,0 +1,45 @@
+// Generic client for the backend expert/handler endpoint.
+//
+//   POST /api/expert/{name}   body: JSON   ->   parsed JSON
+//
+// Mirrors the generic backend dispatcher: any registered expert or handler is
+// callable by name with no per-feature fetch code. Throws ExpertError (with
+// .status and .retryAfter) on a non-2xx response.
+
+export class ExpertError extends Error {
+    constructor(message, { status = 0, retryAfter = null, detail = null } = {}) {
+        super(message);
+        this.name = 'ExpertError';
+        this.status = status;
+        this.retryAfter = retryAfter;   // seconds, from a 429 Retry-After header
+        this.detail = detail;
+    }
+}
+
+export async function invokeExpert(name, body) {
+    let res;
+    try {
+        res = await fetch(`/api/expert/${encodeURIComponent(name)}`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(body || {}),
+        });
+    } catch (_e) {
+        throw new ExpertError('Could not reach the server.', { status: 0 });
+    }
+
+    let data = null;
+    try { data = await res.json(); } catch (_e) { /* tolerate non-JSON bodies */ }
+
+    if (!res.ok) {
+        if (res.status === 429) {
+            const retryAfter = Number(res.headers.get('Retry-After')) || null;
+            throw new ExpertError('Too many requests — please slow down and try again shortly.',
+                                  { status: 429, retryAfter });
+        }
+        const err = data && (data.error || data.detail);
+        const msg = (typeof err === 'string' && err) || `Request failed (${res.status}).`;
+        throw new ExpertError(msg, { status: res.status, detail: data && data.detail });
+    }
+    return data;
+}

--- a/static/expert-client.js
+++ b/static/expert-client.js
@@ -37,9 +37,15 @@ export async function invokeExpert(name, body) {
             throw new ExpertError('Too many requests — please slow down and try again shortly.',
                                   { status: 429, retryAfter });
         }
-        const err = data && (data.error || data.detail);
-        const msg = (typeof err === 'string' && err) || `Request failed (${res.status}).`;
-        throw new ExpertError(msg, { status: res.status, detail: data && data.detail });
+        const detail = data && data.detail;
+        let msg = (data && typeof data.error === 'string' && data.error) || `Request failed (${res.status}).`;
+        // For a 422 (validation), surface the first field error so it's debuggable.
+        if (res.status === 422 && Array.isArray(detail) && detail.length) {
+            const d = detail[0];
+            const loc = Array.isArray(d.loc) ? d.loc.filter(x => x !== 'body').join('.') : '';
+            msg = loc ? `${loc}: ${d.msg}` : (d.msg || msg);
+        }
+        throw new ExpertError(msg, { status: res.status, detail });
     }
     return data;
 }

--- a/static/graph-panel/graph-panel.css
+++ b/static/graph-panel/graph-panel.css
@@ -94,7 +94,8 @@
   top: auto;
   right: auto;
 }
-.graph-panel-info .graph-panel-ai-btn {
+.graph-panel-info .graph-panel-ai-btn,
+.graph-panel-info .graph-panel-derive-btn {
   opacity: 1;
   pointer-events: auto;
 }

--- a/static/graph-panel/sg-chart.js
+++ b/static/graph-panel/sg-chart.js
@@ -213,6 +213,51 @@ export class SgChartManager {
         this._updateUnpinnedPositions();
     }
 
+    /** Point this (per-step, persistent) manager at the step's current graph
+     *  object — it may be replaced across re-renders (e.g. by enrichment). */
+    setGraph(graph) {
+        if (!graph || graph === this.graph) return;
+        this.graph = graph;
+        this._buildNodeIndex();
+        try { this._scriptService = new SgChartScript(graph); } catch (_e) {}
+    }
+
+    /** The renderer recreates .d3-graph-card (and wipes our overlays) on every
+     *  render. Re-create overlays in the fresh card and re-attach this step's
+     *  open charts, so charts persist across navigation/re-renders. */
+    reattach() {
+        if (this._destroyed || !this._ready) return;
+        this._sliderPanel = null;
+        this._pinnedPanel = null;
+        this._legendPanel = null;
+        this._ensureOverlays();
+        const card = this.container.querySelector('.d3-graph-card') || this.container;
+        for (const entry of this.charts.values()) {
+            const dest = entry.pinned ? this._pinnedPanel : card;
+            if (dest && entry.box.parentNode !== dest) dest.appendChild(entry.box);
+            this._applyGridSize(entry);
+        }
+        this._updateSliders();
+        this._updateLegend();
+        this._updateUnpinnedPositions();
+        if (this._resizeObserver) {
+            try { this._resizeObserver.disconnect(); } catch (_e) {}
+            this._resizeObserver = null;
+        }
+        this._observeContainerResize();
+        // Re-parenting a canvas can blank it, and resize() on a not-yet-laid-out
+        // card is a no-op — so redraw AFTER layout settles (two frames to be safe).
+        const redraw = () => {
+            if (this._destroyed) return;
+            for (const entry of this.charts.values()) {
+                if (entry.chart) {
+                    try { entry.chart.resize(); entry.chart.update('none'); } catch (_e) {}
+                }
+            }
+        };
+        requestAnimationFrame(() => { redraw(); requestAnimationFrame(redraw); });
+    }
+
     /**
      * Connect to a D3SemanticGraphRenderer so the chart manager can poll
      * its _currentTransform on every animation frame.  This catches ALL

--- a/static/graph-panel/sg-chart.js
+++ b/static/graph-panel/sg-chart.js
@@ -319,9 +319,14 @@ export class SgChartManager {
         }
 
         if (!this._pinnedPanel) {
-            this._pinnedPanel = document.createElement('div');
-            this._pinnedPanel.className = 'sgc-pinned-panel';
-            card.appendChild(this._pinnedPanel);
+            // Adopt an existing dock panel (e.g. one the proof manager created) so
+            // pinned charts and pinned proof animations share one row, side by side.
+            this._pinnedPanel = card.querySelector('.sgc-pinned-panel');
+            if (!this._pinnedPanel) {
+                this._pinnedPanel = document.createElement('div');
+                this._pinnedPanel.className = 'sgc-pinned-panel';
+                card.appendChild(this._pinnedPanel);
+            }
         }
 
         if (!this._legendPanel) {

--- a/static/graph-panel/sg-chart.js
+++ b/static/graph-panel/sg-chart.js
@@ -10,6 +10,7 @@
 
 import { SgChartScript } from './sg-chart-script.js';
 import { compileExpr, evalExpr } from '/expr.js';
+import { nextDockSeq } from '/proof-animation/dock-seq.js';
 
 const CHART_JS_CDN = 'https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js';
 const NUM_POINTS = 200;
@@ -447,6 +448,7 @@ export class SgChartManager {
         box.className = 'sgc-chart-box';
         box.id = chartId;
         box.dataset.nodeId = nodeId;
+        box.dataset.dockOrder = String(nextDockSeq());   // stable shared dock order
 
         const header = document.createElement('div');
         header.className = 'sgc-chart-header';

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -20,7 +20,7 @@ import { state } from '/state.js';
 import { SemanticGraphPanel } from '/graph-panel/graph-panel.js';
 import { D3SemanticGraphRenderer, nodeLongLabel } from '/graph-panel/d3-semantic-graph.js';
 import { SgChartManager } from '/graph-panel/sg-chart.js';
-import { SgProofManager } from '/proof-animation/sg-proof.js';
+import { SgProofManager, clearDeriveCache } from '/proof-animation/sg-proof.js';
 import { makeAiAskButton, renderKaTeX } from '/labels.js';
 
 let _currentGraphPanel = null;
@@ -817,8 +817,8 @@ async function _renderWithD3(container, graph, step, key) {
 
     // Reuse the proof manager across re-renders (e.g. background enrichment) so
     // open derivation boxes — and in-flight derivations, which take many
-    // seconds — survive instead of being torn down. It's only destroyed when
-    // the graph view is cleared (see clearGraph).
+    // seconds — survive instead of being torn down. It is NOT destroyed by
+    // clearGraph; only a new lesson tears it down (see _resetGraphSession).
     if (!_currentProofManager || _currentProofManager._destroyed) {
         _currentProofManager = new SgProofManager(container, {
             katex: window.katex,
@@ -1045,28 +1045,34 @@ function _d3NodeElById(nodeId) {
 
 /** Strip KaTeX \htmlClass/\htmlData/\htmlId/\htmlStyle wrappers, keeping content.
  *  Proof-step ``math`` carries highlight annotations the LaTeX parser can't read. */
+const _HTML_MACROS = ['htmlClass', 'htmlData', 'htmlId', 'htmlStyle'];
+
 function _stripHtmlMacros(s) {
     if (!s) return s;
-    let out = String(s);
-    for (const m of ['htmlClass', 'htmlData', 'htmlId', 'htmlStyle']) {
-        const needle = '\\' + m + '{';
-        let idx;
-        while ((idx = out.indexOf(needle)) !== -1) {
-            // skip the first {…} (the class/data argument)
-            let i = idx + needle.length, depth = 1;
-            while (i < out.length && depth > 0) {
-                if (out[i] === '{') depth++; else if (out[i] === '}') depth--;
-                i++;
-            }
-            if (out[i] !== '{') { out = out.slice(0, idx) + out.slice(idx + 1); continue; }
-            const contentStart = i + 1;
-            let j = contentStart; depth = 1;
-            while (j < out.length && depth > 0) {
-                if (out[j] === '{') depth++; else if (out[j] === '}') depth--;
-                j++;
-            }
-            out = out.slice(0, idx) + out.slice(contentStart, j - 1) + out.slice(j);
+    const str = String(s);
+    // Return the index just past the '}' matching the '{' at k, or -1 if unbalanced.
+    const skipBalanced = (k) => {
+        let depth = 0;
+        for (; k < str.length; k++) {
+            if (str[k] === '{') depth++;
+            else if (str[k] === '}' && --depth === 0) return k + 1;
         }
+        return -1;
+    };
+    let out = '';
+    let i = 0;
+    while (i < str.length) {
+        const m = str[i] === '\\' && _HTML_MACROS.find(x => str.startsWith('\\' + x, i));
+        if (!m) { out += str[i++]; continue; }
+        let k = i + 1 + m.length;
+        while (k < str.length && /\s/.test(str[k])) k++;       // ws before the class/data arg
+        const arg1End = str[k] === '{' ? skipBalanced(k) : -1;
+        let c = arg1End;
+        if (c > 0) while (c < str.length && /\s/.test(str[c])) c++;   // ws before the content arg
+        const contentEnd = (c > 0 && str[c] === '{') ? skipBalanced(c) : -1;
+        if (contentEnd < 0) { out += str[i++]; continue; }     // malformed — leave intact, advance 1
+        out += _stripHtmlMacros(str.slice(c + 1, contentEnd - 1));   // recurse into the content
+        i = contentEnd;
     }
     return out;
 }
@@ -2028,6 +2034,7 @@ function _resetGraphSession() {
     _chartManagers.clear();
     _currentChartManager = null;
     if (_currentProofManager) { try { _currentProofManager.destroy(); } catch {} _currentProofManager = null; }
+    clearDeriveCache();   // derivation results are lesson-specific
 }
 
 // Monochrome unicode glyphs (LAST QUARTER MOON / BLACK SUN WITH RAYS).

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -29,6 +29,7 @@ let _activeStepForPanel = null;
 let _initDone = false;
 let _currentD3Renderer = null;
 let _currentChartManager = null;
+const _chartManagers = new Map();     // stepKey -> SgChartManager (per-step, persistent)
 let _currentProofManager = null;
 let _d3NodeAskBtn = null;
 let _d3NodeAskHideTimer = null;
@@ -719,10 +720,9 @@ function clearGraph() {
         try { _currentGraphPanel.destroy(); } catch {}
         _currentGraphPanel = null;
     }
-    if (_currentChartManager) {
-        try { _currentChartManager.destroy(); } catch {}
-        _currentChartManager = null;
-    }
+    // NOTE: chart managers are per-step and persistent — NOT destroyed here.
+    // Their charts re-attach to the card via reattach() on the next graph render
+    // (only the active step's manager is shown). Torn down on new-scene load.
     // NOTE: the proof manager is intentionally NOT destroyed here. Derivation
     // boxes persist for the session, scoped to the step they were derived on;
     // setCurrentStep() on the next graph render re-attaches the active step's
@@ -800,12 +800,20 @@ async function _renderWithD3(container, graph, step, key) {
 
     _d3ActiveGraph = graph;
 
-    if (_currentChartManager) {
-        try { _currentChartManager.destroy(); } catch {}
+    // Charts belong to their step too: reuse a per-step chart manager so open
+    // charts persist across navigation/re-renders (they re-attach to the fresh
+    // card via reattach() below). New managers are created lazily per step.
+    {
+        const ckey = stableStepKey(step);
+        let cm = _chartManagers.get(ckey);
+        if (!cm || cm._destroyed) {
+            cm = new SgChartManager(container, graph, { katex: window.katex });
+            _chartManagers.set(ckey, cm);
+        } else {
+            cm.setGraph(graph);
+        }
+        _currentChartManager = cm;
     }
-    _currentChartManager = new SgChartManager(container, graph, {
-        katex: window.katex,
-    });
 
     // Reuse the proof manager across re-renders (e.g. background enrichment) so
     // open derivation boxes — and in-flight derivations, which take many
@@ -885,6 +893,9 @@ async function _renderWithD3(container, graph, step, key) {
     await _currentD3Renderer.render(graph);
     _d3LastStepKey = stepKey;
     _currentSemanticKey = key;
+
+    // Re-attach this step's persisted charts to the freshly-recreated card.
+    if (_currentChartManager) { try { _currentChartManager.reattach(); } catch {} }
 
     // Derivation boxes belong to their step: show only the current step's boxes
     // (re-attaching to the freshly-recreated card), detach the rest. This also
@@ -1984,14 +1995,29 @@ function onGraphSelectionChange(e) {
     // loops when renderCurrentStepGraph preserves a prior selection.
 }
 
+let _lastLessonSpec = null;
+
 function onProofLoad() {
-    // NOTE: this fires on every proof-tree change (incl. navigation), so we do
-    // NOT tear down the proof manager here — derivation boxes persist for the
-    // session and survive navigation (the user's requirement).
+    // Charts and derivation boxes persist per-step across navigation (incl. proof
+    // switches). Only a *new lesson* invalidates them — step keys collide across
+    // lessons — so reset the per-step managers when the lesson actually changes.
+    if (state.lessonSpec !== _lastLessonSpec) {
+        _resetGraphSession();
+        _lastLessonSpec = state.lessonSpec;
+    }
     _d3StepStates.clear();
     _d3LastStepKey = null;
     rebuildProofTree();
     onStepChange();
+}
+
+// New lesson — tear down all per-step chart managers + derivation boxes (their
+// step context no longer applies).
+function _resetGraphSession() {
+    for (const cm of _chartManagers.values()) { try { cm.destroy(); } catch {} }
+    _chartManagers.clear();
+    _currentChartManager = null;
+    if (_currentProofManager) { try { _currentProofManager.destroy(); } catch {} _currentProofManager = null; }
 }
 
 // Monochrome unicode glyphs (LAST QUARTER MOON / BLACK SUN WITH RAYS).

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -20,6 +20,7 @@ import { state } from '/state.js';
 import { SemanticGraphPanel } from '/graph-panel/graph-panel.js';
 import { D3SemanticGraphRenderer, nodeLongLabel } from '/graph-panel/d3-semantic-graph.js';
 import { SgChartManager } from '/graph-panel/sg-chart.js';
+import { SgProofManager } from '/proof-animation/sg-proof.js';
 import { makeAiAskButton, renderKaTeX } from '/labels.js';
 
 let _currentGraphPanel = null;
@@ -28,6 +29,7 @@ let _activeStepForPanel = null;
 let _initDone = false;
 let _currentD3Renderer = null;
 let _currentChartManager = null;
+let _currentProofManager = null;
 let _d3NodeAskBtn = null;
 let _d3NodeAskHideTimer = null;
 let _d3HoveredNodeId = null;
@@ -721,6 +723,10 @@ function clearGraph() {
         try { _currentChartManager.destroy(); } catch {}
         _currentChartManager = null;
     }
+    if (_currentProofManager) {
+        try { _currentProofManager.destroy(); } catch {}
+        _currentProofManager = null;
+    }
     if (_currentD3Renderer) {
         try { _currentD3Renderer.destroy(); } catch {}
         _currentD3Renderer = null;
@@ -801,6 +807,13 @@ async function _renderWithD3(container, graph, step, key) {
         katex: window.katex,
     });
 
+    if (_currentProofManager) {
+        try { _currentProofManager.destroy(); } catch {}
+    }
+    _currentProofManager = new SgProofManager(container, {
+        katex: window.katex,
+    });
+
     // Reuse or create D3 renderer
     if (!_currentD3Renderer || _currentD3Renderer._destroyed) {
         _currentD3Renderer = new D3SemanticGraphRenderer(container, {
@@ -834,6 +847,7 @@ async function _renderWithD3(container, graph, step, key) {
             },
             onTransformChange: (t) => {
                 if (_currentChartManager) _currentChartManager.setTransform(t);
+                if (_currentProofManager) _currentProofManager.setTransform(t);
             },
             onChartClick: (nodeId, nodeData, btnEl) => {
                 if (!_currentChartManager) return;
@@ -848,6 +862,9 @@ async function _renderWithD3(container, graph, step, key) {
     // Connect chart manager to renderer for transform polling + resize observation
     if (_currentChartManager && _currentD3Renderer) {
         _currentChartManager.setRenderer(_currentD3Renderer);
+    }
+    if (_currentProofManager && _currentD3Renderer) {
+        _currentProofManager.setRenderer(_currentD3Renderer);
     }
 
     const stepKey = stableStepKey(step);
@@ -964,6 +981,108 @@ function _hideD3NodeAskBtn() {
     }, 220);
 }
 
+// Derivation ("∴") glyph — a small three-step icon for the Derive button.
+const _DERIVE_SVG =
+    '<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" '
+    + 'stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+    + '<path d="M3 3h7"/><path d="M3 8h10"/><path d="M3 13h6"/>'
+    + '<path d="M12.5 11l2 2-2 2" transform="translate(-1 -3.5)"/></svg>';
+
+/** Build the Derive icon button (matches the AI ask-button styling). */
+function _makeDeriveButton(onClick) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'ai-ask-btn graph-panel-derive-btn';
+    btn.title = 'Derive this expression (proof animation)';
+    btn.setAttribute('aria-label', 'Derive this expression');
+    btn.innerHTML = _DERIVE_SVG;
+    btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        onClick();
+    });
+    return btn;
+}
+
+/** Find a rendered node's SVG <g> element by id (d3 binds the datum to it). */
+function _d3NodeElById(nodeId) {
+    const layer = document.querySelector('#graph-viewport .d3sg-nodes');
+    if (!layer) return null;
+    for (const g of layer.querySelectorAll(':scope > g')) {
+        const d = g.__data__;
+        if (d && d.data && d.data.id === nodeId) return g;
+    }
+    return null;
+}
+
+/** Strip KaTeX \htmlClass/\htmlData/\htmlId/\htmlStyle wrappers, keeping content.
+ *  Proof-step ``math`` carries highlight annotations the LaTeX parser can't read. */
+function _stripHtmlMacros(s) {
+    if (!s) return s;
+    let out = String(s);
+    for (const m of ['htmlClass', 'htmlData', 'htmlId', 'htmlStyle']) {
+        const needle = '\\' + m + '{';
+        let idx;
+        while ((idx = out.indexOf(needle)) !== -1) {
+            // skip the first {…} (the class/data argument)
+            let i = idx + needle.length, depth = 1;
+            while (i < out.length && depth > 0) {
+                if (out[i] === '{') depth++; else if (out[i] === '}') depth--;
+                i++;
+            }
+            if (out[i] !== '{') { out = out.slice(0, idx) + out.slice(idx + 1); continue; }
+            const contentStart = i + 1;
+            let j = contentStart; depth = 1;
+            while (j < out.length && depth > 0) {
+                if (out[j] === '{') depth++; else if (out[j] === '}') depth--;
+                j++;
+            }
+            out = out.slice(0, idx) + out.slice(contentStart, j - 1) + out.slice(j);
+        }
+    }
+    return out;
+}
+
+/** The active proof in scope (graph-view proof tree), or null. */
+function _activeProof() {
+    const spec = state.proofSpec;
+    if (!spec || !spec.length) return null;
+    const entry = spec[state.proofActiveIndex] || spec[0];
+    return (entry && entry.proof) || null;
+}
+
+/** Assemble the DeriveProofRequest payload for a clicked node.
+ *  Target = the node's expression. Givens/goal/start come from the active proof:
+ *  goal + every ``type:"given"`` step's math; start = the first given when present
+ *  (else the backend infers it from a prompt). */
+function _buildDerivePayload(nodeId, fullNode, graph) {
+    const target = _stripHtmlMacros(nodeLongLabel(fullNode) || fullNode.subexpr || fullNode.label || '');
+    const payload = { target_latex: target };
+
+    const domain = graph && (graph.domain || (graph.meta && graph.meta.domain));
+    if (domain) payload.domain = domain;
+
+    const proof = _activeProof();
+    if (proof) {
+        if (proof.title) payload.title = _stripHtmlMacros(proof.title);
+        if (proof.goal) payload.goal = _stripHtmlMacros(proof.goal);
+        const givenSteps = (proof.steps || []).filter(s => s && s.type === 'given' && s.math);
+        const givens = givenSteps.map(s => ({
+            math: _stripHtmlMacros(s.math),
+            label: s.label || null,
+        })).filter(g => g.math);
+        if (givens.length) {
+            payload.givens = givens;
+            // Use a proof given as the START — but never one equal to the target
+            // (a definitional node is its own given, which would derive nothing).
+            // If every given equals the target, omit start so the LM infers one.
+            const norm = (s) => (s || '').replace(/\s+/g, '');
+            const startGiven = givens.find(g => norm(g.math) !== norm(target));
+            if (startGiven) payload.start_latex = startGiven.math;
+        }
+    }
+    return payload;
+}
+
 function _showD3InfoPanel(nodeId, nodeData, graph) {
     const infoHost = document.getElementById('graph-info-panel-host');
     if (!infoHost) return;
@@ -991,6 +1110,16 @@ function _showD3InfoPanel(nodeId, nodeData, graph) {
             },
         );
         header.appendChild(askBtn);
+
+        // Derive button — derives a proof animation for this node's expression
+        // and docks it near the node (like the charts).
+        const deriveBtn = _makeDeriveButton(() => {
+            if (!_currentProofManager) return;
+            const payload = _buildDerivePayload(nodeId, fullNode, graph);
+            const anchor = _d3NodeElById(nodeId) || deriveBtn;
+            _currentProofManager.openProof(nodeId, anchor, payload);
+        });
+        header.appendChild(deriveBtn);
     }
 
     // Populate the inline panel

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -723,10 +723,10 @@ function clearGraph() {
         try { _currentChartManager.destroy(); } catch {}
         _currentChartManager = null;
     }
-    if (_currentProofManager) {
-        try { _currentProofManager.destroy(); } catch {}
-        _currentProofManager = null;
-    }
+    // NOTE: the proof manager is intentionally NOT destroyed here. Derivation
+    // boxes persist for the session, scoped to the step they were derived on;
+    // setCurrentStep() on the next graph render re-attaches the active step's
+    // boxes. It's torn down only when a new scene is loaded.
     if (_currentD3Renderer) {
         try { _currentD3Renderer.destroy(); } catch {}
         _currentD3Renderer = null;
@@ -807,12 +807,15 @@ async function _renderWithD3(container, graph, step, key) {
         katex: window.katex,
     });
 
-    if (_currentProofManager) {
-        try { _currentProofManager.destroy(); } catch {}
+    // Reuse the proof manager across re-renders (e.g. background enrichment) so
+    // open derivation boxes — and in-flight derivations, which take many
+    // seconds — survive instead of being torn down. It's only destroyed when
+    // the graph view is cleared (see clearGraph).
+    if (!_currentProofManager || _currentProofManager._destroyed) {
+        _currentProofManager = new SgProofManager(container, {
+            katex: window.katex,
+        });
     }
-    _currentProofManager = new SgProofManager(container, {
-        katex: window.katex,
-    });
 
     // Reuse or create D3 renderer
     if (!_currentD3Renderer || _currentD3Renderer._destroyed) {
@@ -882,6 +885,11 @@ async function _renderWithD3(container, graph, step, key) {
     await _currentD3Renderer.render(graph);
     _d3LastStepKey = stepKey;
     _currentSemanticKey = key;
+
+    // Derivation boxes belong to their step: show only the current step's boxes
+    // (re-attaching to the freshly-recreated card), detach the rest. This also
+    // makes them survive re-renders within the same step.
+    if (_currentProofManager) _currentProofManager.setCurrentStep(stepKey);
 
     // Background enrichment (shared with Mermaid path)
     enrichGraphInBackground(graph, key, step);
@@ -1074,12 +1082,26 @@ function _buildDerivePayload(nodeId, fullNode, graph) {
             payload.givens = givens;
             // Use a proof given as the START — but never one equal to the target
             // (a definitional node is its own given, which would derive nothing).
+            // Compare loosely: ignore \text{}/\mathrm{} wrappers, braces, spacing
+            // and \le/\leq spelling, so e.g. \gamma_{steep} == \gamma_{\text{steep}}.
             // If every given equals the target, omit start so the LM infers one.
-            const norm = (s) => (s || '').replace(/\s+/g, '');
+            const norm = (s) => (s || '')
+                .replace(/\\(?:text|mathrm|mathbf|operatorname)\s*\{([^{}]*)\}/g, '$1')
+                .replace(/\\le(?![a-zA-Z])/g, '\\leq')
+                .replace(/\\ge(?![a-zA-Z])/g, '\\geq')
+                .replace(/[\s{}]/g, '');
             const startGiven = givens.find(g => norm(g.math) !== norm(target));
             if (startGiven) payload.start_latex = startGiven.math;
         }
     }
+
+    // Lesson/scene/proof context — the SAME shape we send to enrichment — so the
+    // expert derives with awareness of the surrounding lesson (passed through to
+    // the expert's lesson_context input).
+    const ctx = buildEnrichContext(
+        typeof currentProofStep === 'function' ? currentProofStep() : null);
+    if (ctx) payload.context = ctx;
+
     return payload;
 }
 
@@ -1963,6 +1985,9 @@ function onGraphSelectionChange(e) {
 }
 
 function onProofLoad() {
+    // NOTE: this fires on every proof-tree change (incl. navigation), so we do
+    // NOT tear down the proof manager here — derivation boxes persist for the
+    // session and survive navigation (the user's requirement).
     _d3StepStates.clear();
     _d3LastStepKey = null;
     rebuildProofTree();

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -902,6 +902,16 @@ async function _renderWithD3(container, graph, step, key) {
     // makes them survive re-renders within the same step.
     if (_currentProofManager) _currentProofManager.setCurrentStep(stepKey);
 
+    // Charts and proof boxes share the docked overlay panel but re-attach from
+    // two managers — keep their order stable (creation order) so it doesn't
+    // switch after navigation.
+    const dock = container.querySelector('.d3-graph-card .sgc-pinned-panel');
+    if (dock && dock.children.length > 1) {
+        [...dock.children]
+            .sort((a, b) => (+a.dataset.dockOrder || 0) - (+b.dataset.dockOrder || 0))
+            .forEach(c => dock.appendChild(c));
+    }
+
     // Background enrichment (shared with Mermaid path)
     enrichGraphInBackground(graph, key, step);
 }

--- a/static/index.html
+++ b/static/index.html
@@ -21,6 +21,7 @@
 <link rel="stylesheet" href="/graph-panel/graph-panel.css">
 <link rel="stylesheet" href="/graph-panel/d3-semantic-graph.css">
 <link rel="stylesheet" href="/graph-panel/sg-chart.css">
+<link rel="stylesheet" href="/proof-animation/proof-animation.css">
 </head>
 <body data-debug-mode="__DEBUG_MODE__">
 <div id="app">

--- a/static/proof-animation/dock-seq.js
+++ b/static/proof-animation/dock-seq.js
@@ -1,0 +1,6 @@
+// Shared monotonic creation order for docked overlays (charts + proof boxes).
+// Both managers stamp each box's dataset.dockOrder from this, so the shared
+// dock panel can be sorted into a stable, creation-order arrangement that
+// survives navigation/re-attach regardless of which manager re-attaches first.
+let _seq = 0;
+export const nextDockSeq = () => ++_seq;

--- a/static/proof-animation/proof-animation.css
+++ b/static/proof-animation/proof-animation.css
@@ -106,3 +106,166 @@
     --pa-muted: var(--muted-color, #9ca3af);
   }
 }
+
+/* ───────────────────────────────────────────────────────────────────────────
+   SgProofManager dock — a floating box on the semantic graph that hosts a
+   ProofAnimator (matches the .sgc-chart-box glass styling). The animator's own
+   .pa-root supplies its inner padding/border; the box wraps it with a header.
+   ─────────────────────────────────────────────────────────────────────────── */
+.sgp-proof-box {
+    background: rgba(10, 12, 26, 0.92);
+    border: 1px solid rgba(110, 124, 180, 0.35);
+    border-radius: 8px;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    overflow: hidden;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+    color: rgba(210, 218, 245, 0.92);
+}
+.sgp-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 8px 10px;
+    border-bottom: 1px solid rgba(110, 124, 180, 0.22);
+    user-select: none;
+    touch-action: none;
+}
+.sgp-title {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: rgba(220, 228, 252, 0.95);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.sgp-close {
+    flex: none;
+    background: transparent;
+    border: none;
+    color: rgba(190, 200, 230, 0.7);
+    font-size: 1.1rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 2px;
+}
+.sgp-close:hover { color: #fff; }
+
+.sgp-body { padding: 0; }
+/* The animator's .pa-root already brings border/radius; drop the doubled chrome
+   when it's mounted inside a dock body. */
+.sgp-body .pa-root {
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    padding: 14px;
+}
+
+.sgp-status,
+.sgp-error {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 18px 14px;
+    font-size: 0.78rem;
+    color: rgba(210, 218, 245, 0.9);
+}
+.sgp-error { flex-direction: column; align-items: stretch; gap: 10px; }
+.sgp-error-msg { color: rgba(246, 200, 200, 0.95); line-height: 1.35; }
+.sgp-retry {
+    align-self: flex-start;
+    background: rgba(99, 102, 241, 0.18);
+    border: 1px solid rgba(120, 130, 200, 0.5);
+    color: rgba(220, 226, 252, 0.95);
+    border-radius: 6px;
+    padding: 4px 12px;
+    font-size: 0.74rem;
+    cursor: pointer;
+}
+.sgp-retry:hover { background: rgba(99, 102, 241, 0.3); }
+
+/* Animated three-dot spinner, shared look with the enrichment pill. */
+.sgp-dots { display: inline-flex; align-items: center; gap: 3px; }
+.sgp-dots span {
+    width: 5px; height: 5px; border-radius: 50%;
+    background: rgba(166, 184, 240, 0.95);
+    animation: gei-dot-pulse 1.1s ease-in-out infinite;
+}
+.sgp-dots span:nth-child(2) { animation-delay: 0.18s; }
+.sgp-dots span:nth-child(3) { animation-delay: 0.36s; }
+
+/* "Deriving proof…" pill — lives in the shared .graph-enrich-indicator-stack
+   but with its own class so the enrichment step-visibility toggle never hides
+   it. Visual style mirrors .graph-enrich-indicator. */
+.sgp-derive-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px 6px 8px;
+    background: rgba(10, 12, 26, 0.78);
+    border: 1px solid rgba(110, 124, 180, 0.35);
+    border-radius: 999px;
+    font-size: 0.72rem;
+    color: rgba(210, 218, 245, 0.92);
+    letter-spacing: 0.02em;
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    user-select: none;
+    pointer-events: none;
+    animation: gei-fade-in 180ms ease-out;
+}
+.sgp-derive-indicator .gei-dots { display: inline-flex; align-items: center; gap: 3px; }
+.sgp-derive-indicator .gei-dots span {
+    width: 5px; height: 5px; border-radius: 50%;
+    background: rgba(166, 184, 240, 0.95);
+    animation: gei-dot-pulse 1.1s ease-in-out infinite;
+}
+.sgp-derive-indicator .gei-dots span:nth-child(2) { animation-delay: 0.18s; }
+.sgp-derive-indicator .gei-dots span:nth-child(3) { animation-delay: 0.36s; }
+
+/* Header dock button (📌) — mirrors the chart pin button. */
+.sgp-dock-btn {
+    flex: none;
+    background: transparent;
+    border: none;
+    color: rgba(190, 200, 230, 0.7);
+    font-size: 0.82rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 2px;
+    filter: grayscale(0.4) opacity(0.8);
+}
+.sgp-dock-btn:hover { filter: none; }
+.sgp-dock-btn.sgp-dock-active { filter: none; }
+
+/* Resize corner — drag to zoom the animation. */
+.sgp-resize-handle {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 18px;
+    height: 18px;
+    cursor: nwse-resize;
+    z-index: 5;
+    touch-action: none;
+}
+.sgp-resize-handle::after {
+    content: '';
+    position: absolute;
+    bottom: 4px;
+    right: 4px;
+    width: 8px;
+    height: 8px;
+    border-right: 2px solid rgba(110, 124, 180, 0.45);
+    border-bottom: 2px solid rgba(110, 124, 180, 0.45);
+}
+.sgp-resize-handle:hover::after { border-color: rgba(140, 160, 220, 0.75); }
+
+/* Docked state — flows in the shared .sgc-pinned-panel beside pinned charts. */
+.sgp-proof-box.sgp-pinned {
+    position: relative;
+    flex-shrink: 0;
+    pointer-events: all;
+}
+.sgc-pinned-panel .sgp-proof-box { pointer-events: all; }

--- a/static/proof-animation/proof-animation.css
+++ b/static/proof-animation/proof-animation.css
@@ -107,59 +107,39 @@
   }
 }
 
+
 /* ───────────────────────────────────────────────────────────────────────────
-   SgProofManager dock — a floating box on the semantic graph that hosts a
-   ProofAnimator (matches the .sgc-chart-box glass styling). The animator's own
-   .pa-root supplies its inner padding/border; the box wraps it with a header.
+   SgProofManager dock. The box REUSES the chart classes (.sgc-chart-box,
+   .sgc-chart-header, .sgc-btn, .sgc-resize-handle, .sgc-pinned) so borders and
+   buttons are identical to the charts; only these proof-specific rules remain:
+   the body lays out the animator, which is rendered at a fixed width and
+   `zoom`-scaled to fit the grid box.
    ─────────────────────────────────────────────────────────────────────────── */
 .sgp-proof-box {
-    background: rgba(10, 12, 26, 0.92);
-    border: 1px solid rgba(110, 124, 180, 0.35);
-    border-radius: 8px;
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
-    overflow: hidden;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+    display: flex;
+    flex-direction: column;
     color: rgba(210, 218, 245, 0.92);
 }
-.sgp-header {
+
+.sgp-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-    padding: 8px 10px;
-    border-bottom: 1px solid rgba(110, 124, 180, 0.22);
-    user-select: none;
-    touch-action: none;
+    justify-content: center;
 }
-.sgp-title {
-    font-size: 0.82rem;
-    font-weight: 600;
-    color: rgba(220, 228, 252, 0.95);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-.sgp-close {
-    flex: none;
-    background: transparent;
-    border: none;
-    color: rgba(190, 200, 230, 0.7);
-    font-size: 1.1rem;
-    line-height: 1;
-    cursor: pointer;
-    padding: 0 2px;
-}
-.sgp-close:hover { color: #fff; }
 
-.sgp-body { padding: 0; }
-/* The animator's .pa-root already brings border/radius; drop the doubled chrome
-   when it's mounted inside a dock body. */
-.sgp-body .pa-root {
+/* The animator renders at a fixed natural width; _fit() zooms it to the box. */
+.sgp-pa {
+    width: 360px;
+    flex: none;
+}
+.sgp-pa.pa-root {
     border: none;
     border-radius: 0;
     background: transparent;
-    padding: 14px;
+    padding: 12px 14px;
 }
 
 .sgp-status,
@@ -167,14 +147,14 @@
     display: flex;
     align-items: center;
     gap: 10px;
-    padding: 18px 14px;
+    padding: 16px 14px;
     font-size: 0.78rem;
     color: rgba(210, 218, 245, 0.9);
+    text-align: center;
 }
-.sgp-error { flex-direction: column; align-items: stretch; gap: 10px; }
+.sgp-error { flex-direction: column; }
 .sgp-error-msg { color: rgba(246, 200, 200, 0.95); line-height: 1.35; }
 .sgp-retry {
-    align-self: flex-start;
     background: rgba(99, 102, 241, 0.18);
     border: 1px solid rgba(120, 130, 200, 0.5);
     color: rgba(220, 226, 252, 0.95);
@@ -185,7 +165,7 @@
 }
 .sgp-retry:hover { background: rgba(99, 102, 241, 0.3); }
 
-/* Animated three-dot spinner, shared look with the enrichment pill. */
+/* Loading spinner dots — shared look with the enrichment pill. */
 .sgp-dots { display: inline-flex; align-items: center; gap: 3px; }
 .sgp-dots span {
     width: 5px; height: 5px; border-radius: 50%;
@@ -224,48 +204,12 @@
 .sgp-derive-indicator .gei-dots span:nth-child(2) { animation-delay: 0.18s; }
 .sgp-derive-indicator .gei-dots span:nth-child(3) { animation-delay: 0.36s; }
 
-/* Header dock button (📌) — mirrors the chart pin button. */
-.sgp-dock-btn {
-    flex: none;
-    background: transparent;
-    border: none;
-    color: rgba(190, 200, 230, 0.7);
-    font-size: 0.82rem;
-    line-height: 1;
-    cursor: pointer;
-    padding: 0 2px;
-    filter: grayscale(0.4) opacity(0.8);
+/* In the docked proof box, the step (nav) buttons stretch to fill the row. */
+.sgp-proof-box .pa-controls { gap: 6px; }
+.sgp-proof-box .pa-steps { flex: 1 1 auto; }
+.sgp-proof-box .pa-steps .pa-step {
+    flex: 1 1 0;
+    min-width: 0;
+    padding-left: 2px;
+    padding-right: 2px;
 }
-.sgp-dock-btn:hover { filter: none; }
-.sgp-dock-btn.sgp-dock-active { filter: none; }
-
-/* Resize corner — drag to zoom the animation. */
-.sgp-resize-handle {
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    width: 18px;
-    height: 18px;
-    cursor: nwse-resize;
-    z-index: 5;
-    touch-action: none;
-}
-.sgp-resize-handle::after {
-    content: '';
-    position: absolute;
-    bottom: 4px;
-    right: 4px;
-    width: 8px;
-    height: 8px;
-    border-right: 2px solid rgba(110, 124, 180, 0.45);
-    border-bottom: 2px solid rgba(110, 124, 180, 0.45);
-}
-.sgp-resize-handle:hover::after { border-color: rgba(140, 160, 220, 0.75); }
-
-/* Docked state — flows in the shared .sgc-pinned-panel beside pinned charts. */
-.sgp-proof-box.sgp-pinned {
-    position: relative;
-    flex-shrink: 0;
-    pointer-events: all;
-}
-.sgc-pinned-panel .sgp-proof-box { pointer-events: all; }

--- a/static/proof-animation/sg-proof.js
+++ b/static/proof-animation/sg-proof.js
@@ -9,6 +9,7 @@
 
 import { ProofAnimator } from '/proof-animation/proof-animation.js';
 import { invokeExpert } from '/expert-client.js';
+import { nextDockSeq } from '/proof-animation/dock-seq.js';
 
 // Session-persistent cache of derivation results, keyed by the request shape.
 // Survives navigation/re-renders so a derived node is never recomputed and its
@@ -199,6 +200,7 @@ export class SgProofManager {
         const card = this._card();
         const box = document.createElement('div');
         box.className = 'sgc-chart-box sgp-proof-box';
+        box.dataset.dockOrder = String(nextDockSeq());   // stable shared dock order
 
         const header = document.createElement('div');
         header.className = 'sgc-chart-header';

--- a/static/proof-animation/sg-proof.js
+++ b/static/proof-animation/sg-proof.js
@@ -11,11 +11,20 @@ import { ProofAnimator } from '/proof-animation/proof-animation.js';
 import { invokeExpert } from '/expert-client.js';
 import { nextDockSeq } from '/proof-animation/dock-seq.js';
 
-// Session-persistent cache of derivation results, keyed by the request shape.
-// Survives navigation/re-renders so a derived node is never recomputed and its
-// context is not lost.
+// Session-persistent cache of derivation results, keyed by the FULL request
+// shape (everything that affects the derivation — target/start/domain plus
+// goal/givens/intent/context), so different givens or lesson context never reuse
+// a wrong derivation. Cleared on a new lesson (see clearDeriveCache).
 const _DERIVE_CACHE = new Map();
-const _cacheKey = (p) => `${p.target_latex || ''}|${p.start_latex || ''}|${p.domain || ''}`;
+const _cacheKey = (p) => JSON.stringify({
+    t: p.target_latex || '', s: p.start_latex || '', d: p.domain || '',
+    g: p.goal || '', gv: p.givens || [], i: p.intent || '', c: p.context || null,
+});
+
+/** Drop all cached derivations (call on a new lesson — step keys/context change). */
+export function clearDeriveCache() {
+    _DERIVE_CACHE.clear();
+}
 
 const BOX_W = 360;            // natural render width of the animator (zoomed to fit the box)
 const GRID_COLS = 8;          // same grid as SgChartManager

--- a/static/proof-animation/sg-proof.js
+++ b/static/proof-animation/sg-proof.js
@@ -1,0 +1,428 @@
+// SgProofManager — docks on-the-fly proof animations on the semantic graph.
+//
+// Mirrors SgChartManager's docking model (anchor a floating box to a node,
+// track the renderer's pan/zoom transform so it stays put, resolve collisions
+// between concurrent boxes) but mounts a ProofAnimator instead of a Chart.js
+// canvas. Each Derive click opens one box keyed by nodeId; multiple boxes can
+// derive and play at once. Concurrency/abuse is capped server-side by the
+// shared per-IP rate limiter — this manager just renders state.
+
+import { ProofAnimator } from '/proof-animation/proof-animation.js';
+import { invokeExpert } from '/expert-client.js';
+
+const BOX_W = 360;   // fixed dock width (the animator measures against this)
+
+export class SgProofManager {
+    constructor(container, opts = {}) {
+        this.container = container;
+        this.katex = opts.katex || (typeof window !== 'undefined' && window.katex);
+        this.boxes = new Map();      // boxId -> entry
+        this._byNode = new Map();    // nodeId -> boxId (dedup / re-focus)
+        this._transform = { x: 0, y: 0, k: 1 };
+        this._renderer = null;
+        this._rafId = null;
+        this._resizeObserver = null;
+        this._destroyed = false;
+        this._seq = 0;
+        this._z = 30;                // proof boxes sit above charts (z 20)
+    }
+
+    // ── Renderer wiring (identical contract to SgChartManager) ───────────────
+    setTransform(t) {
+        this._transform = t || { x: 0, y: 0, k: 1 };
+        this._updatePositions();
+    }
+
+    setRenderer(renderer) {
+        this._renderer = renderer;
+        this._startTransformPolling();
+        this._observeResize();
+    }
+
+    _card() {
+        return this.container.querySelector('.d3-graph-card') || this.container;
+    }
+
+    _startTransformPolling() {
+        if (this._rafId) return;
+        const poll = () => {
+            this._rafId = requestAnimationFrame(poll);
+            if (!this._renderer) return;
+            const rt = this._renderer._currentTransform;
+            if (!rt) return;
+            const cur = this._transform;
+            if (rt.x !== cur.x || rt.y !== cur.y || rt.k !== cur.k) {
+                this._transform = { x: rt.x, y: rt.y, k: rt.k };
+                this._updatePositions();
+            }
+        };
+        this._rafId = requestAnimationFrame(poll);
+    }
+
+    _observeResize() {
+        if (this._resizeObserver) return;
+        this._resizeObserver = new ResizeObserver(() => this._updatePositions());
+        this._resizeObserver.observe(this._card());
+    }
+
+    // Reposition every unpinned box from its stored graph-space anchor, re-clamp
+    // to the card, and nudge apart any that overlap (mirrors chart docking).
+    _updatePositions() {
+        const rect = this._card().getBoundingClientRect();
+        const { x: tx, y: ty, k } = this._transform;
+        const placed = [];
+        for (const entry of this.boxes.values()) {
+            if (entry.pinned) continue;
+            const w = entry.box.offsetWidth;
+            const h = entry.box.offsetHeight;
+            let left = entry.graphX * k + tx;
+            let top = entry.graphY * k + ty;
+            left = Math.max(4, Math.min(left, rect.width - w - 4));
+            top = Math.max(4, Math.min(top, rect.height - h - 4));
+            for (let attempt = 0; attempt < 4; attempt++) {
+                let collision = false;
+                for (const p of placed) {
+                    if (left < p.right && left + w > p.left &&
+                        top < p.bottom && top + h > p.top) {
+                        collision = true;
+                        top = p.bottom + 4;
+                        if (top + h > rect.height - 4) { top = 4; left = p.right + 4; }
+                        break;
+                    }
+                }
+                if (!collision) break;
+                left = Math.max(4, Math.min(left, rect.width - w - 4));
+                top = Math.max(4, Math.min(top, rect.height - h - 4));
+            }
+            placed.push({ left, top, right: left + w, bottom: top + h });
+            entry.box.style.left = `${left}px`;
+            entry.box.style.top = `${top}px`;
+        }
+    }
+
+    // ── Public entry: derive + dock a proof animation for a node ─────────────
+    openProof(nodeId, anchorEl, payload) {
+        if (this._destroyed) return;
+
+        // Dedup: a node already has a box → re-focus (and retry if it errored).
+        const existingId = this._byNode.get(nodeId);
+        if (existingId && this.boxes.has(existingId)) {
+            const e = this.boxes.get(existingId);
+            e.box.style.zIndex = String(++this._z);
+            if (e.state === 'error') this._runDerivation(e, payload);
+            return;
+        }
+
+        const card = this._card();
+        const box = document.createElement('div');
+        box.className = 'sgp-proof-box';
+        box.style.width = `${BOX_W}px`;
+
+        const header = document.createElement('div');
+        header.className = 'sgp-header';
+        const titleEl = document.createElement('span');
+        titleEl.className = 'sgp-title';
+        titleEl.textContent = 'Derivation';
+        const dockBtn = document.createElement('button');
+        dockBtn.className = 'sgp-dock-btn';
+        dockBtn.type = 'button';
+        dockBtn.title = 'Dock to overlay';
+        dockBtn.setAttribute('aria-label', 'Dock');
+        dockBtn.innerHTML = '\u{1F4CC}';   // 📌
+        const closeBtn = document.createElement('button');
+        closeBtn.className = 'sgp-close';
+        closeBtn.type = 'button';
+        closeBtn.setAttribute('aria-label', 'Close');
+        closeBtn.innerHTML = '&times;';
+        header.append(titleEl, dockBtn, closeBtn);
+
+        const body = document.createElement('div');
+        body.className = 'sgp-body';
+
+        box.append(header, body);
+        card.appendChild(box);
+
+        // Anchor next to the node button, then store the graph-space coords so
+        // the box tracks pan/zoom (same math as SgChartManager.openChart).
+        const cardRect = card.getBoundingClientRect();
+        let left = 4, top = 4;
+        if (anchorEl) {
+            const r = anchorEl.getBoundingClientRect();
+            left = r.right - cardRect.left + 8;
+            top = r.top - cardRect.top;
+        }
+        const w = box.offsetWidth || BOX_W;
+        const h = box.offsetHeight || 120;
+        left = Math.max(4, Math.min(left, cardRect.width - w - 4));
+        top = Math.max(4, Math.min(top, cardRect.height - h - 4));
+        box.style.position = 'absolute';
+        box.style.left = `${left}px`;
+        box.style.top = `${top}px`;
+        box.style.zIndex = String(++this._z);
+
+        const { x: tx, y: ty, k } = this._transform;
+        const boxId = `proof_${++this._seq}`;
+        const entry = {
+            boxId, nodeId, box, body, titleEl, header, dockBtn,
+            graphX: (left - tx) / k,
+            graphY: (top - ty) / k,
+            pinned: false,
+            docked: false,
+            scale: 1,
+            state: 'loading',
+            animator: null,
+        };
+        this.boxes.set(boxId, entry);
+        this._byNode.set(nodeId, boxId);
+
+        closeBtn.addEventListener('click', () => this.closeBox(boxId));
+        dockBtn.addEventListener('click', () => this._toggleDock(boxId));
+        this._makeDraggable(entry, header);
+        this._addResizeHandle(entry);
+
+        this._runDerivation(entry, payload);
+        this._updatePositions();
+    }
+
+    async _runDerivation(entry, payload) {
+        entry.state = 'loading';
+        this._renderLoading(entry);
+        const pill = this._showPill();
+        try {
+            const data = await invokeExpert('proof_animation', payload);
+            if (this._destroyed || !this.boxes.has(entry.boxId)) return;
+            if (data && data.title) this._renderInlineMath(entry.titleEl, data.title);
+            this._mountAnimator(entry, data);
+            entry.state = 'ready';
+        } catch (err) {
+            if (this._destroyed || !this.boxes.has(entry.boxId)) return;
+            entry.state = 'error';
+            this._renderError(entry, err, payload);
+        } finally {
+            this._removePill(pill);
+        }
+    }
+
+    _mountAnimator(entry, data) {
+        entry.body.innerHTML = '';
+        if (!data || !Array.isArray(data.steps) || data.steps.length === 0) {
+            this._renderError(entry, new Error('The derivation produced no steps.'));
+            return;
+        }
+        try {
+            entry.animator = new ProofAnimator(entry.body, data, { katex: this.katex });
+        } catch (e) {
+            this._renderError(entry, e);
+            return;
+        }
+        // Re-apply any user zoom, then re-resolve overlaps (height changed).
+        if (entry.scale && entry.scale !== 1) this._applyScale(entry, entry.scale);
+        this._updatePositions();
+    }
+
+    // Render a caption that may contain inline $…$ LaTeX (e.g. a proof goal) into
+    // an element, KaTeX-rendering the math segments and leaving prose as text.
+    _renderInlineMath(el, text) {
+        el.innerHTML = '';
+        if (!text) { el.textContent = 'Derivation'; return; }
+        for (const part of String(text).split(/(\$[^$]+\$)/g)) {
+            if (part.length > 1 && part.startsWith('$') && part.endsWith('$') && this.katex) {
+                const span = document.createElement('span');
+                try { this.katex.render(part.slice(1, -1), span, { throwOnError: false, displayMode: false }); }
+                catch (_e) { span.textContent = part; }
+                el.appendChild(span);
+            } else if (part) {
+                el.appendChild(document.createTextNode(part));
+            }
+        }
+    }
+
+    _renderLoading(entry) {
+        entry.body.innerHTML =
+            '<div class="sgp-status"><span class="sgp-dots"><span></span><span></span><span></span></span>'
+            + '<span>Deriving proof…</span></div>';
+    }
+
+    _renderError(entry, err, payload) {
+        const msg = (err && err.message) || 'Derivation failed.';
+        entry.body.innerHTML = '';
+        const wrap = document.createElement('div');
+        wrap.className = 'sgp-error';
+        const m = document.createElement('div');
+        m.className = 'sgp-error-msg';
+        m.textContent = msg;
+        wrap.appendChild(m);
+        if (payload) {
+            const retry = document.createElement('button');
+            retry.className = 'sgp-retry';
+            retry.type = 'button';
+            retry.textContent = 'Retry';
+            retry.addEventListener('click', () => this._runDerivation(entry, payload));
+            wrap.appendChild(retry);
+        }
+        entry.body.appendChild(wrap);
+        this._updatePositions();
+    }
+
+    closeBox(boxId) {
+        const entry = this.boxes.get(boxId);
+        if (!entry) return;
+        try { entry.animator && entry.animator.destroy && entry.animator.destroy(); } catch (_e) {}
+        if (entry.box.parentNode) entry.box.parentNode.removeChild(entry.box);
+        this.boxes.delete(boxId);
+        if (this._byNode.get(entry.nodeId) === boxId) this._byNode.delete(entry.nodeId);
+    }
+
+    // Drag the box by its header; update the stored graph anchor so it stays put
+    // under subsequent pan/zoom. Dragging marks the box "pinned" only while the
+    // pointer is down (so transform polling doesn't fight the drag).
+    _makeDraggable(entry, handle) {
+        handle.style.cursor = 'grab';
+        let startX = 0, startY = 0, baseLeft = 0, baseTop = 0;
+        const onMove = (ev) => {
+            const card = this._card().getBoundingClientRect();
+            let left = baseLeft + (ev.clientX - startX);
+            let top = baseTop + (ev.clientY - startY);
+            left = Math.max(4, Math.min(left, card.width - entry.box.offsetWidth - 4));
+            top = Math.max(4, Math.min(top, card.height - entry.box.offsetHeight - 4));
+            entry.box.style.left = `${left}px`;
+            entry.box.style.top = `${top}px`;
+        };
+        const onUp = () => {
+            entry.pinned = false;
+            const { x: tx, y: ty, k } = this._transform;
+            entry.graphX = (parseFloat(entry.box.style.left) - tx) / k;
+            entry.graphY = (parseFloat(entry.box.style.top) - ty) / k;
+            handle.style.cursor = 'grab';
+            window.removeEventListener('pointermove', onMove);
+            window.removeEventListener('pointerup', onUp);
+        };
+        handle.addEventListener('pointerdown', (ev) => {
+            if (entry.docked) return;                       // docked boxes flow in the panel
+            if (ev.target.closest('button')) return;        // not from header buttons
+            ev.preventDefault();
+            entry.pinned = true;                            // freeze transform-driven moves
+            entry.box.style.zIndex = String(++this._z);
+            startX = ev.clientX; startY = ev.clientY;
+            baseLeft = parseFloat(entry.box.style.left) || 0;
+            baseTop = parseFloat(entry.box.style.top) || 0;
+            handle.style.cursor = 'grabbing';
+            window.addEventListener('pointermove', onMove);
+            window.addEventListener('pointerup', onUp);
+        });
+    }
+
+    // ── Resize corner — drag to zoom the animation (scale the .pa-root) ──────
+    _addResizeHandle(entry) {
+        const handle = document.createElement('div');
+        handle.className = 'sgp-resize-handle';
+        handle.title = 'Resize';
+        entry.box.appendChild(handle);
+        let startX = 0, startScale = 1;
+        const onMove = (ev) => {
+            const s = Math.max(0.6, Math.min(2.4, startScale + (ev.clientX - startX) / BOX_W));
+            this._applyScale(entry, s);
+        };
+        const onUp = () => {
+            window.removeEventListener('pointermove', onMove);
+            window.removeEventListener('pointerup', onUp);
+        };
+        handle.addEventListener('pointerdown', (ev) => {
+            ev.preventDefault();
+            ev.stopPropagation();
+            entry.box.style.zIndex = String(++this._z);
+            startX = ev.clientX;
+            startScale = entry.scale || 1;
+            window.addEventListener('pointermove', onMove);
+            window.addEventListener('pointerup', onUp);
+        });
+    }
+
+    // Zoom the animation content. ProofAnimator turns the body into the
+    // `.pa-root`, so we CSS-`zoom` that element (zoom reflows, so the box sizes
+    // to the scaled content with no gaps); the box width tracks the scale.
+    _applyScale(entry, s) {
+        entry.scale = s;
+        const pa = entry.box.querySelector('.pa-root') || entry.body;
+        pa.style.zoom = s;
+        entry.box.style.width = `${Math.round(BOX_W * s)}px`;
+        if (!entry.docked) this._updatePositions();
+    }
+
+    // ── Dock / undock — share the chart manager's pinned panel (side by side) ─
+    _sharedPinnedPanel() {
+        const card = this._card();
+        let panel = card.querySelector('.sgc-pinned-panel');
+        if (!panel) {
+            panel = document.createElement('div');
+            panel.className = 'sgc-pinned-panel';
+            card.appendChild(panel);
+        }
+        return panel;
+    }
+
+    _toggleDock(boxId) {
+        const entry = this.boxes.get(boxId);
+        if (!entry) return;
+        entry.docked ? this._undock(entry) : this._dock(entry);
+    }
+
+    _dock(entry) {
+        entry.docked = true;
+        entry.pinned = true;                  // skip transform-driven repositioning
+        entry.box.classList.add('sgp-pinned');
+        entry.box.style.position = '';
+        entry.box.style.left = '';
+        entry.box.style.top = '';
+        entry.box.style.zIndex = '';
+        this._sharedPinnedPanel().appendChild(entry.box);
+        if (entry.dockBtn) { entry.dockBtn.classList.add('sgp-dock-active'); entry.dockBtn.title = 'Undock'; }
+    }
+
+    _undock(entry) {
+        entry.docked = false;
+        entry.pinned = false;
+        entry.box.classList.remove('sgp-pinned');
+        this._card().appendChild(entry.box);
+        entry.box.style.position = 'absolute';
+        entry.box.style.zIndex = String(++this._z);
+        if (entry.dockBtn) { entry.dockBtn.classList.remove('sgp-dock-active'); entry.dockBtn.title = 'Dock to overlay'; }
+        this._updatePositions();          // re-anchor from stored graphX/graphY
+    }
+
+    // ── "Deriving proof…" pill — coexists in the enrichment indicator stack ──
+    // Uses a distinct class so the enrichment step-visibility logic never hides
+    // it; dispatches sgc:legend-change so graph-view re-stacks it above legends.
+    _showPill() {
+        const vp = document.getElementById('graph-viewport');
+        if (!vp) return null;
+        let stack = vp.querySelector('.graph-enrich-indicator-stack');
+        if (!stack) {
+            stack = document.createElement('div');
+            stack.className = 'graph-enrich-indicator-stack';
+            vp.appendChild(stack);
+        }
+        const el = document.createElement('div');
+        el.className = 'sgp-derive-indicator';
+        el.setAttribute('role', 'status');
+        el.innerHTML = '<span class="gei-dots"><span></span><span></span><span></span></span>'
+            + '<span class="gei-text">Deriving proof…</span>';
+        stack.appendChild(el);
+        document.dispatchEvent(new CustomEvent('sgc:legend-change'));
+        return el;
+    }
+
+    _removePill(pill) {
+        if (pill && pill.parentNode) {
+            pill.parentNode.removeChild(pill);
+            document.dispatchEvent(new CustomEvent('sgc:legend-change'));
+        }
+    }
+
+    destroy() {
+        this._destroyed = true;
+        if (this._rafId) { cancelAnimationFrame(this._rafId); this._rafId = null; }
+        if (this._resizeObserver) { try { this._resizeObserver.disconnect(); } catch (_e) {} this._resizeObserver = null; }
+        for (const boxId of Array.from(this.boxes.keys())) this.closeBox(boxId);
+    }
+}

--- a/static/proof-animation/sg-proof.js
+++ b/static/proof-animation/sg-proof.js
@@ -1,23 +1,34 @@
 // SgProofManager — docks on-the-fly proof animations on the semantic graph.
 //
-// Mirrors SgChartManager's docking model (anchor a floating box to a node,
-// track the renderer's pan/zoom transform so it stays put, resolve collisions
-// between concurrent boxes) but mounts a ProofAnimator instead of a Chart.js
-// canvas. Each Derive click opens one box keyed by nodeId; multiple boxes can
-// derive and play at once. Concurrency/abuse is capped server-side by the
-// shared per-IP rate limiter — this manager just renders state.
+// Mirrors SgChartManager: a floating box anchored to a node that tracks the
+// renderer's pan/zoom, snap-to-grid resize, and a dock button that shares the
+// SAME overlay panel as pinned charts (so charts and proofs dock side by side).
+// It reuses the chart's CSS classes verbatim (.sgc-chart-box / .sgc-chart-header
+// / .sgc-btn / .sgc-resize-handle / .sgc-pinned) so borders and buttons match
+// the charts exactly; only the body hosts a ProofAnimator instead of a canvas.
 
 import { ProofAnimator } from '/proof-animation/proof-animation.js';
 import { invokeExpert } from '/expert-client.js';
 
-const BOX_W = 360;   // fixed dock width (the animator measures against this)
+// Session-persistent cache of derivation results, keyed by the request shape.
+// Survives navigation/re-renders so a derived node is never recomputed and its
+// context is not lost.
+const _DERIVE_CACHE = new Map();
+const _cacheKey = (p) => `${p.target_latex || ''}|${p.start_latex || ''}|${p.domain || ''}`;
+
+const BOX_W = 360;            // natural render width of the animator (zoomed to fit the box)
+const GRID_COLS = 8;          // same grid as SgChartManager
+const GRID_ROWS = 8;
+const GRID_GAP = 8;
+const DEFAULT_COLSPAN = 4;
+const DEFAULT_ROWSPAN = 3;
 
 export class SgProofManager {
     constructor(container, opts = {}) {
         this.container = container;
         this.katex = opts.katex || (typeof window !== 'undefined' && window.katex);
         this.boxes = new Map();      // boxId -> entry
-        this._byNode = new Map();    // nodeId -> boxId (dedup / re-focus)
+        this._byKey = new Map();     // `${stepKey}|${nodeId}` -> boxId (dedup / re-focus)
         this._transform = { x: 0, y: 0, k: 1 };
         this._renderer = null;
         this._rafId = null;
@@ -25,6 +36,7 @@ export class SgProofManager {
         this._destroyed = false;
         this._seq = 0;
         this._z = 30;                // proof boxes sit above charts (z 20)
+        this._stepKey = null;        // boxes belong to the step they were derived in
     }
 
     // ── Renderer wiring (identical contract to SgChartManager) ───────────────
@@ -41,6 +53,39 @@ export class SgProofManager {
 
     _card() {
         return this.container.querySelector('.d3-graph-card') || this.container;
+    }
+
+    // A derivation belongs to the step it was created on. ``setCurrentStep`` is
+    // called on every (re)render with the active step's key; only that step's
+    // boxes are shown — others are detached (kept in memory) and re-shown when
+    // their step is revisited. Their position/scale/dock are per-box, so docking
+    // on one step never carries over to another.
+    setCurrentStep(stepKey) {
+        this._stepKey = stepKey;
+        this._syncStep();
+    }
+
+    // Show this step's boxes (re-attaching to the freshly-recreated card / shared
+    // panel), detach all others.
+    _syncStep() {
+        if (this._destroyed) return;
+        const card = this._card();
+        if (!card) return;
+        for (const entry of this.boxes.values()) {
+            if (entry.stepKey === this._stepKey) {
+                const dest = entry.docked ? this._sharedPinnedPanel() : card;
+                if (entry.box.parentNode !== dest) dest.appendChild(entry.box);
+            } else if (entry.box.parentNode) {
+                entry.box.parentNode.removeChild(entry.box);   // hide (keep in memory)
+            }
+        }
+        // Re-observe the fresh card for resize, then re-snap positions.
+        if (this._resizeObserver) {
+            try { this._resizeObserver.disconnect(); } catch (_e) {}
+            this._resizeObserver = null;
+        }
+        this._observeResize();
+        this._updatePositions();
     }
 
     _startTransformPolling() {
@@ -61,18 +106,56 @@ export class SgProofManager {
 
     _observeResize() {
         if (this._resizeObserver) return;
-        this._resizeObserver = new ResizeObserver(() => this._updatePositions());
+        this._resizeObserver = new ResizeObserver(() => {
+            // Grid steps depend on the card size — re-snap every box, then refit.
+            for (const entry of this.boxes.values()) {
+                this._applyGridSize(entry);
+                this._fit(entry);
+            }
+            this._updatePositions();
+        });
         this._resizeObserver.observe(this._card());
     }
 
-    // Reposition every unpinned box from its stored graph-space anchor, re-clamp
-    // to the card, and nudge apart any that overlap (mirrors chart docking).
+    // ── Grid sizing (copied from SgChartManager so it snaps identically) ─────
+    _getGridSteps() {
+        const rect = this._card().getBoundingClientRect();
+        const availW = rect.width - 16;
+        const availH = rect.height - 16;
+        return {
+            w: Math.floor((availW - (GRID_COLS - 1) * GRID_GAP) / GRID_COLS),
+            h: Math.floor((availH - (GRID_ROWS - 1) * GRID_GAP) / GRID_ROWS),
+        };
+    }
+
+    _applyGridSize(entry) {
+        const step = this._getGridSteps();
+        const w = entry.colSpan * step.w + (entry.colSpan - 1) * GRID_GAP;
+        const h = entry.rowSpan * step.h + (entry.rowSpan - 1) * GRID_GAP;
+        entry.box.style.width = `${w}px`;
+        entry.box.style.height = `${h}px`;
+    }
+
+    // Zoom the animator (rendered at a fixed BOX_W) to fit the grid-sized body,
+    // preserving aspect — the body flex-centers it.
+    _fit(entry) {
+        const pa = entry.paWrap;
+        if (!pa) return;
+        pa.style.zoom = 1;
+        const natH = pa.offsetHeight || 1;
+        const bw = entry.body.clientWidth;
+        const bh = entry.body.clientHeight;
+        if (bw <= 0 || bh <= 0) return;
+        const scale = Math.max(0.35, Math.min(bw / BOX_W, bh / natH));
+        pa.style.zoom = scale;
+    }
+
     _updatePositions() {
         const rect = this._card().getBoundingClientRect();
         const { x: tx, y: ty, k } = this._transform;
         const placed = [];
         for (const entry of this.boxes.values()) {
-            if (entry.pinned) continue;
+            if (entry.docked || entry.stepKey !== this._stepKey) continue;  // only current step
             const w = entry.box.offsetWidth;
             const h = entry.box.offsetHeight;
             let left = entry.graphX * k + tx;
@@ -104,8 +187,8 @@ export class SgProofManager {
     openProof(nodeId, anchorEl, payload) {
         if (this._destroyed) return;
 
-        // Dedup: a node already has a box → re-focus (and retry if it errored).
-        const existingId = this._byNode.get(nodeId);
+        const dedupKey = `${this._stepKey}|${nodeId}`;   // one box per node PER STEP
+        const existingId = this._byKey.get(dedupKey);
         if (existingId && this.boxes.has(existingId)) {
             const e = this.boxes.get(existingId);
             e.box.style.zIndex = String(++this._z);
@@ -115,35 +198,45 @@ export class SgProofManager {
 
         const card = this._card();
         const box = document.createElement('div');
-        box.className = 'sgp-proof-box';
-        box.style.width = `${BOX_W}px`;
+        box.className = 'sgc-chart-box sgp-proof-box';
 
         const header = document.createElement('div');
-        header.className = 'sgp-header';
+        header.className = 'sgc-chart-header';
         const titleEl = document.createElement('span');
-        titleEl.className = 'sgp-title';
+        titleEl.className = 'sgc-chart-title';
         titleEl.textContent = 'Derivation';
+        const controls = document.createElement('div');
+        controls.className = 'sgc-chart-controls';
         const dockBtn = document.createElement('button');
-        dockBtn.className = 'sgp-dock-btn';
+        dockBtn.className = 'sgc-btn sgc-pin-btn';
         dockBtn.type = 'button';
-        dockBtn.title = 'Dock to overlay';
-        dockBtn.setAttribute('aria-label', 'Dock');
-        dockBtn.innerHTML = '\u{1F4CC}';   // 📌
+        dockBtn.title = 'Pin to overlay';
+        dockBtn.innerHTML = '&#x1F4CC;';   // 📌
         const closeBtn = document.createElement('button');
-        closeBtn.className = 'sgp-close';
+        closeBtn.className = 'sgc-btn sgc-close-btn';
         closeBtn.type = 'button';
-        closeBtn.setAttribute('aria-label', 'Close');
-        closeBtn.innerHTML = '&times;';
-        header.append(titleEl, dockBtn, closeBtn);
+        closeBtn.title = 'Close';
+        closeBtn.textContent = '×';
+        controls.append(dockBtn, closeBtn);
+        header.append(titleEl, controls);
 
         const body = document.createElement('div');
         body.className = 'sgp-body';
-
         box.append(header, body);
         card.appendChild(box);
 
-        // Anchor next to the node button, then store the graph-space coords so
-        // the box tracks pan/zoom (same math as SgChartManager.openChart).
+        const entry = {
+            boxId: `proof_${++this._seq}`, nodeId, stepKey: this._stepKey, box, body, titleEl, header, dockBtn,
+            paWrap: null,
+            colSpan: DEFAULT_COLSPAN, rowSpan: DEFAULT_ROWSPAN,
+            graphX: 0, graphY: 0,
+            pinned: false, docked: false,
+            state: 'loading', animator: null,
+        };
+        this._applyGridSize(entry);
+
+        // Anchor next to the node button, then store graph-space coords so the
+        // box tracks pan/zoom (same math as SgChartManager.openChart).
         const cardRect = card.getBoundingClientRect();
         let left = 4, top = 4;
         if (anchorEl) {
@@ -151,32 +244,23 @@ export class SgProofManager {
             left = r.right - cardRect.left + 8;
             top = r.top - cardRect.top;
         }
-        const w = box.offsetWidth || BOX_W;
-        const h = box.offsetHeight || 120;
+        const w = box.offsetWidth || 300;
+        const h = box.offsetHeight || 200;
         left = Math.max(4, Math.min(left, cardRect.width - w - 4));
         top = Math.max(4, Math.min(top, cardRect.height - h - 4));
         box.style.position = 'absolute';
         box.style.left = `${left}px`;
         box.style.top = `${top}px`;
         box.style.zIndex = String(++this._z);
-
         const { x: tx, y: ty, k } = this._transform;
-        const boxId = `proof_${++this._seq}`;
-        const entry = {
-            boxId, nodeId, box, body, titleEl, header, dockBtn,
-            graphX: (left - tx) / k,
-            graphY: (top - ty) / k,
-            pinned: false,
-            docked: false,
-            scale: 1,
-            state: 'loading',
-            animator: null,
-        };
-        this.boxes.set(boxId, entry);
-        this._byNode.set(nodeId, boxId);
+        entry.graphX = (left - tx) / k;
+        entry.graphY = (top - ty) / k;
 
-        closeBtn.addEventListener('click', () => this.closeBox(boxId));
-        dockBtn.addEventListener('click', () => this._toggleDock(boxId));
+        this.boxes.set(entry.boxId, entry);
+        this._byKey.set(dedupKey, entry.boxId);
+
+        closeBtn.addEventListener('click', () => this.closeBox(entry.boxId));
+        dockBtn.addEventListener('click', () => this._toggleDock(entry.boxId));
         this._makeDraggable(entry, header);
         this._addResizeHandle(entry);
 
@@ -185,12 +269,30 @@ export class SgProofManager {
     }
 
     async _runDerivation(entry, payload) {
+        // Guard non-derivable nodes (operators / structural nodes with no
+        // expression) — fire nothing, just explain.
+        if (!payload || !payload.target_latex || !String(payload.target_latex).trim()) {
+            entry.state = 'error';
+            this._renderError(entry, new Error('This node has no expression to derive.'));
+            return;
+        }
+        // Session cache: a previously-derived expression mounts instantly and is
+        // never recomputed (persists across navigation/re-renders).
+        const key = _cacheKey(payload);
+        const cached = _DERIVE_CACHE.get(key);
+        if (cached) {
+            if (cached.title) this._renderInlineMath(entry.titleEl, cached.title);
+            this._mountAnimator(entry, cached);
+            entry.state = 'ready';
+            return;
+        }
         entry.state = 'loading';
         this._renderLoading(entry);
         const pill = this._showPill();
         try {
             const data = await invokeExpert('proof_animation', payload);
             if (this._destroyed || !this.boxes.has(entry.boxId)) return;
+            _DERIVE_CACHE.set(key, data);
             if (data && data.title) this._renderInlineMath(entry.titleEl, data.title);
             this._mountAnimator(entry, data);
             entry.state = 'ready';
@@ -205,52 +307,44 @@ export class SgProofManager {
 
     _mountAnimator(entry, data) {
         entry.body.innerHTML = '';
+        entry.paWrap = null;
         if (!data || !Array.isArray(data.steps) || data.steps.length === 0) {
             this._renderError(entry, new Error('The derivation produced no steps.'));
             return;
         }
+        // Mount into a fixed-width wrapper so the animator renders at BOX_W; the
+        // wrapper is then `zoom`-scaled to fit the grid box (_fit).
+        const paWrap = document.createElement('div');
+        paWrap.className = 'sgp-pa';
+        entry.body.appendChild(paWrap);
+        entry.paWrap = paWrap;
         try {
-            entry.animator = new ProofAnimator(entry.body, data, { katex: this.katex });
+            entry.animator = new ProofAnimator(paWrap, data, { katex: this.katex });
         } catch (e) {
+            entry.paWrap = null;
             this._renderError(entry, e);
             return;
         }
-        // Re-apply any user zoom, then re-resolve overlaps (height changed).
-        if (entry.scale && entry.scale !== 1) this._applyScale(entry, entry.scale);
+        this._fit(entry);
         this._updatePositions();
     }
 
-    // Render a caption that may contain inline $…$ LaTeX (e.g. a proof goal) into
-    // an element, KaTeX-rendering the math segments and leaving prose as text.
-    _renderInlineMath(el, text) {
-        el.innerHTML = '';
-        if (!text) { el.textContent = 'Derivation'; return; }
-        for (const part of String(text).split(/(\$[^$]+\$)/g)) {
-            if (part.length > 1 && part.startsWith('$') && part.endsWith('$') && this.katex) {
-                const span = document.createElement('span');
-                try { this.katex.render(part.slice(1, -1), span, { throwOnError: false, displayMode: false }); }
-                catch (_e) { span.textContent = part; }
-                el.appendChild(span);
-            } else if (part) {
-                el.appendChild(document.createTextNode(part));
-            }
-        }
-    }
-
     _renderLoading(entry) {
+        entry.paWrap = null;
         entry.body.innerHTML =
             '<div class="sgp-status"><span class="sgp-dots"><span></span><span></span><span></span></span>'
             + '<span>Deriving proof…</span></div>';
     }
 
     _renderError(entry, err, payload) {
+        entry.paWrap = null;
         const msg = (err && err.message) || 'Derivation failed.';
         entry.body.innerHTML = '';
         const wrap = document.createElement('div');
         wrap.className = 'sgp-error';
         const m = document.createElement('div');
         m.className = 'sgp-error-msg';
-        m.textContent = msg;
+        this._renderInlineMath(m, msg);   // render any $…$ expressions as KaTeX
         wrap.appendChild(m);
         if (payload) {
             const retry = document.createElement('button');
@@ -261,7 +355,6 @@ export class SgProofManager {
             wrap.appendChild(retry);
         }
         entry.body.appendChild(wrap);
-        this._updatePositions();
     }
 
     closeBox(boxId) {
@@ -270,14 +363,13 @@ export class SgProofManager {
         try { entry.animator && entry.animator.destroy && entry.animator.destroy(); } catch (_e) {}
         if (entry.box.parentNode) entry.box.parentNode.removeChild(entry.box);
         this.boxes.delete(boxId);
-        if (this._byNode.get(entry.nodeId) === boxId) this._byNode.delete(entry.nodeId);
+        const k = `${entry.stepKey}|${entry.nodeId}`;
+        if (this._byKey.get(k) === boxId) this._byKey.delete(k);
     }
 
     // Drag the box by its header; update the stored graph anchor so it stays put
-    // under subsequent pan/zoom. Dragging marks the box "pinned" only while the
-    // pointer is down (so transform polling doesn't fight the drag).
+    // under subsequent pan/zoom.
     _makeDraggable(entry, handle) {
-        handle.style.cursor = 'grab';
         let startX = 0, startY = 0, baseLeft = 0, baseTop = 0;
         const onMove = (ev) => {
             const card = this._card().getBoundingClientRect();
@@ -289,39 +381,45 @@ export class SgProofManager {
             entry.box.style.top = `${top}px`;
         };
         const onUp = () => {
-            entry.pinned = false;
             const { x: tx, y: ty, k } = this._transform;
             entry.graphX = (parseFloat(entry.box.style.left) - tx) / k;
             entry.graphY = (parseFloat(entry.box.style.top) - ty) / k;
-            handle.style.cursor = 'grab';
             window.removeEventListener('pointermove', onMove);
             window.removeEventListener('pointerup', onUp);
         };
         handle.addEventListener('pointerdown', (ev) => {
-            if (entry.docked) return;                       // docked boxes flow in the panel
-            if (ev.target.closest('button')) return;        // not from header buttons
+            if (entry.docked) return;                  // docked boxes flow in the panel
+            if (ev.target.closest('button')) return;   // not from header buttons
             ev.preventDefault();
-            entry.pinned = true;                            // freeze transform-driven moves
             entry.box.style.zIndex = String(++this._z);
             startX = ev.clientX; startY = ev.clientY;
             baseLeft = parseFloat(entry.box.style.left) || 0;
             baseTop = parseFloat(entry.box.style.top) || 0;
-            handle.style.cursor = 'grabbing';
             window.addEventListener('pointermove', onMove);
             window.addEventListener('pointerup', onUp);
         });
     }
 
-    // ── Resize corner — drag to zoom the animation (scale the .pa-root) ──────
+    // ── Resize corner — snap-to-grid (col/row spans), identical to charts ────
     _addResizeHandle(entry) {
         const handle = document.createElement('div');
-        handle.className = 'sgp-resize-handle';
+        handle.className = 'sgc-resize-handle';
         handle.title = 'Resize';
         entry.box.appendChild(handle);
-        let startX = 0, startScale = 1;
+        let startX = 0, startY = 0, startCol = 0, startRow = 0;
         const onMove = (ev) => {
-            const s = Math.max(0.6, Math.min(2.4, startScale + (ev.clientX - startX) / BOX_W));
-            this._applyScale(entry, s);
+            const step = this._getGridSteps();
+            const unitW = step.w + GRID_GAP;
+            const unitH = step.h + GRID_GAP;
+            const col = Math.max(2, Math.min(GRID_COLS, startCol + Math.round((ev.clientX - startX) / unitW)));
+            const row = Math.max(2, Math.min(GRID_ROWS, startRow + Math.round((ev.clientY - startY) / unitH)));
+            if (col !== entry.colSpan || row !== entry.rowSpan) {
+                entry.colSpan = col;
+                entry.rowSpan = row;
+                this._applyGridSize(entry);
+                this._fit(entry);
+                if (!entry.docked) this._updatePositions();
+            }
         };
         const onUp = () => {
             window.removeEventListener('pointermove', onMove);
@@ -331,22 +429,11 @@ export class SgProofManager {
             ev.preventDefault();
             ev.stopPropagation();
             entry.box.style.zIndex = String(++this._z);
-            startX = ev.clientX;
-            startScale = entry.scale || 1;
+            startX = ev.clientX; startY = ev.clientY;
+            startCol = entry.colSpan; startRow = entry.rowSpan;
             window.addEventListener('pointermove', onMove);
             window.addEventListener('pointerup', onUp);
         });
-    }
-
-    // Zoom the animation content. ProofAnimator turns the body into the
-    // `.pa-root`, so we CSS-`zoom` that element (zoom reflows, so the box sizes
-    // to the scaled content with no gaps); the box width tracks the scale.
-    _applyScale(entry, s) {
-        entry.scale = s;
-        const pa = entry.box.querySelector('.pa-root') || entry.body;
-        pa.style.zoom = s;
-        entry.box.style.width = `${Math.round(BOX_W * s)}px`;
-        if (!entry.docked) this._updatePositions();
     }
 
     // ── Dock / undock — share the chart manager's pinned panel (side by side) ─
@@ -369,25 +456,44 @@ export class SgProofManager {
 
     _dock(entry) {
         entry.docked = true;
-        entry.pinned = true;                  // skip transform-driven repositioning
-        entry.box.classList.add('sgp-pinned');
+        entry.box.classList.add('sgc-pinned');
         entry.box.style.position = '';
         entry.box.style.left = '';
         entry.box.style.top = '';
         entry.box.style.zIndex = '';
         this._sharedPinnedPanel().appendChild(entry.box);
-        if (entry.dockBtn) { entry.dockBtn.classList.add('sgp-dock-active'); entry.dockBtn.title = 'Undock'; }
+        this._applyGridSize(entry);
+        this._fit(entry);
+        if (entry.dockBtn) { entry.dockBtn.classList.add('sgc-pin-active'); entry.dockBtn.title = 'Unpin from overlay'; }
     }
 
     _undock(entry) {
         entry.docked = false;
-        entry.pinned = false;
-        entry.box.classList.remove('sgp-pinned');
+        entry.box.classList.remove('sgc-pinned');
         this._card().appendChild(entry.box);
         entry.box.style.position = 'absolute';
         entry.box.style.zIndex = String(++this._z);
-        if (entry.dockBtn) { entry.dockBtn.classList.remove('sgp-dock-active'); entry.dockBtn.title = 'Dock to overlay'; }
-        this._updatePositions();          // re-anchor from stored graphX/graphY
+        this._applyGridSize(entry);
+        this._fit(entry);
+        if (entry.dockBtn) { entry.dockBtn.classList.remove('sgc-pin-active'); entry.dockBtn.title = 'Pin to overlay'; }
+        this._updatePositions();    // re-anchor from stored graphX/graphY
+    }
+
+    // Render a caption that may contain inline $…$ LaTeX (e.g. a proof goal) into
+    // an element, KaTeX-rendering the math segments and leaving prose as text.
+    _renderInlineMath(el, text) {
+        el.innerHTML = '';
+        if (!text) { el.textContent = 'Derivation'; return; }
+        for (const part of String(text).split(/(\$[^$]+\$)/g)) {
+            if (part.length > 1 && part.startsWith('$') && part.endsWith('$') && this.katex) {
+                const span = document.createElement('span');
+                try { this.katex.render(part.slice(1, -1), span, { throwOnError: false, displayMode: false }); }
+                catch (_e) { span.textContent = part; }
+                el.appendChild(span);
+            } else if (part) {
+                el.appendChild(document.createTextNode(part));
+            }
+        }
     }
 
     // ── "Deriving proof…" pill — coexists in the enrichment indicator stack ──


### PR DESCRIPTION
Closes #353

## What

Adds a **Derive** button next to the AI button in a semantic-graph node's details panel. Clicking it derives a step-by-step **proof animation** for that node's expression on the fly (server-side, via the existing `ProofCompletionExpert`) and docks it next to the node — exactly like the existing Chart.js charts.

## Why

The proof-animation engine (`ProofAnimator`) already existed but was only reachable from an offline CLI that rendered a standalone page. This wires it into the live app so any expression on the graph can be derived and animated in place.

## How it works

**Generic expert framework (backend)**
- `experts/registry.py`: a handler registry (`HandlerSpec` / `@register_handler`) beside the expert registry.
- `experts/service.py`: `run(name, body)` beside `invoke()` — dispatches to a handler (custom pre/post around an expert) or the generic `invoke()` path.
- One generic route `POST /api/expert/{name}` in `server.py` — **new experts/handlers need zero endpoint wiring**. Guarded by the shared per-IP `_agentic_rate_limit` (renamed from `_enrich_rate_limit`, now used by enrich + experts). One-line `🧠` request log + flushed error logs for `--debug`.
- `experts/handlers/proof_animation/`: wraps `proof_completion` via `invoke()` — infer the start (or use a proof given) → run the expert → `build()` the FLIP animation data. Resilient: a state that can't parse **or** can't re-render (e.g. `partial_derivative`, `ket`/`bra`) is shown as raw LaTeX instead of failing the whole derivation.

**Frontend**
- `expert-client.js`: generic `invokeExpert(name, body)`.
- `proof-animation/sg-proof.js`: `SgProofManager` docks a `ProofAnimator` like a chart — anchored to the node, pan/zoom tracking, grid-snap resize, dock button (shares the chart overlay panel so charts & proofs sit side by side), loading/error/429 states, "Deriving proof…" pill.
- `graph-view.js`: the Derive button + payload (proof title/goal/givens; start = a non-target given, else inferred; lesson/scene/proof **context** passed through like enrichment).

**Per-step persistence**
- Charts and derivations belong to the step they were created on: session-persistent, shown only on their step, restored on return, reset on a new lesson. Charts redraw on re-attach. A shared `dock-seq` keeps the docked charts+proofs in a stable order across navigation.

## Commits
- `af4c694` initial feature
- `78899d1` per-step persistence, resilient grounding, endpoint hardening, context passing
- `8b8940d` per-step chart persistence + redraw on re-attach
- `7fc1e24` stable docked-overlay order across navigation

## Notes for reviewers
- The proof box reuses the chart CSS classes/grid-snap verbatim for identical styling.
- Follow-up #361: unify the two overlay managers (charts + proofs) into one.

## Testing
Verified end-to-end in the browser (debug-chrome/preview): derive on result nodes (quadratic formula, Schrödinger, Bloch), per-step persistence across navigation/proofs, dock side-by-side with charts, ungroundable pass-through (`partial_derivative`, `ket`), retry, 404/422/429 paths, and the CLI regressions (`scripts/proof_animation/derive.py`, `scripts/proof_completion_derive.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
