### PR TITLE
Document running AlgeBench locally (README + landing page)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -50,6 +50,13 @@
       "port": 5736
     },
     {
+      "name": "landing-page",
+      "runtimeExecutable": "python3",
+      "runtimeArgs": ["-m", "http.server", "5760", "--directory", "docs/landing-page"],
+      "port": 5760,
+      "autoPort": false
+    },
+    {
       "name": "sg-report",
       "runtimeExecutable": "./scripts/serve_sg_report.sh",
       "runtimeArgs": ["--port", "5740"],

--- a/README.md
+++ b/README.md
@@ -110,17 +110,16 @@ No clone, no Python setup — run the prebuilt AlgeBench image from the Hugging
 Face Space registry and pass **your own** `GEMINI_API_KEY`:
 
 ```bash
-docker run -it -p 7860:7860 --platform=linux/amd64 \
+docker run -it --pull=always -p 7860:7860 --platform=linux/amd64 \
 	-e GEMINI_API_KEY="your_key_here" \
-	registry.hf.space/ibenian-algebench:cpu-3fdcb6b
+	registry.hf.space/ibenian-algebench:latest
 ```
 
 Open [http://localhost:7860](http://localhost:7860) in your browser.
 
-> `--platform=linux/amd64` is needed on Apple Silicon and other ARM hosts since
-> the Space image is built for `amd64`. The image tag (`cpu-3fdcb6b`) pins a
-> specific build — check the [Space](https://huggingface.co/spaces/ibenian/algebench)
-> for the latest tag.
+> `--pull=always` ensures you get the newest published build (Docker otherwise
+> reuses a cached `:latest`). `--platform=linux/amd64` is needed on Apple Silicon
+> and other ARM hosts since the Space image is built for `amd64`.
 
 To map a different host port, change the left side of `-p` (e.g. `-p 9000:7860`)
 and open that port instead.

--- a/README.md
+++ b/README.md
@@ -64,17 +64,23 @@ The AI's job is to set the table — pick what's worth showing, build the appara
 
 ## Quick Start
 
-**Prerequisites:** Python 3.10+, a [Gemini API key](https://aistudio.google.com/apikey)
+There are two ways to run AlgeBench locally. Either way you'll need your own Gemini API
+key — see [Get a Gemini API key](#get-a-gemini-api-key).
+
+### Option 1 — Run locally from a cloned repo
+
+**Prerequisites:** Python 3.10+, a [Gemini API key](#get-a-gemini-api-key).
 
 ```bash
 git clone https://github.com/ibenian/algebench
 cd algebench
-pip install -r requirements.txt
 export GEMINI_API_KEY=your_key_here
 ./algebench
 ```
 
-Open [http://localhost:8785](http://localhost:8785) in your browser.
+On first run, `./algebench` creates a virtual environment and installs the
+dependencies automatically — no manual `pip install` needed. Then open
+[http://localhost:8785](http://localhost:8785) in your browser.
 
 To launch directly into a scene:
 
@@ -95,6 +101,44 @@ For all available CLI options including TTS settings:
 ```bash
 ./algebench --help
 ```
+
+### Option 2 — Docker image from Hugging Face
+
+**Prerequisites:** Docker, a [Gemini API key](#get-a-gemini-api-key).
+
+No clone, no Python setup — run the prebuilt AlgeBench image from the Hugging
+Face Space registry and pass **your own** `GEMINI_API_KEY`:
+
+```bash
+docker run -it -p 7860:7860 --platform=linux/amd64 \
+	-e GEMINI_API_KEY="your_key_here" \
+	registry.hf.space/ibenian-algebench:cpu-3fdcb6b
+```
+
+Open [http://localhost:7860](http://localhost:7860) in your browser.
+
+> `--platform=linux/amd64` is needed on Apple Silicon and other ARM hosts since
+> the Space image is built for `amd64`. The image tag (`cpu-3fdcb6b`) pins a
+> specific build — check the [Space](https://huggingface.co/spaces/ibenian/algebench)
+> for the latest tag.
+
+To map a different host port, change the left side of `-p` (e.g. `-p 9000:7860`)
+and open that port instead.
+
+### Get a Gemini API key
+
+AlgeBench's AI narrator runs on Google's Gemini models, so you need your own
+free API key from [Google AI Studio](https://aistudio.google.com/):
+
+1. Go to **[aistudio.google.com](https://aistudio.google.com/)** and sign in with a Google account.
+2. Open **[Get API key](https://aistudio.google.com/apikey)** (the **Get API key** button in the left sidebar).
+3. Click **Create API key**. If you don't have a Google Cloud project yet, choose
+   **Create API key in new project** — AI Studio creates one for you automatically.
+   Otherwise pick an existing project from the list.
+4. Copy the generated key. Keep it secret — treat it like a password.
+
+> The free tier is enough to try AlgeBench. For higher rate limits, enable billing
+> on the Google Cloud project backing your key.
 
 ### TTS Modes
 

--- a/docs/landing-page/index.html
+++ b/docs/landing-page/index.html
@@ -418,11 +418,11 @@ export GEMINI_API_KEY=your_key_here
         <p class="opt-sub">No clone, no Python setup &mdash; just Docker. Runs the prebuilt image from the Hugging Face Space registry.</p>
         <div class="code-block">
           <button class="copy-btn" type="button">Copy</button>
-          <pre><code>docker run -it -p 7860:7860 --platform=linux/amd64 \
+          <pre><code>docker run -it --pull=always -p 7860:7860 --platform=linux/amd64 \
   -e GEMINI_API_KEY="your_key_here" \
-  registry.hf.space/ibenian-algebench:cpu-3fdcb6b</code></pre>
+  registry.hf.space/ibenian-algebench:latest</code></pre>
         </div>
-        <p class="run-note">Then open <a href="http://localhost:7860" target="_blank" rel="noopener">localhost:7860</a> in your browser. <code>--platform=linux/amd64</code> is needed on Apple Silicon and other ARM hosts.</p>
+        <p class="run-note">Then open <a href="http://localhost:7860" target="_blank" rel="noopener">localhost:7860</a> in your browser. <code>--pull=always</code> fetches the newest build; <code>--platform=linux/amd64</code> is needed on Apple Silicon and other ARM hosts.</p>
       </div>
     </div>
   </section>

--- a/docs/landing-page/index.html
+++ b/docs/landing-page/index.html
@@ -200,6 +200,7 @@
   }
   .copy-btn:hover { border-color: #58a6ff; color: #e6edf3; }
   .copy-btn.copied { color: #3fb950; border-color: #238636; background: #122117; }
+  .copy-btn.failed { color: #d29922; border-color: #9e6a03; background: #21160a; }
 
   /* ── Videos ── */
   .more-videos-grid {
@@ -525,8 +526,10 @@ export GEMINI_API_KEY=your_key_here
       ta.style.opacity = '0';
       document.body.appendChild(ta);
       ta.select();
-      try { document.execCommand('copy'); resolve(); }
-      catch (e) { reject(e); }
+      try {
+        var ok = document.execCommand('copy');
+        if (ok) { resolve(); } else { reject(new Error('copy command rejected')); }
+      } catch (e) { reject(e); }
       finally { document.body.removeChild(ta); }
     });
   }
@@ -535,13 +538,18 @@ export GEMINI_API_KEY=your_key_here
     btn.addEventListener('click', function () {
       var code = btn.parentElement.querySelector('code');
       var text = code ? code.innerText : '';
+      var original = btn.getAttribute('data-label') || btn.textContent;
+      btn.setAttribute('data-label', original);
       copyText(text).then(function () {
-        var original = btn.textContent;
         btn.textContent = 'Copied';
         btn.classList.add('copied');
+      }).catch(function () {
+        btn.textContent = 'Press Ctrl+C';
+        btn.classList.add('failed');
+      }).finally(function () {
         setTimeout(function () {
           btn.textContent = original;
-          btn.classList.remove('copied');
+          btn.classList.remove('copied', 'failed');
         }, 1600);
       });
     });

--- a/docs/landing-page/index.html
+++ b/docs/landing-page/index.html
@@ -152,6 +152,55 @@
     color: #c9d1d9;
   }
 
+  /* ── Run Locally ── */
+  .run-local { max-width: 760px; margin: 0 auto; }
+  .run-intro {
+    text-align: center; color: #8b949e; font-size: 0.95rem;
+    max-width: 620px; margin: 0 auto 2rem;
+  }
+  .run-option { margin-bottom: 2rem; }
+  .run-option h3 {
+    font-size: 1.05rem; font-weight: 600; color: #e6edf3;
+    margin-bottom: 0.35rem;
+  }
+  .run-option .opt-sub {
+    color: #8b949e; font-size: 0.88rem; margin-bottom: 0.85rem;
+  }
+  .run-option .opt-sub a { color: #58a6ff; text-decoration: none; }
+  .run-option .opt-sub a:hover { text-decoration: underline; }
+  .run-note {
+    color: #8b949e; font-size: 0.84rem; margin-top: 0.6rem; line-height: 1.6;
+  }
+  .run-note code {
+    background: #21262d; padding: 0.1rem 0.35rem; border-radius: 4px;
+    font-family: 'JetBrains Mono', 'Fira Code', monospace; font-size: 0.78rem;
+    color: #c9d1d9;
+  }
+  .run-note a { color: #58a6ff; text-decoration: none; }
+  .run-note a:hover { text-decoration: underline; }
+
+  .code-block {
+    position: relative; background: #0d1117;
+    border: 1px solid #30363d; border-radius: 10px;
+    margin: 0.5rem 0;
+  }
+  .code-block pre {
+    margin: 0; padding: 1rem 1.1rem; overflow-x: auto;
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+    font-size: 0.82rem; line-height: 1.65; color: #c9d1d9;
+  }
+  .code-block .prompt { color: #484f58; user-select: none; }
+  .copy-btn {
+    position: absolute; top: 0.5rem; right: 0.5rem;
+    display: inline-flex; align-items: center; gap: 0.3rem;
+    background: #21262d; border: 1px solid #30363d; color: #8b949e;
+    border-radius: 6px; padding: 0.3rem 0.6rem;
+    font-size: 0.72rem; font-family: 'Inter', sans-serif; cursor: pointer;
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
+  }
+  .copy-btn:hover { border-color: #58a6ff; color: #e6edf3; }
+  .copy-btn.copied { color: #3fb950; border-color: #238636; background: #122117; }
+
   /* ── Videos ── */
   .more-videos-grid {
     display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -342,6 +391,42 @@
   </section>
 
   <!-- FAQ -->
+  <!-- Run Locally -->
+  <section class="section" id="run-locally">
+    <h2>Run Locally</h2>
+    <div class="run-local">
+      <p class="run-intro">
+        Run AlgeBench on your own machine in one of two ways. Either way you'll need a
+        free <a href="https://aistudio.google.com/app/apikey" target="_blank" rel="noopener" style="color:#58a6ff;text-decoration:none;">Gemini API key</a>.
+      </p>
+
+      <div class="run-option">
+        <h3>Option 1 — Clone the repo</h3>
+        <p class="opt-sub">Requires Python 3.10+. The launcher sets up its virtual environment and installs dependencies on first run.</p>
+        <div class="code-block">
+          <button class="copy-btn" type="button">Copy</button>
+          <pre><code>git clone https://github.com/ibenian/algebench
+cd algebench
+export GEMINI_API_KEY=your_key_here
+./algebench</code></pre>
+        </div>
+        <p class="run-note">Then open <a href="http://localhost:8785" target="_blank" rel="noopener">localhost:8785</a> in your browser.</p>
+      </div>
+
+      <div class="run-option">
+        <h3>Option 2 — Docker image from Hugging Face</h3>
+        <p class="opt-sub">No clone, no Python setup &mdash; just Docker. Runs the prebuilt image from the Hugging Face Space registry.</p>
+        <div class="code-block">
+          <button class="copy-btn" type="button">Copy</button>
+          <pre><code>docker run -it -p 7860:7860 --platform=linux/amd64 \
+  -e GEMINI_API_KEY="your_key_here" \
+  registry.hf.space/ibenian-algebench:cpu-3fdcb6b</code></pre>
+        </div>
+        <p class="run-note">Then open <a href="http://localhost:7860" target="_blank" rel="noopener">localhost:7860</a> in your browser. <code>--platform=linux/amd64</code> is needed on Apple Silicon and other ARM hosts.</p>
+      </div>
+    </div>
+  </section>
+
   <section class="section">
     <h2>Frequently Asked Questions</h2>
     <ul class="faq">
@@ -359,11 +444,22 @@
       </li>
       <li>
         <details>
+          <summary>Why run locally?</summary>
+          <div class="faq-body">
+            It's faster, and you get to use your own <code>GEMINI_API_KEY</code> &mdash; billed to
+            your own account &mdash; instead of the shared public key on the hosted version, which is
+            rate-limited across all visitors.
+          </div>
+        </details>
+      </li>
+      <li>
+        <details>
           <summary>What do I need to run it locally?</summary>
           <div class="faq-body">
             Just a <code>GEMINI_API_KEY</code> environment variable. You can create one for free at
             <a href="https://aistudio.google.com/app/apikey" target="_blank" rel="noopener">Google AI Studio</a>.
             We recommend making a dedicated key for AlgeBench so you can track API usage separately.
+            See the <a href="#run-locally">Run Locally</a> section above for the exact commands.
           </div>
         </details>
       </li>
@@ -415,6 +511,42 @@
 <footer>
   <a href="https://github.com/ibenian/algebench">github.com/ibenian/algebench</a>
 </footer>
+
+<script>
+  function copyText(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text);
+    }
+    // Fallback for non-secure contexts (plain HTTP).
+    return new Promise(function (resolve, reject) {
+      var ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      try { document.execCommand('copy'); resolve(); }
+      catch (e) { reject(e); }
+      finally { document.body.removeChild(ta); }
+    });
+  }
+
+  document.querySelectorAll('.code-block .copy-btn').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var code = btn.parentElement.querySelector('code');
+      var text = code ? code.innerText : '';
+      copyText(text).then(function () {
+        var original = btn.textContent;
+        btn.textContent = 'Copied';
+        btn.classList.add('copied');
+        setTimeout(function () {
+          btn.textContent = original;
+          btn.classList.remove('copied');
+        }, 1600);
+      });
+    });
+  });
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
## What changed

Documents the two ways to run AlgeBench locally with your own `GEMINI_API_KEY`, in both the README and the landing page.

**README** (`README.md`)
- Restructured **Quick Start** into two clear options:
  - **Option 1 — Clone the repo** (`./algebench`, port 8785). Dropped the redundant manual `pip install` since the launcher sets up the venv and installs deps on first run.
  - **Option 2 — Docker image from Hugging Face** — `docker run … registry.hf.space/ibenian-algebench:latest` (port 7860).
- Added a shared **Get a Gemini API key** walkthrough (AI Studio → create key), linked from both options' prerequisites.

**Landing page** (`docs/landing-page/index.html`)
- New **Run Locally** section mirroring the two options, each in a copy-pasteable code block with a one-click **Copy** button.
- FAQ: new **"Why run locally?"** entry, and **"What do I need to run it locally?"** now links up to the Run Locally section.

**Tooling** (`.claude/launch.json`)
- Dev-only `landing-page` static-server config for local preview.

## Why

Lower the barrier to self-hosting: running locally is faster and lets users use their own paid Gemini key instead of the rate-limited shared public key on the hosted app.

## Notes for reviewers

- **Docker tag:** intentionally uses `:latest` with `--pull=always`. Hugging Face maintains a `latest` tag tracking the current Space build (verified: it resolves to the same digest as the latest `cpu-<sha>` build), so users don't copy a SHA that goes stale. `--pull=always` ensures Docker fetches the newest build rather than reusing a cached `:latest`.
- **Copy button:** uses the clipboard API with an `execCommand` fallback for non-HTTPS contexts (GitHub Pages serves HTTPS, where the native API works). The fallback rejects on a failed copy, and the click handler catches failures to show a "Press Ctrl+C" hint instead of an unhandled rejection.
- **No key prefixes are documented** — Google's key format is in flux (legacy `AIza` keys are being replaced by new `AQ.` "auth keys" through 2026), so examples use a neutral `your_key_here` placeholder.

Verified the landing page renders and the Copy buttons (success + failure paths) and the FAQ → Run Locally anchor jump all work in the local preview.

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>