### PR TITLE
Agent-initiated proof derivations + tab-follow + disable add_scene

### DIFF
--- a/agent-tools-reference.md
+++ b/agent-tools-reference.md
@@ -1,63 +1,7 @@
 ## Agent Tools Reference
 
-**Always use tool calls — never write scene JSON as raw text in chat.**
-The tools are the only way to make visualizations actually render. When in doubt, make a tool call.
-
----
-
-### `add_scene` — Build a visualization
-
-Pass scene fields as direct top-level arguments. The client auto-navigates after adding — do NOT call `navigate_to` afterwards.
-For interactive controls, place sliders under `steps[].sliders` (not top-level `sliders`).
-
-```
-add_scene(
-  title="Cross Product $\\vec{a} \\times \\vec{b}$",
-  description="Two vectors and their cross product.",
-  range=[[-3,3],[-3,3],[-3,3]],
-  camera={"position":[4,3,5],"target":[0,0,0]},
-  elements=[
-    {"type":"axis","axis":"x","range":[-3,3],"color":"#ff4444","width":1.5,"label":"x"},
-    {"type":"axis","axis":"y","range":[-3,3],"color":"#44cc44","width":1.5,"label":"y"},
-    {"type":"axis","axis":"z","range":[-3,3],"color":"#4488ff","width":1.5,"label":"z"},
-    {"id":"va","type":"vector","from":[0,0,0],"to":[2,1,0],"color":"#ff6644","width":5,"label":"$\\vec{a}$"},
-    {"id":"vb","type":"vector","from":[0,0,0],"to":[1,2,0],"color":"#44aaff","width":5,"label":"$\\vec{b}$"}
-  ],
-  steps=[
-    {
-      "title":"The Cross Product",
-      "description":"$\\vec{a}\\times\\vec{b}$ is perpendicular to both — it points in the $z$ direction here.",
-      "add":[
-        {"id":"vc","type":"vector","from":[0,0,0],"to":[0,0,3],"color":"#ffcc00","width":5,"label":"$\\vec{a}\\times\\vec{b}$"}
-      ]
-    }
-  ],
-  markdown="# Cross Product\n\n$\\vec{a}\\times\\vec{b}$ gives a vector perpendicular to both..."
-)
-```
-
-**Animated elements** — use math.js expressions (scope: `t` + slider ids):
-```
-{"type":"animated_vector","from":[0,0,0],"to":["cos(t)","sin(t)","0"],"color":"#ff6644","width":5}
-{"type":"animated_point","position":["a*cos(t)","a*sin(t)","0"],"color":"#ffcc00","size":8}
-{"type":"parametric_curve","x":"cos(u)","y":"sin(u)","z":"u/pi","range":[0,6.28],"steps":128,"color":"#44aaff"}
-{"type":"vector_field","fx":"-y","fy":"x","fz":"0","density":4,"scale":0.3,"color":"#44aaff"}
-```
-
-**Sliders (inside a step):**
-```
-{
-  "steps": [
-    {
-      "title": "Interactive controls",
-      "sliders": [
-        {"id":"a","label":"Amplitude $a$","min":0.5,"max":3,"value":1,"step":0.01},
-        {"id":"t","label":"$t$","min":0,"max":1,"value":0,"step":0.01,"animate":true,"duration":2000}
-      ]
-    }
-  ]
-}
-```
+**Always use tool calls — never write tool arguments as raw text in chat.**
+The tools are the only way to actually affect the visualization. When in doubt, make a tool call.
 
 ---
 
@@ -97,11 +41,7 @@ eval_math(expression="sin(x)", sweep_var="x", sweep_start=0, sweep_end=6.28, swe
 eval_math(expression="norm(a - b)", variables={"a":[3,0,0],"b":[0,4,0]})
 ```
 
-Use `store_as` for large sweep results — reference them in `add_scene` as `"$key"`:
-```
-eval_math(expression="[cos(t), sin(t), 0]", sweep_var="t", sweep_start=0, sweep_end=6.28, sweep_steps=64, store_as="circle_pts")
-add_scene(title="Circle", elements=[{"type":"line","points":"$circle_pts","color":"#44aaff"}])
-```
+Use `store_as` for large sweep results to keep them out of the chat context; stored values are then available as variables in later `eval_math` calls.
 
 ---
 
@@ -158,7 +98,7 @@ mem_get(key="basis_x")         // retrieve a stored value
 mem_set(key="origin", value=[0,0,0])
 ```
 
-Stored values are available as variables in `eval_math` and as `"$key"` in `add_scene` fields.
+Stored values are available as variables in `eval_math`.
 
 ---
 
@@ -174,7 +114,7 @@ Call **once** per response, after your main action. Keep each prompt under 60 ch
 
 ### math.js Expression Reference
 
-Used in animated element fields, `parametric_curve`, and `{{expr}}` overlay placeholders.
+Used in `{{expr}}` overlay placeholders (`set_info_overlay`).
 
 | Category | Functions |
 |----------|-----------|

--- a/agent-tools-reference.md
+++ b/agent-tools-reference.md
@@ -138,6 +138,18 @@ set_camera(position=[0,0,8], target=[0,0,0], zoom=1.5)
 
 ---
 
+### `derive_proof_animation` — Derive a proof on the graph
+
+```
+derive_proof_animation(target_latex="x = \\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}", start_latex="a x^2 + b x + c = 0")
+derive_proof_animation(target_latex="2x", start_latex="\\frac{d}{dx} x^2", prompt="differentiate using the power rule")
+derive_proof_animation(target_latex="x = 2")   // target only — starts from the current proof's givens
+```
+
+Generates a SymPy-verified, step-by-step derivation and docks it into the **current step's** semantic graph — just like the user clicking a node's *Derive* button, but initiated by you. Fire-and-forget: the animation appears **on the graph, not in chat**, and persists on that step even if the user navigates away. After calling, briefly tell the user you're deriving it — **do not** write out the steps yourself. Requires a graph to be visible.
+
+---
+
 ### `mem_get` / `mem_set` — Agent memory
 
 ```

--- a/agent-tools-reference.md
+++ b/agent-tools-reference.md
@@ -86,7 +86,7 @@ derive_proof_animation(target_latex="2x", start_latex="\\frac{d}{dx} x^2", promp
 derive_proof_animation(target_latex="x = 2")   // target only — starts from the current proof's givens
 ```
 
-Generates a SymPy-verified, step-by-step derivation and docks it into the **current step's** semantic graph — just like the user clicking a node's *Derive* button, but initiated by you. Fire-and-forget: the animation appears **on the graph, not in chat**, and persists on that step even if the user navigates away. After calling, briefly tell the user you're deriving it — **do not** write out the steps yourself. Requires a graph to be visible.
+Generates a SymPy-verified, step-by-step derivation and docks it into the **current step's** semantic graph — just like the user clicking a node's *Derive* button, but initiated by you. Fire-and-forget: the animation appears **on the graph, not in chat**, and persists on that step even if the user navigates away. After calling, briefly tell the user you're deriving it — **do not** write out the steps yourself. It auto-switches to the Math view to show the result (works even from the 3D scene); you don't need to open the graph first. The current step must have a semantic graph — if it doesn't, the tool reports back so you can ask the user to navigate to one.
 
 ---
 

--- a/backend/agent_tools.py
+++ b/backend/agent_tools.py
@@ -286,6 +286,48 @@ NAVIGATE_PROOF_TOOL_DECL = types.FunctionDeclaration(
     ),
 )
 
+DERIVE_PROOF_TOOL_DECL = types.FunctionDeclaration(
+    name="derive_proof_animation",
+    description=(
+        "Generate a step-by-step, SymPy-verified proof/derivation animation on the "
+        "semantic graph — identical to the user clicking a node's 'Derive' button, "
+        "but initiated by you. The derivation is computed on the client and docked "
+        "into the graph for the CURRENT step, where it persists even if the user "
+        "navigates away. Use when the user asks to derive, prove, simplify, or show "
+        "how to get to an expression. This is fire-and-forget: it appears on the "
+        "graph, NOT in chat — do not write out the steps yourself; just tell the user "
+        "you're deriving it. REQUIRES an open semantic graph (the '## Active "
+        "Semantic Graph' section in context) — if none is open, do NOT call this "
+        "tool; ask the user to open the Math (semantic graph) view first. Provide TARGET; "
+        "optionally a START and/or a natural-language prompt:\n"
+        "  • start + target — derive from start to target.\n"
+        "  • start + target + prompt — derive with extra guidance.\n"
+        "  • target only — start from a sensible point in the current proof's givens."
+    ),
+    parameters=types.Schema(
+        type="OBJECT",
+        properties={
+            "target_latex": types.Schema(
+                type="STRING",
+                description="The expression to derive / arrive at, as LaTeX (no surrounding $). Required.",
+            ),
+            "start_latex": types.Schema(
+                type="STRING",
+                description="Optional starting expression as LaTeX. Omit to start from a given/inferred point in the current proof.",
+            ),
+            "prompt": types.Schema(
+                type="STRING",
+                description="Optional natural-language guidance for the derivation (e.g. 'use the quadratic formula', 'differentiate term by term').",
+            ),
+            "reason": types.Schema(
+                type="STRING",
+                description="Brief user-facing explanation of what's being derived (used for narration).",
+            ),
+        },
+        required=["target_latex"],
+    ),
+)
+
 ALL_TOOL_DECLS = [
     NAVIGATE_TOOL_DECL,
     SET_CAMERA_TOOL_DECL,
@@ -298,6 +340,7 @@ ALL_TOOL_DECLS = [
     SET_INFO_OVERLAY_TOOL_DECL,
     CLEAR_INFO_OVERLAYS_TOOL_DECL,
     NAVIGATE_PROOF_TOOL_DECL,
+    DERIVE_PROOF_TOOL_DECL,
 ]
 
 def _make_tools(*exclude_names):
@@ -367,6 +410,7 @@ def build_system_prompt(context, agent_memory=None):
   - `add_scene`: build a visualization. **Only call when the user explicitly requests it or when it clearly serves the current interaction — not as a default response to every question.** A `line` with many `points` draws a curve; `vectors` with `froms`/`tos` arrays draws a series of arrows. Do not hardcode arrays that could be computed — use `eval_math` first. **Put sliders only in `steps[].sliders` (never top-level `scene.sliders`).**
   - `set_sliders`: animate sliders to show how parameters change the visualization.
   - `set_preset_prompts`: call this **once** per response to surface 2–4 follow-up chips. Always a function call — never inline JSON. Never call it more than once per turn. **Do NOT also list them as links or bullets in your response text** — they already appear as buttons in the UI.
+  - `derive_proof_animation`: generate a SymPy-verified, step-by-step derivation that docks on the **current step's** semantic graph (like the node Derive button, but agent-initiated). Fire-and-forget — it appears on the graph, NOT in chat, so don't write the steps yourself; just say you're deriving it. Pass a `target_latex` (+ optional `start_latex` / `prompt`). **Requires an open semantic graph** — if the `## Active Semantic Graph` section isn't in context, don't call it; ask the user to open the Math view first. Especially handy to fulfil a "Derive …" preset-prompt chip.
   - `set_info_overlay`: show a live LaTeX panel on the canvas. Pass a stable `id` (e.g. `'matrix'`, `'formula'`, `'energy'`) and `content`. Reuse the same id to update an overlay; pick a new id for a distinct one. Use `{{expr}}` placeholders (math.js syntax) so values update automatically. Examples: `{{a}}` (slider value), `{{a*d-b*c}}` (determinant), `{{toFixed(sqrt(a^2+b^2), 2)}}` (formatted magnitude), `{{toFixed(2*pi*rpm/60, 3)}}` (angular velocity), `{{v > 0 ? "stable" : "unstable"}}` (conditional string). Do NOT use single-brace `{...}` placeholders. Always add a matrix overlay when sliders define a matrix.
   - `clear_info_overlays`: remove all info overlays from the canvas. Takes no parameters.
   - `parametric_curve`: continuous smooth curve using math.js expressions — use `sin(t)` not `Math.sin(t)`, `pi` not `Math.PI`, `pow(x,n)` or `x^n` not `x**n`. Use only when a slider drives the shape live and exact point values are not needed.
@@ -517,6 +561,23 @@ def build_system_prompt(context, agent_memory=None):
         if upcoming:
             lines = [f"{s['step']}. {s.get('label', '?')}" for s in upcoming]
             parts.append(f"\n## Upcoming Proof Steps\n" + "\n".join(lines))
+
+        # A proof step in view is a natural place to offer an on-graph derivation.
+        # Suggest (don't force) a preset-prompt chip the user can take — fulfilled
+        # by `derive_proof_animation`. Only when there's something real to derive.
+        derivable = (current_step or {}).get('math') or proof_ctx.get('goal')
+        if derivable:
+            parts.append(
+                "\n*Offer a derivation:* A proof step is in view. When it genuinely "
+                "helps, include ONE `set_preset_prompts` chip that offers to derive it "
+                "on the graph — phrased meaningfully from this step's expression, the "
+                "proof goal, and the givens (e.g. \"Derive this from the previous step\" "
+                "or \"Derive the quadratic formula from $ax^2+bx+c=0$\"). If the user "
+                "takes it, fulfil it with `derive_proof_animation`, which docks a "
+                "SymPy-verified animated derivation on the current step. Only offer when "
+                "a real derivation makes sense — skip it for a given/definition, a "
+                "trivial restatement, or a step that's already fully shown."
+            )
 
     # Active Semantic Graph — placed right after the proof block since it's
     # generally derived from the active proof step. Mirrors the

--- a/backend/agent_tools.py
+++ b/backend/agent_tools.py
@@ -163,7 +163,6 @@ EVAL_MATH_TOOL_DECL = types.FunctionDeclaration(
                     "Store the result in agent memory under this key instead of returning the full value. "
                     "Use short descriptive names like 'sin_pts', 'froms', 'eigenvals'. "
                     "Stored values are automatically available as variables in future eval_math expressions. "
-                    "Reference them in add_scene element fields as '$key' (e.g. 'points': '$sin_pts'). "
                     "Always use store_as for large arrays (sweep results, matrices) to keep context small."
                 ),
             ),
@@ -198,7 +197,7 @@ MEM_SET_TOOL_DECL = types.FunctionDeclaration(
     description=(
         "Store any value in agent memory under a key. "
         "Use for scalars, vectors, matrices, or any data you want to reference later. "
-        "Stored values can be referenced as variables in eval_math, or as '$key' in add_scene fields. "
+        "Stored values can be referenced as variables in eval_math. "
         "Prefer eval_math store_as for computed results; use mem_set for literals you already have."
     ),
     parameters=types.Schema(
@@ -296,9 +295,10 @@ DERIVE_PROOF_TOOL_DECL = types.FunctionDeclaration(
         "navigates away. Use when the user asks to derive, prove, simplify, or show "
         "how to get to an expression. This is fire-and-forget: it appears on the "
         "graph, NOT in chat — do not write out the steps yourself; just tell the user "
-        "you're deriving it. REQUIRES an open semantic graph (the '## Active "
-        "Semantic Graph' section in context) — if none is open, do NOT call this "
-        "tool; ask the user to open the Math (semantic graph) view first. Provide TARGET; "
+        "you're deriving it. It auto-switches to the Math (semantic graph) view to "
+        "show the result, so it works even from the 3D scene. The current step must "
+        "HAVE a semantic graph — if it doesn't, the tool reports back and you should "
+        "ask the user to navigate to a step that has one. Provide TARGET; "
         "optionally a START and/or a natural-language prompt:\n"
         "  • start + target — derive from start to target.\n"
         "  • start + target + prompt — derive with extra guidance.\n"
@@ -331,7 +331,8 @@ DERIVE_PROOF_TOOL_DECL = types.FunctionDeclaration(
 ALL_TOOL_DECLS = [
     NAVIGATE_TOOL_DECL,
     SET_CAMERA_TOOL_DECL,
-    ADD_SCENE_TOOL_DECL,
+    # ADD_SCENE_TOOL_DECL intentionally NOT exposed — scene-building is disabled
+    # (unreliable output). The decl/handlers remain dormant for easy re-enable.
     SET_SLIDERS_TOOL_DECL,
     EVAL_MATH_TOOL_DECL,
     MEM_GET_TOOL_DECL,
@@ -388,7 +389,7 @@ def build_system_prompt(context, agent_memory=None):
     parts = ["You are an AI math tutor embedded in an interactive 3D linear algebra visualization.\n"]
     instructions_text = """
 ## Instructions
-- You are a math tutor. **Only call `add_scene` when the user explicitly asks to "show", "visualize", "build", "create", or "plot" something, or when you are already in an active scene and a new visualization clearly improves understanding.** For questions, explanations, calculations, and navigation — answer in chat without building a new scene. Unsolicited scene creation distracts the user and risks errors.
+- You are a math tutor working within the lesson's existing scenes. For questions, explanations, calculations, and navigation — answer in chat. You do NOT build scenes.
 - Use LaTeX ($...$) for math notation — the client renders it. Always use single backslashes: `$\\theta$` not `$\\\\theta$`.
 - **Navigation — answer first, navigate only when explicitly asked**: If the user asks a question, answer it in chat. Do NOT navigate as a response to a question. Only call `navigate_to` when the user uses explicit navigation words: "next", "previous", "back", "go to step N", "show me scene X", "skip to", etc. A question like "what does this mean?" or "why does that happen?" is a request for explanation, not navigation. When in doubt, answer in text.
 - **Proposing navigation**: If you think the user would benefit from seeing a different step or scene, propose it in chat first — e.g. "Step 3 shows this geometrically — want me to take you there?" — and only navigate if they say yes or use an explicit navigation word in reply.
@@ -396,25 +397,20 @@ def build_system_prompt(context, agent_memory=None):
 - **One navigation per turn**: Never call `navigate_to` more than once in a single response. Never auto-advance through multiple steps in one turn.
 - Use the set_camera tool to adjust the viewing angle. You can use a preset view name (e.g. view="top") or custom position/target coordinates. Use zoom (e.g. zoom=1.5 closer, zoom=0.5 farther) with custom positions to control distance.
 - Use the tools in whatever order makes sense for the request. You have full discretion.
-- Build scenes with 4-7 steps that progressively reveal the concept. Each step should have a detailed, conversational description that teaches.
-- Always include a comprehensive markdown explanation with LaTeX formulas, definitions, and worked calculations.
 - Describe what's visible when asked "what am I looking at?"
 - **Keep chat responses short and direct** — 1–3 sentences max for explanations, unless the user explicitly asks for more detail. Let the scene, steps, and markdown panel do the heavy teaching. Never re-explain what's already visible in the scene or markdown.
 - **Unclear or vague questions**: If the user's request is ambiguous (e.g. "show me something", "explain it", "make it nicer"), do NOT guess — ask one clarifying question. Keep the question brief: "Which part would you like explained?" or "Do you mean [X] or [Y]?"
-- Do not write scene JSON as text in chat — make tool calls so things actually render.
 - **CRITICAL**: Always call `set_preset_prompts` as a function tool call. NEVER write the prompts as JSON text in your response.
 - **CRITICAL**: NEVER use `{{expr}}` placeholders in your chat response text. Placeholders like `{{theta}}` or `{{toFixed(v,1)}}` only work inside `set_info_overlay` content, not in chat messages. In chat, write computed values directly or describe them in words.
 - **STATE over history**: The Current State section is always authoritative for scene, step, sliders, semantic graph and camera.
 - **Tool capabilities**:
-  - `eval_math`: compute exact numbers. When asked to "compute", "calculate", "get", or "make a series" — call `eval_math` and let the result appear in chat. To sweep a range: set `sweep_var="x"`, `sweep_start`, `sweep_end`, `sweep_steps`. Only pipe the result into `add_scene` if the user also wants a visualization. Expression syntax is Python: `sin(x)` not `Math.sin(x)`, `x**2` not `x^2`.
-  - `add_scene`: build a visualization. **Only call when the user explicitly requests it or when it clearly serves the current interaction — not as a default response to every question.** A `line` with many `points` draws a curve; `vectors` with `froms`/`tos` arrays draws a series of arrows. Do not hardcode arrays that could be computed — use `eval_math` first. **Put sliders only in `steps[].sliders` (never top-level `scene.sliders`).**
+  - `eval_math`: compute exact numbers. When asked to "compute", "calculate", "get", or "make a series" — call `eval_math` and let the result appear in chat. To sweep a range: set `sweep_var="x"`, `sweep_start`, `sweep_end`, `sweep_steps`. Expression syntax is Python: `sin(x)` not `Math.sin(x)`, `x**2` not `x^2`.
   - `set_sliders`: animate sliders to show how parameters change the visualization.
   - `set_preset_prompts`: call this **once** per response to surface 2–4 follow-up chips. Always a function call — never inline JSON. Never call it more than once per turn. **Do NOT also list them as links or bullets in your response text** — they already appear as buttons in the UI.
-  - `derive_proof_animation`: generate a SymPy-verified, step-by-step derivation that docks on the **current step's** semantic graph (like the node Derive button, but agent-initiated). Fire-and-forget — it appears on the graph, NOT in chat, so don't write the steps yourself; just say you're deriving it. Pass a `target_latex` (+ optional `start_latex` / `prompt`). **Requires an open semantic graph** — if the `## Active Semantic Graph` section isn't in context, don't call it; ask the user to open the Math view first. Especially handy to fulfil a "Derive …" preset-prompt chip.
+  - `derive_proof_animation`: generate a SymPy-verified, step-by-step derivation that docks on the **current step's** semantic graph (like the node Derive button, but agent-initiated). Fire-and-forget — it appears on the graph, NOT in chat, so don't write the steps yourself; just say you're deriving it. Pass a `target_latex` (+ optional `start_latex` / `prompt`). It auto-switches to the Math view to show the derivation (works even from the 3D scene). The current step must have a semantic graph; if it doesn't, the tool will say so — relay that and ask the user to go to a step that has one. Especially handy to fulfil a "Derive …" preset-prompt chip.
   - `set_info_overlay`: show a live LaTeX panel on the canvas. Pass a stable `id` (e.g. `'matrix'`, `'formula'`, `'energy'`) and `content`. Reuse the same id to update an overlay; pick a new id for a distinct one. Use `{{expr}}` placeholders (math.js syntax) so values update automatically. Examples: `{{a}}` (slider value), `{{a*d-b*c}}` (determinant), `{{toFixed(sqrt(a^2+b^2), 2)}}` (formatted magnitude), `{{toFixed(2*pi*rpm/60, 3)}}` (angular velocity), `{{v > 0 ? "stable" : "unstable"}}` (conditional string). Do NOT use single-brace `{...}` placeholders. Always add a matrix overlay when sliders define a matrix.
   - `clear_info_overlays`: remove all info overlays from the canvas. Takes no parameters.
-  - `parametric_curve`: continuous smooth curve using math.js expressions — use `sin(t)` not `Math.sin(t)`, `pi` not `Math.PI`, `pow(x,n)` or `x^n` not `x**n`. Use only when a slider drives the shape live and exact point values are not needed.
-  - **math.js expression syntax** (used in all animated elements, parametric_curve, and info overlay placeholders): trig `sin cos tan asin acos atan atan2` · power `pow(x,n)` or `x^n` · roots `sqrt cbrt` · exp/log `exp log log2 log10` · rounding `floor ceil round fix` · misc `abs sign min max hypot` · constants `pi e` · ternary `cond ? a : b` · formatting `toFixed(val, n)`. Do NOT use `Math.sin`, `Math.PI`, `x.toFixed()`, or JS keywords (`let`, `return`, `=>`).
+  - **math.js expression syntax** (used in info overlay `{{expr}}` placeholders): trig `sin cos tan asin acos atan atan2` · power `pow(x,n)` or `x^n` · roots `sqrt cbrt` · exp/log `exp log log2 log10` · rounding `floor ceil round fix` · misc `abs sign min max hypot` · constants `pi e` · ternary `cond ? a : b` · formatting `toFixed(val, n)`. Do NOT use `Math.sin`, `Math.PI`, `x.toFixed()`, or JS keywords (`let`, `return`, `=>`).
 """
     parts.append(instructions_text)
 
@@ -505,7 +501,7 @@ def build_system_prompt(context, agent_memory=None):
     # Agent memory — show stored keys so agent knows what's available
     if agent_memory:
         mem_lines = [f"  - {k}: {_memory_summary_line(k, v)}" for k, v in agent_memory.items()]
-        parts.append("\n## Agent Memory\nKeys currently in memory (reference as variable or '$key' in add_scene):\n" + "\n".join(mem_lines))
+        parts.append("\n## Agent Memory\nKeys currently in memory (reference as a variable in eval_math):\n" + "\n".join(mem_lines))
 
     # Scene-specific agent instructions
     if scene.get('prompt'):

--- a/backend/server.py
+++ b/backend/server.py
@@ -1146,16 +1146,18 @@ def call_gemini_chat(message, history, context):
                     # graph. We only acknowledge — the steps never enter the chat.
                     target = (tc_args.get('target_latex') or '').strip()
                     reason = tc_args.get('reason', '')
-                    # A derivation docks onto a visible semantic graph; with none
-                    # open the client would silently no-op. Guard here so the agent
-                    # is told to ask the user to open one instead.
+                    # A derivation docks onto the current step's semantic graph. We
+                    # only require that a graph EXISTS for the step — the client
+                    # auto-switches to the Math view if it's hidden behind the 3D
+                    # viewport. With no graph at all there's nothing to derive on, so
+                    # tell the agent to send the user to a step that has one.
                     gp = (context.get('runtime') or {}).get('graphPanel') or {}
-                    graph_open = bool(gp.get('open') and gp.get('hasGraph'))
-                    if not graph_open:
+                    has_graph = bool(gp.get('hasGraph'))
+                    if not has_graph:
                         tc_result = {"status": "error", "needsGraph": True,
-                                     "error": ("No semantic graph is open. Ask the user to open the "
-                                               "Math (semantic graph) view on a step that has one before "
-                                               "deriving — do not call this tool again until then.")}
+                                     "error": ("This step has no semantic graph to derive on. Ask the user "
+                                               "to navigate to a step that has one before deriving — do not "
+                                               "call this tool again until then.")}
                     elif not target:
                         tc_result = {"status": "error",
                                      "error": "target_latex is required to derive."}

--- a/backend/server.py
+++ b/backend/server.py
@@ -1140,6 +1140,37 @@ def call_gemini_chat(message, history, context):
                     }
                     if DEBUG_MODE:
                         print(f"   📐 navigate_proof: step={proof_step} reason={reason}")
+                elif tc_name == 'derive_proof_animation':
+                    # Fire-and-forget: the client runs the SymPy-verified derivation
+                    # (proof_animation handler) and docks it on the current step's
+                    # graph. We only acknowledge — the steps never enter the chat.
+                    target = (tc_args.get('target_latex') or '').strip()
+                    reason = tc_args.get('reason', '')
+                    # A derivation docks onto a visible semantic graph; with none
+                    # open the client would silently no-op. Guard here so the agent
+                    # is told to ask the user to open one instead.
+                    gp = (context.get('runtime') or {}).get('graphPanel') or {}
+                    graph_open = bool(gp.get('open') and gp.get('hasGraph'))
+                    if not graph_open:
+                        tc_result = {"status": "error", "needsGraph": True,
+                                     "error": ("No semantic graph is open. Ask the user to open the "
+                                               "Math (semantic graph) view on a step that has one before "
+                                               "deriving — do not call this tool again until then.")}
+                    elif not target:
+                        tc_result = {"status": "error",
+                                     "error": "target_latex is required to derive."}
+                    else:
+                        tc_result = {
+                            "status": "success",
+                            "initiated": True,
+                            "message": ("Derivation started on the graph — it will appear "
+                                        "docked on the current step. Briefly tell the user "
+                                        "you're deriving it; do NOT write the steps yourself."),
+                        }
+                    if DEBUG_MODE:
+                        print(f"   ∴ derive_proof_animation: target={target[:60]!r} "
+                              f"start={ (tc_args.get('start_latex') or '')[:40]!r} "
+                              f"prompt={ (tc_args.get('prompt') or '')[:40]!r} reason={reason}")
                 else:
                     tc_result = {"status": "success"}
                 tool_calls.append({

--- a/static/chat.js
+++ b/static/chat.js
@@ -683,6 +683,15 @@ async function sendChatMessage(text, { silent = false } = {}) {
                     const proofStep = parseInt(tc.result?.step ?? tc.args?.step ?? 0);
                     // Agent uses 1-based, navigateProof uses 0-based (-1 = goal)
                     if (typeof navigateProof === 'function') navigateProof(proofStep - 1);
+                } else if (tc.name === 'derive_proof_animation') {
+                    // Initiate a client-side derivation, docked into the current
+                    // step's graph (same as clicking a node's Derive button). The
+                    // result lives on the graph, not in chat.
+                    if (typeof window.algebenchDeriveProof === 'function') {
+                        window.algebenchDeriveProof(tc.args || {});
+                    } else {
+                        console.warn('derive_proof_animation: graph view not ready to derive');
+                    }
                 }
             }
         }

--- a/static/chat.js
+++ b/static/chat.js
@@ -692,8 +692,12 @@ async function sendChatMessage(text, { silent = false } = {}) {
                 } else if (tc.name === 'derive_proof_animation') {
                     // Initiate a client-side derivation, docked into the current
                     // step's graph (same as clicking a node's Derive button). The
-                    // result lives on the graph, not in chat.
-                    if (typeof window.algebenchDeriveProof === 'function') {
+                    // result lives on the graph, not in chat. Respect the server
+                    // guard: a non-success result (e.g. needsGraph) means there's no
+                    // graph to derive on — skip it; the agent relays the message.
+                    if (tc.result && tc.result.status !== 'success') {
+                        console.log('derive_proof_animation: skipped —', tc.result.error || 'not permitted');
+                    } else if (typeof window.algebenchDeriveProof === 'function') {
                         window.algebenchDeriveProof(tc.args || {});
                     } else {
                         console.warn('derive_proof_animation: graph view not ready to derive');

--- a/static/chat.js
+++ b/static/chat.js
@@ -556,6 +556,9 @@ async function sendChatMessage(text, { silent = false } = {}) {
                         console.error('📍 navigate_to REJECTED: scene ' + agentScene + ' out of bounds (1-' + totalScenes + ')');
                     } else if (typeof navigateTo === 'function') {
                         navigateTo(internalScene, internalStep);
+                        // Surface the scene the agent moved to: if the user is on the
+                        // full-screen Math view, switch back to Scenes (unless split).
+                        if (typeof window.algebenchEnsureSceneVisible === 'function') window.algebenchEnsureSceneVisible();
                         console.log('%c📍 navigate_to result: %cnow at scene ' + (currentSceneIndex + 1) + ' step ' + (currentStepIndex + 1) +
                             (currentSceneIndex === beforeScene && currentStepIndex === beforeStep ? ' ⚠️ NO CHANGE' : ''),
                             'color: #ff8844; font-weight: bold', 'color: #ccc');
@@ -656,6 +659,9 @@ async function sendChatMessage(text, { silent = false } = {}) {
                         if (typeof buildSceneTree === 'function') buildSceneTree(lessonSpec);
                         if (typeof updateDockVisibility === 'function') updateDockVisibility();
                         if (typeof navigateTo === 'function') navigateTo(targetIdx, targetStep);
+                        // A freshly-added scene must be visible — switch off the Math
+                        // view if the user is on it (unless split-docked).
+                        if (typeof window.algebenchEnsureSceneVisible === 'function') window.algebenchEnsureSceneVisible();
                         console.log('%c🎬 add_scene complete', 'color: #44ff44; font-weight: bold');
                     } catch(e) {
                         console.error('add_scene: navigation/render failed:', e);

--- a/static/expert-client.js
+++ b/static/expert-client.js
@@ -7,25 +7,38 @@
 // .status and .retryAfter) on a non-2xx response.
 
 export class ExpertError extends Error {
-    constructor(message, { status = 0, retryAfter = null, detail = null } = {}) {
+    constructor(message, { status = 0, retryAfter = null, detail = null, timedOut = false } = {}) {
         super(message);
         this.name = 'ExpertError';
         this.status = status;
         this.retryAfter = retryAfter;   // seconds, from a 429 Retry-After header
         this.detail = detail;
+        this.timedOut = timedOut;       // true when aborted by the client timeout
     }
 }
 
-export async function invokeExpert(name, body) {
+// ``opts.timeoutMs`` (>0) aborts the request after that many ms so a hung or
+// pathologically slow handler (e.g. an LM derivation that never returns) fails
+// with a clear, retryable error instead of spinning forever. 0 = no timeout.
+export async function invokeExpert(name, body, { timeoutMs = 0 } = {}) {
     let res;
+    const ctrl = timeoutMs > 0 ? new AbortController() : null;
+    const timer = ctrl ? setTimeout(() => ctrl.abort(), timeoutMs) : null;
     try {
         res = await fetch(`/api/expert/${encodeURIComponent(name)}`, {
             method: 'POST',
             headers: { 'content-type': 'application/json' },
             body: JSON.stringify(body || {}),
+            signal: ctrl ? ctrl.signal : undefined,
         });
     } catch (_e) {
+        if (ctrl && ctrl.signal.aborted) {
+            throw new ExpertError('This derivation took too long and was stopped — try again.',
+                                  { status: 0, timedOut: true });
+        }
         throw new ExpertError('Could not reach the server.', { status: 0 });
+    } finally {
+        if (timer) clearTimeout(timer);
     }
 
     let data = null;

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -1085,14 +1085,22 @@ function _activeProof() {
     return (entry && entry.proof) || null;
 }
 
-/** Assemble the DeriveProofRequest payload for a clicked node.
- *  Target = the node's expression. Givens/goal/start come from the active proof:
- *  goal + every ``type:"given"`` step's math; start = the first given when present
- *  (else the backend infers it from a prompt). */
-function _buildDerivePayload(nodeId, fullNode, graph) {
-    const target = _stripHtmlMacros(nodeLongLabel(fullNode) || fullNode.subexpr || fullNode.label || '');
-    const payload = { target_latex: target };
+// Loose LaTeX comparison: ignore \text{}/\mathrm{} wrappers, braces, spacing and
+// \le/\leq spelling, so e.g. \gamma_{steep} == \gamma_{\text{steep}}.
+function _normLatex(s) {
+    return (s || '')
+        .replace(/\\(?:text|mathrm|mathbf|operatorname)\s*\{([^{}]*)\}/g, '$1')
+        .replace(/\\le(?![a-zA-Z])/g, '\\leq')
+        .replace(/\\ge(?![a-zA-Z])/g, '\\geq')
+        .replace(/[\s{}]/g, '');
+}
 
+/** Proof-context portion of a DeriveProofRequest (everything except target):
+ *  domain + the active proof's title/goal/givens + a sensible START given +
+ *  lesson/scene/proof context. ``target`` is used only to avoid picking a START
+ *  equal to it. Shared by the node Derive button and the agent's derive tool. */
+function _proofContextPayload(graph, target) {
+    const payload = {};
     const domain = graph && (graph.domain || (graph.meta && graph.meta.domain));
     if (domain) payload.domain = domain;
 
@@ -1109,15 +1117,10 @@ function _buildDerivePayload(nodeId, fullNode, graph) {
             payload.givens = givens;
             // Use a proof given as the START — but never one equal to the target
             // (a definitional node is its own given, which would derive nothing).
-            // Compare loosely: ignore \text{}/\mathrm{} wrappers, braces, spacing
-            // and \le/\leq spelling, so e.g. \gamma_{steep} == \gamma_{\text{steep}}.
             // If every given equals the target, omit start so the LM infers one.
-            const norm = (s) => (s || '')
-                .replace(/\\(?:text|mathrm|mathbf|operatorname)\s*\{([^{}]*)\}/g, '$1')
-                .replace(/\\le(?![a-zA-Z])/g, '\\leq')
-                .replace(/\\ge(?![a-zA-Z])/g, '\\geq')
-                .replace(/[\s{}]/g, '');
-            const startGiven = givens.find(g => norm(g.math) !== norm(target));
+            const startGiven = target
+                ? givens.find(g => _normLatex(g.math) !== _normLatex(target))
+                : givens[0];
             if (startGiven) payload.start_latex = startGiven.math;
         }
     }
@@ -1131,6 +1134,58 @@ function _buildDerivePayload(nodeId, fullNode, graph) {
 
     return payload;
 }
+
+/** Assemble the DeriveProofRequest payload for a clicked node.
+ *  Target = the node's expression; the rest comes from the active proof. */
+function _buildDerivePayload(nodeId, fullNode, graph) {
+    const target = _stripHtmlMacros(nodeLongLabel(fullNode) || fullNode.subexpr || fullNode.label || '');
+    return { ..._proofContextPayload(graph, target), target_latex: target };
+}
+
+/** Find a graph node whose displayed expression matches ``target`` (loose
+ *  compare), so an agent-initiated derivation can anchor to it like the Derive
+ *  button. Returns the node id, or null when nothing matches. */
+function _findNodeIdByLatex(graph, target) {
+    if (!graph || !Array.isArray(graph.nodes) || !target) return null;
+    const t = _normLatex(target);
+    for (const n of graph.nodes) {
+        const lbl = _stripHtmlMacros(nodeLongLabel(n) || n.subexpr || n.label || '');
+        if (lbl && _normLatex(lbl) === t) return n.id;
+    }
+    return null;
+}
+
+/** Agent entry point — initiate a proof derivation on the CURRENT step's graph,
+ *  exactly as if the user clicked a node's Derive button. Fire-and-forget: the
+ *  SgProofManager runs the (verified) derivation and docks it; it persists on
+ *  this step across navigation. ``args`` = { target_latex, start_latex?, prompt? }. */
+window.algebenchDeriveProof = function (args) {
+    if (!_currentProofManager) {
+        console.warn('algebenchDeriveProof: no active graph/proof manager to derive into');
+        return false;
+    }
+    const target = _stripHtmlMacros(((args && args.target_latex) || '')).trim();
+    if (!target) {
+        console.warn('algebenchDeriveProof: target_latex is required');
+        return false;
+    }
+    const graph = _d3ActiveGraph;
+    const payload = { ..._proofContextPayload(graph, target), target_latex: target };
+    // Agent overrides take precedence over the proof-derived defaults.
+    const start = ((args && args.start_latex) || '').trim();
+    if (start) payload.start_latex = start;
+    const prompt = ((args && args.prompt) || '').trim();
+    if (prompt) payload.intent = prompt;
+
+    // Anchor to a matching node when one exists (docks beside it); otherwise use
+    // a synthetic id keyed on the target so re-issuing the same derivation on the
+    // same step re-focuses its box instead of stacking duplicates.
+    const matchedId = _findNodeIdByLatex(graph, target);
+    const nodeId = matchedId || ('agent::' + _normLatex(target));
+    const anchor = matchedId ? _d3NodeElById(matchedId) : null;
+    _currentProofManager.openProof(nodeId, anchor, payload);
+    return true;
+};
 
 function _showD3InfoPanel(nodeId, nodeData, graph) {
     const infoHost = document.getElementById('graph-info-panel-host');

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -360,8 +360,11 @@ function setDockTab(name) {
 
     const graphVp = document.getElementById('graph-viewport');
     const mathWrap = document.getElementById('mathbox-wrapper');
-    if (!graphVp || !mathWrap) return;
+    if (!graphVp || !mathWrap) return Promise.resolve();
 
+    // Resolves when the graph (and its proof manager) has finished rendering, so
+    // callers that switch *in order to* act on the graph can await it.
+    let rendered = Promise.resolve();
     if (name === 'graph') {
         graphVp.classList.remove('hidden');
         if (_docked) {
@@ -371,13 +374,14 @@ function setDockTab(name) {
         }
         loadMermaidLib().catch(() => { /* error surfaced at render time */ });
         rebuildProofTree();
-        renderCurrentStepGraph(true);
+        rendered = renderCurrentStepGraph(true);
     } else {
         graphVp.classList.add('hidden');
         mathWrap.style.visibility = '';
         _removeDockedLayout();
     }
     _syncDockButton();
+    return rendered;
 }
 
 /* ------------------------------------------------------------------ */
@@ -1159,14 +1163,18 @@ function _findNodeIdByLatex(graph, target) {
  *  exactly as if the user clicked a node's Derive button. Fire-and-forget: the
  *  SgProofManager runs the (verified) derivation and docks it; it persists on
  *  this step across navigation. ``args`` = { target_latex, start_latex?, prompt? }. */
-window.algebenchDeriveProof = function (args) {
-    if (!_currentProofManager) {
-        console.warn('algebenchDeriveProof: no active graph/proof manager to derive into');
-        return false;
-    }
+window.algebenchDeriveProof = async function (args) {
     const target = _stripHtmlMacros(((args && args.target_latex) || '')).trim();
     if (!target) {
         console.warn('algebenchDeriveProof: target_latex is required');
+        return false;
+    }
+    // Make the semantic graph visible first — switching to the Math view also
+    // renders the graph and wires its proof manager (awaited so the box docks on
+    // the right step). No-op if the graph is already showing.
+    await window.algebenchEnsureGraphVisible();
+    if (!_currentProofManager) {
+        console.warn('algebenchDeriveProof: no semantic graph to derive into');
         return false;
     }
     const graph = _d3ActiveGraph;
@@ -1184,6 +1192,35 @@ window.algebenchDeriveProof = function (args) {
     const nodeId = matchedId || ('agent::' + _normLatex(target));
     const anchor = matchedId ? _d3NodeElById(matchedId) : null;
     _currentProofManager.openProof(nodeId, anchor, payload);
+    return true;
+};
+
+/** After an agent-driven navigation, make sure the 3D scene is actually visible.
+ *  If the user is on the full-screen Math (semantic graph) view, switch back to
+ *  the Scenes tab so they see the scene they were moved to. In split/docked mode
+ *  the scene is already shown alongside the graph, so leave the view untouched.
+ *  Returns true if it switched tabs. */
+window.algebenchEnsureSceneVisible = function () {
+    if (isGraphModeActive() && !_docked) {
+        setDockTab('scenes');
+        return true;
+    }
+    return false;
+};
+
+/** Counterpart for derivations: make the semantic graph visible. Only relevant
+ *  for the agent-initiated path (the Derive button is already on the graph).
+ *  Switches to the Math view ONLY when the current step actually has a semantic
+ *  graph that's just hidden behind the active 3D viewport — never yanks the user
+ *  to an empty Math view. Awaits the render so the proof manager is ready to dock
+ *  onto. No-op when the graph is already visible or the step has no graph.
+ *  Returns true if it switched. */
+window.algebenchEnsureGraphVisible = async function () {
+    if (isGraphModeActive()) return false;          // already visible
+    const step = (typeof currentProofStep === 'function') ? currentProofStep() : null;
+    const hasGraph = !!(step && step.semanticGraph && step.semanticGraph.graph);
+    if (!hasGraph) return false;                     // nothing to show — don't switch
+    await setDockTab('graph');
     return true;
 };
 

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -1216,12 +1216,33 @@ window.algebenchEnsureSceneVisible = function () {
  *  onto. No-op when the graph is already visible or the step has no graph.
  *  Returns true if it switched. */
 window.algebenchEnsureGraphVisible = async function () {
-    if (isGraphModeActive()) return false;          // already visible
     const step = (typeof currentProofStep === 'function') ? currentProofStep() : null;
     const hasGraph = !!(step && step.semanticGraph && step.semanticGraph.graph);
     if (!hasGraph) return false;                     // nothing to show — don't switch
-    await setDockTab('graph');
-    return true;
+
+    // Derivations dock only in the D3 renderer (SgProofManager is D3-only). Force
+    // D3 if the user picked Mermaid, else the proof manager is never created and
+    // the derivation would silently no-op.
+    let forcedD3 = false;
+    if (_currentRenderer !== 'd3') {
+        _currentRenderer = 'd3';
+        _lsSet(LS_KEYS.renderer, 'd3');
+        const sel = document.getElementById('graph-renderer-select');
+        if (sel) sel.value = 'd3';
+        _updateFitControls();
+        forcedD3 = true;
+    }
+
+    if (!isGraphModeActive()) {
+        await setDockTab('graph');                   // switch + render (D3) + wire the proof manager
+        return true;
+    }
+    // Already on the Math tab: re-render if we just forced D3, or if the proof
+    // manager isn't ready yet, so the box has something to dock onto.
+    if (forcedD3 || !_currentProofManager || _currentProofManager._destroyed) {
+        await renderCurrentStepGraph(true);
+    }
+    return forcedD3;
 };
 
 function _showD3InfoPanel(nodeId, nodeData, graph) {

--- a/static/proof-animation/sg-proof.js
+++ b/static/proof-animation/sg-proof.js
@@ -26,6 +26,11 @@ export function clearDeriveCache() {
     _DERIVE_CACHE.clear();
 }
 
+// A derivation is an LM call (sometimes retried server-side); a hard goal can
+// run long, but past this it's almost certainly stuck — fail with a retryable
+// error rather than spin the "Deriving proof…" pill forever.
+const DERIVE_TIMEOUT_MS = 90_000;
+
 const BOX_W = 360;            // natural render width of the animator (zoomed to fit the box)
 const GRID_COLS = 8;          // same grid as SgChartManager
 const GRID_ROWS = 8;
@@ -301,7 +306,7 @@ export class SgProofManager {
         this._renderLoading(entry);
         const pill = this._showPill();
         try {
-            const data = await invokeExpert('proof_animation', payload);
+            const data = await invokeExpert('proof_animation', payload, { timeoutMs: DERIVE_TIMEOUT_MS });
             if (this._destroyed || !this.boxes.has(entry.boxId)) return;
             _DERIVE_CACHE.set(key, data);
             if (data && data.title) this._renderInlineMath(entry.titleEl, data.title);


### PR DESCRIPTION
Closes #354

## What

Delivers `proof_completion` to the chat agent and tightens how the agent's actions surface in the UI.

### 1. `derive_proof_animation` — agent-initiated, on-graph derivations
A new chat-agent tool that kicks off a **SymPy-verified** derivation on the current step's semantic graph — the same effect as clicking a node's **Derive** button, but driven by the agent. Fire-and-forget: the agent only *initiates*; the client runs the derivation (the existing `proof_animation` handler) and docks it into the graph context where it started, persisting on that step across navigation. **Results never enter the chat history** — the agent just says it's deriving.

Covers three cases via the existing handler: `start`+`target`, `start`+`target`+`prompt`, and `target`-only (start inferred from the proof's givens).

- Reuses the Derive button's payload logic via a shared `_proofContextPayload()` / `_normLatex` (no duplication); `_findNodeIdByLatex()` anchors the proof to a matching node.
- Server dispatch is fire-and-forget with a **deterministic guard**: if the current step has no semantic graph it returns an actionable error so the agent asks the user to navigate to one (instead of a silent no-op).
- A **contextual nudge**: when a proof step is in view the agent is told to offer a "Derive …" preset-prompt chip — only when a real derivation makes sense.

### 2. Tab-follow so the agent's actions are visible
- **navigate_to / add_scene** → switch to the **Scenes** tab so the user sees the scene they were moved to — unless split-docked (scene already visible alongside the graph).
- **derive_proof_animation** → switch to the **Math** (semantic graph) tab so the docked derivation is visible — but only when an active graph is hidden behind the 3D viewport (never yanks the user to an empty Math view). `algebenchDeriveProof` is now async and awaits the graph render before docking; `setDockTab()` returns the render promise.

### 3. Robustness — derivation timeout
Client-side **90s timeout** on derivations (`AbortController` in `expert-client.js`): a hung/slow LM call now fails gracefully (error + Retry) and the "Deriving proof…" pill is always cleared, instead of spinning forever. Applies to both the agent tool and the Derive button.

### 4. Disable `add_scene`
Scene-builder output was unreliable, so it's removed from the agent's surface entirely: dropped from the exposed tool list and scrubbed from all agent-facing text (system-prompt instructions + `agent-tools-reference.md`), including the orphaned `parametric_curve` element type and `$key in add_scene` references. The decl object and server/client handlers remain **dormant** for easy re-enable. The agent now works within the lesson's existing scenes.

## Why

The `proof_completion` expert + `proof_animation` handler shipped in #353/#362 but were only reachable from the node Derive button. This wires them to the chat agent so a user can ask for any derivation in natural language and get an accurate, reproducible, verified animation on the graph — without the agent hand-waving algebra into chat.

## Notes for reviewers
- The agent tool is a thin initiator; all the heavy lifting (dedup, anchoring, loading/timeout/error, the network call, mounting the animator) is the shared `SgProofManager.openProof()` path already used by the Derive button.
- `add_scene` is disabled, not deleted — re-enabling is a one-line change (restore it to `ALL_TOOL_DECLS`).

## Testing
Verified end-to-end in the browser (preview): agent-initiated derivation docks and renders; auto-switch to Math from the 3D scene when an active graph is hidden; navigate→Scenes switch (and split-mode exception); timeout path fails gracefully with Retry; `add_scene` absent from the built system prompt and tool list; the derivation preset-prompt nudge fires only with a proof step in context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)