### PR TITLE
Proof animation: AI ask buttons, fixed-zone box layout, and derivation title

### DIFF
--- a/backend/experts/handlers/proof_animation/handler.py
+++ b/backend/experts/handlers/proof_animation/handler.py
@@ -163,8 +163,10 @@ def derive_proof_animation(req: DeriveProofRequest) -> dict:
         return {"error": f"No derivation found — couldn't get from ${start}$ to ${req.target_latex}$."}
 
     # --- post: render the trajectory into FLIP animation data -------------------
-    # Prefer a human-readable title (proof title) over the raw goal expression.
-    title = (req.title or lm_title or req.goal or "Derivation").strip()
+    # Title priority: an explicit proof/client title, then the model's own display
+    # title for the derivation (returned by the expert), then the LM endpoint title
+    # (only set when we inferred the start), then the raw goal, then a generic name.
+    title = (req.title or traj.title or lm_title or req.goal or "Derivation").strip()
     start_operation = given_label or f"Given ${start}$"
     # A short caption for step 0 — never the goal formula (it renders as raw $…$).
     start_justification = start_note or "the starting expression"

--- a/backend/experts/modules/proof_completion/dataset.py
+++ b/backend/experts/modules/proof_completion/dataset.py
@@ -164,11 +164,12 @@ def build_example(seed: Seed, rng: random.Random, max_steps: int, max_ops: int =
         context_id=context_id,
         lesson_context="",
         instruction=f"{seed.intent}: transform the start graph into the target graph.",
-        # gold output the optimizer can demonstrate from (matches the sig's
-        # `trajectory` OutputField), plus the atomic gold ops for internal checks
+        # gold outputs the optimizer can demonstrate from (match the sig's
+        # `trajectory` + `title` OutputFields), plus the atomic gold ops for checks
         trajectory=ProofTrajectory(steps=gold_steps,
                                    start_latex=graph_to_latex(start),
                                    target_latex=graph_to_latex(target)),
+        title=seed.intent or None,
         gold_steps=gold_steps,
         gold_ops=gold_ops,
         domain=seed.domain,
@@ -212,6 +213,7 @@ def example_to_dict(ex) -> dict:
         "context_id": ex.context_id,
         "lesson_context": ex.lesson_context,
         "instruction": ex.instruction,
+        "title": ex.get("title"),
         "gold_steps": [s.model_dump() for s in (ex.get("gold_steps") or [])],
         "gold_ops": [op.model_dump(by_alias=True, exclude_none=True) for op in ex.gold_ops],
         "domain": ex.domain,
@@ -242,6 +244,7 @@ def example_from_dict(d: dict):
         context_id=d["context_id"],
         lesson_context=d.get("lesson_context", ""),
         instruction=d.get("instruction", ""),
+        title=d.get("title"),
         trajectory=ProofTrajectory(steps=gold_steps,
                                    start_latex=graph_to_latex(context.start),
                                    target_latex=graph_to_latex(context.target)),

--- a/backend/experts/modules/proof_completion/module.py
+++ b/backend/experts/modules/proof_completion/module.py
@@ -68,4 +68,7 @@ class ProofCompletionExpert(dspy.Module):
         # attach the endpoints so the trajectory is self-contained (not LM output)
         traj.start_latex = start_latex or None
         traj.target_latex = target_latex or None
+        # the model-produced display title travels with the trajectory too
+        # (normalise an empty/whitespace title to None so callers can fall back)
+        traj.title = (pred.title or "").strip() or None
         return [traj]  # the canonical list[Output] (one trajectory)

--- a/backend/experts/modules/proof_completion/outputs.py
+++ b/backend/experts/modules/proof_completion/outputs.py
@@ -163,10 +163,13 @@ class ProofTrajectory(Output):
     ``start_latex`` / ``target_latex`` are the **reconstructed ("proper") LaTeX**
     of the start and target graphs, attached by the expert after inference so the
     trajectory is self-contained (the endpoints it derived between travel with
-    it). They are NOT produced by the model.
+    it). They are NOT produced by the model. ``title`` IS model-produced — a short
+    display name for the derivation, bound onto the trajectory by the expert so it
+    travels with it (Optional; older data / non-titled callers leave it None).
     """
 
     kind: Literal["proof_trajectory"] = "proof_trajectory"
     start_latex: Optional[str] = None
     target_latex: Optional[str] = None
+    title: Optional[str] = None
     steps: List[DerivationStep] = Field(default_factory=list)

--- a/backend/experts/modules/proof_completion/signature.py
+++ b/backend/experts/modules/proof_completion/signature.py
@@ -41,6 +41,9 @@ class ProofCompletionSig(dspy.Signature):
       expression. If a transformation is large, split it into as many smaller
       steps as needed. Prefer more small, valid steps over one big jump.
     - The final step's `expr_latex` must equal `target_latex`.
+    - Also give a short `title`: a few plain words naming what the derivation
+      shows (e.g. "Completing the square", "Lorentz time dilation"). It is a
+      human-readable display label, NOT a formula or a restatement of the target.
     """
 
     start_latex: str = dspy.InputField(desc="the starting expression, as LaTeX")
@@ -51,4 +54,8 @@ class ProofCompletionSig(dspy.Signature):
     instruction: str = dspy.InputField(desc="the user's request, may be empty")
     trajectory: ProofTrajectory = dspy.OutputField(
         desc="the ordered derivation steps, each a complete expression, from start to target"
+    )
+    title: str = dspy.OutputField(
+        desc="a short, human-readable display title naming what this derivation shows "
+             "(e.g. 'Completing the square') — plain words, NOT a formula"
     )

--- a/scripts/proof_animation/derive.py
+++ b/scripts/proof_animation/derive.py
@@ -93,6 +93,11 @@ def main() -> int:
         print("the expert returned no steps.")
         return 1
 
+    # Prefer the model's own derivation title over the prompt/endpoint fallback
+    # (an explicit --title still wins).
+    if not args.title and traj.title:
+        title = traj.title
+
     anim = ProofAnimation(title=title, domain=domain, trajectory=traj,
                           start_operation=start_operation, start_justification=start_justification)
 

--- a/static/proof-animation/proof-animation.css
+++ b/static/proof-animation/proof-animation.css
@@ -51,6 +51,7 @@
 /* the expression canvas — relative so delete-ghosts can be absolutely placed */
 .pa-stage {
   position: relative;
+  flex: 0 0 auto;            /* FIXED height (set by _fit to the tallest step) — never shrinks */
   /* Establish a stacking context so the inserts' z-index:-1 (they slide in BEHIND
      the moving glyphs) stays scoped to the stage. Without this it escapes to the
      root context and paints new glyphs BEHIND the panel background — they fade in
@@ -96,9 +97,12 @@
 .pa-ghost { pointer-events: none; z-index: 4; }
 .pa-move.pa-insert { z-index: -1; }
 
-/* operation (explanation) stacked above justification, then the "Next" pill */
+/* operation (explanation) stacked above justification, then the "Next" pill.
+   FIXED height (set by _fixMetaSize to the tallest step) + flex:none so the text
+   zone never changes height between steps — the controls below it never shift. */
 .pa-meta {
   position: relative;        /* anchor for absolutely-positioned meta ghosts */
+  flex: 0 0 auto;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -185,6 +189,13 @@
    button stays beside the text rather than being pushed to the far edge. */
 .pa-op-row { display: flex; align-items: center; gap: 8px; max-width: 100%; }
 .pa-op-row .pa-op { min-width: 0; }
+/* Never let the button shrink. In a narrow box the op-row overflows and flexbox
+   would squeeze the button — and it squeezes the empty measuring-probe button
+   MORE than the live (SVG-bearing) one, so the probe gives the caption extra
+   width and under-reserves the meta min-height by a line → the box height jumps
+   between steps. A fixed-size button keeps probe == live so the reservation is
+   exact (and the icon never gets squished). */
+.pa-op-row .pa-ask-btn { flex: 0 0 auto; }
 /* Next-step button rides inside the Next pill as a third grid column. */
 .pa-next-pill.pa-has-ask { grid-template-columns: auto minmax(0, max-content) auto; }
 .pa-next-pill .pa-ask-btn {
@@ -201,16 +212,19 @@
 .pa-meta-ghost { position: absolute; pointer-events: none; margin: 0; }
 .pa-promoting { will-change: transform, opacity; }
 
-/* controls */
+/* controls — FIXED-height nav row that NEVER wraps (overflowing step numbers are
+   hidden by _fitControls via .pa-compact instead). It's the last zone, so the
+   stage's flex-grow above it (in container mode) keeps it docked to the bottom. */
 .pa-controls {
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
   gap: 10px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   border-top: 1px solid var(--pa-border);
   padding-top: 12px;
 }
-.pa-steps { display: flex; gap: 6px; }
+.pa-steps { display: flex; gap: 6px; min-width: 0; }
 /* When the controls row can't fit, _fitControls() adds .pa-compact and the
    numbered step buttons are hidden — only prev / next / play / speed / mode
    remain (navigate with the arrows). */
@@ -225,6 +239,10 @@
   border-radius: 8px;
   padding: 6px 12px;
   line-height: 1;
+  /* Labels never wrap to a second line — otherwise a fixed-width button (e.g.
+     .pa-play at 6em) would grow taller in a narrow box, or change height when its
+     label toggles Play↔Pause, breaking the fixed-height nav row. */
+  white-space: nowrap;
   transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
 .pa-step { min-width: 34px; text-align: center; }
@@ -267,7 +285,7 @@
    .sgc-chart-header, .sgc-btn, .sgc-resize-handle, .sgc-pinned) so borders and
    buttons are identical to the charts; only these proof-specific rules remain:
    the body lays out the animator, which is rendered at a fixed width and
-   `zoom`-scaled to fit the grid box.
+   `transform: scale()`-d to fit the grid box.
    ─────────────────────────────────────────────────────────────────────────── */
 .sgp-proof-box {
     display: flex;
@@ -280,17 +298,32 @@
     min-height: 0;
     overflow: hidden;
     display: flex;
+    /* Centre the loading / error states; the animator (.sgp-pa) is height:100%,
+       so it fills the box regardless of these alignment values. */
     align-items: center;
     justify-content: center;
 }
 
-/* The animator fills the box width; its responsive _fit scales the expression
-   to that width and the caption/controls use the full width. _fit() in
-   SgProofManager only zooms it DOWN if the height would overflow the box. */
+/* The animator FILLS the box (width + height). Its three zones are a flex column:
+   the stage grows to fill the space left by the FIXED text + nav bars, and the
+   engine (fitHeight mode) scales the expression to fit that fixed stage — so the
+   animation area is the same size on every step and never overflows. No transform
+   scaling of the whole widget (which would un-anchor the nav). */
 .sgp-pa {
     width: 100%;
-    flex: 0 1 auto;
+    height: 100%;
+    flex: 0 0 auto;
 }
+/* Stage absorbs the remaining height; text + nav are fixed bars below it. Drop
+   the pa-root's uniform gap and space the zones with margins instead, so the
+   text zone sits flush above the nav divider (only the expression keeps a gap). */
+.sgp-proof-box .sgp-pa { gap: 0; }
+.sgp-proof-box .pa-stage { flex: 1 1 0; min-height: 0; margin-bottom: 12px; }
+/* A little breathing room between the text zone and the nav divider. */
+.sgp-proof-box .pa-meta { margin-bottom: 8px; }
+/* The NEXT pill anchors to the BOTTOM of the fixed-height text zone, so it always
+   sits just above the nav divider regardless of how long the caption is. */
+.sgp-proof-box .pa-next-pill { margin-top: auto; }
 .sgp-pa.pa-root {
     border: none;
     border-radius: 0;
@@ -362,11 +395,17 @@
 
 /* In the docked proof box the step (nav) buttons grow to fill a NARROW row, but
    cap their width so they don't stretch into giant bars when the box is wide
-   (the animator now fills the full box width). */
+   (the animator now fills the full box width). They NEVER wrap — when they don't
+   fit, _fitControls() hides them (.pa-compact) and the arrows drive navigation,
+   so the nav row stays a single fixed-height line. */
 .sgp-proof-box .pa-controls { gap: 6px; }
-.sgp-proof-box .pa-steps { flex: 1 1 auto; flex-wrap: wrap; }
+/* Natural-width step buttons (no grow, no shrink) so _fitControls measures the
+   row's TRUE width and compacts (hides the step numbers) when they don't fit —
+   instead of the steps box silently shrinking while its buttons overflow and
+   overlap the rest of the no-wrap row. */
+.sgp-proof-box .pa-steps { flex: 0 0 auto; flex-wrap: nowrap; }
 .sgp-proof-box .pa-steps .pa-step {
-    flex: 1 1 0;
+    flex: 0 0 auto;
     min-width: 30px;
     max-width: 52px;
     padding-left: 2px;

--- a/static/proof-animation/proof-animation.css
+++ b/static/proof-animation/proof-animation.css
@@ -179,8 +179,12 @@
   border-color: var(--pa-accent);
 }
 .pa-root .pa-ask-btn svg { pointer-events: none; }
-/* Current-step button: inline, right after the explanation text, with a gap. */
-.pa-op-row { display: flex; align-items: center; gap: 8px; }
+/* Current-step button: inline, right after the explanation text, with a gap.
+   max-width + the op's min-width:0 let a long (KaTeX-bearing) caption shrink and
+   wrap in a narrow box instead of overflowing; the op keeps flex-grow:0 so the
+   button stays beside the text rather than being pushed to the far edge. */
+.pa-op-row { display: flex; align-items: center; gap: 8px; max-width: 100%; }
+.pa-op-row .pa-op { min-width: 0; }
 /* Next-step button rides inside the Next pill as a third grid column. */
 .pa-next-pill.pa-has-ask { grid-template-columns: auto minmax(0, max-content) auto; }
 .pa-next-pill .pa-ask-btn {

--- a/static/proof-animation/proof-animation.css
+++ b/static/proof-animation/proof-animation.css
@@ -224,7 +224,11 @@
   border-top: 1px solid var(--pa-border);
   padding-top: 12px;
 }
-.pa-steps { display: flex; gap: 6px; min-width: 0; }
+/* Never shrink: the row is nowrap, and _fitControls() measures children's
+   offsetWidth to decide when to compact. If the steps box (or its buttons) could
+   shrink, that measurement would under-report the true width and miss the point
+   where the step numbers should be hidden. */
+.pa-steps { display: flex; gap: 6px; flex-shrink: 0; }
 /* When the controls row can't fit, _fitControls() adds .pa-compact and the
    numbered step buttons are hidden — only prev / next / play / speed / mode
    remain (navigate with the arrows). */
@@ -233,6 +237,7 @@
 .pa-btn, .pa-step {
   font: inherit;
   cursor: pointer;
+  flex-shrink: 0;          /* keep _fitControls' width measurement accurate (see .pa-steps) */
   border: 1px solid var(--pa-border);
   background: var(--pa-bg);
   color: var(--pa-fg);
@@ -284,8 +289,8 @@
    SgProofManager dock. The box REUSES the chart classes (.sgc-chart-box,
    .sgc-chart-header, .sgc-btn, .sgc-resize-handle, .sgc-pinned) so borders and
    buttons are identical to the charts; only these proof-specific rules remain:
-   the body lays out the animator, which is rendered at a fixed width and
-   `transform: scale()`-d to fit the grid box.
+   the body hosts the animator, which fills the box (fitHeight mode) and scales
+   its expression to fit — no whole-widget transform scaling.
    ─────────────────────────────────────────────────────────────────────────── */
 .sgp-proof-box {
     display: flex;
@@ -411,3 +416,8 @@
     padding-left: 2px;
     padding-right: 2px;
 }
+/* Once compacted (a narrow box — the step numbers are already hidden), tighten
+   the remaining controls so the essential buttons fit instead of overflowing:
+   smaller gap and a content-width Play button (drop its fixed 6em). */
+.sgp-proof-box .pa-controls.pa-compact { gap: 4px; }
+.sgp-proof-box .pa-controls.pa-compact .pa-play { width: auto; }

--- a/static/proof-animation/proof-animation.css
+++ b/static/proof-animation/proof-animation.css
@@ -102,7 +102,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 6px;                  /* equal vertical spacing between op / just / pill */
+  gap: 10px;                 /* equal vertical spacing between op / just / pill */
   min-height: 1.4em;
   font-size: 0.95rem;
 }
@@ -120,7 +120,7 @@
   box-sizing: border-box;
   min-width: 0;
   max-width: 100%;
-  padding: 3px 11px;
+  padding: 5px 11px;
   border-radius: 999px;
   background: rgba(99, 102, 241, 0.16);
   border: 1px solid rgba(120, 130, 200, 0.40);
@@ -151,6 +151,46 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* AI ask buttons — only rendered when the host passes an aiAskButton factory
+   (the app does; the standalone report doesn't). Hidden until the widget is
+   hovered, matching the app-wide ask-button convention. */
+.pa-root .pa-ask-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 2px;
+  background: rgba(99, 102, 241, 0.14);
+  border: 1px solid rgba(120, 130, 200, 0.35);
+  border-radius: 4px;
+  color: var(--pa-accent);
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s, background 0.15s, border-color 0.15s;
+}
+.pa-root:hover .pa-ask-btn,
+.pa-root .pa-ask-btn:focus-visible { opacity: 1; pointer-events: auto; }
+.pa-root .pa-ask-btn:hover {
+  background: rgba(99, 102, 241, 0.30);
+  border-color: var(--pa-accent);
+}
+.pa-root .pa-ask-btn svg { pointer-events: none; }
+/* Current-step button: inline, right after the explanation text, with a gap. */
+.pa-op-row { display: flex; align-items: center; gap: 8px; }
+/* Next-step button rides inside the Next pill as a third grid column. */
+.pa-next-pill.pa-has-ask { grid-template-columns: auto minmax(0, max-content) auto; }
+.pa-next-pill .pa-ask-btn {
+  align-self: center;
+  margin-left: 5px;
+  width: 16px;
+  height: 16px;
+  padding: 1px;
+  border: none;
+  background: transparent;
 }
 
 /* Transient clones used by the meta promote animation. */

--- a/static/proof-animation/proof-animation.js
+++ b/static/proof-animation/proof-animation.js
@@ -99,16 +99,18 @@ export class ProofAnimator {
     const op = document.createElement("span"); op.className = "pa-op";
     const just = document.createElement("span"); just.className = "pa-just";
     const next = document.createElement("span"); next.className = "pa-next-pill";
-    // Mirror the live layout when AI ask buttons are present (the op-row's inline
-    // button can make that line taller than the bare text, and the pill grows a
-    // third grid column) so the measured min-height matches.
-    let opHost = op;
+    // Mirror the LIVE markup exactly: .pa-op always lives inside a .pa-op-row
+    // (regardless of AI buttons), so the probe must too — otherwise the measured
+    // min-height wouldn't match and captions/controls could shift between steps.
+    // The inline ask button (taller than the bare text) and the pill's extra grid
+    // column are added only when a factory is present, matching _build.
+    const opHost = document.createElement("div"); opHost.className = "pa-op-row";
+    opHost.append(op);
     if (this._aiAsk) {
       probe.classList.add("pa-has-ask");
       next.classList.add("pa-has-ask");
-      opHost = document.createElement("div"); opHost.className = "pa-op-row";
       const ask = document.createElement("span"); ask.className = "pa-ask-btn pa-ask-current";
-      opHost.append(op, ask);
+      opHost.append(ask);
     }
     probe.append(opHost, just, next);
     this.container.appendChild(probe);

--- a/static/proof-animation/proof-animation.js
+++ b/static/proof-animation/proof-animation.js
@@ -54,6 +54,18 @@ export class ProofAnimator {
     // has no chat panel and omits it — no factory, no buttons rendered.
     this._aiAsk = opts.aiAskButton || null;
     this._nextAskBtn = null;
+    // Optional host hook fired after every internal relayout (resize / fonts), so
+    // a host that scales this widget to fit a box (SgProofManager) can re-fit AFTER
+    // our fixed zone heights are final — otherwise its scale races our relayout and
+    // ends up stale (content overflows / positions shift on the next step).
+    this._onRelayout = typeof opts.onRelayout === "function" ? opts.onRelayout : null;
+    // Container-fit mode (set by a host that gives the widget a FIXED-size box,
+    // e.g. SgProofManager's grid cell): the stage fills the height the box leaves
+    // after the fixed text + nav bars, and the expression is scaled to fit that
+    // box (width AND height) instead of the stage growing to the expression. The
+    // standalone report leaves this false — there the stage grows to the tallest
+    // step and the page scrolls.
+    this._fitHeight = !!opts.fitHeight;
     this.mode = opts.mode || "parallel";    // 'parallel' | 'sequential'
     // Base timings; the speed multiplier scales them live via animation.playbackRate.
     this._baseDuration = opts.duration ?? 650;
@@ -73,8 +85,8 @@ export class ProofAnimator {
     this._build();
     // Base (unscaled) expression font; _fit() shrinks from here to fit the width.
     this._baseFontPx = parseFloat(getComputedStyle(this.stage).fontSize) || 30;
-    this._fit();            // size the stage to the largest step, scaled to fit the width
-    this._fixMetaSize();    // pin the caption area to the tallest op+justification
+    this._fixMetaSize();    // pin the caption area first so the stage's flex height is known
+    this._fit();            // scale the expression to fit the stage (width; +height in container mode)
     this._renderInto(this.stage, this.data.steps[0].latex);
     this._syncUI();
     this._capOverflow();    // never let the expression spill past the stage
@@ -122,7 +134,14 @@ export class ProofAnimator {
       h = Math.max(h, probe.getBoundingClientRect().height);
     });
     probe.remove();
-    if (h > 0) meta.style.minHeight = Math.ceil(h) + "px";
+    // FIXED height (not min-height): the text zone is locked to the tallest step,
+    // so it never grows/shrinks as captions change between steps and the controls
+    // below it never shift. Both set so a stale min-height can't override.
+    if (h > 0) {
+      const px = Math.ceil(h) + "px";
+      meta.style.height = px;
+      meta.style.minHeight = px;
+    }
   }
 
   // Measure every step at the base font and lock the stage to the max width/
@@ -145,20 +164,30 @@ export class ProofAnimator {
       h = Math.max(h, r.height);
     }
     probe.remove();
-    if (w <= 0) return;
+    if (w <= 0 || h <= 0) return;
     this._maxExprW = w;
-    // Shrink the font so the widest step fits the available width (a tiny gutter
-    // keeps it off the edges). The same scale applies to every step, so there's
+    // Small symmetric gutter so the expression never touches the edges. The SAME
+    // scale applies to every step (computed from the widest/tallest), so there is
     // no per-step zoom jump.
-    const availW = Math.max(40, this.stage.clientWidth - 8);
-    const scale = Math.min(1, availW / w);
+    const PAD = 8;
+    const availW = Math.max(40, this.stage.clientWidth - 2 * PAD);
+    let scale = Math.min(1, availW / w);
+    if (this._fitHeight) {
+      // Container mode: the stage fills a FIXED height (flex remaining after the
+      // text + nav bars). Scale so the tallest step also fits that height; don't
+      // pin the stage height (flex owns it). Result: the animation area is a fixed
+      // size across all steps and the expression never overflows it.
+      const availH = Math.max(20, this.stage.clientHeight - 2 * PAD);
+      scale = Math.min(scale, availH / h);
+    } else {
+      // Report mode: the stage GROWS to the tallest step (pinned, scaled) so it
+      // never jumps between steps; the page scrolls if the card is short.
+      this.stage.style.height = `${Math.ceil(h * scale + 8)}px`;
+    }
     this.stage.style.fontSize = `${this._baseFontPx * scale}px`;
-    // Height is pinned (scaled) so the stage never jumps between steps. The
-    // expression renders into a fixed-width block (the scaled max) that is
-    // centred in the stage with its CONTENT left-aligned (see CSS), so persistent
-    // tokens keep a stable left anchor instead of re-centring — and drifting —
-    // every step.
-    this.stage.style.height = `${Math.ceil(h * scale + 8)}px`;
+    // The expression renders into a fixed-width block (the scaled max) centred in
+    // the stage with its CONTENT left-aligned (see CSS), so persistent tokens keep
+    // a stable left anchor instead of re-centring — and drifting — every step.
     this.stage.style.setProperty("--pa-expr-w", `${Math.ceil(w * scale)}px`);
   }
 
@@ -171,12 +200,20 @@ export class ProofAnimator {
     if (!expr) return;
     const k = expr.querySelector(".katex-display") || expr.querySelector(".katex");
     if (!k) return;
-    const avail = Math.max(40, this.stage.clientWidth - 8);
-    const w = k.getBoundingClientRect().width;
-    if (w > avail + 0.5) {
+    const PAD = 8;
+    const availW = Math.max(40, this.stage.clientWidth - 2 * PAD);
+    const r = k.getBoundingClientRect();
+    // Shrink to whichever axis overflows more. In container mode the stage height
+    // is fixed, so a tall expression must also be capped to it (not just width).
+    let ratio = r.width > availW + 0.5 ? availW / r.width : 1;
+    if (this._fitHeight) {
+      const availH = Math.max(20, this.stage.clientHeight - 2 * PAD);
+      if (r.height > availH + 0.5) ratio = Math.min(ratio, availH / r.height);
+    }
+    if (ratio < 1) {
       const cur = parseFloat(getComputedStyle(this.stage).fontSize) || this._baseFontPx;
-      this.stage.style.fontSize = `${cur * (avail / w)}px`;
-      this.stage.style.setProperty("--pa-expr-w", `${Math.ceil(avail)}px`);
+      this.stage.style.fontSize = `${cur * ratio}px`;
+      this.stage.style.setProperty("--pa-expr-w", `${Math.ceil(r.width * ratio)}px`);
     }
   }
 
@@ -186,11 +223,19 @@ export class ProofAnimator {
   _observeResize() {
     if (this._ro || typeof ResizeObserver === "undefined") return;
     this._lastFitW = this.container.clientWidth;
+    this._lastFitH = this.container.clientHeight;
     this._ro = new ResizeObserver(() => {
       if (this._destroyed) return;
       const w = this.container.clientWidth;
-      if (Math.abs(w - this._lastFitW) < 1) return;   // height-only change → skip
+      const h = this.container.clientHeight;
+      // Width changes always matter. In container mode HEIGHT changes matter too
+      // (the stage's flex height changed → the expression must re-fit it); since
+      // container _fit() never alters the container's own size, this can't loop.
+      const widthChanged = Math.abs(w - this._lastFitW) >= 1;
+      const heightChanged = this._fitHeight && Math.abs(h - this._lastFitH) >= 1;
+      if (!widthChanged && !heightChanged) return;
       this._lastFitW = w;
+      this._lastFitH = h;
       // Debounce: _relayout() re-renders every step via KaTeX in _fit() (expensive),
       // and a live drag-resize fires many events per frame. Coalesce to one
       // relayout per animation frame — same result, far less jank.
@@ -225,12 +270,13 @@ export class ProofAnimator {
   // change), so it doesn't run the fade-out → move → fade-in sequence.
   _relayout() {
     this._cancel();
-    this._fit();
-    this._fixMetaSize();
+    this._fixMetaSize();   // text bar height first → fixes the stage's flex height
+    this._fit();           // then scale the expression to fit the stage (w + h in container mode)
     this._renderInto(this.stage, this.data.steps[this.current].latex);
     this._capOverflow();
     this._fitControls();
     this._updateNextTip();   // truncation depends on width → re-check on resize
+    if (this._onRelayout) { try { this._onRelayout(); } catch (e) {} }
   }
 
   // Tear down the ResizeObserver and any running animations (called when the

--- a/static/proof-animation/proof-animation.js
+++ b/static/proof-animation/proof-animation.js
@@ -49,6 +49,11 @@ export class ProofAnimator {
     this.data = data;
     this.katex = opts.katex || (typeof window !== "undefined" && window.katex);
     if (!this.katex) throw new Error("ProofAnimator: KaTeX not available");
+    // Optional AI-ask integration: a factory (className, title, getMessage) →
+    // <button>. The app passes labels.js makeAiAskButton; the standalone report
+    // has no chat panel and omits it — no factory, no buttons rendered.
+    this._aiAsk = opts.aiAskButton || null;
+    this._nextAskBtn = null;
     this.mode = opts.mode || "parallel";    // 'parallel' | 'sequential'
     // Base timings; the speed multiplier scales them live via animation.playbackRate.
     this._baseDuration = opts.duration ?? 650;
@@ -94,7 +99,18 @@ export class ProofAnimator {
     const op = document.createElement("span"); op.className = "pa-op";
     const just = document.createElement("span"); just.className = "pa-just";
     const next = document.createElement("span"); next.className = "pa-next-pill";
-    probe.append(op, just, next);
+    // Mirror the live layout when AI ask buttons are present (the op-row's inline
+    // button can make that line taller than the bare text, and the pill grows a
+    // third grid column) so the measured min-height matches.
+    let opHost = op;
+    if (this._aiAsk) {
+      probe.classList.add("pa-has-ask");
+      next.classList.add("pa-has-ask");
+      opHost = document.createElement("div"); opHost.className = "pa-op-row";
+      const ask = document.createElement("span"); ask.className = "pa-ask-btn pa-ask-current";
+      opHost.append(op, ask);
+    }
+    probe.append(opHost, just, next);
     this.container.appendChild(probe);
     let h = 0;
     this.data.steps.forEach((s, i) => {
@@ -251,7 +267,7 @@ export class ProofAnimator {
     this.container.classList.add("pa-root");
     this.container.innerHTML = `
       <div class="pa-stage" aria-live="polite"></div>
-      <div class="pa-meta"><span class="pa-op"></span><span class="pa-just"></span><span class="pa-next-pill" role="button" tabindex="0"></span></div>
+      <div class="pa-meta"><div class="pa-op-row"><span class="pa-op"></span></div><span class="pa-just"></span><span class="pa-next-pill" role="button" tabindex="0"></span></div>
       <div class="pa-controls">
         <button type="button" class="pa-btn pa-prev" data-tip="Previous step" aria-label="Previous step">◀</button>
         <div class="pa-steps"></div>
@@ -277,10 +293,27 @@ export class ProofAnimator {
     this.container.querySelector(".pa-next").onclick = () => this._userGoTo(this.current + 1);
     // The "Next" pill acts like the next button.
     const nextPill = this.container.querySelector(".pa-next-pill");
+    this._nextPillEl = nextPill;
     nextPill.onclick = () => this._userGoTo(this.current + 1);
     nextPill.onkeydown = (e) => {
+      if (e.target !== nextPill) return;   // e.g. Enter on the AI ask button inside
       if (e.key === "Enter" || e.key === " ") { e.preventDefault(); this._userGoTo(this.current + 1); }
     };
+    // AI ask buttons (app-provided factory only — see constructor).
+    if (this._aiAsk) {
+      const meta = this.container.querySelector(".pa-meta");
+      meta.classList.add("pa-has-ask");
+      // Current-step button sits inline right after the explanation text (in the
+      // op-row), so it reads as "ask about THIS step" rather than floating loose.
+      meta.querySelector(".pa-op-row").appendChild(
+        this._aiAsk("pa-ask-btn pa-ask-current", "Ask AI about this step",
+          () => this._askCurrentMessage()));
+      // The next-step button lives INSIDE the pill (re-attached by _setNextPill on
+      // every step), so the pill's hide-on-last-step and promote fade cover it too.
+      this._nextAskBtn = this._aiAsk("pa-ask-btn pa-ask-next", "Predict the next step with AI",
+        () => this._askNextMessage());
+      nextPill.classList.add("pa-has-ask");
+    }
     this.container.querySelector(".pa-play").onclick = () => this._togglePlay();
     this.container.querySelector(".pa-speed").onclick = () => {
       this._speedIdx = (this._speedIdx + 1) % SPEEDS.length;
@@ -1064,6 +1097,47 @@ export class ProofAnimator {
     const n = this.data.steps[idx + 1];
     return n ? (n.operation || `state ${idx + 1}`) : null;
   }
+
+  // Clean LaTeX for a step's expression — `plain` is the id-free render the
+  // server emits alongside the annotated `latex`; fall back to the raw input.
+  _stepExpr(idx) {
+    const s = this.data.steps[idx];
+    return s.plain || s.input_latex || s.latex || "";
+  }
+
+  // Chat message for the "ask about the current step" button.
+  _askCurrentMessage() {
+    const i = this.current;
+    const s = this.data.steps[i];
+    let msg = `I'm looking at step ${i} of the derivation`
+      + (this.data.title ? ` "${this.data.title}"` : "") + `:\n$$${this._stepExpr(i)}$$`;
+    if (s.operation) msg += `\nOperation: ${s.operation}`;
+    if (s.justification) msg += `\nJustification: ${s.justification}`;
+    msg += `\nCan you explain this step — what it does and why it's valid?`;
+    return msg;
+  }
+
+  // Chat message for the "predict the next step" button — predict-before-reveal:
+  // give the AI the next operation/justification as context, but ask it to coach
+  // the learner to the resulting expression instead of just stating it. The next
+  // expression itself is deliberately NOT included (the message is visible in the
+  // chat, so including it would spoil the reveal).
+  _askNextMessage() {
+    const i = this.current;
+    const n = this.data.steps[i + 1];
+    let msg = `I'm working through the derivation`
+      + (this.data.title ? ` "${this.data.title}"` : "")
+      + ` and the current expression (step ${i}) is:\n$$${this._stepExpr(i)}$$`;
+    if (n) {
+      msg += `\nThe next step is "${n.operation || `state ${i + 1}`}"`;
+      if (n.justification) msg += ` (justification: ${n.justification})`;
+      msg += `.`;
+    }
+    msg += `\nBefore revealing the resulting expression, help me predict it myself:`
+      + ` ask me what this operation does to the expression and why it's justified,`
+      + ` let me attempt the result, and only then confirm or correct it.`;
+    return msg;
+  }
   // Meta "promote" animation for a forward (next) step: the current explanation
   // and justification fade OUT, and the title shown in the "Next" pill slides UP
   // into the title position to become the new explanation. Returns a finish()
@@ -1173,6 +1247,12 @@ export class ProofAnimator {
     body.className = "pa-next-body";
     this._caption(body, txt);
     el.append(label, body);
+    // Re-attach the AI ask button (the innerHTML reset above detached it). The
+    // offscreen measuring probe in _fixMetaSize gets a listener-less clone so the
+    // live button is never moved into — and destroyed with — the probe.
+    if (this._nextAskBtn) {
+      el.appendChild(el === this._nextPillEl ? this._nextAskBtn : this._nextAskBtn.cloneNode(true));
+    }
     this._updateNextTip(el);
   }
 

--- a/static/proof-animation/sg-proof.js
+++ b/static/proof-animation/sg-proof.js
@@ -124,8 +124,7 @@ export class SgProofManager {
         this._resizeObserver = new ResizeObserver(() => {
             // Grid steps depend on the card size — re-snap every box, then refit.
             for (const entry of this.boxes.values()) {
-                this._applyGridSize(entry);
-                this._fit(entry);
+                this._applyGridSize(entry);   // animator re-fits via its own ResizeObserver
             }
             this._updatePositions();
         });
@@ -151,15 +150,13 @@ export class SgProofManager {
         entry.box.style.height = `${h}px`;
     }
 
-    // The box CSS (.sgp-pa height:100% + the flex zones) makes the animator fill
-    // the grid cell, and the animator re-fits its own expression on size change
-    // (its ResizeObserver reacts to width AND height in fitHeight mode). We just
-    // force an immediate relayout so resize/dock feels instant instead of waiting
-    // for the animator's debounced observer.
-    _fit(entry) {
-        const a = entry && entry.animator;
-        if (a && typeof a._relayout === 'function') a._relayout();
-    }
+    // NOTE: there is no host-side re-fit. The box CSS (.sgp-pa height:100% + the
+    // flex zones) makes the animator fill the grid cell, and resizing the box
+    // (via _applyGridSize) changes the animator's container size, which its OWN
+    // ResizeObserver picks up (it reacts to width AND height in fitHeight mode)
+    // and re-fits — debounced to one relayout per frame. Triggering _relayout from
+    // here too would double the (expensive) KaTeX re-measure and, on a drag, fire
+    // it un-debounced many times per frame.
 
     _updatePositions() {
         const rect = this._card().getBoundingClientRect();
@@ -324,9 +321,8 @@ export class SgProofManager {
             this._renderError(entry, new Error('The derivation produced no steps.'));
             return;
         }
-        // Mount into a full-width wrapper (.sgp-pa is width:100%): the animator
-        // fills the box width and its responsive _fit scales the expression to
-        // it; _fit() here only zooms down if the height would overflow.
+        // Mount into a wrapper that fills the box (.sgp-pa is width/height:100%):
+        // the animator's fitHeight mode scales the expression to fit the box.
         const paWrap = document.createElement('div');
         paWrap.className = 'sgp-pa';
         entry.body.appendChild(paWrap);
@@ -345,7 +341,8 @@ export class SgProofManager {
             this._renderError(entry, e);
             return;
         }
-        this._fit(entry);
+        // No re-fit here: the ProofAnimator constructor already fit itself, and any
+        // later size change is handled by its own ResizeObserver.
         this._updatePositions();
     }
 
@@ -454,8 +451,7 @@ export class SgProofManager {
             if (col !== entry.colSpan || row !== entry.rowSpan) {
                 entry.colSpan = col;
                 entry.rowSpan = row;
-                this._applyGridSize(entry);
-                this._fit(entry);
+                this._applyGridSize(entry);   // animator re-fits via its own ResizeObserver
                 if (!entry.docked) this._updatePositions();
             }
         };
@@ -500,8 +496,7 @@ export class SgProofManager {
         entry.box.style.top = '';
         entry.box.style.zIndex = '';
         this._sharedPinnedPanel().appendChild(entry.box);
-        this._applyGridSize(entry);
-        this._fit(entry);
+        this._applyGridSize(entry);   // animator re-fits via its own ResizeObserver
         if (entry.dockBtn) { entry.dockBtn.classList.add('sgc-pin-active'); entry.dockBtn.title = 'Unpin from overlay'; }
     }
 
@@ -511,8 +506,7 @@ export class SgProofManager {
         this._card().appendChild(entry.box);
         entry.box.style.position = 'absolute';
         entry.box.style.zIndex = String(++this._z);
-        this._applyGridSize(entry);
-        this._fit(entry);
+        this._applyGridSize(entry);   // animator re-fits via its own ResizeObserver
         if (entry.dockBtn) { entry.dockBtn.classList.remove('sgc-pin-active'); entry.dockBtn.title = 'Pin to overlay'; }
         this._updatePositions();    // re-anchor from stored graphX/graphY
     }

--- a/static/proof-animation/sg-proof.js
+++ b/static/proof-animation/sg-proof.js
@@ -10,6 +10,7 @@
 import { ProofAnimator } from '/proof-animation/proof-animation.js';
 import { invokeExpert } from '/expert-client.js';
 import { nextDockSeq } from '/proof-animation/dock-seq.js';
+import { makeAiAskButton } from '/labels.js';
 
 // Session-persistent cache of derivation results, keyed by the FULL request
 // shape (everything that affects the derivation — target/start/domain plus
@@ -338,7 +339,7 @@ export class SgProofManager {
         entry.body.appendChild(paWrap);
         entry.paWrap = paWrap;
         try {
-            entry.animator = new ProofAnimator(paWrap, data, { katex: this.katex });
+            entry.animator = new ProofAnimator(paWrap, data, { katex: this.katex, aiAskButton: makeAiAskButton });
         } catch (e) {
             entry.paWrap = null;
             this._renderError(entry, e);

--- a/static/proof-animation/sg-proof.js
+++ b/static/proof-animation/sg-proof.js
@@ -151,21 +151,14 @@ export class SgProofManager {
         entry.box.style.height = `${h}px`;
     }
 
-    // The animator fills the box WIDTH (.sgp-pa is width:100%); its own
-    // responsive ProofAnimator._fit scales the expression to that width while
-    // the caption and controls use the full width (no longer squeezed into a
-    // fixed 360px column). We only zoom DOWN here when the natural height at full
-    // width would overflow the box, so a short box never clips; a tall-enough box
-    // keeps zoom 1 — full width, full-size caption text. The body flex-centers
-    // the result when it's zoomed below full width.
+    // The box CSS (.sgp-pa height:100% + the flex zones) makes the animator fill
+    // the grid cell, and the animator re-fits its own expression on size change
+    // (its ResizeObserver reacts to width AND height in fitHeight mode). We just
+    // force an immediate relayout so resize/dock feels instant instead of waiting
+    // for the animator's debounced observer.
     _fit(entry) {
-        const pa = entry.paWrap;
-        if (!pa) return;
-        pa.style.zoom = 1;
-        const bh = entry.body.clientHeight;
-        if (bh <= 0) return;
-        const natH = pa.offsetHeight || 1;
-        pa.style.zoom = Math.max(0.35, Math.min(1, bh / natH));
+        const a = entry && entry.animator;
+        if (a && typeof a._relayout === 'function') a._relayout();
     }
 
     _updatePositions() {
@@ -306,7 +299,7 @@ export class SgProofManager {
             return;
         }
         entry.state = 'loading';
-        this._renderLoading(entry);
+        this._renderLoading(entry, payload);
         const pill = this._showPill();
         try {
             const data = await invokeExpert('proof_animation', payload, { timeoutMs: DERIVE_TIMEOUT_MS });
@@ -339,7 +332,14 @@ export class SgProofManager {
         entry.body.appendChild(paWrap);
         entry.paWrap = paWrap;
         try {
-            entry.animator = new ProofAnimator(paWrap, data, { katex: this.katex, aiAskButton: makeAiAskButton });
+            // fitHeight: the animator fills this fixed-size box and scales its
+            // expression to fit (the box CSS owns the layout — see .sgp-pa). No
+            // host-side transform, so the nav bar stays anchored to the bottom.
+            entry.animator = new ProofAnimator(paWrap, data, {
+                katex: this.katex,
+                aiAskButton: makeAiAskButton,
+                fitHeight: true,
+            });
         } catch (e) {
             entry.paWrap = null;
             this._renderError(entry, e);
@@ -349,11 +349,29 @@ export class SgProofManager {
         this._updatePositions();
     }
 
-    _renderLoading(entry) {
+    _renderLoading(entry, payload) {
         entry.paWrap = null;
-        entry.body.innerHTML =
-            '<div class="sgp-status"><span class="sgp-dots"><span></span><span></span><span></span></span>'
-            + '<span>Deriving proof…</span></div>';
+        entry.body.innerHTML = '';
+        const wrap = document.createElement('div');
+        wrap.className = 'sgp-status';
+        wrap.innerHTML =
+            '<span class="sgp-dots"><span></span><span></span><span></span></span>';
+        const label = document.createElement('span');
+        label.className = 'sgp-status-label';
+        const target = payload && payload.target_latex;
+        if (target && String(target).trim()) {
+            // Qualify with the expression being derived, e.g. "Deriving $a = …$".
+            label.appendChild(document.createTextNode('Deriving '));
+            const m = document.createElement('span');
+            try { this.katex.render(String(target), m, { throwOnError: false, displayMode: false }); }
+            catch (_e) { m.textContent = String(target); }
+            label.appendChild(m);
+            label.appendChild(document.createTextNode('…'));
+        } else {
+            label.textContent = 'Deriving proof…';
+        }
+        wrap.appendChild(label);
+        entry.body.appendChild(wrap);
     }
 
     _renderError(entry, err, payload) {


### PR DESCRIPTION
Started as the two AI "ask" buttons (#366) and grew to fix the docked proof box's layout end-to-end and thread a model-produced derivation title through. Three themes:

## 1. AI ask buttons (Closes #366)

Two AI buttons in the `ProofAnimator` meta area, reusing the app-wide `makeAiAskButton` pattern (plain click sends; ⌘/Ctrl-click fills the prompt box to edit first):

- **Current-step button** — inline after the explanation — asks the AI to explain the step on screen (expression + operation + justification).
- **Next-step button** — rides inside the `NEXT` pill (hidden on the last step) — a **predict-before-reveal** prompt: it gives the AI the upcoming operation/justification but **omits the resulting expression**, asking it to coach the learner to predict the move first.

The engine stays self-contained: buttons render only when the host passes an `aiAskButton` factory. The app (`sg-proof.js`) passes it; the standalone report omits it, so the no-chat-panel path is unaffected.

## 2. Fixed-zone box layout

Reworked the docked proof box so it never jumps, overflows, or mis-fits across steps or resizes:

- **Three fixed zones** in a flex column — latex stage (fills remaining space), text bar (fixed height = tallest step), nav bar (fixed, **anchored to the bottom**, never wraps). The expression scales to fit the stage on **both** width and height (new `fitHeight` mode) with small symmetric padding, so the animation area is identical on every step and never overflows.
- Replaced the whole-widget CSS `zoom`/transform scaling — it re-wrapped captions at a different width each step, un-anchored the nav, and stuttered on resize — with the flex-fill layout. The engine re-fits on width **and** height via its own (debounced) ResizeObserver; no host-side relayout racing it.
- Nav step buttons **compact** (hide → arrows navigate) instead of shrinking and overflowing the no-wrap row; the Play label never wraps; the NEXT pill anchors just above the divider.
- Loading state reads "Deriving $<target>$…" with the expression rendered.

## 3. Derivation title

`ProofCompletionSig` gains a `title` output; it rides on `ProofTrajectory`, is threaded through the dataset/optimizer, and the handler/`derive.py` now prefer this model title over the raw goal expression for the animation header.

## Test plan

- [x] AI buttons: plain click sends, ⌘/Ctrl-click fills; next-step button doesn't advance the step and hides on the last step; survives the meta "promote" animation; standalone report renders with no buttons / no console errors.
- [x] Layout: all three zones + nav position pixel-stable (variance 0) across every step and across resizes; expression never overflows (width or height) in boxes from 220px to 1000px+; nav docked to the bottom; step numbers compact when they don't fit and show when they do; Play never wraps.
- [x] Resize: the animator's ResizeObserver re-fits on box size change with no host-side relayout (font re-fits 30→7→30px across resizes); stepping triggers zero relayouts (no per-step recompute, no feedback loop).
- [x] Full backend suite green (3570 passed) for the title-feature changes.

Closes #366

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>