### PR TITLE
Proof animation: smoother morph, responsive layout, and a clickable Next pill

### DIFF
--- a/static/proof-animation/proof-animation.css
+++ b/static/proof-animation/proof-animation.css
@@ -1,5 +1,34 @@
 /* proof-animation.css — styles for the ProofAnimator (themeable via CSS vars). */
 
+/* Custom tooltip (reliable everywhere, unlike the native title which is slow and
+   doesn't render in some embedded/zoomed contexts). Any element with data-tip
+   shows it on hover/focus. */
+.pa-root [data-tip] { position: relative; }
+.pa-root [data-tip]:hover::after,
+.pa-root [data-tip]:focus-visible::after {
+  content: attr(data-tip);
+  position: absolute;
+  bottom: calc(100% + 7px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 30;
+  padding: 5px 9px;
+  border-radius: 6px;
+  background: rgba(10, 12, 26, 0.97);
+  border: 1px solid var(--pa-border);
+  color: #e5e7eb;
+  font: 400 0.72rem/1.35 var(--font-sans, system-ui, -apple-system, "Segoe UI", sans-serif);
+  font-style: normal;
+  letter-spacing: normal;
+  text-transform: none;
+  text-align: center;
+  white-space: normal;
+  width: max-content;
+  max-width: 240px;
+  pointer-events: none;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.45);
+}
+
 .pa-root {
   --pa-fg: var(--text-color, #1a1a2e);
   --pa-muted: var(--muted-color, #6b7280);
@@ -73,7 +102,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 3px;
+  gap: 6px;                  /* equal vertical spacing between op / just / pill */
   min-height: 1.4em;
   font-size: 0.95rem;
 }
@@ -82,10 +111,14 @@
 
 /* "Next" pill — mirrors the proof-navigator step pills; clickable (= next btn). */
 .pa-next-pill {
-  margin-top: 5px;
-  display: inline-flex;
+  /* grid (not flex) so the title column can shrink to 0 and ellipsize — a flex
+     item won't shrink past an inline-block (KaTeX) child even with min-width:0. */
+  display: inline-grid;
+  grid-template-columns: auto minmax(0, max-content);
   align-items: baseline;
   gap: 7px;
+  box-sizing: border-box;
+  min-width: 0;
   max-width: 100%;
   padding: 3px 11px;
   border-radius: 999px;
@@ -95,7 +128,6 @@
   font-size: 0.82em;
   line-height: 1.3;
   white-space: nowrap;
-  overflow: hidden;
   cursor: pointer;
   user-select: none;
   transition: background 0.15s, border-color 0.15s;
@@ -112,7 +144,16 @@
   text-transform: uppercase;
   color: var(--pa-accent);
 }
-.pa-next-body { overflow: hidden; text-overflow: ellipsis; }
+/* The title shrinks and gets an ellipsis so the pill never exceeds the
+   container width (full text is in the title attribute → tooltip). min-width:0
+   lets the flex item shrink below its content size. */
+.pa-next-body {
+  flex: 0 1 auto;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
 /* Transient clones used by the meta promote animation. */
 .pa-meta-ghost { position: absolute; pointer-events: none; margin: 0; }
@@ -128,6 +169,10 @@
   padding-top: 12px;
 }
 .pa-steps { display: flex; gap: 6px; }
+/* When the controls row can't fit, _fitControls() adds .pa-compact and the
+   numbered step buttons are hidden — only prev / next / play / speed / mode
+   remain (navigate with the arrows). */
+.pa-controls.pa-compact .pa-steps { display: none; }
 
 .pa-btn, .pa-step {
   font: inherit;
@@ -151,13 +196,17 @@
 }
 .pa-play { margin-left: auto; width: 6em; box-sizing: border-box; text-align: center; }
 
+/* sequential toggle — icon button (label moved to the title/tooltip) */
 .pa-mode {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  color: var(--pa-muted);
-  font-size: 0.9rem;
-  user-select: none;
+  min-width: 2.4em;
+  text-align: center;
+  font-size: 1.05em;
+  line-height: 1;
+}
+.pa-mode.pa-active {
+  background: var(--pa-accent);
+  color: var(--pa-active-fg);
+  border-color: var(--pa-accent);
 }
 
 /* dark theme friendliness when the host sets a dark background var */

--- a/static/proof-animation/proof-animation.css
+++ b/static/proof-animation/proof-animation.css
@@ -137,7 +137,6 @@
 .pa-next-pill:focus-visible { outline: 2px solid var(--pa-accent); outline-offset: 2px; }
 .pa-next-pill.pa-next-hidden { display: none; }
 .pa-next-label {
-  flex: none;
   font-size: 0.82em;
   font-weight: 700;
   letter-spacing: 0.10em;

--- a/static/proof-animation/proof-animation.css
+++ b/static/proof-animation/proof-animation.css
@@ -67,16 +67,56 @@
 .pa-ghost { pointer-events: none; z-index: 4; }
 .pa-move.pa-insert { z-index: -1; }
 
-/* operation (explanation) stacked above justification */
+/* operation (explanation) stacked above justification, then the "Next" pill */
 .pa-meta {
+  position: relative;        /* anchor for absolutely-positioned meta ghosts */
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: 3px;
   min-height: 1.4em;
   font-size: 0.95rem;
 }
 .pa-op { font-weight: 600; color: var(--pa-fg); }
 .pa-just { color: var(--pa-muted); font-style: italic; }
+
+/* "Next" pill — mirrors the proof-navigator step pills; clickable (= next btn). */
+.pa-next-pill {
+  margin-top: 5px;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 7px;
+  max-width: 100%;
+  padding: 3px 11px;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.16);
+  border: 1px solid rgba(120, 130, 200, 0.40);
+  color: var(--pa-fg);
+  font-size: 0.82em;
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.15s, border-color 0.15s;
+}
+.pa-next-pill, .pa-next-pill * { cursor: pointer; }
+.pa-next-pill:hover { background: rgba(99, 102, 241, 0.30); border-color: var(--pa-accent); }
+.pa-next-pill:focus-visible { outline: 2px solid var(--pa-accent); outline-offset: 2px; }
+.pa-next-pill.pa-next-hidden { display: none; }
+.pa-next-label {
+  flex: none;
+  font-size: 0.82em;
+  font-weight: 700;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  color: var(--pa-accent);
+}
+.pa-next-body { overflow: hidden; text-overflow: ellipsis; }
+
+/* Transient clones used by the meta promote animation. */
+.pa-meta-ghost { position: absolute; pointer-events: none; margin: 0; }
+.pa-promoting { will-change: transform, opacity; }
 
 /* controls */
 .pa-controls {

--- a/static/proof-animation/proof-animation.css
+++ b/static/proof-animation/proof-animation.css
@@ -22,6 +22,11 @@
 /* the expression canvas — relative so delete-ghosts can be absolutely placed */
 .pa-stage {
   position: relative;
+  /* Establish a stacking context so the inserts' z-index:-1 (they slide in BEHIND
+     the moving glyphs) stays scoped to the stage. Without this it escapes to the
+     root context and paints new glyphs BEHIND the panel background — they fade in
+     invisibly, then "pop" into view at the end. */
+  isolation: isolate;
   min-height: 96px;
   display: flex;
   align-items: center;
@@ -31,6 +36,20 @@
   line-height: 1.2;
 }
 .pa-stage .katex { color: var(--pa-fg); }
+
+/* The expression renders into a fixed-width block (pinned to the scaled widest
+   step via --pa-expr-w), centred in the stage. Its CONTENT is left-aligned so
+   persistent tokens keep a stable left anchor across steps instead of
+   re-centring — which made every token drift sideways at each boundary. KaTeX
+   display mode centres by default, so undo that on the block AND the inner
+   .katex it wraps. */
+.pa-stage > .pa-expr {
+  display: block;
+  width: var(--pa-expr-w, auto);
+  max-width: 100%;
+}
+.pa-stage > .pa-expr .katex-display { margin: 0; text-align: left; }
+.pa-stage > .pa-expr .katex-display > .katex { text-align: left; }
 
 /* Animated tokens must be inline-block — CSS transforms are IGNORED on
    display:inline elements (KaTeX renders tokens inline), so without this the
@@ -42,7 +61,11 @@
   z-index: 2;
   will-change: transform;
 }
-.pa-ghost { pointer-events: none; z-index: 1; }
+/* Paint order during a morph (back → front): inserting items, then moving
+   items, then the disappearing ghosts on top. So new items grow in from BEHIND
+   and never occlude the items that are still moving or fading out. */
+.pa-ghost { pointer-events: none; z-index: 4; }
+.pa-move.pa-insert { z-index: -1; }
 
 /* operation (explanation) stacked above justification */
 .pa-meta {
@@ -130,10 +153,12 @@
     justify-content: center;
 }
 
-/* The animator renders at a fixed natural width; _fit() zooms it to the box. */
+/* The animator fills the box width; its responsive _fit scales the expression
+   to that width and the caption/controls use the full width. _fit() in
+   SgProofManager only zooms it DOWN if the height would overflow the box. */
 .sgp-pa {
-    width: 360px;
-    flex: none;
+    width: 100%;
+    flex: 0 1 auto;
 }
 .sgp-pa.pa-root {
     border: none;
@@ -204,12 +229,15 @@
 .sgp-derive-indicator .gei-dots span:nth-child(2) { animation-delay: 0.18s; }
 .sgp-derive-indicator .gei-dots span:nth-child(3) { animation-delay: 0.36s; }
 
-/* In the docked proof box, the step (nav) buttons stretch to fill the row. */
+/* In the docked proof box the step (nav) buttons grow to fill a NARROW row, but
+   cap their width so they don't stretch into giant bars when the box is wide
+   (the animator now fills the full box width). */
 .sgp-proof-box .pa-controls { gap: 6px; }
-.sgp-proof-box .pa-steps { flex: 1 1 auto; }
+.sgp-proof-box .pa-steps { flex: 1 1 auto; flex-wrap: wrap; }
 .sgp-proof-box .pa-steps .pa-step {
     flex: 1 1 0;
-    min-width: 0;
+    min-width: 30px;
+    max-width: 52px;
     padding-left: 2px;
     padding-right: 2px;
 }

--- a/static/proof-animation/proof-animation.css
+++ b/static/proof-animation/proof-animation.css
@@ -145,10 +145,9 @@
   color: var(--pa-accent);
 }
 /* The title shrinks and gets an ellipsis so the pill never exceeds the
-   container width (full text is in the title attribute → tooltip). min-width:0
-   lets the flex item shrink below its content size. */
+   container width (full text is exposed via the custom data-tip tooltip when
+   truncated). min-width:0 lets this grid column shrink below its content size. */
 .pa-next-body {
-  flex: 0 1 auto;
   min-width: 0;
   white-space: nowrap;
   overflow: hidden;

--- a/static/proof-animation/proof-animation.js
+++ b/static/proof-animation/proof-animation.js
@@ -76,14 +76,16 @@ export class ProofAnimator {
       `position:absolute; visibility:hidden; left:-9999px; top:0; width:${meta.clientWidth}px;`;
     const op = document.createElement("span"); op.className = "pa-op";
     const just = document.createElement("span"); just.className = "pa-just";
-    probe.append(op, just);
+    const next = document.createElement("span"); next.className = "pa-next-pill";
+    probe.append(op, just, next);
     this.container.appendChild(probe);
     let h = 0;
-    for (const s of this.data.steps) {
-      this._caption(op, s.operation ? `${s.index}. ${s.operation}` : `state ${s.index}`);
+    this.data.steps.forEach((s, i) => {
+      this._caption(op, this._opText(i));
       this._caption(just, s.justification || "");
+      this._setNextPill(next, i);
       h = Math.max(h, probe.getBoundingClientRect().height);
-    }
+    });
     probe.remove();
     if (h > 0) meta.style.minHeight = Math.ceil(h) + "px";
   }
@@ -199,7 +201,7 @@ export class ProofAnimator {
     this.container.classList.add("pa-root");
     this.container.innerHTML = `
       <div class="pa-stage" aria-live="polite"></div>
-      <div class="pa-meta"><span class="pa-op"></span><span class="pa-just"></span></div>
+      <div class="pa-meta"><span class="pa-op"></span><span class="pa-just"></span><span class="pa-next-pill" role="button" tabindex="0" title="Go to next step"></span></div>
       <div class="pa-controls">
         <button class="pa-btn pa-prev" title="Previous step" aria-label="Previous step">◀</button>
         <div class="pa-steps"></div>
@@ -220,6 +222,12 @@ export class ProofAnimator {
     });
     this.container.querySelector(".pa-prev").onclick = () => this._userGoTo(this.current - 1);
     this.container.querySelector(".pa-next").onclick = () => this._userGoTo(this.current + 1);
+    // The "Next" pill acts like the next button.
+    const nextPill = this.container.querySelector(".pa-next-pill");
+    nextPill.onclick = () => this._userGoTo(this.current + 1);
+    nextPill.onkeydown = (e) => {
+      if (e.key === "Enter" || e.key === " ") { e.preventDefault(); this._userGoTo(this.current + 1); }
+    };
     this.container.querySelector(".pa-play").onclick = () => this._togglePlay();
     this.container.querySelector(".pa-speed").onclick = () => {
       this._speedIdx = (this._speedIdx + 1) % SPEEDS.length;
@@ -387,6 +395,7 @@ export class ProofAnimator {
     this._running = [];
     this._ghosts.forEach((g) => g.remove());
     this._ghosts = [];
+    this._cancelMeta();
   }
 
   // Instantly show a step's final state — no animation. Used when the page can't
@@ -401,6 +410,7 @@ export class ProofAnimator {
   async goTo(target) {
     target = Math.max(0, Math.min(this.data.steps.length - 1, target));
     if (target === this.current && this._running.length === 0) return;
+    const prev = this.current;
     // When the tab/page is hidden, browsers FREEZE the document timeline, so WAAPI
     // animations never progress and `anim.finished` never resolves — the morph
     // would stall between phases and leave inserted glyphs stuck at opacity 0
@@ -450,7 +460,17 @@ export class ProofAnimator {
 
     this._cancel();
     this.current = target;
-    this._syncUI();
+    // Meta: a forward (next) step gets the "promote" animation — the Next title
+    // slides up into the explanation slot while the old caption fades out; the new
+    // Next pill fades in only AFTER the morph (metaFinish, below). Any other jump
+    // just snaps the caption.
+    let metaFinish = null;
+    if (target === prev + 1) {
+      this._updateStepButtons();
+      metaFinish = this._beginMetaPromote(prev, target);
+    } else {
+      this._syncUI();
+    }
 
     // LAST: render target, measure
     this._renderInto(this.stage, this.data.steps[target].latex);
@@ -693,6 +713,8 @@ export class ProofAnimator {
       // it, so the resting expression is guaranteed correct and identical to a fresh
       // render. It's visually identical to the just-finished frame, so no flicker.
       this._renderInto(this.stage, this.data.steps[target].latex);
+      // Step animation done → now fade in the new justification + "Next" pill.
+      if (metaFinish) metaFinish();
     }
   }
 
@@ -775,12 +797,129 @@ export class ProofAnimator {
   }
 
   _syncUI() {
+    this._updateStepButtons();
+    this._caption(this.container.querySelector(".pa-op"), this._opText(this.current));
+    this._caption(this.container.querySelector(".pa-just"), this.data.steps[this.current].justification || "");
+    this._setNextPill(this.container.querySelector(".pa-next-pill"), this.current);
+  }
+
+  _updateStepButtons() {
     this.container.querySelectorAll(".pa-step").forEach((b, i) =>
       b.classList.toggle("pa-active", i === this.current));
-    const s = this.data.steps[this.current];
-    // both the explanation (operation) and the justification — each may use $…$ LaTeX
-    this._caption(this.container.querySelector(".pa-op"),
-      s.operation ? `${this.current}. ${s.operation}` : `state ${this.current}`);
-    this._caption(this.container.querySelector(".pa-just"), s.justification || "");
+  }
+
+  // The explanation/title text for a step (numbered).
+  _opText(idx) {
+    const s = this.data.steps[idx];
+    return s.operation ? `${idx}. ${s.operation}` : `state ${idx}`;
+  }
+  // The plain title (no number) of the step AFTER idx, or null if idx is the last.
+  _nextOpText(idx) {
+    const n = this.data.steps[idx + 1];
+    return n ? (n.operation || `state ${idx + 1}`) : null;
+  }
+  // Meta "promote" animation for a forward (next) step: the current explanation
+  // and justification fade OUT, and the title shown in the "Next" pill slides UP
+  // into the title position to become the new explanation. Returns a finish()
+  // closure that the caller runs AFTER the expression morph completes, which
+  // fades in the new justification and the new "Next" pill (never during).
+  _beginMetaPromote(prev, target) {
+    const meta = this.container.querySelector(".pa-meta");
+    const opEl = meta.querySelector(".pa-op");
+    const justEl = meta.querySelector(".pa-just");
+    const nextEl = meta.querySelector(".pa-next-pill");
+    const metaRect = meta.getBoundingClientRect();
+    const opRect = opEl.getBoundingClientRect();
+    const justRect = justEl.getBoundingClientRect();
+    const nextRect = nextEl.getBoundingClientRect();
+    const nextWasShown = !nextEl.classList.contains("pa-next-hidden");
+    this._metaGhosts = this._metaGhosts || [];
+    this._metaAnims = this._metaAnims || [];
+
+    // 1. Ghost the OLD explanation + justification at their spots and fade out.
+    const ghostOut = (el, rect) => {
+      if (!el.textContent.trim()) return;
+      const g = el.cloneNode(true);
+      g.classList.add("pa-meta-ghost");
+      g.style.left = (rect.left - metaRect.left) + "px";
+      g.style.top = (rect.top - metaRect.top) + "px";
+      g.style.width = Math.ceil(rect.width) + "px";
+      meta.appendChild(g);
+      this._metaGhosts.push(g);
+      const a = this._tween(g, [{ opacity: 1 }, { opacity: 0 }],
+        { duration: this._baseDuration * 0.55, easing: EASE, fill: "forwards" });
+      a.onfinish = () => g.remove();
+      this._metaAnims.push(a);
+    };
+    ghostOut(opEl, opRect);
+    ghostOut(justEl, justRect);
+
+    // 2. The new explanation IS the promoted "Next" title. Put it in the op slot,
+    //    hide the (now-promoted) next pill and the old justification, then FLIP the
+    //    op up from the Next position into place.
+    this._caption(opEl, this._opText(target));
+    this._caption(justEl, this.data.steps[target].justification || "");
+    justEl.style.opacity = "0";
+    nextEl.style.opacity = "0";
+    const newOpRect = opEl.getBoundingClientRect();
+    const dx = (nextWasShown ? nextRect.left : newOpRect.left) - newOpRect.left;
+    const dy = (nextWasShown ? nextRect.top : newOpRect.top) - newOpRect.top;
+    if (dx || dy) {
+      opEl.classList.add("pa-promoting");
+      const a = this._tween(opEl,
+        [{ transform: `translate(${dx}px, ${dy}px)` }, { transform: "none" }],
+        { duration: this._baseDuration, easing: EASE, fill: "both" });
+      a.onfinish = () => { opEl.style.transform = ""; opEl.classList.remove("pa-promoting"); };
+      this._metaAnims.push(a);
+    }
+
+    // 3. finish(): after the step animation, fade in the new justification first,
+    //    then the new "Next" pill on a longer delay (so it trails the caption).
+    return () => {
+      const ja = this._tween(justEl, [{ opacity: 0 }, { opacity: 1 }],
+        { duration: this._baseDuration * 0.6, easing: EASE, fill: "both" });
+      ja.onfinish = () => (justEl.style.opacity = "");
+      this._metaAnims.push(ja);
+      this._setNextPill(nextEl, target);
+      if (!nextEl.classList.contains("pa-next-hidden")) {
+        nextEl.style.opacity = "0";
+        const na = this._tween(nextEl, [{ opacity: 0 }, { opacity: 1 }],
+          { duration: this._baseDuration * 0.6, delay: this._baseDuration * 0.7, easing: EASE, fill: "both" });
+        na.onfinish = () => (nextEl.style.opacity = "");
+        this._metaAnims.push(na);
+      }
+    };
+  }
+
+  // Cancel any in-flight meta animation and reset the meta elements to a clean
+  // resting state (called from _cancel so a new navigation never inherits a
+  // half-promoted caption).
+  _cancelMeta() {
+    (this._metaAnims || []).forEach((a) => { try { a.cancel(); } catch (e) {} });
+    this._metaAnims = [];
+    (this._metaGhosts || []).forEach((g) => g.remove());
+    this._metaGhosts = [];
+    const opEl = this.container.querySelector(".pa-op");
+    if (opEl) { opEl.style.transform = ""; opEl.style.opacity = ""; opEl.classList.remove("pa-promoting"); }
+    const justEl = this.container.querySelector(".pa-just");
+    if (justEl) justEl.style.opacity = "";
+    const nextEl = this.container.querySelector(".pa-next-pill");
+    if (nextEl) nextEl.style.opacity = "";
+  }
+
+  // Render the "Next" pill for the step after idx (hidden on the last step).
+  _setNextPill(el, idx) {
+    if (!el) return;
+    const txt = this._nextOpText(idx);
+    el.innerHTML = "";
+    if (txt == null) { el.classList.add("pa-next-hidden"); return; }
+    el.classList.remove("pa-next-hidden");
+    const label = document.createElement("span");
+    label.className = "pa-next-label";
+    label.textContent = "Next";
+    const body = document.createElement("span");
+    body.className = "pa-next-body";
+    this._caption(body, txt);
+    el.append(label, body);
   }
 }

--- a/static/proof-animation/proof-animation.js
+++ b/static/proof-animation/proof-animation.js
@@ -479,17 +479,16 @@ export class ProofAnimator {
       rect: el.getBoundingClientRect(),
       fontSize: getComputedStyle(el).fontSize,
     }));
-    // which (node, decoration-type) pairs the SOURCE had — used to tell a
-    // genuinely new fraction/root apart from one whose node id was merely reused,
-    // and (with the clones below) to FADE OUT decorations that disappear.
-    const fromDecoKeys = new Set();
+    // Source decorations (fraction bar, radical, stretchy delimiter), keyed by
+    // their owning node (nearest [data-n]) + type. Snapshotted before re-render
+    // so the target ones can be matched against them — to MORPH a preserved
+    // decoration that resized/moved, FADE OUT removed ones, FADE IN new ones.
     const fromDecos = [];
     for (const sel of DECORATIONS) {
       this.stage.querySelectorAll(sel).forEach((el) => {
         const o = el.closest("[data-n]");
         if (!o) return;
         const key = o.getAttribute("data-n") + "|" + sel;
-        fromDecoKeys.add(key);
         fromDecos.push({ key, clone: el.cloneNode(true), rect: el.getBoundingClientRect(), fontSize: getComputedStyle(el).fontSize });
       });
     }
@@ -563,26 +562,39 @@ export class ProofAnimator {
       if (!_uMatch.bKeep.has(j)) { el.style.opacity = "0"; untagInserts.push(el); }  // newly added → fade in last
     });
 
-    // newly-introduced structural decorations → also fade in last. A decoration
-    // (fraction bar, radical, delimiter) belongs to the node that emitted it: its
-    // nearest [data-n] ancestor. If that subtree already existed in the source the
-    // decoration persists (never blink it); if the subtree is new, so is the
-    // decoration → fade it in. This catches a *new inner* fraction even when an
-    // outer fraction is already on screen.
+    // Diff target decorations against the source ones (matched by owner|type):
+    //   • preserved but moved/resized → FLIP it (hold at the source pose now, the
+    //     move phase tweens it to identity) so a fraction bar or radical grows /
+    //     shrinks / slides smoothly instead of snapping to its new shape;
+    //   • new → fade in last (phase 2);   • removed → ghost out (phase 0, below).
     const decoEls = [];
-    const toDecoKeys = new Set();
+    const decoMovers = [];
+    const srcDecoByKey = new Map();
+    for (const d of fromDecos) {
+      if (!srcDecoByKey.has(d.key)) srcDecoByKey.set(d.key, []);
+      srcDecoByKey.get(d.key).push(d);
+    }
+    const matchedSrcDeco = new Set();
     for (const sel of DECORATIONS) {
       this.stage.querySelectorAll(sel).forEach((el) => {
         const owner = el.closest("[data-n]");
-        const ownerId = owner && owner.getAttribute("data-n");
-        if (ownerId) toDecoKeys.add(ownerId + "|" + sel);
-        // keep visible only if that very node already had this decoration in the
-        // source (so the outer fraction persists, but a new inner one fades in).
-        if (ownerId && fromDecoKeys.has(ownerId + "|" + sel)) return;
-        el.style.opacity = "0";
-        decoEls.push(el);
+        const key = (owner ? owner.getAttribute("data-n") : "") + "|" + sel;
+        const pool = srcDecoByKey.get(key);
+        const src = pool && pool.find((s) => !matchedSrcDeco.has(s));
+        if (!src) { el.style.opacity = "0"; decoEls.push(el); return; }   // new → fade in
+        matchedSrcDeco.add(src);
+        const tr = el.getBoundingClientRect();
+        const dx = src.rect.left - tr.left, dy = src.rect.top - tr.top;
+        const sx = tr.width > 0 ? src.rect.width / tr.width : 1;
+        const sy = tr.height > 0 ? src.rect.height / tr.height : 1;
+        if (Math.abs(dx) > 1 || Math.abs(dy) > 1 || Math.abs(sx - 1) > 0.02 || Math.abs(sy - 1) > 0.02) {
+          el.style.transformOrigin = "0 0";
+          el.style.transform = `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`;   // hold at source pose
+          decoMovers.push({ el, dx, dy, sx, sy });
+        }
       });
     }
+    const removedDecos = fromDecos.filter((d) => !matchedSrcDeco.has(d));
 
     // source-only glyphs → DELETE ghosts: clones placed at their old spot. Each
     // ghost is wrapped in a `.katex` host so KaTeX's font CSS (scoped under
@@ -630,8 +642,7 @@ export class ProofAnimator {
     // Decorations (fraction bar, radical, stretchy delimiter) that DISAPPEARED →
     // ghost the cloned decoration (which keeps its stretched size) at its old spot
     // and fade it out with the other id-less items, instead of letting it vanish.
-    for (const d of fromDecos) {
-      if (toDecoKeys.has(d.key)) continue;   // still present → persists
+    for (const d of removedDecos) {
       const host = document.createElement("span");
       host.className = "katex pa-ghost";
       let left = d.rect.left - stageRect.left, top = d.rect.top - stageRect.top;
@@ -703,6 +714,17 @@ export class ProofAnimator {
         blk.el.style.transformOrigin = "";
         if (!blk.single) blk.el.classList.remove("pa-move");
       };
+      moveAnims.push(a);
+    }
+    // preserved decorations (fraction bar, radical, delimiter) glide/stretch from
+    // their old pose to the new one, in lockstep with the glyphs they wrap.
+    for (const dm of decoMovers) {
+      const a = this._tween(dm.el,
+        [{ transform: `translate(${dm.dx}px, ${dm.dy}px) scale(${dm.sx}, ${dm.sy})` },
+         { transform: "translate(0px, 0px) scale(1, 1)" }],
+        { duration: this._baseDuration, delay: seq ? mi++ * this._baseStagger : 0, easing: EASE, fill: "both" }
+      );
+      a.onfinish = () => { dm.el.style.transform = ""; dm.el.style.transformOrigin = ""; };
       moveAnims.push(a);
     }
     this._running = moveAnims;

--- a/static/proof-animation/proof-animation.js
+++ b/static/proof-animation/proof-animation.js
@@ -173,7 +173,17 @@ export class ProofAnimator {
       const w = this.container.clientWidth;
       if (Math.abs(w - this._lastFitW) < 1) return;   // height-only change → skip
       this._lastFitW = w;
-      this._relayout();
+      // Debounce: _relayout() re-renders every step via KaTeX in _fit() (expensive),
+      // and a live drag-resize fires many events per frame. Coalesce to one
+      // relayout per animation frame — same result, far less jank.
+      if (this._raf || typeof requestAnimationFrame === "undefined") {
+        if (typeof requestAnimationFrame === "undefined") this._relayout();
+        return;
+      }
+      this._raf = requestAnimationFrame(() => {
+        this._raf = 0;
+        if (!this._destroyed) this._relayout();
+      });
     });
     this._ro.observe(this.container);
     // If the tab is hidden WHILE a morph is mid-flight, its animations freeze and
@@ -210,6 +220,7 @@ export class ProofAnimator {
   destroy() {
     this._destroyed = true;
     this._cancel();
+    if (this._raf && typeof cancelAnimationFrame !== "undefined") { cancelAnimationFrame(this._raf); this._raf = 0; }
     if (this._ro) { try { this._ro.disconnect(); } catch (e) {} this._ro = null; }
     if (this._onVisibility) {
       try { document.removeEventListener("visibilitychange", this._onVisibility); } catch (e) {}
@@ -242,17 +253,18 @@ export class ProofAnimator {
       <div class="pa-stage" aria-live="polite"></div>
       <div class="pa-meta"><span class="pa-op"></span><span class="pa-just"></span><span class="pa-next-pill" role="button" tabindex="0"></span></div>
       <div class="pa-controls">
-        <button class="pa-btn pa-prev" data-tip="Previous step" aria-label="Previous step">◀</button>
+        <button type="button" class="pa-btn pa-prev" data-tip="Previous step" aria-label="Previous step">◀</button>
         <div class="pa-steps"></div>
-        <button class="pa-btn pa-next" data-tip="Next step" aria-label="Next step">▶</button>
-        <button class="pa-btn pa-play" data-tip="Play through" aria-label="Play through">▶ Play</button>
-        <button class="pa-btn pa-speed" data-tip="Animation speed (click to cycle)" aria-label="Animation speed">${_speedLabel(this.speed)}</button>
+        <button type="button" class="pa-btn pa-next" data-tip="Next step" aria-label="Next step">▶</button>
+        <button type="button" class="pa-btn pa-play" data-tip="Play through" aria-label="Play through">▶ Play</button>
+        <button type="button" class="pa-btn pa-speed" data-tip="Animation speed (click to cycle)" aria-label="Animation speed">${_speedLabel(this.speed)}</button>
         <button class="pa-btn pa-mode" type="button" data-tip="Sequential — stagger the moves" aria-label="Sequential — stagger the moves" aria-pressed="false">⇉</button>
       </div>`;
     this.stage = this.container.querySelector(".pa-stage");
     const steps = this.container.querySelector(".pa-steps");
     this.data.steps.forEach((s, i) => {
       const b = document.createElement("button");
+      b.type = "button";   // never submit a surrounding <form>
       b.className = "pa-step";
       b.textContent = String(i);
       const tip = `${i}. ${this._plainOp(s.operation || `state ${i}`)}`;
@@ -568,7 +580,7 @@ export class ProofAnimator {
     let metaFinish = null;
     if (target === prev + 1) {
       this._updateStepButtons();
-      metaFinish = this._beginMetaPromote(prev, target);
+      metaFinish = this._beginMetaPromote(target);
     } else {
       this._syncUI();
     }
@@ -1057,7 +1069,7 @@ export class ProofAnimator {
   // into the title position to become the new explanation. Returns a finish()
   // closure that the caller runs AFTER the expression morph completes, which
   // fades in the new justification and the new "Next" pill (never during).
-  _beginMetaPromote(prev, target) {
+  _beginMetaPromote(target) {
     const meta = this.container.querySelector(".pa-meta");
     const opEl = meta.querySelector(".pa-op");
     const justEl = meta.querySelector(".pa-just");

--- a/static/proof-animation/proof-animation.js
+++ b/static/proof-animation/proof-animation.js
@@ -21,10 +21,20 @@
 const EASE = "cubic-bezier(0.42, 0, 0.58, 1)"; // ease-in-out
 
 // Untagged structural decorations KaTeX draws (no data-n of their own): the
-// fraction bar, the radical sign, and stretchy delimiters. When newly
-// introduced they must fade in LAST with the other new items — never instantly.
-// (These selectors hold no tagged glyphs, so hiding them won't hide content.)
-const DECORATIONS = [".frac-line", ".sqrt svg", ".delimsizing"];
+// fraction bar and the radical sign. When newly introduced they must fade in
+// LAST with the other new items — never instantly. (These selectors hold no
+// tagged glyphs, so hiding them won't hide content.)
+// NOTE: stretchy delimiters (`.delimsizing`) are NOT here — parentheses (plain
+// OR stretchy) are handled together by the unified paren matcher (`_parens`),
+// so a paren that flips representation between steps morphs as one unit.
+const DECORATIONS = [".frac-line", ".sqrt svg"];
+
+// Delimiter glyphs the renderer emits via \left…\right (plain or stretchy).
+const PAREN_RE = /^[()[\]|]$/;
+const _parenChar = (s) => {
+  const t = (s || "").replace(/[​-‍﻿]/g, "").trim();
+  return PAREN_RE.test(t) ? t : null;
+};
 
 // Playback speed multipliers the speed button cycles through (click → next).
 const SPEEDS = [0.25, 0.5, 1, 2, 4];
@@ -302,11 +312,9 @@ export class ProofAnimator {
       // they're not real glyphs and `String.trim()` doesn't remove them.
       const t = (el.textContent || "").replace(/[​-‍﻿]/g, "").trim();
       if (!t) return;
-      // A stretchy delimiter (\left(\right) around tall content) renders as a
-      // `.delimsizing` decoration that CONTAINS a glyph span — skip that inner
-      // glyph so the paren is handled once, by the decoration path (clone keeps
-      // its stretched size/position), not double-counted as a bare leaf.
-      if (el.closest(".delimsizing")) return;
+      // Parentheses (plain or stretchy `.delimsizing`) are handled by the unified
+      // paren matcher (`_parens`) — exclude them here so they're not animated twice.
+      if (_parenChar(t) || el.closest(".delimsizing")) return;
       if (el.hasAttribute("data-n")) return;   // itself a tagged glyph
       const p = el.closest("[data-n]");
       // No tagged ancestor, OR the nearest tagged ancestor is STRUCTURAL (it has
@@ -317,6 +325,54 @@ export class ProofAnimator {
       if (!p || p.querySelector("[data-n]")) out.push(el);
     });
     return out;
+  }
+
+  // Every parenthesis in `root`, in DOCUMENT ORDER, whether the renderer drew it
+  // as a plain glyph or a stretchy `.delimsizing` box. The "unit" is the
+  // `.delimsizing` box when present (so a clone keeps its stretched size), else
+  // the bare glyph span. Unifying both representations lets a paren that FLIPS
+  // between them across a step (KaTeX picks plain vs stretchy by content height)
+  // be matched as one and morph — instead of ghosting the old AND fading the new
+  // at the same spot (which looked like DUPLICATE parentheses).
+  _parens(root) {
+    const html = root.querySelector(".katex-html");
+    if (!html) return [];
+    const out = [];
+    const seen = new Set();
+    html.querySelectorAll("*").forEach((el) => {
+      if (el.firstElementChild) return;        // leaf glyph only
+      const ch = _parenChar(el.textContent);
+      if (!ch) return;
+      const delim = el.closest(".delimsizing");
+      const unit = delim || el;
+      if (seen.has(unit)) return;
+      seen.add(unit);
+      if (!delim) {
+        if (el.hasAttribute("data-n")) return;            // part of a tagged glyph
+        const p = el.closest("[data-n]");
+        if (p && !p.querySelector("[data-n]")) return;    // inside a tagged leaf glyph
+      }
+      out.push({ char: ch, el: unit, delim: !!delim });
+    });
+    return out;
+  }
+
+  // Like _lcsMatch but returns the actual aligned index PAIRS [srcIdx, tgtIdx],
+  // so a preserved paren can be morphed from its source pose to its target pose.
+  _lcsPairs(a, b) {
+    const n = a.length, m = b.length;
+    const dp = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+    for (let i = n - 1; i >= 0; i--)
+      for (let j = m - 1; j >= 0; j--)
+        dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    const pairs = [];
+    let i = 0, j = 0;
+    while (i < n && j < m) {
+      if (a[i] === b[j]) { pairs.push([i, j]); i++; j++; }
+      else if (dp[i + 1][j] >= dp[i][j + 1]) i++;
+      else j++;
+    }
+    return pairs;
   }
 
   // Longest-common-subsequence match between two text sequences. Returns the sets
@@ -479,6 +535,15 @@ export class ProofAnimator {
       rect: el.getBoundingClientRect(),
       fontSize: getComputedStyle(el).fontSize,
     }));
+    // Source parentheses (plain + stretchy), in document order — snapshot before
+    // re-render so a preserved paren can morph from its old pose and a removed
+    // one can ghost out.
+    const fromParens = this._parens(this.stage).map((p) => ({
+      char: p.char, delim: p.delim,
+      clone: p.el.cloneNode(true),
+      rect: p.el.getBoundingClientRect(),
+      fontSize: getComputedStyle(p.el).fontSize,
+    }));
     // Source decorations (fraction bar, radical, stretchy delimiter), keyed by
     // their owning node (nearest [data-n]) + type. Snapshotted before re-render
     // so the target ones can be matched against them — to MORPH a preserved
@@ -607,6 +672,39 @@ export class ProofAnimator {
     }
     const removedDecos = fromDecos.filter((d) => !matchedSrcDeco.has(d));
 
+    // ── Parentheses (plain + stretchy), matched as ONE category in document order.
+    // A preserved paren MORPHS from its source pose to its target pose (so a paren
+    // that flips plain↔stretchy, or grows with its content, glides as one unit
+    // instead of duplicating). Genuinely new parens fade in; removed ones ghost out.
+    const toParens = this._parens(this.stage);
+    const parenPairs = this._lcsPairs(fromParens.map((p) => p.char), toParens.map((p) => p.char));
+    const _pFromKeep = new Set(parenPairs.map((pr) => pr[0]));
+    const _pToKeep = new Set(parenPairs.map((pr) => pr[1]));
+    const parenMovers = [];
+    for (const [si, ti] of parenPairs) {
+      const src = fromParens[si], el = toParens[ti].el;
+      const tr = el.getBoundingClientRect();
+      const dx = src.rect.left - tr.left, dy = src.rect.top - tr.top;
+      // A stretchy SVG delimiter distorts under a non-uniform scale (like a
+      // radical), so scale only when the target isn't an SVG; otherwise glide
+      // position only and let it settle to its true size at the end.
+      const isSvg = !!el.querySelector("svg");
+      const sx = !isSvg && tr.width > 0 ? src.rect.width / tr.width : 1;
+      const sy = !isSvg && tr.height > 0 ? src.rect.height / tr.height : 1;
+      const changed = Math.abs(dx) > 1 || Math.abs(dy) > 1 || Math.abs(sx - 1) > 0.02 || Math.abs(sy - 1) > 0.02;
+      if (changed) {
+        el.classList.add("pa-move");
+        el.style.transformOrigin = "0 0";
+        el.style.transform = `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`;   // hold at source pose
+        parenMovers.push({ el, dx, dy, sx, sy });
+      }
+    }
+    const parenInserts = [];
+    toParens.forEach((p, j) => {
+      if (!_pToKeep.has(j)) { p.el.style.opacity = "0"; parenInserts.push(p.el); }   // new → fade in
+    });
+    const removedParens = fromParens.filter((p, i) => !_pFromKeep.has(i));            // removed → ghost out
+
     // source-only glyphs → DELETE ghosts: clones placed at their old spot. Each
     // ghost is wrapped in a `.katex` host so KaTeX's font CSS (scoped under
     // `.katex …`) still applies — otherwise the glyph reverts to the default
@@ -679,6 +777,27 @@ export class ProofAnimator {
       this._ghosts.push(host);
       untagGhosts.push(host);
     }
+    // Parentheses (plain or stretchy) that DISAPPEARED → ghost the clone at its
+    // old spot. A stretchy delimiter clone carries a vertical-align offset, so
+    // apply the same stage-relative nudge used for decorations above.
+    for (const p of removedParens) {
+      const host = document.createElement("span");
+      host.className = "katex pa-ghost";
+      let left = p.rect.left - stageRect.left, top = p.rect.top - stageRect.top;
+      Object.assign(host.style, {
+        position: "absolute", margin: "0", lineHeight: "0",
+        left: left + "px", top: top + "px", fontSize: p.fontSize,
+      });
+      host.appendChild(p.clone);
+      this.stage.appendChild(host);
+      const sr = this.stage.getBoundingClientRect();
+      const cr = p.clone.getBoundingClientRect();
+      const dx = (p.rect.left - stageRect.left) - (cr.left - sr.left);
+      const dy = (p.rect.top - stageRect.top) - (cr.top - sr.top);
+      if (dx || dy) { host.style.left = (left + dx) + "px"; host.style.top = (top + dy) + "px"; }
+      this._ghosts.push(host);
+      untagGhosts.push(host);
+    }
 
     // ── PHASE 0: dropped items fade OUT first, before any motion ──
     const D_OUT = this._baseDuration * 0.6;
@@ -738,6 +857,19 @@ export class ProofAnimator {
       a.onfinish = () => { dm.el.style.transform = ""; dm.el.style.transformOrigin = ""; };
       moveAnims.push(a);
     }
+    // preserved parentheses glide/scale from their old pose to the new one (handles
+    // a paren that flips plain↔stretchy or grows with its content), in lockstep.
+    for (const pm of parenMovers) {
+      const a = this._tween(pm.el,
+        [{ transform: `translate(${pm.dx}px, ${pm.dy}px) scale(${pm.sx}, ${pm.sy})` },
+         { transform: "translate(0px, 0px) scale(1, 1)" }],
+        { duration: this._baseDuration, delay: seq ? mi++ * this._baseStagger : 0, easing: EASE, fill: "both" }
+      );
+      a.onfinish = () => {
+        pm.el.style.transform = ""; pm.el.style.transformOrigin = ""; pm.el.classList.remove("pa-move");
+      };
+      moveAnims.push(a);
+    }
     this._running = moveAnims;
     await await_(moveAnims);
     if (this._token !== token) return;
@@ -763,7 +895,7 @@ export class ProofAnimator {
     // last, without shifting anything.
     const _inAfter = (seq ? ii * this._baseStagger : 0) + D_IN;
     let ik = 0;
-    for (const el of [...decoEls, ...untagInserts]) {
+    for (const el of [...decoEls, ...untagInserts, ...parenInserts]) {
       const a = this._tween(el,
         [{ opacity: 0 }, { opacity: 1 }],
         { duration: D_IN, delay: _inAfter + (seq ? ik++ * this._baseStagger : 0), easing: EASE, fill: "both" }

--- a/static/proof-animation/proof-animation.js
+++ b/static/proof-animation/proof-animation.js
@@ -184,6 +184,7 @@ export class ProofAnimator {
         if (document.hidden && this._running.length) {
           this._cancel();
           this._renderInto(this.stage, this.data.steps[this.current].latex);
+          this._capOverflow();   // webfonts may have loaded while hidden → re-cap width
           this._syncUI();
         }
       };
@@ -1160,13 +1161,15 @@ export class ProofAnimator {
     body.className = "pa-next-body";
     this._caption(body, txt);
     el.append(label, body);
-    this._updateNextTip();
+    this._updateNextTip(el);
   }
 
   // Show the Next pill's tooltip only when its title is truncated (re-checked on
-  // resize, since the available width — and thus truncation — changes).
-  _updateNextTip() {
-    const el = this.container.querySelector(".pa-next-pill");
+  // resize, since the available width — and thus truncation — changes). Operates
+  // on the given pill (defaults to the live one) so the offscreen probe pill in
+  // _fixMetaSize() is measured in isolation, not the live pill.
+  _updateNextTip(el) {
+    el = el || this.container.querySelector(".pa-next-pill");
     if (!el || el.classList.contains("pa-next-hidden")) return;
     const body = el.querySelector(".pa-next-body");
     const full = el.getAttribute("data-fulltip");

--- a/static/proof-animation/proof-animation.js
+++ b/static/proof-animation/proof-animation.js
@@ -62,7 +62,14 @@ export class ProofAnimator {
     this._fixMetaSize();    // pin the caption area to the tallest op+justification
     this._renderInto(this.stage, this.data.steps[0].latex);
     this._syncUI();
+    this._capOverflow();    // never let the expression spill past the stage
+    this._fitControls();    // hide step enumerations if the controls don't fit
     this._observeResize();  // responsive: re-fit on container/window resize
+    // KaTeX webfonts load async; the first _fit() may have measured with narrower
+    // fallback-font metrics. Re-fit once the real fonts are ready.
+    if (typeof document !== "undefined" && document.fonts && document.fonts.ready) {
+      document.fonts.ready.then(() => { if (!this._destroyed) this._relayout(); });
+    }
   }
 
   // Reserve the height of the tallest caption (operation + justification) so the
@@ -127,6 +134,24 @@ export class ProofAnimator {
     this.stage.style.setProperty("--pa-expr-w", `${Math.ceil(w * scale)}px`);
   }
 
+  // Hard guarantee that the CURRENT rendered expression never overflows the stage
+  // width — a safety net for cases _fit()'s probe under-measures (e.g. it ran
+  // before the KaTeX webfonts loaded, so fallback-font metrics were narrower).
+  // Shrinks the stage font (which reflows the existing render) until it fits.
+  _capOverflow() {
+    const expr = this.stage.querySelector(".pa-expr");
+    if (!expr) return;
+    const k = expr.querySelector(".katex-display") || expr.querySelector(".katex");
+    if (!k) return;
+    const avail = Math.max(40, this.stage.clientWidth - 8);
+    const w = k.getBoundingClientRect().width;
+    if (w > avail + 0.5) {
+      const cur = parseFloat(getComputedStyle(this.stage).fontSize) || this._baseFontPx;
+      this.stage.style.fontSize = `${cur * (avail / w)}px`;
+      this.stage.style.setProperty("--pa-expr-w", `${Math.ceil(avail)}px`);
+    }
+  }
+
   // Re-fit when the container (or window) resizes so the expression always fits
   // the available width. Only width changes matter — guard against the height
   // changes _fit() itself triggers (which would otherwise loop forever).
@@ -164,6 +189,9 @@ export class ProofAnimator {
     this._fit();
     this._fixMetaSize();
     this._renderInto(this.stage, this.data.steps[this.current].latex);
+    this._capOverflow();
+    this._fitControls();
+    this._updateNextTip();   // truncation depends on width → re-check on resize
   }
 
   // Tear down the ResizeObserver and any running animations (called when the
@@ -201,14 +229,14 @@ export class ProofAnimator {
     this.container.classList.add("pa-root");
     this.container.innerHTML = `
       <div class="pa-stage" aria-live="polite"></div>
-      <div class="pa-meta"><span class="pa-op"></span><span class="pa-just"></span><span class="pa-next-pill" role="button" tabindex="0" title="Go to next step"></span></div>
+      <div class="pa-meta"><span class="pa-op"></span><span class="pa-just"></span><span class="pa-next-pill" role="button" tabindex="0"></span></div>
       <div class="pa-controls">
-        <button class="pa-btn pa-prev" title="Previous step" aria-label="Previous step">◀</button>
+        <button class="pa-btn pa-prev" data-tip="Previous step" aria-label="Previous step">◀</button>
         <div class="pa-steps"></div>
-        <button class="pa-btn pa-next" title="Next step" aria-label="Next step">▶</button>
-        <button class="pa-btn pa-play" title="Play through">▶ Play</button>
-        <button class="pa-btn pa-speed" title="Animation speed (click to cycle)">${_speedLabel(this.speed)}</button>
-        <label class="pa-mode"><input type="checkbox"> sequential</label>
+        <button class="pa-btn pa-next" data-tip="Next step" aria-label="Next step">▶</button>
+        <button class="pa-btn pa-play" data-tip="Play through" aria-label="Play through">▶ Play</button>
+        <button class="pa-btn pa-speed" data-tip="Animation speed (click to cycle)" aria-label="Animation speed">${_speedLabel(this.speed)}</button>
+        <button class="pa-btn pa-mode" type="button" data-tip="Sequential — stagger the moves" aria-label="Sequential — stagger the moves" aria-pressed="false">⇉</button>
       </div>`;
     this.stage = this.container.querySelector(".pa-stage");
     const steps = this.container.querySelector(".pa-steps");
@@ -216,7 +244,9 @@ export class ProofAnimator {
       const b = document.createElement("button");
       b.className = "pa-step";
       b.textContent = String(i);
-      b.title = s.operation || `state ${i}`;
+      const tip = `${i}. ${this._plainOp(s.operation || `state ${i}`)}`;
+      b.setAttribute("data-tip", tip);
+      b.setAttribute("aria-label", tip);
       b.addEventListener("click", () => this._userGoTo(i));
       steps.appendChild(b);
     });
@@ -233,8 +263,13 @@ export class ProofAnimator {
       this._speedIdx = (this._speedIdx + 1) % SPEEDS.length;
       this._applySpeed();
     };
-    this.container.querySelector(".pa-mode input").onchange = (e) =>
-      (this.mode = e.target.checked ? "sequential" : "parallel");
+    const modeBtn = this.container.querySelector(".pa-mode");
+    modeBtn.onclick = () => {
+      this.mode = this.mode === "sequential" ? "parallel" : "sequential";
+      const on = this.mode === "sequential";
+      modeBtn.classList.toggle("pa-active", on);
+      modeBtn.setAttribute("aria-pressed", String(on));
+    };
   }
 
   _renderInto(el, latex) {
@@ -404,6 +439,7 @@ export class ProofAnimator {
     this._cancel();
     this.current = target;
     this._renderInto(this.stage, this.data.steps[target].latex);
+    this._capOverflow();
     this._syncUI();
   }
 
@@ -713,6 +749,7 @@ export class ProofAnimator {
       // it, so the resting expression is guaranteed correct and identical to a fresh
       // render. It's visually identical to the just-finished frame, so no flicker.
       this._renderInto(this.stage, this.data.steps[target].latex);
+      this._capOverflow();
       // Step animation done → now fade in the new justification + "Next" pill.
       if (metaFinish) metaFinish();
     }
@@ -723,7 +760,9 @@ export class ProofAnimator {
     const b = this.container.querySelector(".pa-play");
     if (!b) return;
     b.textContent = playing ? "⏸ Pause" : "▶ Play";
-    b.title = playing ? "Pause" : "Play through";
+    const tip = playing ? "Pause" : "Play through";
+    b.setAttribute("data-tip", tip);
+    b.setAttribute("aria-label", tip);
   }
   _togglePlay() {
     if (this._paused) return this._resume();                          // frozen → resume
@@ -808,11 +847,40 @@ export class ProofAnimator {
       b.classList.toggle("pa-active", i === this.current));
   }
 
+  // If the controls row would overflow the container width, hide the numbered
+  // step buttons (keep prev / next / play / speed / mode). Re-runs on resize.
+  _fitControls() {
+    const controls = this.container.querySelector(".pa-controls");
+    const steps = this.container.querySelector(".pa-steps");
+    if (!controls || !steps) return;
+    controls.classList.remove("pa-compact");           // measure with steps shown
+    const cs = getComputedStyle(controls);
+    const gap = parseFloat(cs.columnGap || cs.gap) || 0;
+    const kids = [...controls.children];
+    let natural = kids.reduce((sum, k) => sum + k.offsetWidth, 0) + gap * Math.max(0, kids.length - 1);
+    if (natural > controls.clientWidth + 1) controls.classList.add("pa-compact");
+  }
+
   // The explanation/title text for a step (numbered).
   _opText(idx) {
     const s = this.data.steps[idx];
     return s.operation ? `${idx}. ${s.operation}` : `state ${idx}`;
   }
+  // Flatten an operation string (text + inline LaTeX) to readable plain text for
+  // a native tooltip — strip delimiters and turn the most common LaTeX into
+  // legible ASCII/Unicode.
+  _plainOp(s) {
+    return String(s)
+      .replace(/\$|`|\\\(|\\\)|\\\[|\\\]/g, "")                       // math delimiters
+      .replace(/\\left|\\right/g, "")                                  // \left( -> (
+      .replace(/\\frac\s*\{([^{}]*)\}\s*\{([^{}]*)\}/g, "$1/$2")       // \frac{a}{b} -> a/b
+      .replace(/\\sqrt\s*\{([^{}]*)\}/g, "√($1)")                      // \sqrt{x} -> √(x)
+      .replace(/\\cdot/g, "·").replace(/\\times/g, "×")
+      .replace(/\^\{([^{}]*)\}/g, "^$1").replace(/_\{([^{}]*)\}/g, "_$1")  // ^{2}->^2, _{0}->_0
+      .replace(/\\[a-zA-Z]+/g, "").replace(/[{}]/g, "")               // drop leftover commands/braces
+      .replace(/\s+/g, " ").trim();
+  }
+
   // The plain title (no number) of the step AFTER idx, or null if idx is the last.
   _nextOpText(idx) {
     const n = this.data.steps[idx + 1];
@@ -912,8 +980,14 @@ export class ProofAnimator {
     if (!el) return;
     const txt = this._nextOpText(idx);
     el.innerHTML = "";
-    if (txt == null) { el.classList.add("pa-next-hidden"); return; }
+    el.removeAttribute("data-tip");
+    if (txt == null) { el.classList.add("pa-next-hidden"); el.removeAttribute("aria-label"); el.removeAttribute("data-fulltip"); return; }
     el.classList.remove("pa-next-hidden");
+    // Full text (LaTeX flattened to plain) kept in data-fulltip; data-tip (which
+    // is what shows the tooltip) is only set when the title is actually truncated.
+    const tip = "Next: " + this._plainOp(txt);
+    el.setAttribute("data-fulltip", tip);
+    el.setAttribute("aria-label", tip);
     const label = document.createElement("span");
     label.className = "pa-next-label";
     label.textContent = "Next";
@@ -921,5 +995,17 @@ export class ProofAnimator {
     body.className = "pa-next-body";
     this._caption(body, txt);
     el.append(label, body);
+    this._updateNextTip();
+  }
+
+  // Show the Next pill's tooltip only when its title is truncated (re-checked on
+  // resize, since the available width — and thus truncation — changes).
+  _updateNextTip() {
+    const el = this.container.querySelector(".pa-next-pill");
+    if (!el || el.classList.contains("pa-next-hidden")) return;
+    const body = el.querySelector(".pa-next-body");
+    const full = el.getAttribute("data-fulltip");
+    if (body && full && body.scrollWidth > body.clientWidth + 1) el.setAttribute("data-tip", full);
+    else el.removeAttribute("data-tip");
   }
 }

--- a/static/proof-animation/proof-animation.js
+++ b/static/proof-animation/proof-animation.js
@@ -52,12 +52,17 @@ export class ProofAnimator {
     this._token = null;
     this._playId = null;  // identifies the active play() loop; user nav clears it
     this._paused = false; // freeze in-flight animations (works mid-interpolation)
+    this._destroyed = false;
+    this._ro = null;      // ResizeObserver → re-fit when the container resizes
     this._applySpeed();   // sets this.speed (needs _running to exist)
     this._build();
-    this._fixStageSize();   // pin the stage to the largest step so it never resizes
+    // Base (unscaled) expression font; _fit() shrinks from here to fit the width.
+    this._baseFontPx = parseFloat(getComputedStyle(this.stage).fontSize) || 30;
+    this._fit();            // size the stage to the largest step, scaled to fit the width
     this._fixMetaSize();    // pin the caption area to the tallest op+justification
     this._renderInto(this.stage, this.data.steps[0].latex);
     this._syncUI();
+    this._observeResize();  // responsive: re-fit on container/window resize
   }
 
   // Reserve the height of the tallest caption (operation + justification) so the
@@ -83,13 +88,17 @@ export class ProofAnimator {
     if (h > 0) meta.style.minHeight = Math.ceil(h) + "px";
   }
 
-  // Measure every step and lock the stage to the max width/height, so the canvas
-  // (and the controls below it) never jump as expressions grow or shrink between
-  // steps. Each step then renders centered inside this fixed box.
-  _fixStageSize() {
+  // Measure every step at the base font and lock the stage to the max width/
+  // height, then scale the font down (only down, never up) so the WIDEST step
+  // fits the current stage width. Pinning to the max keeps the canvas — and the
+  // controls below it — from jumping as expressions grow/shrink between steps;
+  // scaling by the SHARED max keeps the scale identical across steps (no per-step
+  // zoom jump); and recomputing on resize makes the whole thing responsive
+  // instead of overflowing a narrowed container.
+  _fit() {
     const probe = document.createElement("span");
     probe.style.cssText =
-      "position:absolute; visibility:hidden; left:-9999px; top:0; white-space:nowrap;";
+      `position:absolute; visibility:hidden; left:-9999px; top:0; white-space:nowrap; font-size:${this._baseFontPx}px;`;
     this.stage.appendChild(probe);
     let w = 0, h = 0;
     for (const step of this.data.steps) {
@@ -99,10 +108,72 @@ export class ProofAnimator {
       h = Math.max(h, r.height);
     }
     probe.remove();
-    // Height is the only dimension that varies (the stage already stretches to
-    // the fixed panel width), so pinning it stops the vertical jump. Add a little
-    // headroom so nothing clips.
-    if (h > 0) this.stage.style.height = Math.ceil(h + 8) + "px";
+    if (w <= 0) return;
+    this._maxExprW = w;
+    // Shrink the font so the widest step fits the available width (a tiny gutter
+    // keeps it off the edges). The same scale applies to every step, so there's
+    // no per-step zoom jump.
+    const availW = Math.max(40, this.stage.clientWidth - 8);
+    const scale = Math.min(1, availW / w);
+    this.stage.style.fontSize = `${this._baseFontPx * scale}px`;
+    // Height is pinned (scaled) so the stage never jumps between steps. The
+    // expression renders into a fixed-width block (the scaled max) that is
+    // centred in the stage with its CONTENT left-aligned (see CSS), so persistent
+    // tokens keep a stable left anchor instead of re-centring — and drifting —
+    // every step.
+    this.stage.style.height = `${Math.ceil(h * scale + 8)}px`;
+    this.stage.style.setProperty("--pa-expr-w", `${Math.ceil(w * scale)}px`);
+  }
+
+  // Re-fit when the container (or window) resizes so the expression always fits
+  // the available width. Only width changes matter — guard against the height
+  // changes _fit() itself triggers (which would otherwise loop forever).
+  _observeResize() {
+    if (this._ro || typeof ResizeObserver === "undefined") return;
+    this._lastFitW = this.container.clientWidth;
+    this._ro = new ResizeObserver(() => {
+      if (this._destroyed) return;
+      const w = this.container.clientWidth;
+      if (Math.abs(w - this._lastFitW) < 1) return;   // height-only change → skip
+      this._lastFitW = w;
+      this._relayout();
+    });
+    this._ro.observe(this.container);
+    // If the tab is hidden WHILE a morph is mid-flight, its animations freeze and
+    // their `finished` promises never resolve — the morph would be stuck forever
+    // (partial final step). Snap to the current target's final state instead.
+    if (typeof document !== "undefined") {
+      this._onVisibility = () => {
+        if (document.hidden && this._running.length) {
+          this._cancel();
+          this._renderInto(this.stage, this.data.steps[this.current].latex);
+          this._syncUI();
+        }
+      };
+      document.addEventListener("visibilitychange", this._onVisibility);
+    }
+  }
+
+  // Width changed: cancel any in-flight morph, re-fit, and re-render the current
+  // step at the new scale. A resize is an instantaneous reflow (not a step
+  // change), so it doesn't run the fade-out → move → fade-in sequence.
+  _relayout() {
+    this._cancel();
+    this._fit();
+    this._fixMetaSize();
+    this._renderInto(this.stage, this.data.steps[this.current].latex);
+  }
+
+  // Tear down the ResizeObserver and any running animations (called when the
+  // host removes the proof box — see SgProofManager.closeBox).
+  destroy() {
+    this._destroyed = true;
+    this._cancel();
+    if (this._ro) { try { this._ro.disconnect(); } catch (e) {} this._ro = null; }
+    if (this._onVisibility) {
+      try { document.removeEventListener("visibilitychange", this._onVisibility); } catch (e) {}
+      this._onVisibility = null;
+    }
   }
 
   // Apply the current speed multiplier. Animations are created at base duration
@@ -172,6 +243,31 @@ export class ProofAnimator {
     return host;
   }
 
+  // Leaf glyph spans that carry NO id — e.g. parentheses, which the renderer
+  // emits as `\left(\right)` without an \htmlData wrapper (and `\left…\right`
+  // can't be split to tag each glyph). The morph keys off data-n, so these are
+  // invisible to it and would POP in/out; we fade them as a group when the
+  // untagged sequence changes between steps.
+  _untaggedGlyphs(root) {
+    const html = root.querySelector(".katex-html");
+    if (!html) return [];
+    const out = [];
+    html.querySelectorAll("*").forEach((el) => {
+      if (el.firstElementChild) return;        // not a leaf element
+      const t = el.textContent;
+      if (!t || !t.trim()) return;
+      if (el.hasAttribute("data-n")) return;   // itself a tagged glyph
+      const p = el.closest("[data-n]");
+      // No tagged ancestor, OR the nearest tagged ancestor is STRUCTURAL (it has
+      // tagged descendants) → this is a loose decoration glyph the renderer added
+      // without an id (e.g. a parenthesis from \left(\right)). If the nearest
+      // tagged ancestor is a LEAF glyph, this span is just part of that glyph's
+      // rendering → skip.
+      if (!p || p.querySelector("[data-n]")) out.push(el);
+    });
+    return out;
+  }
+
   // leaf glyph spans: a `data-n` with no nested `data-n` (excludes hidden MathML)
   _leaves(root) {
     const map = new Map();
@@ -207,7 +303,7 @@ export class ProofAnimator {
   // descendant glyph maps from→to under one shared (scale s about the block's
   // top-left, then translate). Singletons (lone glyphs) fall out as size-1 blocks.
   // Returns { blocks: [{el, dx, dy, scale, single}] }.
-  _rigidBlocks(stage, fromRects, toRects, fromFontSize) {
+  _rigidBlocks(stage, fromRects, toRects, fromFontSize, changedIds = new Set()) {
     const els = [...stage.querySelectorAll(".katex-html [data-n]")];
     const depth = (el) => {
       let d = 0, p = el.parentElement;
@@ -222,14 +318,15 @@ export class ProofAnimator {
     for (const el of els) {
       if (claimed.has(el)) continue;
       const id = el.getAttribute("data-n");
-      if (!fromRects.has(id) || !toRects.has(id)) continue;       // inserted node
+      if (!fromRects.has(id) || !toRects.has(id) || changedIds.has(id)) continue;  // inserted / changed-glyph node
       const fb = fromRects.get(id), tb = toRects.get(id);
       const inner = el.querySelectorAll("[data-n]");
       const leafEls = inner.length
         ? [...inner].filter((x) => !x.querySelector("[data-n]"))
         : [el];
       const leafIds = leafEls.map((x) => x.getAttribute("data-n"));
-      if (!leafIds.every((lid) => fromRects.has(lid))) continue;  // holds an inserted glyph → not rigid
+      // holds an inserted glyph OR a changed-glyph reuse → not rigid (recurse)
+      if (!leafIds.every((lid) => fromRects.has(lid) && !changedIds.has(lid))) continue;
 
       // Scale = the glyph FONT-SIZE ratio, NOT the box-width ratio. Box width
       // changes when content restructures (parens removed, c^2→c^4) even though
@@ -265,9 +362,27 @@ export class ProofAnimator {
     this._ghosts = [];
   }
 
+  // Instantly show a step's final state — no animation. Used when the page can't
+  // animate (hidden tab, or a phase whose clock is frozen by window occlusion).
+  _snapTo(target) {
+    this._cancel();
+    this.current = target;
+    this._renderInto(this.stage, this.data.steps[target].latex);
+    this._syncUI();
+  }
+
   async goTo(target) {
     target = Math.max(0, Math.min(this.data.steps.length - 1, target));
     if (target === this.current && this._running.length === 0) return;
+    // When the tab/page is hidden, browsers FREEZE the document timeline, so WAAPI
+    // animations never progress and `anim.finished` never resolves — the morph
+    // would stall between phases and leave inserted glyphs stuck at opacity 0
+    // (a half-rendered final step). There's nothing to watch anyway, so snap
+    // straight to the target state; it animates normally once visible again.
+    if (typeof document !== "undefined" && document.hidden) {
+      this._snapTo(target);
+      return;
+    }
     const token = (this._token = {});
     const seq = this.mode === "sequential";
 
@@ -283,6 +398,14 @@ export class ProofAnimator {
       cloneOf.set(id, el.cloneNode(true));
       fromFontSize.set(id, getComputedStyle(el).fontSize);
     });
+    // Source untagged glyphs (parens etc.) — snapshot before re-render so we can
+    // ghost them out if they disappear (they have no id to thread).
+    const fromUntagged = this._untaggedGlyphs(this.stage).map((el) => ({
+      text: el.textContent,
+      clone: el.cloneNode(true),
+      rect: el.getBoundingClientRect(),
+      fontSize: getComputedStyle(el).fontSize,
+    }));
     // which (node, decoration-type) pairs the SOURCE already had — used to tell a
     // genuinely new fraction/root apart from one whose node id was merely reused.
     const fromDecoKeys = new Set();
@@ -302,6 +425,17 @@ export class ProofAnimator {
     const toLeaves = this._leaves(this.stage);
     const toRects = this._nodeRects(this.stage);
 
+    // Matched ids whose GLYPH CHANGED — the diff reused a node id for a different
+    // symbol (e.g. + → −, or a coefficient 2 → 3). Without this, such a node is
+    // treated as "matched/stationary" and the NEW glyph renders instantly at full
+    // opacity (popping in before anything fades). Treat them as delete+insert
+    // instead: the old glyph fades OUT (phase 0) and the new one fades IN (phase 2).
+    const changedIds = new Set();
+    toLeaves.forEach((el, id) => {
+      const old = cloneOf.get(id);
+      if (old && old.textContent !== el.textContent) changedIds.add(id);
+    });
+
     const await_ = (anims) =>
       Promise.all(anims.map((a) => a.finished.catch(() => {})));
 
@@ -309,7 +443,7 @@ export class ProofAnimator {
     // stage still looks like the source state while dropped items fade out ──
     // matched → MOVE the LARGEST rigid groups together (translate + uniform scale,
     // about each block's top-left, so a sub-expression glides/shrinks as one unit)
-    const { blocks } = this._rigidBlocks(this.stage, fromRects, toRects, fromFontSize);
+    const { blocks } = this._rigidBlocks(this.stage, fromRects, toRects, fromFontSize, changedIds);
     const movers = [];
     for (const blk of blocks) {
       const moved = Math.abs(blk.dx) > 0.5 || Math.abs(blk.dy) > 0.5;
@@ -322,11 +456,22 @@ export class ProofAnimator {
       movers.push(blk);
     }
 
-    // target-only glyphs → INSERT (hidden until the very end)
+    // target-only glyphs (and changed-glyph reuses) → INSERT (hidden until the end)
     const insertEls = [];
     toLeaves.forEach((el, id) => {
-      if (!fromRects.has(id)) { el.style.opacity = "0"; insertEls.push(el); }
+      if (!fromRects.has(id) || changedIds.has(id)) { el.style.opacity = "0"; insertEls.push(el); }
     });
+
+    // Untagged glyphs (parens etc.): only animate when the sequence actually
+    // CHANGED between states, so persistent parens never flicker. New untagged
+    // glyphs fade in (phase 2); disappeared ones ghost out (phase 0, below).
+    const toUntagged = this._untaggedGlyphs(this.stage);
+    const SEP = "";
+    const untaggedChanged =
+      fromUntagged.map((u) => u.text).join(SEP) !== toUntagged.map((el) => el.textContent).join(SEP);
+    if (untaggedChanged) {
+      for (const el of toUntagged) { el.style.opacity = "0"; insertEls.push(el); }
+    }
 
     // newly-introduced structural decorations → also fade in last. A decoration
     // (fraction bar, radical, delimiter) belongs to the node that emitted it: its
@@ -353,7 +498,7 @@ export class ProofAnimator {
     // font for a frame before fading.
     const ghosts = [];
     fromLeaves.forEach((el, id) => {
-      if (toRects.has(id)) return;   // still present (as glyph or subtree)
+      if (toRects.has(id) && !changedIds.has(id)) return;   // still present, same glyph
       const f = fromRects.get(id);
       const host = document.createElement("span");
       host.className = "katex pa-ghost";
@@ -371,6 +516,24 @@ export class ProofAnimator {
       this._ghosts.push(host);
       ghosts.push(host);
     });
+    // Untagged source glyphs (parens etc.) that disappeared → ghost them out too,
+    // so removed parentheses FADE rather than pop. Only when the set changed.
+    if (untaggedChanged) {
+      for (const u of fromUntagged) {
+        const host = document.createElement("span");
+        host.className = "katex pa-ghost";
+        Object.assign(host.style, {
+          position: "absolute", margin: "0",
+          left: u.rect.left - stageRect.left + "px",
+          top: u.rect.top - stageRect.top + "px",
+          fontSize: u.fontSize,
+        });
+        host.appendChild(u.clone);
+        this.stage.appendChild(host);
+        this._ghosts.push(host);
+        ghosts.push(host);
+      }
+    }
 
     // ── PHASE 0: dropped items fade OUT first, before any motion ──
     const delAnims = [];
@@ -394,7 +557,10 @@ export class ProofAnimator {
       const a = this._tween(blk.el,
         [{ transform: `translate(${blk.dx}px, ${blk.dy}px) scale(${blk.scale})` },
          { transform: "translate(0px, 0px) scale(1)" }],
-        { duration: this._baseDuration, delay: seq ? mi++ * this._baseStagger : 0, easing: EASE, fill: "backwards" }
+        // fill BOTH: holds the from-pose during a staggered delay AND keeps the
+        // resting pose after it ends, so the block stays put even if the finish
+        // event never fires (e.g. a backgrounded tab freezes the timeline).
+        { duration: this._baseDuration, delay: seq ? mi++ * this._baseStagger : 0, easing: EASE, fill: "both" }
       );
       a.onfinish = () => {                              // restore normal flow at rest
         blk.el.style.transform = "";
@@ -411,10 +577,12 @@ export class ProofAnimator {
     const insAnims = [];
     let ii = 0;
     for (const el of insertEls) {
-      el.classList.add("pa-move");
+      el.classList.add("pa-move", "pa-insert");   // pa-insert → paints behind movers/ghosts
       const a = this._tween(el,
         [{ opacity: 0, transform: "scale(.6)" }, { opacity: 1, transform: "none" }],
-        { duration: this._baseDuration * 0.7, delay: seq ? ii++ * this._baseStagger : 0, easing: EASE, fill: "backwards" }
+        // fill BOTH: stays at opacity 1 after it ends, so a new glyph never gets
+        // stuck invisible if the finish event doesn't fire (frozen/backgrounded tab).
+        { duration: this._baseDuration * 0.7, delay: seq ? ii++ * this._baseStagger : 0, easing: EASE, fill: "both" }
       );
       a.onfinish = () => (el.style.opacity = "");
       insAnims.push(a);
@@ -423,14 +591,23 @@ export class ProofAnimator {
     for (const el of decoEls) {
       const a = this._tween(el,
         [{ opacity: 0 }, { opacity: 1 }],
-        { duration: this._baseDuration * 0.7, delay: seq ? ii++ * this._baseStagger : 0, easing: EASE, fill: "backwards" }
+        { duration: this._baseDuration * 0.7, delay: seq ? ii++ * this._baseStagger : 0, easing: EASE, fill: "both" }
       );
       a.onfinish = () => (el.style.opacity = "");
       insAnims.push(a);
     }
     this._running = insAnims;
     await await_(insAnims);
-    if (this._token === token) this._running = [];
+    if (this._token === token) {
+      this._running = [];
+      // Settle to a PRISTINE final render. The animated DOM carries leftover morph
+      // styles — pa-move (display:inline-block), pa-insert (z-index:-1), held
+      // transforms, inline opacity — any of which can leave a glyph mis-layered or
+      // invisible in some browsers/themes. Re-rendering the clean step drops ALL of
+      // it, so the resting expression is guaranteed correct and identical to a fresh
+      // render. It's visually identical to the just-finished frame, so no flicker.
+      this._renderInto(this.stage, this.data.steps[target].latex);
+    }
   }
 
   // the one Play/Pause button — toggles its icon+label and starts/stops autoplay

--- a/static/proof-animation/proof-animation.js
+++ b/static/proof-animation/proof-animation.js
@@ -582,12 +582,23 @@ export class ProofAnimator {
         const pool = srcDecoByKey.get(key);
         const src = pool && pool.find((s) => !matchedSrcDeco.has(s));
         if (!src) { el.style.opacity = "0"; decoEls.push(el); return; }   // new → fade in
-        matchedSrcDeco.add(src);
         const tr = el.getBoundingClientRect();
         const dx = src.rect.left - tr.left, dy = src.rect.top - tr.top;
         const sx = tr.width > 0 ? src.rect.width / tr.width : 1;
         const sy = tr.height > 0 ? src.rect.height / tr.height : 1;
-        if (Math.abs(dx) > 1 || Math.abs(dy) > 1 || Math.abs(sx - 1) > 0.02 || Math.abs(sy - 1) > 0.02) {
+        const changed = Math.abs(dx) > 1 || Math.abs(dy) > 1 || Math.abs(sx - 1) > 0.02 || Math.abs(sy - 1) > 0.02;
+        // A radical (`.sqrt svg`) is a single SVG whose path distorts under a
+        // non-uniform transform (hook detaches from the overline). So when it
+        // changes, CROSS-FADE it like parentheses — leave the source UNmatched so
+        // it ghosts out (phase 0) and fade the new one in (phase 2).
+        if (sel === ".sqrt svg") {
+          if (changed) { el.style.opacity = "0"; decoEls.push(el); }
+          else { matchedSrcDeco.add(src); }
+          return;
+        }
+        // A fraction bar / delimiter is one self-contained box → FLIP it.
+        matchedSrcDeco.add(src);
+        if (changed) {
           el.style.transformOrigin = "0 0";
           el.style.transform = `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`;   // hold at source pose
           decoMovers.push({ el, dx, dy, sx, sy });

--- a/static/proof-animation/proof-animation.js
+++ b/static/proof-animation/proof-animation.js
@@ -259,6 +259,11 @@ export class ProofAnimator {
       // they're not real glyphs and `String.trim()` doesn't remove them.
       const t = (el.textContent || "").replace(/[​-‍﻿]/g, "").trim();
       if (!t) return;
+      // A stretchy delimiter (\left(\right) around tall content) renders as a
+      // `.delimsizing` decoration that CONTAINS a glyph span — skip that inner
+      // glyph so the paren is handled once, by the decoration path (clone keeps
+      // its stretched size/position), not double-counted as a bare leaf.
+      if (el.closest(".delimsizing")) return;
       if (el.hasAttribute("data-n")) return;   // itself a tagged glyph
       const p = el.closest("[data-n]");
       // No tagged ancestor, OR the nearest tagged ancestor is STRUCTURAL (it has
@@ -428,13 +433,18 @@ export class ProofAnimator {
       rect: el.getBoundingClientRect(),
       fontSize: getComputedStyle(el).fontSize,
     }));
-    // which (node, decoration-type) pairs the SOURCE already had — used to tell a
-    // genuinely new fraction/root apart from one whose node id was merely reused.
+    // which (node, decoration-type) pairs the SOURCE had — used to tell a
+    // genuinely new fraction/root apart from one whose node id was merely reused,
+    // and (with the clones below) to FADE OUT decorations that disappear.
     const fromDecoKeys = new Set();
+    const fromDecos = [];
     for (const sel of DECORATIONS) {
       this.stage.querySelectorAll(sel).forEach((el) => {
         const o = el.closest("[data-n]");
-        if (o) fromDecoKeys.add(o.getAttribute("data-n") + "|" + sel);
+        if (!o) return;
+        const key = o.getAttribute("data-n") + "|" + sel;
+        fromDecoKeys.add(key);
+        fromDecos.push({ key, clone: el.cloneNode(true), rect: el.getBoundingClientRect(), fontSize: getComputedStyle(el).fontSize });
       });
     }
 
@@ -504,10 +514,12 @@ export class ProofAnimator {
     // decoration → fade it in. This catches a *new inner* fraction even when an
     // outer fraction is already on screen.
     const decoEls = [];
+    const toDecoKeys = new Set();
     for (const sel of DECORATIONS) {
       this.stage.querySelectorAll(sel).forEach((el) => {
         const owner = el.closest("[data-n]");
         const ownerId = owner && owner.getAttribute("data-n");
+        if (ownerId) toDecoKeys.add(ownerId + "|" + sel);
         // keep visible only if that very node already had this decoration in the
         // source (so the outer fraction persists, but a new inner one fades in).
         if (ownerId && fromDecoKeys.has(ownerId + "|" + sel)) return;
@@ -559,6 +571,36 @@ export class ProofAnimator {
         untagGhosts.push(host);
       }
     });
+    // Decorations (fraction bar, radical, stretchy delimiter) that DISAPPEARED →
+    // ghost the cloned decoration (which keeps its stretched size) at its old spot
+    // and fade it out with the other id-less items, instead of letting it vanish.
+    for (const d of fromDecos) {
+      if (toDecoKeys.has(d.key)) continue;   // still present → persists
+      const host = document.createElement("span");
+      host.className = "katex pa-ghost";
+      let left = d.rect.left - stageRect.left, top = d.rect.top - stageRect.top;
+      Object.assign(host.style, {
+        position: "absolute", margin: "0", lineHeight: "0",
+        left: left + "px", top: top + "px", fontSize: d.fontSize,
+      });
+      host.appendChild(d.clone);
+      this.stage.appendChild(host);
+      // A delimiter clone sits at a vertical-align offset inside its host, so its
+      // visual box lands above/below the source spot (looks like it "jumps up").
+      // Nudge the host to cancel that offset — comparing in STAGE-RELATIVE coords
+      // (re-measuring the stage now) so page scroll/reflow between the source
+      // snapshot and here can't skew the alignment.
+      const sr = this.stage.getBoundingClientRect();
+      const cr = d.clone.getBoundingClientRect();
+      const dx = (d.rect.left - stageRect.left) - (cr.left - sr.left);
+      const dy = (d.rect.top - stageRect.top) - (cr.top - sr.top);
+      if (dx || dy) {
+        host.style.left = (left + dx) + "px";
+        host.style.top = (top + dy) + "px";
+      }
+      this._ghosts.push(host);
+      untagGhosts.push(host);
+    }
 
     // ── PHASE 0: dropped items fade OUT first, before any motion ──
     const D_OUT = this._baseDuration * 0.6;

--- a/static/proof-animation/proof-animation.js
+++ b/static/proof-animation/proof-animation.js
@@ -246,16 +246,19 @@ export class ProofAnimator {
   // Leaf glyph spans that carry NO id — e.g. parentheses, which the renderer
   // emits as `\left(\right)` without an \htmlData wrapper (and `\left…\right`
   // can't be split to tag each glyph). The morph keys off data-n, so these are
-  // invisible to it and would POP in/out; we fade them as a group when the
-  // untagged sequence changes between steps.
+  // invisible to it and would POP in/out; we fade in the ones that are genuinely
+  // ADDED and fade out the ones genuinely REMOVED (matched via _lcsMatch), so
+  // parentheses that persist across a step are left untouched.
   _untaggedGlyphs(root) {
     const html = root.querySelector(".katex-html");
     if (!html) return [];
     const out = [];
     html.querySelectorAll("*").forEach((el) => {
       if (el.firstElementChild) return;        // not a leaf element
-      const t = el.textContent;
-      if (!t || !t.trim()) return;
+      // Strip zero-width spacers (U+200B/C/D, BOM) KaTeX inserts for structure —
+      // they're not real glyphs and `String.trim()` doesn't remove them.
+      const t = (el.textContent || "").replace(/[​-‍﻿]/g, "").trim();
+      if (!t) return;
       if (el.hasAttribute("data-n")) return;   // itself a tagged glyph
       const p = el.closest("[data-n]");
       // No tagged ancestor, OR the nearest tagged ancestor is STRUCTURAL (it has
@@ -266,6 +269,25 @@ export class ProofAnimator {
       if (!p || p.querySelector("[data-n]")) out.push(el);
     });
     return out;
+  }
+
+  // Longest-common-subsequence match between two text sequences. Returns the sets
+  // of source/target indices that align (the items that PERSIST). Used to tell a
+  // parenthesis that stays put from one that was added or removed.
+  _lcsMatch(a, b) {
+    const n = a.length, m = b.length;
+    const dp = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+    for (let i = n - 1; i >= 0; i--)
+      for (let j = m - 1; j >= 0; j--)
+        dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    const aKeep = new Set(), bKeep = new Set();
+    let i = 0, j = 0;
+    while (i < n && j < m) {
+      if (a[i] === b[j]) { aKeep.add(i); bKeep.add(j); i++; j++; }
+      else if (dp[i + 1][j] >= dp[i][j + 1]) i++;
+      else j++;
+    }
+    return { aKeep, bKeep };
   }
 
   // leaf glyph spans: a `data-n` with no nested `data-n` (excludes hidden MathML)
@@ -462,16 +484,18 @@ export class ProofAnimator {
       if (!fromRects.has(id) || changedIds.has(id)) { el.style.opacity = "0"; insertEls.push(el); }
     });
 
-    // Untagged glyphs (parens etc.): only animate when the sequence actually
-    // CHANGED between states, so persistent parens never flicker. New untagged
-    // glyphs fade in (phase 2); disappeared ones ghost out (phase 0, below).
+    // Untagged glyphs (parens etc.): LCS-match source↔target by text so a paren
+    // that PERSISTS across the step is left untouched. Only genuinely ADDED ones
+    // fade in; genuinely REMOVED ones ghost out. They are kept SEPARATE from the
+    // id'd glyphs so they can animate in their own sub-phase — AFTER all id'd
+    // fades — with a PLAIN opacity tween (no scale/move, so they never shift).
     const toUntagged = this._untaggedGlyphs(this.stage);
-    const SEP = "";
-    const untaggedChanged =
-      fromUntagged.map((u) => u.text).join(SEP) !== toUntagged.map((el) => el.textContent).join(SEP);
-    if (untaggedChanged) {
-      for (const el of toUntagged) { el.style.opacity = "0"; insertEls.push(el); }
-    }
+    const _uMatch = this._lcsMatch(fromUntagged.map((u) => u.text), toUntagged.map((el) => el.textContent));
+    const _uFromKeep = _uMatch.aKeep;
+    const untagInserts = [];
+    toUntagged.forEach((el, j) => {
+      if (!_uMatch.bKeep.has(j)) { el.style.opacity = "0"; untagInserts.push(el); }  // newly added → fade in last
+    });
 
     // newly-introduced structural decorations → also fade in last. A decoration
     // (fraction bar, radical, delimiter) belongs to the node that emitted it: its
@@ -516,10 +540,11 @@ export class ProofAnimator {
       this._ghosts.push(host);
       ghosts.push(host);
     });
-    // Untagged source glyphs (parens etc.) that disappeared → ghost them out too,
-    // so removed parentheses FADE rather than pop. Only when the set changed.
-    if (untaggedChanged) {
-      for (const u of fromUntagged) {
+    // Untagged source glyphs (parens etc.) that were REMOVED (not LCS-matched)
+    // → ghost them out (in their own array, so they fade AFTER the id'd ghosts).
+    const untagGhosts = [];
+    fromUntagged.forEach((u, ui) => {
+      if (!_uFromKeep.has(ui)) {
         const host = document.createElement("span");
         host.className = "katex pa-ghost";
         Object.assign(host.style, {
@@ -531,17 +556,30 @@ export class ProofAnimator {
         host.appendChild(u.clone);
         this.stage.appendChild(host);
         this._ghosts.push(host);
-        ghosts.push(host);
+        untagGhosts.push(host);
       }
-    }
+    });
 
     // ── PHASE 0: dropped items fade OUT first, before any motion ──
+    const D_OUT = this._baseDuration * 0.6;
     const delAnims = [];
     let di = 0;
     for (const host of ghosts) {
       const a = this._tween(host,
         [{ opacity: 1 }, { opacity: 0 }],
-        { duration: this._baseDuration * 0.6, delay: seq ? di++ * this._baseStagger : 0, easing: EASE, fill: "forwards" }
+        { duration: D_OUT, delay: seq ? di++ * this._baseStagger : 0, easing: EASE, fill: "forwards" }
+      );
+      a.onfinish = () => host.remove();
+      delAnims.push(a);
+    }
+    // Untagged (parens) fade out AFTER every id'd ghost has gone — plain opacity,
+    // no move, clones already pinned in place.
+    const _outAfter = (seq ? di * this._baseStagger : 0) + D_OUT;
+    let dk = 0;
+    for (const host of untagGhosts) {
+      const a = this._tween(host,
+        [{ opacity: 1 }, { opacity: 0 }],
+        { duration: D_OUT, delay: _outAfter + (seq ? dk++ * this._baseStagger : 0), easing: EASE, fill: "forwards" }
       );
       a.onfinish = () => host.remove();
       delAnims.push(a);
@@ -574,6 +612,7 @@ export class ProofAnimator {
     if (this._token !== token) return;
 
     // ── PHASE 2: new items fade IN last (glyphs + structural decorations) ──
+    const D_IN = this._baseDuration * 0.7;
     const insAnims = [];
     let ii = 0;
     for (const el of insertEls) {
@@ -582,16 +621,21 @@ export class ProofAnimator {
         [{ opacity: 0, transform: "scale(.6)" }, { opacity: 1, transform: "none" }],
         // fill BOTH: stays at opacity 1 after it ends, so a new glyph never gets
         // stuck invisible if the finish event doesn't fire (frozen/backgrounded tab).
-        { duration: this._baseDuration * 0.7, delay: seq ? ii++ * this._baseStagger : 0, easing: EASE, fill: "both" }
+        { duration: D_IN, delay: seq ? ii++ * this._baseStagger : 0, easing: EASE, fill: "both" }
       );
       a.onfinish = () => (el.style.opacity = "");
       insAnims.push(a);
     }
-    // decorations fade in by opacity only (no scale → no layout shift)
-    for (const el of decoEls) {
+    // Items WITHOUT an id — structural decorations (fraction bar, radical,
+    // stretchy delimiters) AND untagged parentheses — fade in AFTER every id'd
+    // insert, with plain opacity only (no move/scale), so they appear in place,
+    // last, without shifting anything.
+    const _inAfter = (seq ? ii * this._baseStagger : 0) + D_IN;
+    let ik = 0;
+    for (const el of [...decoEls, ...untagInserts]) {
       const a = this._tween(el,
         [{ opacity: 0 }, { opacity: 1 }],
-        { duration: this._baseDuration * 0.7, delay: seq ? ii++ * this._baseStagger : 0, easing: EASE, fill: "both" }
+        { duration: D_IN, delay: _inAfter + (seq ? ik++ * this._baseStagger : 0), easing: EASE, fill: "both" }
       );
       a.onfinish = () => (el.style.opacity = "");
       insAnims.push(a);

--- a/static/proof-animation/sg-proof.js
+++ b/static/proof-animation/sg-proof.js
@@ -31,7 +31,6 @@ export function clearDeriveCache() {
 // error rather than spin the "Deriving proof…" pill forever.
 const DERIVE_TIMEOUT_MS = 90_000;
 
-const BOX_W = 360;            // natural render width of the animator (zoomed to fit the box)
 const GRID_COLS = 8;          // same grid as SgChartManager
 const GRID_ROWS = 8;
 const GRID_GAP = 8;
@@ -151,18 +150,21 @@ export class SgProofManager {
         entry.box.style.height = `${h}px`;
     }
 
-    // Zoom the animator (rendered at a fixed BOX_W) to fit the grid-sized body,
-    // preserving aspect — the body flex-centers it.
+    // The animator fills the box WIDTH (.sgp-pa is width:100%); its own
+    // responsive ProofAnimator._fit scales the expression to that width while
+    // the caption and controls use the full width (no longer squeezed into a
+    // fixed 360px column). We only zoom DOWN here when the natural height at full
+    // width would overflow the box, so a short box never clips; a tall-enough box
+    // keeps zoom 1 — full width, full-size caption text. The body flex-centers
+    // the result when it's zoomed below full width.
     _fit(entry) {
         const pa = entry.paWrap;
         if (!pa) return;
         pa.style.zoom = 1;
-        const natH = pa.offsetHeight || 1;
-        const bw = entry.body.clientWidth;
         const bh = entry.body.clientHeight;
-        if (bw <= 0 || bh <= 0) return;
-        const scale = Math.max(0.35, Math.min(bw / BOX_W, bh / natH));
-        pa.style.zoom = scale;
+        if (bh <= 0) return;
+        const natH = pa.offsetHeight || 1;
+        pa.style.zoom = Math.max(0.35, Math.min(1, bh / natH));
     }
 
     _updatePositions() {
@@ -328,8 +330,9 @@ export class SgProofManager {
             this._renderError(entry, new Error('The derivation produced no steps.'));
             return;
         }
-        // Mount into a fixed-width wrapper so the animator renders at BOX_W; the
-        // wrapper is then `zoom`-scaled to fit the grid box (_fit).
+        // Mount into a full-width wrapper (.sgp-pa is width:100%): the animator
+        // fills the box width and its responsive _fit scales the expression to
+        // it; _fit() here only zooms down if the height would overflow.
         const paWrap = document.createElement('div');
         paWrap.className = 'sgp-pa';
         entry.body.appendChild(paWrap);


### PR DESCRIPTION
Overhauls the proof-animation morph engine for smoothness, responsiveness, and adds a clickable **Next** pill. Five commits, all scoped to `static/proof-animation/` (`proof-animation.js`, `proof-animation.css`, `sg-proof.js`).

## Morph quality
- **Responsive sizing**: the expression scales its font to fit the container width and re-fits on resize; wide expressions no longer overflow.
- **Stable anchor**: expressions render into a fixed-width, left-anchored block so persistent tokens stop drifting sideways at each step boundary.
- **Correct layering**: inserts paint behind, movers in the middle, disappearing ghosts on top — new items grow in from behind instead of over the items they replace.
- **Changed-glyph crossfade**: when the diff reuses a node id for a different symbol (e.g. `+`→`−`), the old glyph fades out and the new one fades in instead of an instant swap/pop.
- **Id-less glyphs (parentheses, decorations)**: LCS-matched so persistent parens are left untouched; only genuinely added/removed ones animate, with plain-opacity fades sequenced *after* the id'd glyphs. Stretchy `\left(\right)` delimiters are handled once (as decorations, cloned at their stretched size and aligned in stage-relative coords) so they fade in place instead of vanishing or jumping.
- **Completion guarantee**: `fill:"both"` + a clean final re-render + a `document.hidden` snap so a morph can never settle with a glyph stuck invisible. (Earlier timer-based snaps that caused a "wait-then-jump" were removed.)
- **Math never overflows**: re-fit once `document.fonts.ready` (the first measure can use narrower fallback-font metrics) plus a hard cap that shrinks the stage font if a rendered expression still exceeds the stage.

## Next pill (new)
- Each step shows a **Next** pill with the next step's title (LaTeX-rendered, styled like the proof-navigator pills); hidden on the last step.
- **Promote animation** on a forward step: the current explanation + justification fade out, the Next title slides up into the title position, and the new justification + new Next pill fade in *after* the step animation completes.
- **Clickable** (and keyboard-accessible) — acts like the next button.
- Fits the container (CSS grid `minmax(0,max-content)`), truncates with ellipsis, and shows a tooltip **only when truncated**.

## Controls
- **Sequential** checkbox → an icon toggle (⇉) with the label moved to a tooltip.
- The numbered step buttons are hidden when the controls row doesn't fit the container width (prev/next/play/speed/mode remain).
- Native `title` tooltips (unreliable / don't render in some embedded/zoomed contexts) replaced with a **custom CSS tooltip** on every control + the pill; `aria-label` kept for accessibility.
- Fixed a class-name collision (`pa-next` pill vs the nav next button) that had broken the next button.

## Docked proof box (`sg-proof.js`)
- `.sgp-pa` fills the box width so the caption/controls use the full width at full size; `_fit()` only zooms down if the height would overflow. Nav-button width capped.

## Testing
Verified in the standalone launcher (`./scripts/proof_animation/serve.sh`) across desktop/tablet/mobile widths: morph phase ordering, paren/decoration fade in-place, no-overflow scaling, the promote choreography, pill truncation + conditional tooltip, and the responsive controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)