### PR TITLE
Step-to-step grounding confidence badges for proof animation

### DIFF
--- a/backend/experts/handlers/proof_animation/animation.py
+++ b/backend/experts/handlers/proof_animation/animation.py
@@ -168,15 +168,17 @@ def build(trajectory: ProofTrajectory, domain: str, title: str = "", *,
         # derivation. ``working`` only advances on a fully-rendered state, so the
         # next good state rebases onto the last good one.
         annotated = plain = ltx
-        # A placeholder token (\dots, or a \pm/\mp pseudo-symbol) still RENDERS
-        # and morphs, but is not real math — its grounding expr stays None so
-        # the confidence tier is honestly "unchecked", never a fake verdict.
         expr = None
-        if g is not None and not any(tok in ltx for tok in PLACEHOLDER_TOKENS):
-            try:
-                expr = graph_to_sympy(g)
-            except Exception:
-                expr = None
+        if g is not None:
+            # A placeholder token (\dots, or a \pm/\mp pseudo-symbol) still
+            # renders and FLIP-morphs as a graph, but is not real math — gate
+            # ONLY the sympy conversion so its grounding expr stays None (tier
+            # "unchecked"), while the state still rebases/animates normally.
+            if not any(tok in ltx for tok in PLACEHOLDER_TOKENS):
+                try:
+                    expr = graph_to_sympy(g)
+                except Exception:
+                    expr = None
             try:
                 cand = g if working is None else _rebase(working, g)
                 annotated = to_latex(cand, with_ids=True)   # annotated, stable ids

--- a/backend/experts/handlers/proof_animation/animation.py
+++ b/backend/experts/handlers/proof_animation/animation.py
@@ -19,7 +19,12 @@ from collections import defaultdict
 from backend.semantic_graph.service import SemanticGraphService
 from backend.semantic_graph.latex_renderer import to_latex
 from backend.experts.modules.proof_completion.graph_ops import wl_colors, _content
+from backend.experts.modules.proof_completion.grounding import graph_to_sympy
+from backend.experts.modules.proof_completion.metric import PLACEHOLDER_TOKENS
 from backend.experts.modules.proof_completion.outputs import ProofTrajectory
+from backend.experts.modules.proof_completion.step_grounding import (
+    TIER_ICON, TIER_LABEL, TIER_MEANING, Tier, ground_steps,
+)
 
 
 def _children(graph):
@@ -151,6 +156,7 @@ def build(trajectory: ProofTrajectory, domain: str, title: str = "", *,
     svc = SemanticGraphService()
     working = None
     out = []
+    state_exprs = []   # per-state sympy expr (None: not convertible) for grounding
     for i, (operation, justification, ltx) in enumerate(chain):
         try:
             g = svc.latex_to_graph(ltx, domain=domain)
@@ -162,7 +168,15 @@ def build(trajectory: ProofTrajectory, domain: str, title: str = "", *,
         # derivation. ``working`` only advances on a fully-rendered state, so the
         # next good state rebases onto the last good one.
         annotated = plain = ltx
-        if g is not None:
+        # A placeholder token (\dots, or a \pm/\mp pseudo-symbol) still RENDERS
+        # and morphs, but is not real math — its grounding expr stays None so
+        # the confidence tier is honestly "unchecked", never a fake verdict.
+        expr = None
+        if g is not None and not any(tok in ltx for tok in PLACEHOLDER_TOKENS):
+            try:
+                expr = graph_to_sympy(g)
+            except Exception:
+                expr = None
             try:
                 cand = g if working is None else _rebase(working, g)
                 annotated = to_latex(cand, with_ids=True)   # annotated, stable ids
@@ -170,6 +184,7 @@ def build(trajectory: ProofTrajectory, domain: str, title: str = "", *,
                 working = cand
             except Exception:
                 annotated = plain = ltx
+        state_exprs.append(expr)
         out.append({
             "index": i,
             "operation": operation,
@@ -178,4 +193,59 @@ def build(trajectory: ProofTrajectory, domain: str, title: str = "", *,
             "latex": annotated,
             "plain": plain,
         })
-    return {"title": title, "domain": domain, "steps": out}
+
+    overall = _attach_confidence(out, state_exprs, trajectory, svc, domain)
+    return {"title": title, "domain": domain, "steps": out,
+            "overall_confidence": overall}
+
+
+def _confidence_payload(tier: Tier, relation=None, reason: str = "",
+                        type_consistent: bool = True) -> dict:
+    return {
+        "tier": tier.value,
+        "label": TIER_LABEL[tier],
+        "icon": TIER_ICON[tier],
+        "meaning": TIER_MEANING[tier],
+        "relation": relation,
+        "reason": reason,
+        "type_consistent": type_consistent,
+    }
+
+
+def _attach_confidence(out, state_exprs, trajectory, svc, domain) -> dict:
+    """Rank the chain with ``ground_steps`` and attach per-step + overall verdicts.
+
+    Strictly additive and isolated: any failure degrades to a uniform GRAY —
+    confidence ranking must never break the animation build.
+    """
+    try:
+        # change_types align to TRANSITIONS: when the chain leads with the start
+        # state every step is a transition; otherwise the first step IS state 0.
+        steps = trajectory.steps
+        change_types = [s.change_type for s in
+                        (steps if trajectory.start_latex else steps[1:])]
+        target_expr = None
+        if trajectory.target_latex:
+            try:
+                tg = svc.latex_to_graph(trajectory.target_latex, domain=domain)
+                target_expr = graph_to_sympy(tg) if tg is not None else None
+            except Exception:
+                target_expr = None
+        report = ground_steps(state_exprs, change_types=change_types,
+                              target=target_expr, domain=domain)
+        for entry, sc in zip(out, report.steps):
+            entry["confidence"] = _confidence_payload(
+                sc.tier, sc.relation, sc.reason, sc.type_consistent)
+        overall = _confidence_payload(report.overall, reason=report.reason)
+        overall["counts"] = report.counts
+        overall["endpoint_reached"] = report.endpoint_reached
+        return overall
+    except Exception:
+        fallback = _confidence_payload(
+            Tier.GRAY, reason="confidence ranking unavailable for this derivation")
+        for entry in out:
+            entry.setdefault("confidence", dict(fallback))
+        overall = dict(fallback)
+        overall["counts"] = {t.value: 0 for t in Tier}
+        overall["endpoint_reached"] = None
+        return overall

--- a/backend/experts/modules/proof_completion/dataset.py
+++ b/backend/experts/modules/proof_completion/dataset.py
@@ -156,6 +156,9 @@ def build_example(seed: Seed, rng: random.Random, max_steps: int, max_ops: int =
             # rule (a symbol before "(" is a function call, not multiplication).
             expr_latex=sp.latex(e, mul_symbol="dot"),
             justification="equivalent transformation (sympy-verified)",
+            # gold chains are equivalence-preserving by construction (each state
+            # is sympy-verified equivalent to the seed expression)
+            change_type="rewrite",
         )
         for (e, _g) in kept[1:]
     ]

--- a/backend/experts/modules/proof_completion/grounding.py
+++ b/backend/experts/modules/proof_completion/grounding.py
@@ -190,6 +190,15 @@ def _eval_relation(op, ins, ev) -> sp.Expr:
     if fn is None:
         raise UngroundableGraph(f"relation {op!r}")
     left, right = _binary_operands(op, ins, ev)
+    # Chained comparison (``a <= g <= b`` parses as a relation whose operand is
+    # itself a relation): read it as the standard conjunction sharing the
+    # middle operand — ``And(a <= g, g <= b)``. sympy itself refuses to build
+    # a Relational over a Relational.
+    Rel = sp.core.relational.Relational
+    if isinstance(left, Rel) and not isinstance(right, Rel):
+        return sp.And(left, fn(left.rhs, right))
+    if isinstance(right, Rel) and not isinstance(left, Rel):
+        return sp.And(fn(left, right.lhs), right)
     return fn(left, right)
 
 

--- a/backend/experts/modules/proof_completion/metric.py
+++ b/backend/experts/modules/proof_completion/metric.py
@@ -63,9 +63,14 @@ def extract_steps(pred: Any) -> list:
 
 # Placeholder/ellipsis tokens that are NOT valid math — a state containing one
 # (e.g. "1 + 2 + \dots + n") is not a real sympy expression even if the latex
-# parser tolerates the token, so it must not count as convertible.
-_PLACEHOLDER = ("\\dots", "\\ldots", "\\cdots", "\\dotsb", "\\ddots",
-                "\\vdots", "\\dotsc", "...")
+# parser tolerates the token, so it must not count as convertible. \pm / \mp
+# belong here too: the parser renders them as an opaque scalar SYMBOL ("x =
+# 3·±"), which silently converts; a multivalued state must be written as a
+# disjunction ("x = 3 or x = -3") or as a branch step instead. Shared by the
+# derive CLI and the animation builder (single source of truth).
+PLACEHOLDER_TOKENS = ("\\dots", "\\ldots", "\\cdots", "\\dotsb", "\\ddots",
+                      "\\vdots", "\\dotsc", "...", "\\pm", "\\mp")
+_PLACEHOLDER = PLACEHOLDER_TOKENS
 
 
 def _state_graph(expr_latex: str, domain) -> SemanticGraph | None:

--- a/backend/experts/modules/proof_completion/outputs.py
+++ b/backend/experts/modules/proof_completion/outputs.py
@@ -127,6 +127,12 @@ GraphOp = Annotated[
 GRAPH_OP_ADAPTER: TypeAdapter = TypeAdapter(GraphOp)
 
 
+# The KIND of move a step makes. The CAS (step_grounding) is the judge of what
+# a step actually did; ``change_type`` is the model's declared expectation —
+# it selects which check applies and surfaces mislabels, never overrides sympy.
+ChangeType = Literal["rewrite", "solve", "substitute", "approximate", "given"]
+
+
 class DerivationStep(BaseModel):
     """One derivation step: a complete reachable state + the move that reached it.
 
@@ -150,6 +156,11 @@ class DerivationStep(BaseModel):
                             description="the COMPLETE LaTeX of the resulting expression")
     justification: str = Field(min_length=1, max_length=400,
                                description="why this step is valid; wrap any math in $…$")
+    change_type: ChangeType = Field(
+        description="the KIND of move: 'rewrite' (equivalence-preserving "
+                    "rearrangement), 'solve' (narrows toward a solution / picks a "
+                    "branch), 'substitute' (introduce a new variable, let $u=…$), "
+                    "'approximate' (≈, not exact), 'given' (a premise, not derived)")
 
 
 class ProofTrajectory(Output):

--- a/backend/experts/modules/proof_completion/signature.py
+++ b/backend/experts/modules/proof_completion/signature.py
@@ -31,6 +31,12 @@ class ProofCompletionSig(dspy.Signature):
       $b^2 - 4ac$". Do NOT use backticks or bare text for math; plain words stay plain.
     - Every `expr_latex` MUST be a single, complete, parseable expression — one
       you could hand to a CAS. Never a partial or malformed fragment.
+    - NEVER write `\pm` or `\mp` inside `expr_latex` — `x = \pm 3` is not a
+      single expression. Emit the explicit disjunction (`x = 3 \lor x = -3`)
+      or pick one branch as its own step with `change_type` = `solve`.
+      (`\pm` is fine inside `operation`/`justification` prose.)
+    - `expr_latex` is MATH ONLY: no `\text{…}` annotations, labels, or units
+      tacked onto the expression — put commentary in `justification`.
     - Write EVERY multiplication explicitly with `\cdot`. A symbol written
       directly before a parenthesis is read as a FUNCTION CALL, not a product:
       `n(n+1)` means "apply function n to (n+1)" and is INVALID. Write
@@ -40,6 +46,14 @@ class ProofCompletionSig(dspy.Signature):
     - Make each step small enough that its `expr_latex` is a clean intermediate
       expression. If a transformation is large, split it into as many smaller
       steps as needed. Prefer more small, valid steps over one big jump.
+    - Each step also declares its `change_type` — the KIND of move it makes:
+      `rewrite` (equivalence-preserving rearrangement: expand, factor, move a
+      term across `=`), `solve` (narrows toward a solution: take a root, pick a
+      branch, isolate the unknown), `substitute` (introduce a new variable,
+      "let $u = …$"), `approximate` (the result is `\approx`, not exact), or
+      `given` (a premise stated, not derived). A CAS verifies each step against
+      its declared type, so label honestly: a step that picks one root of
+      $x^2 = 4$ is `solve`, NOT `rewrite`.
     - The final step's `expr_latex` must equal `target_latex`.
     - Also give a short `title`: a few plain words naming what the derivation
       shows (e.g. "Completing the square", "Lorentz time dilation"). It is a

--- a/backend/experts/modules/proof_completion/step_grounding.py
+++ b/backend/experts/modules/proof_completion/step_grounding.py
@@ -35,6 +35,7 @@ guard so a pathological expression degrades to "unknown" instead of hanging.
 
 from __future__ import annotations
 
+import atexit
 import os
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -163,23 +164,33 @@ _singularities = sp.singularities
 _limit = sp.limit
 
 
+# One SHARED, bounded pool for every guarded call. A timed-out sympy call keeps
+# its worker busy (Python can't kill a thread), so a fresh executor per call
+# would let repeated timeouts accumulate background threads without limit. A
+# fixed-size pool caps that — the worst case is a bounded number of stuck
+# workers, after which guards return ``default`` (grounding degrades to
+# "unknown") instead of leaking. The cap is generous so a single classify's
+# handful of sequential calls never saturates it (fast calls don't queue behind
+# a stuck one); it only bounds the pathological flood of simultaneous overruns.
+_GUARD_POOL = ThreadPoolExecutor(max_workers=32, thread_name_prefix="sg-guard")
+atexit.register(_GUARD_POOL.shutdown, wait=False)
+
+
 def _guard(fn, *args, default=None, timeout=None):
     """Run ``fn(*args)`` with a wall-clock bound; ``default`` on timeout/error.
 
     ``signal.alarm`` is unsafe under the threaded server (and on non-main
-    threads generally), so we wait on a worker thread instead. Caveat: Python
-    cannot kill a thread — the bound is on *waiting*, not CPU; a runaway sympy
-    call keeps its worker busy until it finishes. We mitigate by gating which
-    calls run at all (cheap checks first, univariate only).
+    threads generally), so we wait on a shared, bounded worker pool instead.
+    Caveat: Python cannot kill a thread — the bound is on *waiting*, not CPU; a
+    runaway sympy call keeps its worker busy until it finishes. We mitigate by
+    (a) gating which calls run at all (cheap checks first, univariate only) and
+    (b) capping the pool so background threads can never grow unbounded.
     """
     t = _TIMEOUT_S if timeout is None else timeout
-    ex = ThreadPoolExecutor(max_workers=1)
     try:
-        return ex.submit(fn, *args).result(timeout=t)
+        return _GUARD_POOL.submit(fn, *args).result(timeout=t)
     except Exception:
         return default
-    finally:
-        ex.shutdown(wait=False)
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/experts/modules/proof_completion/step_grounding.py
+++ b/backend/experts/modules/proof_completion/step_grounding.py
@@ -1,0 +1,686 @@
+"""Step-to-step grounding: rank each derivation transition by CAS-verified confidence.
+
+``grounding.py`` answers "does a single state mean the right math?". This module
+answers the question it leaves open: **does step n actually follow from step
+n-1?** A well-formed-but-wrong middle step (``x^2 = 4 -> x = 7``) parses fine
+and reaches no verdict today; here every consecutive transition is classified
+and ranked into one of five confidence tiers. The point is never to fail or
+stop processing — only to rank, so consumers (animation badges, CLI, API) can
+*show* how solid each step is.
+
+Per transition ``state[k-1] -> state[k]`` we establish a relation:
+
+* ``equivalent`` — ``sympy_equiv`` holds (rewriting / rearrangement).
+* ``narrows``    — not equivalent, but the new statement's solution set is
+  contained in the previous one's (a valid solving step / branch selection).
+* ``refuted``    — provably wrong: introduces non-solutions, or the
+  characteristic fingerprints (roots / singularities / limits) provably differ.
+* ``unknown``    — sympy can decide neither way.
+
+When symbolic checks are inconclusive we compare **characteristic
+fingerprints** — the defining landmarks of a univariate expression (real roots,
+singularities, limits at ±oo and at each pole) — instead of sampling points.
+Matching landmarks is strong evidence (Verified), differing landmarks a proof
+of difference (Refuted), uncomputable landmarks no evidence at all (Plausible).
+
+The model's per-step ``change_type`` (rewrite / solve / substitute /
+approximate / given) is an advisory *claim*, never the authority: sympy is the
+judge, and a mislabel (e.g. a narrowing step declared ``rewrite``) downgrades
+the tier by one notch.
+
+Pure module: sympy only — no LM, no DSPy, no SemanticGraphService. Heavy sympy
+calls (solveset / singularities / limit / simplify) run under a wall-clock
+guard so a pathological expression degrades to "unknown" instead of hanging.
+"""
+
+from __future__ import annotations
+
+import os
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal, Optional, Sequence
+
+import sympy as sp
+
+from .grounding import _coerce_expr, sympy_equiv
+
+# --------------------------------------------------------------------------- #
+# tiers
+# --------------------------------------------------------------------------- #
+
+
+class Tier(str, Enum):
+    """Confidence tiers, weakest to strongest (see ``TIER_RANK``)."""
+
+    RED = "refuted"        # computed and wrong
+    GRAY = "unchecked"     # state not sympy-convertible — nothing to check
+    BLUE = "plausible"     # convertible, not refuted, undecided
+    SILVER = "verified"    # landmarks match / proven but mislabeled
+    GOLD = "grounded"      # symbolically proven, label consistent
+
+
+TIER_RANK = {Tier.RED: 0, Tier.GRAY: 1, Tier.BLUE: 2, Tier.SILVER: 3, Tier.GOLD: 4}
+
+TIER_LABEL = {
+    Tier.GOLD: "Grounded",
+    Tier.SILVER: "Verified",
+    Tier.BLUE: "Plausible",
+    Tier.GRAY: "Unchecked",
+    Tier.RED: "Refuted",
+}
+
+TIER_ICON = {
+    Tier.GOLD: "🥇",
+    Tier.SILVER: "🥈",
+    Tier.BLUE: "🔹",
+    Tier.GRAY: "○",
+    Tier.RED: "✗",
+}
+
+# What each tier means, in user-facing words (tooltips). Phrased to follow the
+# tier label ("Proven — <meaning>"), so they never repeat it.
+TIER_MEANING = {
+    Tier.GOLD: "symbolically proven to follow from the previous step",
+    Tier.SILVER: "strong CAS evidence, short of a symbolic proof",
+    Tier.BLUE: "valid math, but the CAS could not decide this step",
+    Tier.GRAY: "this state is not a single convertible expression",
+    Tier.RED: "the CAS shows this does NOT follow from the previous step",
+}
+
+Relation = Literal["equivalent", "narrows", "refuted", "unknown"]
+# "scaled": equivalence up to a nonzero residual factor (multiply/divide both
+# sides) — conditional on that factor being nonzero, hence Verified not Proven.
+# "numeric": declared-approximate step confirmed within numeric tolerance.
+# "parametric": multivariate narrows proven with one symbol as the unknown and
+# the rest as GENERIC parameters (solveset's generic manipulations) — Verified.
+# "branch": the two equations SQUARE to the same statement — equal up to the
+# choice of root branch (principal-root simplifications) — Verified.
+Method = Literal["symbolic", "scaled", "fingerprint", "numeric", "parametric",
+                 "branch", "none"]
+
+# change_type -> the relations that label would predict. sympy is the judge;
+# disagreement marks the pair type-inconsistent (one-notch downgrade). ``solve``
+# accepts ``equivalent`` because the canonical solve step (x^2=4 -> x=±2)
+# preserves the solution set exactly.
+_EXPECTED_RELATIONS = {
+    "rewrite": {"equivalent"},
+    "solve": {"narrows", "equivalent"},
+    "substitute": {"equivalent", "unknown"},
+    "approximate": {"unknown", "equivalent"},
+    "given": {"equivalent"},
+}
+
+
+# --------------------------------------------------------------------------- #
+# report dataclasses
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class PairVerdict:
+    """Verdict for one transition ``state[index-1] -> state[index]``."""
+
+    index: int                      # 1-based: the state this transition reaches
+    tier: Tier
+    relation: Relation
+    method: Method
+    change_type: Optional[str]      # the model's declared claim, if any
+    type_consistent: bool           # did the CAS finding agree with the claim?
+    reason: str                     # human one-liner (tooltip text)
+
+
+@dataclass(frozen=True)
+class StepConfidence:
+    """Per-STATE confidence (index 0 is the start / premise)."""
+
+    index: int
+    tier: Tier
+    relation: Optional[Relation]    # None for the start state
+    reason: str
+    type_consistent: bool
+
+
+@dataclass(frozen=True)
+class StepGroundingReport:
+    steps: list                     # list[StepConfidence], one per state
+    pairs: list                     # list[PairVerdict], one per transition
+    overall: Tier
+    counts: dict                    # tier.value -> count, over transitions
+    endpoint_reached: Optional[bool]  # final state equiv target (None: unknowable)
+    reason: str                     # overall one-liner
+
+
+# --------------------------------------------------------------------------- #
+# timeout guard
+# --------------------------------------------------------------------------- #
+
+_TIMEOUT_S = float(os.environ.get("ALGEBENCH_VERIFY_TIMEOUT", "2.0"))
+
+# Indirection so tests can monkeypatch the heavy sympy entry points.
+_solveset = sp.solveset
+_singularities = sp.singularities
+_limit = sp.limit
+
+
+def _guard(fn, *args, default=None, timeout=None):
+    """Run ``fn(*args)`` with a wall-clock bound; ``default`` on timeout/error.
+
+    ``signal.alarm`` is unsafe under the threaded server (and on non-main
+    threads generally), so we wait on a worker thread instead. Caveat: Python
+    cannot kill a thread — the bound is on *waiting*, not CPU; a runaway sympy
+    call keeps its worker busy until it finishes. We mitigate by gating which
+    calls run at all (cheap checks first, univariate only).
+    """
+    t = _TIMEOUT_S if timeout is None else timeout
+    ex = ThreadPoolExecutor(max_workers=1)
+    try:
+        return ex.submit(fn, *args).result(timeout=t)
+    except Exception:
+        return default
+    finally:
+        ex.shutdown(wait=False)
+
+
+# --------------------------------------------------------------------------- #
+# expression shape helpers
+# --------------------------------------------------------------------------- #
+
+
+def _kind(e) -> str:
+    from sympy.logic.boolalg import BooleanFunction
+
+    if e is None:
+        return "none"
+    if isinstance(e, sp.Equality):
+        return "equation"
+    if isinstance(e, sp.core.relational.Relational):
+        return "inequality"
+    if isinstance(e, BooleanFunction):
+        return "boolean"
+    return "expression"
+
+
+def _residual(e):
+    """Equation -> lhs - rhs; plain expression unchanged."""
+    return e.lhs - e.rhs if isinstance(e, sp.Equality) else e
+
+
+def _sole_symbol(*exprs):
+    """The single shared free symbol, or None (multivariate / constant)."""
+    syms = set()
+    for e in exprs:
+        syms |= e.free_symbols
+    return next(iter(syms)) if len(syms) == 1 else None
+
+
+def _solution_set(e, x, domain=sp.S.Reals):
+    """Solution set of a relational / boolean combination of relationals.
+
+    ``Or`` is a union of branches (e.g. ``x = 2 or x = -2``), ``And`` an
+    intersection. Raises if sympy can't solve — callers run this under _guard.
+    Univariate checks use the reals; the parametric path uses the default
+    complex domain, where solveset handles symbolic parameters much better.
+    """
+    if isinstance(e, sp.Or):
+        return sp.Union(*[_solution_set(a, x, domain) for a in e.args])
+    if isinstance(e, sp.And):
+        return sp.Intersection(*[_solution_set(a, x, domain) for a in e.args])
+    return _solveset(e, x, domain)
+
+
+# --------------------------------------------------------------------------- #
+# characteristic fingerprint (roots / singularities / limits — not sampling)
+# --------------------------------------------------------------------------- #
+
+# Sentinel for a landmark that exists but is not a finite, comparable set
+# (interval / ConditionSet / ImageSet). Distinct from None = "couldn't compute".
+_NONFINITE = "nonfinite"
+
+
+@dataclass(frozen=True)
+class _Fingerprint:
+    roots: object    # frozenset | _NONFINITE | None
+    sings: object    # frozenset | _NONFINITE | None
+    limits: dict     # (point_label,) -> sympy value | None
+
+
+def _finite_set(s):
+    """frozenset for a FiniteSet, _NONFINITE for other sets, None otherwise."""
+    if isinstance(s, sp.FiniteSet):
+        return frozenset(s)
+    if isinstance(s, sp.Set):
+        return _NONFINITE
+    return None
+
+
+def _fingerprint(e) -> Optional[_Fingerprint]:
+    """Defining landmarks of a univariate expression/equation over the reals.
+
+    Returns None when fingerprinting does not apply (inequalities, booleans,
+    multivariate, constants) — the caller then has symbolic evidence only.
+    """
+    if _kind(e) in ("inequality", "boolean", "none"):
+        return None
+    f = _residual(e)
+    x = _sole_symbol(f)
+    if x is None:
+        return None
+
+    roots = _finite_set(_guard(_solveset, sp.Eq(f, 0), x, sp.S.Reals))
+    sings = _finite_set(_guard(_singularities, f, x, sp.S.Reals))
+
+    limits: dict = {}
+    limits["+oo"] = _guard(_limit, f, x, sp.oo)
+    limits["-oo"] = _guard(_limit, f, x, -sp.oo)
+    if isinstance(sings, frozenset):
+        for p in sings:
+            limits[f"{p}+"] = _guard(_limit, f, x, p, "+")
+            limits[f"{p}-"] = _guard(_limit, f, x, p, "-")
+    return _Fingerprint(roots=roots, sings=sings, limits=limits)
+
+
+def _vals_equal(a, b) -> Optional[bool]:
+    """True/False if two landmark values are provably equal/different, else None."""
+    if a is None or b is None:
+        return None
+    try:
+        if a == b:
+            return True
+        if a.has(sp.oo, -sp.oo, sp.zoo, sp.nan) or b.has(sp.oo, -sp.oo, sp.zoo, sp.nan):
+            return None  # only finite values are compared for difference
+        return bool(sp.simplify(a - b) == 0)
+    except Exception:
+        return None
+
+
+def _sets_equal(a, b) -> Optional[bool]:
+    """True/False for two finite landmark sets, None if either is unusable."""
+    if not isinstance(a, frozenset) or not isinstance(b, frozenset):
+        return None
+    if a == b:
+        return True
+    try:
+        norm = lambda s: {sp.nsimplify(sp.simplify(v)) for v in s}  # noqa: E731
+        return norm(a) == norm(b)
+    except Exception:
+        return None
+
+
+def _fp_compare(a: _Fingerprint, b: _Fingerprint) -> Optional[bool]:
+    """True = landmarks all match, False = a landmark provably differs, None = inconclusive."""
+    roots = _sets_equal(a.roots, b.roots)
+    sings = _sets_equal(a.sings, b.sings)
+    if roots is False or sings is False:
+        return False
+    lims = []
+    for key in set(a.limits) & set(b.limits):
+        eq = _vals_equal(a.limits.get(key), b.limits.get(key))
+        if eq is False:
+            return False
+        lims.append(eq)
+    if roots is True and sings is True and lims and all(lims):
+        return True
+    return None
+
+
+def _fingerprint_relation(prev, curr) -> Optional[bool]:
+    """Fingerprint verdict for prev vs curr; equations tried up to sign.
+
+    True = equivalent-by-landmarks, False = refuted, None = inconclusive.
+    """
+    # Different variable sets (e.g. a substitution introduced `u`): the two
+    # landmark sets live on different axes — comparing them proves nothing.
+    if getattr(prev, "free_symbols", set()) != getattr(curr, "free_symbols", set()):
+        return None
+    fa, fb = _fingerprint(prev), _fingerprint(curr)
+    if fa is None or fb is None:
+        return None
+    verdict = _fp_compare(fa, fb)
+    # An equation's residual is sign-ambiguous (lhs-rhs vs rhs-lhs): limits
+    # negate under the flip, so only refute if BOTH orientations refute.
+    if verdict is not True and (_kind(prev) == "equation" or _kind(curr) == "equation"):
+        flipped = _fp_compare(fa, _fingerprint(sp.Mul(-1, _residual(curr), evaluate=False)) or fb)
+        if flipped is True:
+            return True
+        if verdict is False and flipped is False:
+            return False
+        return None
+    return verdict
+
+
+# --------------------------------------------------------------------------- #
+# pair classification
+# --------------------------------------------------------------------------- #
+
+
+def classify_pair(prev, curr, change_type: Optional[str] = None,
+                  index: int = 1) -> PairVerdict:
+    """Classify one transition and rank it. Never raises."""
+    if prev is None or curr is None:
+        which = "previous" if prev is None else "this"
+        return PairVerdict(index, Tier.GRAY, "unknown", "none", change_type, False,
+                           f"{which} state is not a single convertible expression")
+
+    relation: Relation = "unknown"
+    method: Method = "none"
+    reason = "neither equivalence nor a valid narrowing could be established"
+
+    # 1) symbolic equivalence — the cheap, common case (rewrite / rearrange)
+    if _guard(sympy_equiv, prev, curr, default=False):
+        relation, method = "equivalent", "symbolic"
+        reason = "symbolically equivalent to the previous step"
+    else:
+        # 1b) declared-approximate steps are not exact BY DESIGN — verify them
+        # numerically before the exact checks get a chance to "refute" the
+        # rounding. A genuinely wrong value still falls through and gets RED.
+        if change_type == "approximate":
+            close = _approx_close(prev, curr)
+            if close is True:
+                relation, method = "equivalent", "numeric"
+                reason = "numerically equal to the previous step within tolerance (≈)"
+
+        # 2) narrows — a solving step: solution set must not grow
+        if relation == "unknown":
+            relation, method, reason = _narrows_check(prev, curr, relation, method, reason)
+
+        # 2b) scaled residual — "multiply/divide both sides by k": residuals
+        # proportional. A NUMERIC factor is an unconditional proof; a symbolic
+        # one is conditional on k != 0, hence method "scaled" (-> Verified).
+        if relation == "unknown":
+            k = _scaled_residual(prev, curr)
+            if k is not None:
+                relation = "equivalent"
+                if k.is_number:
+                    method = "symbolic"
+                    reason = f"both sides scaled by the nonzero constant {k}"
+                else:
+                    method = "scaled"
+                    reason = (f"both sides scaled by {k} — "
+                              f"equivalent wherever {k} ≠ 0")
+
+        # 2c) parametric narrows — multivariate solving steps (weakest of the
+        # equation checks, so it runs only when scaled equivalence failed)
+        if relation == "unknown" and _kind(prev) != "expression" \
+                and _kind(curr) != "expression":
+            relation, method, reason = _parametric_narrows(
+                prev, curr, relation, method, reason)
+
+        # 2d) branch pair — principal-root simplifications (√(K/4a²) → √K/2a):
+        # the two equations square to the SAME statement, so they are equal up
+        # to the choice of root branch. Runs after the refuting checks (a
+        # univariate wrong branch like x=3 → x=-3 is refuted at step 2 first).
+        if relation == "unknown" and _branch_pair(prev, curr):
+            relation, method = "equivalent", "branch"
+            reason = ("both sides square to the same statement — equal up to "
+                      "the choice of root branch (principal root assumed)")
+
+        # 3) characteristic fingerprint — landmarks instead of sampling
+        if relation == "unknown":
+            fp = _fingerprint_relation(prev, curr)
+            if fp is True:
+                relation, method = "equivalent", "fingerprint"
+                reason = "characteristic landmarks (roots, poles, limits) all match"
+            elif fp is False:
+                relation, method = "refuted", "fingerprint"
+                reason = "characteristic landmarks provably differ from the previous step"
+
+    expected = _EXPECTED_RELATIONS.get(change_type or "")
+    # No declared type = no claim to contradict; undecided pairs aren't mislabels.
+    type_consistent = expected is None or relation in expected or relation == "unknown"
+
+    tier = _tier_for(relation, method, type_consistent)
+    if not type_consistent:
+        reason += f" — but the step was declared '{change_type}'"
+    return PairVerdict(index, tier, relation, method, change_type,
+                       type_consistent, reason)
+
+
+def _squared_pair(prev, curr) -> bool:
+    """Is ``prev`` exactly ``curr`` with both sides squared (sides either way)?
+
+    ``u = w  =>  u² = w²`` holds unconditionally — any symbols, any signs — so
+    a take-the-square-root step whose previous state IS its square is a proven
+    narrowing with no solveset and no parameter conditions. This catches the
+    multivariate root steps the solution-set checks can't settle (sympy writes
+    the two sides' roots in |a|-ambiguous forms and is_subset returns None).
+    """
+    if not (isinstance(prev, sp.Equality) and isinstance(curr, sp.Equality)):
+        return False
+    def _matches(lhs, rhs):
+        return (sp.simplify(prev.lhs - lhs ** 2) == 0
+                and sp.simplify(prev.rhs - rhs ** 2) == 0)
+    return bool(_guard(_matches, curr.lhs, curr.rhs, default=False)
+                or _guard(_matches, curr.rhs, curr.lhs, default=False))
+
+
+def _branch_pair(prev, curr) -> bool:
+    """Do the two equations SQUARE to the same statement?
+
+    ``u = s`` and ``u = t`` with ``s² = t²`` differ at most by the sign of a
+    root (``t = ±s``) — the situation of principal-root simplifications like
+    ``√(K/4a²) → √K/(2a)``, where solveset only returns undecidable
+    ConditionSets. Equal-up-to-branch is Verified-grade evidence, not a proof:
+    the identification is exact on the principal branch and sign-flipped off
+    it. Refutable cases (e.g. univariate ``x=3 → x=-3``) never reach this
+    check — the solution-set pass refutes them first.
+    """
+    if not (isinstance(prev, sp.Equality) and isinstance(curr, sp.Equality)):
+        return False
+    sq = lambda e: sp.Eq(e.lhs ** 2, e.rhs ** 2)  # noqa: E731
+    return bool(_guard(lambda: sympy_equiv(sq(prev), sq(curr)), default=False))
+
+
+def _narrows_check(prev, curr, relation, method, reason):
+    """Solution-set containment for relational/boolean states (solving steps)."""
+    rel_kinds = ("equation", "inequality", "boolean")
+    if _kind(prev) not in rel_kinds or _kind(curr) not in rel_kinds:
+        return relation, method, reason
+    # take-the-root pattern: an unconditional implication, decided structurally
+    if _squared_pair(prev, curr):
+        return ("narrows", "symbolic",
+                "the previous step is exactly this step squared — taking a root "
+                "keeps only solutions of the original")
+    x = _sole_symbol(prev, curr)
+    if x is None:
+        # multivariate — handled later by the (weaker) parametric pass, AFTER
+        # the scaled-residual check has had its chance to prove equivalence
+        return relation, method, reason
+    prev_sols = _guard(_solution_set, prev, x)
+    curr_sols = _guard(_solution_set, curr, x)
+    if prev_sols is None or curr_sols is None:
+        return relation, method, reason
+    contained = _guard(lambda: curr_sols.is_subset(prev_sols))
+    if contained:
+        # equal sets are equivalence, not narrowing — don't punish a `rewrite`
+        # label (e.g. "multiply both sides by 2") for preserving every solution
+        if _guard(lambda: prev_sols.is_subset(curr_sols)):
+            return ("equivalent", "symbolic",
+                    "same solution set as the previous step")
+        return ("narrows", "symbolic",
+                "every solution of this step solves the previous one (valid narrowing)")
+    # provably introduces non-solutions? (only claim it when the gap is concrete)
+    gap = _guard(lambda: curr_sols - prev_sols)
+    if isinstance(gap, sp.FiniteSet) and len(gap) > 0:
+        extra = ", ".join(sorted(str(v) for v in gap))
+        return ("refuted", "symbolic",
+                f"introduces value(s) that do not solve the previous step: {extra}")
+    return relation, method, reason
+
+
+# Relative tolerance for declared-approximate steps (covers e.g. pi -> 3.14).
+_APPROX_TOL = 1e-2
+
+
+def _approx_close(prev, curr) -> Optional[bool]:
+    """For declared-approximate steps: residual difference numerically tiny?
+
+    True/False when the difference evaluates to a number (within / beyond
+    tolerance), None when it stays symbolic (tolerance undecidable).
+    """
+    d = _guard(lambda: sp.simplify(_residual(prev) - _residual(curr)))
+    if d is None or d.free_symbols:
+        return None
+    try:
+        return abs(float(d)) <= _APPROX_TOL
+    except Exception:
+        return None
+
+
+def _scaled_residual(prev, curr):
+    """Residual-proportionality: ``residual(prev) == k * residual(curr)``.
+
+    Catches "multiply/divide both sides by k" — the residuals differ by the
+    factor, so the strict residual comparison in ``sympy_equiv`` rejects the
+    step even though the solution set is unchanged wherever ``k != 0``.
+
+    Returns the factor ``k`` (nonzero, and — when symbolic — free of at least
+    one shared symbol, the would-be unknown), or None if the residuals are not
+    cleanly proportional. A factor that CONTAINS every shared symbol could
+    change the solution set, so it is conservatively rejected.
+    """
+    if not (isinstance(prev, sp.Equality) and isinstance(curr, sp.Equality)):
+        return None
+    ra, rb = prev.lhs - prev.rhs, curr.lhs - curr.rhs
+    k = _guard(lambda: sp.simplify(sp.cancel(ra / rb)))
+    if k is None or k == 0 or k.has(sp.oo, -sp.oo, sp.zoo, sp.nan):
+        return None
+    if k.is_number:
+        return k
+    shared = ra.free_symbols & rb.free_symbols
+    if not (shared - k.free_symbols):
+        return None
+    return k
+
+
+def _parametric_narrows(prev, curr, relation, method, reason):
+    """Multivariate narrows: prove containment with ONE symbol as the unknown.
+
+    If, for some shared symbol v (the others held as generic parameters),
+    every v-solution of ``curr`` is a v-solution of ``prev``, then any point
+    satisfying ``curr`` satisfies ``prev`` — the step introduces no
+    non-solutions. solveset's parametric manipulations are *generic* (it
+    squares / divides freely in the parameters), so this is Verified-grade
+    evidence, not a proof; we therefore never REFUTE in this mode, and we
+    conservatively report ``narrows`` (not ``equivalent``) even for two-way
+    containment.
+    """
+    shared = sorted(prev.free_symbols & curr.free_symbols, key=str)
+    if not (1 <= len(shared) <= 5):     # bound the work (each try is guarded)
+        return relation, method, reason
+    # prefer the symbol the step is visibly solved for (a bare-symbol lhs)
+    if isinstance(curr, sp.Equality) and curr.lhs in shared:
+        shared.remove(curr.lhs)
+        shared.insert(0, curr.lhs)
+    for v in shared:
+        prev_sols = _guard(_solution_set, prev, v, sp.S.Complexes)
+        curr_sols = _guard(_solution_set, curr, v, sp.S.Complexes)
+        if prev_sols is None or curr_sols is None:
+            continue
+        if _guard(lambda: curr_sols.is_subset(prev_sols)):
+            return ("narrows", "parametric",
+                    f"treating {v} as the unknown, every solution of this step "
+                    f"solves the previous one (other symbols as generic parameters)")
+    return relation, method, reason
+
+
+def _tier_for(relation: Relation, method: Method, type_consistent: bool) -> Tier:
+    if relation == "refuted":
+        return Tier.RED                       # a mislabel can't make it worse
+    if relation == "unknown":
+        return Tier.BLUE
+    base = Tier.GOLD if method == "symbolic" else Tier.SILVER
+    if not type_consistent:                   # one-notch downgrade for mislabels
+        return Tier.SILVER if base is Tier.GOLD else Tier.BLUE
+    return base
+
+
+# --------------------------------------------------------------------------- #
+# the standalone helper (issue #355)
+# --------------------------------------------------------------------------- #
+
+
+def ground_steps(states: Sequence, *, change_types: Optional[Sequence] = None,
+                 target=None, domain=None) -> StepGroundingReport:
+    """Rank an ordered chain of derivation states by step-to-step confidence.
+
+    ``states``: sympy expressions or sympify-able strings (None marks a state
+    that is known to be non-convertible). ``states[0]`` is the start / premise.
+    ``change_types``: optional per-TRANSITION claims (len == len(states) - 1).
+    ``target``: optional expression the chain should reach (endpoint gate).
+    ``domain`` is advisory (kept for signature symmetry with the parsers).
+
+    Pure and total: never raises, never blocks past the per-call timeout.
+    """
+    exprs = [_safe_coerce(s) for s in states]
+    n_trans = max(len(exprs) - 1, 0)
+    declared = list(change_types or [])
+    declared += [None] * (n_trans - len(declared))
+
+    steps: list[StepConfidence] = []
+    pairs: list[PairVerdict] = []
+    if exprs:
+        start_ok = exprs[0] is not None
+        steps.append(StepConfidence(
+            0,
+            Tier.GOLD if start_ok else Tier.GRAY,
+            None,
+            "the given starting expression" if start_ok
+            else "the starting state is not a single convertible expression",
+            True,
+        ))
+    for i in range(1, len(exprs)):
+        pv = classify_pair(exprs[i - 1], exprs[i], declared[i - 1], index=i)
+        pairs.append(pv)
+        steps.append(StepConfidence(i, pv.tier, pv.relation, pv.reason,
+                                    pv.type_consistent))
+
+    endpoint = None
+    if target is not None:
+        target_expr = _safe_coerce(target)
+        final = next((e for e in reversed(exprs) if e is not None), None)
+        if target_expr is not None and final is not None:
+            endpoint = bool(_guard(sympy_equiv, final, target_expr, default=False))
+
+    counts = {t.value: 0 for t in Tier}
+    for pv in pairs:
+        counts[pv.tier.value] += 1
+
+    overall = min((pv.tier for pv in pairs), key=TIER_RANK.get, default=Tier.BLUE)
+    # Endpoint gate: GOLD additionally requires *reaching the goal*. Unverified
+    # endpoint caps at SILVER, a missed endpoint at BLUE (locally fine, off-goal).
+    if endpoint is False:
+        overall = min(overall, Tier.BLUE, key=TIER_RANK.get)
+    elif endpoint is None and overall is Tier.GOLD:
+        overall = Tier.SILVER
+
+    return StepGroundingReport(
+        steps=steps, pairs=pairs, overall=overall, counts=counts,
+        endpoint_reached=endpoint, reason=_overall_reason(pairs, counts, endpoint),
+    )
+
+
+def _safe_coerce(s):
+    """sympy expr | sympify-able string -> expr; None on anything else."""
+    if s is None:
+        return None
+    try:
+        return _coerce_expr(s)
+    except Exception:
+        return None
+
+
+def _overall_reason(pairs, counts, endpoint) -> str:
+    n = len(pairs)
+    if n == 0:
+        return "no steps to verify"
+    best = counts[Tier.GOLD.value] + counts[Tier.SILVER.value]
+    parts = [f"{best}/{n} steps verified"]
+    for tier in (Tier.RED, Tier.GRAY, Tier.BLUE):
+        if counts[tier.value]:
+            parts.append(f"{counts[tier.value]} {TIER_LABEL[tier].lower()}")
+    if endpoint is True:
+        parts.append("endpoint reached")
+    elif endpoint is False:
+        parts.append("endpoint NOT reached")
+    return " · ".join(parts)

--- a/scripts/proof_animation/report.py
+++ b/scripts/proof_animation/report.py
@@ -106,8 +106,10 @@ def main() -> int:
     elif args.states:
         traj = ProofTrajectory(
             start_latex=args.states[0],
+            # ad-hoc chains carry no per-step claim; "rewrite" is the common
+            # case (a non-rewrite step simply ranks Verified instead of Proven)
             steps=[DerivationStep(operation=f"step {i}", expr_latex=s,
-                                  justification="(manual)")
+                                  justification="(manual)", change_type="rewrite")
                    for i, s in enumerate(args.states[1:], start=1)],
         )
         animations = [build(traj, args.domain, args.title)]

--- a/scripts/proof_completion_derive.py
+++ b/scripts/proof_completion_derive.py
@@ -34,6 +34,9 @@ from backend.experts.modules.proof_completion.graph_ops import canonical_equal, 
 from backend.experts.modules.proof_completion.grounding import (  # noqa: E402
     graph_to_latex, graph_to_sympy, sympy_equiv,
 )
+from backend.experts.modules.proof_completion.step_grounding import (  # noqa: E402
+    TIER_ICON, TIER_LABEL, ground_steps,
+)
 from backend.experts.modules.proof_completion.outputs import (  # noqa: E402
     AddEdge, AddNode, RemoveEdge, RemoveNode,
 )
@@ -53,11 +56,9 @@ def _describe(op) -> str:
     return op.op
 
 
-# Placeholder/ellipsis tokens that are NOT valid math — a state containing one
-# (e.g. "1 + 2 + \dots + n") cannot be a real sympy expression even if the
-# parser tolerates the token.
-_PLACEHOLDER = ("\\dots", "\\ldots", "\\cdots", "\\dotsb", "\\ddots",
-                "\\vdots", "\\dotsc", "...")
+# Placeholder tokens (incl. \pm/\mp pseudo-symbols) — the canonical list lives
+# in the metric module so the CLI, metric, and animation builder agree.
+from backend.experts.modules.proof_completion.metric import PLACEHOLDER_TOKENS as _PLACEHOLDER  # noqa: E402
 
 
 def state_graph(svc, expr_latex: str, domain):
@@ -185,12 +186,31 @@ def main() -> int:
         recon = graph_to_latex(g) or f"{s.expr_latex}   (not a valid SymPy expression)"
         derived.append((s, g, recon))
 
+    # step-to-step grounding: rank every consecutive transition (standalone
+    # helper — also importable as proof_completion.step_grounding.ground_steps)
+    def _state_expr(g):
+        if g is None:
+            return None
+        try:
+            return graph_to_sympy(g)
+        except Exception:
+            return None
+
+    report = ground_steps(
+        [_state_expr(start_g)] + [_state_expr(g) for _s, g, _ in derived],
+        change_types=[s.change_type for s in steps],
+        target=_state_expr(target_g),
+    )
+
     # always: the LaTeX chain (start -> each state), reconstructed from the graph
     start_latex = graph_to_latex(start_g) or args.start
     print(f"\n=== derivation (LaTeX): {len(steps)} step(s) ===")
     print(f"   start :   {start_latex}")
     for i, (s, _g, recon) in enumerate(derived, start=1):
-        print(f"   step {i}:  {recon}")
+        sc = report.steps[i]
+        print(f"   step {i}:  {TIER_ICON[sc.tier]} {recon}")
+        if sc.relation in ("refuted", "unknown") or not sc.type_consistent:
+            print(f"             ({TIER_LABEL[sc.tier].lower()}: {sc.reason})")
 
     # opt-in detail: one step = one math operation + one full state + one
     # justification. With --trajectory we also recover the atomic graph edits
@@ -233,6 +253,10 @@ def main() -> int:
           f"(each state is a single sympy-convertible expression)")
     print(f"  math correct      : {math}    (final state reaches the target expression)")
     print(f"  exact graph       : {struct}    (identical structure to the parsed target)")
+    glyphs = "".join(TIER_ICON[sc.tier] for sc in report.steps[1:])
+    print(f"  step grounding    : {glyphs}    (each transition follows from the previous state)")
+    print(f"  confidence        : {TIER_ICON[report.overall]} "
+          f"{TIER_LABEL[report.overall]}    ({report.reason})")
     return 0
 
 

--- a/static/proof-animation/proof-animation.css
+++ b/static/proof-animation/proof-animation.css
@@ -46,6 +46,7 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
+  position: relative;       /* anchor for the overall-confidence overlay */
 }
 
 /* the expression canvas — relative so delete-ghosts can be absolutely placed */
@@ -187,7 +188,10 @@
    max-width + the op's min-width:0 let a long (KaTeX-bearing) caption shrink and
    wrap in a narrow box instead of overflowing; the op keeps flex-grow:0 so the
    button stays beside the text rather than being pushed to the far edge. */
-.pa-op-row { display: flex; align-items: center; gap: 8px; max-width: 100%; }
+/* min-height reserves the confidence badge's box (22px + 1px borders) even
+   while it's hidden, so revealing/pinning badges never changes the row height
+   (the badge is taller than a single text line). */
+.pa-op-row { display: flex; align-items: center; gap: 8px; max-width: 100%; min-height: 24px; }
 .pa-op-row .pa-op { min-width: 0; }
 /* Never let the button shrink. In a narrow box the op-row overflows and flexbox
    would squeeze the button — and it squeezes the empty measuring-probe button
@@ -274,6 +278,119 @@
   border-color: var(--pa-accent);
 }
 
+/* ───────────────────────────────────────────────────────────────────────────
+   Step-grounding confidence tiers (server-attached `confidence` per step +
+   `overall_confidence`; see step_grounding.py). Five ranked tiers, each with a
+   color pair; a pa-conf-<tier> class sets the pair, and the badge / overall
+   pill / step-dot strip all read it. Payloads without confidence render none
+   of this (the badge is :empty-hidden, the pill is removed).
+   ─────────────────────────────────────────────────────────────────────────── */
+.pa-root {
+  --pa-tier-grounded: #d4a017;                      /* gold   — all checks pass */
+  --pa-tier-grounded-bg: rgba(212, 160, 23, 0.16);
+  --pa-tier-verified: #9aa3b5;                    /* silver — strong evidence */
+  --pa-tier-verified-bg: rgba(154, 163, 181, 0.18);
+  --pa-tier-plausible: var(--pa-accent);          /* blue   — undecided */
+  --pa-tier-plausible-bg: rgba(99, 102, 241, 0.16);
+  --pa-tier-unchecked: var(--pa-muted);           /* gray   — not convertible */
+  --pa-tier-unchecked-bg: rgba(120, 130, 150, 0.12);
+  --pa-tier-refuted: #d05a5a;                     /* red    — provably wrong */
+  --pa-tier-refuted-bg: rgba(208, 90, 90, 0.18);
+}
+.pa-conf-grounded    { --pa-conf-fg: var(--pa-tier-grounded);    --pa-conf-bg: var(--pa-tier-grounded-bg); }
+.pa-conf-verified  { --pa-conf-fg: var(--pa-tier-verified);  --pa-conf-bg: var(--pa-tier-verified-bg); }
+.pa-conf-plausible { --pa-conf-fg: var(--pa-tier-plausible); --pa-conf-bg: var(--pa-tier-plausible-bg); }
+.pa-conf-unchecked { --pa-conf-fg: var(--pa-tier-unchecked); --pa-conf-bg: var(--pa-tier-unchecked-bg); }
+.pa-conf-refuted   { --pa-conf-fg: var(--pa-tier-refuted);   --pa-conf-bg: var(--pa-tier-refuted-bg); }
+
+/* Per-step badge: a small tier-colored chip right after the explanation text.
+   Empty (no confidence data) → hidden entirely. */
+.pa-conf-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;             /* never squeezed by a long caption (probe == live) */
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  font-size: 0.78em;
+  line-height: 1;
+  background: var(--pa-conf-bg, transparent);
+  border: 1px solid var(--pa-conf-fg, transparent);
+  cursor: default;
+  user-select: none;
+}
+.pa-conf-badge:empty { display: none; }
+/* Reveal-on-demand: badges are hidden until the user peeks (hovers the overall
+   chip) or pins (clicks it → pa-conf-on on the root). */
+.pa-root:not(.pa-conf-on):not(.pa-conf-peek) .pa-conf-badge { display: none; }
+
+/* Overall-confidence pill: the derivation's seal — an absolute OVERLAY in the
+   widget's top-right corner, out of flow so it never shifts the stage, the
+   text zone, or the controls. Tooltip (data-tip) carries the tally. */
+/* `.pa-root .pa-overall` (not bare `.pa-overall`): must outrank the tooltip
+   rule `.pa-root [data-tip] { position: relative }` or the overlay loses its
+   absolute positioning. */
+.pa-root .pa-overall {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  z-index: 10;               /* foreground: above the stage + every morph layer */
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 11px;
+  border-radius: 999px;
+  font-size: 0.8em;
+  line-height: 1.3;
+  /* OPAQUE: the tier tint is translucent, so composite it (as a gradient
+     layer — a plain color can't be a background layer) over the solid panel
+     color. Otherwise a tall expression behind the chip bleeds through and it
+     stops reading as foreground. */
+  background-color: var(--pa-bg);
+  background-image: linear-gradient(var(--pa-conf-bg, transparent),
+                                    var(--pa-conf-bg, transparent));
+  border: 1px solid var(--pa-conf-fg, var(--pa-border));
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);   /* lift off the canvas */
+  cursor: pointer;           /* click pins/unpins the full badge display */
+  user-select: none;
+  transition: padding 0.15s, gap 0.15s;
+}
+.pa-root .pa-overall:empty { display: none; }    /* not yet populated (or no data) */
+/* COMPACT by default: icon-only chip. Expands (label + tally) on its own hover
+   (peek) or while pinned. */
+.pa-root:not(.pa-conf-on):not(.pa-conf-peek) .pa-overall { padding: 4px 8px; gap: 0; }
+.pa-root:not(.pa-conf-on):not(.pa-conf-peek) .pa-overall-label,
+.pa-root:not(.pa-conf-on):not(.pa-conf-peek) .pa-overall-count { display: none; }
+.pa-root .pa-overall:focus-visible { outline: 2px solid var(--pa-accent); outline-offset: 2px; }
+/* Its tooltip opens DOWNWARD and right-aligned (the pill sits at the top-right
+   edge — the default above-centered tooltip would clip outside the widget). */
+.pa-root .pa-overall[data-tip]:hover::after,
+.pa-root .pa-overall[data-tip]:focus-visible::after {
+  bottom: auto;
+  top: calc(100% + 7px);
+  left: auto;
+  right: 0;
+  transform: none;
+}
+.pa-overall-label {
+  font-weight: 700;
+  font-size: 0.85em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--pa-conf-fg);
+}
+.pa-overall-count { color: var(--pa-muted); font-variant-numeric: tabular-nums; }
+
+/* Confidence strip: each step-nav button carries its tier as a colored bottom
+   bar, so the dot row reads the whole proof at a glance. The active step's
+   accent background stays dominant; the bar stays visible under it. Part of
+   the full badge display — shown only while peeking or pinned. */
+.pa-root.pa-conf-on .pa-steps .pa-step[class*="pa-conf-"],
+.pa-root.pa-conf-peek .pa-steps .pa-step[class*="pa-conf-"] {
+  box-shadow: inset 0 -3px 0 var(--pa-conf-fg);
+}
+
 /* dark theme friendliness when the host sets a dark background var */
 @media (prefers-color-scheme: dark) {
   .pa-root {
@@ -281,6 +398,10 @@
     --pa-bg: var(--panel-bg, #1a1a2e);
     --pa-border: var(--border-color, #2d2d44);
     --pa-muted: var(--muted-color, #9ca3af);
+    /* tier colors brighten slightly for dark backgrounds */
+    --pa-tier-grounded: #e6b832;
+    --pa-tier-verified: #aeb8cc;
+    --pa-tier-refuted: #e07a7a;
   }
 }
 

--- a/static/proof-animation/proof-animation.js
+++ b/static/proof-animation/proof-animation.js
@@ -118,17 +118,27 @@ export class ProofAnimator {
     // column are added only when a factory is present, matching _build.
     const opHost = document.createElement("div"); opHost.className = "pa-op-row";
     opHost.append(op);
+    // Confidence badge mirrors the live op-row (probe == live, same as the ask
+    // button below) so the reserved height accounts for it. Badges are hidden
+    // until revealed (pa-conf-on/peek) — force the probe's visible so the
+    // reservation covers the REVEALED state and toggling never shifts layout.
+    const badge = document.createElement("span"); badge.className = "pa-conf-badge";
+    badge.style.display = "inline-flex";
+    opHost.append(badge);
     if (this._aiAsk) {
       probe.classList.add("pa-has-ask");
       next.classList.add("pa-has-ask");
       const ask = document.createElement("span"); ask.className = "pa-ask-btn pa-ask-current";
       opHost.append(ask);
     }
+    // (The overall-confidence pill is an absolute OVERLAY on the widget — out
+    // of flow, so it does not participate in the meta height reservation.)
     probe.append(opHost, just, next);
     this.container.appendChild(probe);
     let h = 0;
     this.data.steps.forEach((s, i) => {
       this._caption(op, this._opText(i));
+      this._setConfBadge(i, badge);
       this._caption(just, s.justification || "");
       this._setNextPill(next, i);
       h = Math.max(h, probe.getBoundingClientRect().height);
@@ -315,7 +325,8 @@ export class ProofAnimator {
     this.container.classList.add("pa-root");
     this.container.innerHTML = `
       <div class="pa-stage" aria-live="polite"></div>
-      <div class="pa-meta"><div class="pa-op-row"><span class="pa-op"></span></div><span class="pa-just"></span><span class="pa-next-pill" role="button" tabindex="0"></span></div>
+      <span class="pa-overall"></span>
+      <div class="pa-meta"><div class="pa-op-row"><span class="pa-op"></span><span class="pa-conf-badge"></span></div><span class="pa-just"></span><span class="pa-next-pill" role="button" tabindex="0"></span></div>
       <div class="pa-controls">
         <button type="button" class="pa-btn pa-prev" data-tip="Previous step" aria-label="Previous step">◀</button>
         <div class="pa-steps"></div>
@@ -331,12 +342,20 @@ export class ProofAnimator {
       b.type = "button";   // never submit a surrounding <form>
       b.className = "pa-step";
       b.textContent = String(i);
-      const tip = `${i}. ${this._plainOp(s.operation || `state ${i}`)}`;
+      let tip = `${i}. ${this._plainOp(s.operation || `state ${i}`)}`;
+      // Confidence tint: the row of step buttons doubles as an at-a-glance
+      // confidence strip (a colored bar per step, tier-keyed).
+      const c = this._conf(i);
+      if (c && c.tier) {
+        b.classList.add(`pa-conf-${c.tier}`);
+        tip += ` — ${c.label || c.tier}`;
+      }
       b.setAttribute("data-tip", tip);
       b.setAttribute("aria-label", tip);
       b.addEventListener("click", () => this._userGoTo(i));
       steps.appendChild(b);
     });
+    this._setOverall();   // overall-confidence pill (removed when data lacks it)
     this.container.querySelector(".pa-prev").onclick = () => this._userGoTo(this.current - 1);
     this.container.querySelector(".pa-next").onclick = () => this._userGoTo(this.current + 1);
     // The "Next" pill acts like the next button.
@@ -1097,8 +1116,89 @@ export class ProofAnimator {
   _syncUI() {
     this._updateStepButtons();
     this._caption(this.container.querySelector(".pa-op"), this._opText(this.current));
+    this._setConfBadge(this.current);
     this._caption(this.container.querySelector(".pa-just"), this.data.steps[this.current].justification || "");
     this._setNextPill(this.container.querySelector(".pa-next-pill"), this.current);
+  }
+
+  // ── step-grounding confidence (tier badges) ─────────────────────────────
+  // Per-step `confidence` and top-level `overall_confidence` are attached by
+  // the server (animation.build → step_grounding.ground_steps). All reads are
+  // guarded: payloads without them render exactly as before (no badges).
+  _conf(idx) {
+    const s = this.data.steps[idx];
+    return (s && s.confidence && s.confidence.tier) ? s.confidence : null;
+  }
+
+  // The per-step badge beside the explanation: tier icon + color, with a
+  // self-explanatory tooltip (label — meaning, then the concrete reason).
+  _setConfBadge(idx, el) {
+    el = el || this.container.querySelector(".pa-conf-badge");
+    if (!el) return;
+    const c = this._conf(idx);
+    el.className = "pa-conf-badge";
+    el.textContent = "";
+    el.removeAttribute("data-tip");
+    el.removeAttribute("aria-label");
+    if (!c) return;
+    el.classList.add(`pa-conf-${c.tier}`);
+    el.textContent = c.icon || "";
+    // Tooltip: when the CAS reached a verdict (or for the start state) the
+    // concrete reason IS the story — including a mislabel downgrade, where the
+    // generic tier meaning ("could not decide") would contradict it. Only a
+    // genuinely undecided step leads with the tier meaning.
+    let tip = (c.relation === "unknown")
+      ? `${c.label} — ${c.meaning || ""}${c.reason ? ` (${c.reason})` : ""}`
+      : `${c.label} — ${c.reason || c.meaning || ""}`;
+    el.setAttribute("data-tip", tip);
+    el.setAttribute("aria-label", tip);
+  }
+
+  // The overall-confidence pill (static for the derivation): icon + tier label
+  // + how many transitions verified, e.g. "🥇 Grounded · 6/7".
+  _setOverall() {
+    const el = this.container.querySelector(".pa-overall");
+    if (!el) return;
+    const oc = this.data.overall_confidence;
+    if (!oc || !oc.tier) { el.remove(); return; }   // legacy payload → no pill
+    el.classList.add(`pa-conf-${oc.tier}`);
+    const icon = document.createElement("span");
+    icon.className = "pa-overall-icon";
+    icon.textContent = oc.icon || "";
+    const label = document.createElement("span");
+    label.className = "pa-overall-label";
+    label.textContent = oc.label || oc.tier;
+    el.append(icon, label);
+    const counts = oc.counts || {};
+    const total = Object.values(counts).reduce((a, b) => a + (b || 0), 0);
+    if (total > 0) {
+      const good = (counts.grounded || 0) + (counts.verified || 0);
+      const count = document.createElement("span");
+      count.className = "pa-overall-count";
+      count.textContent = `· ${good}/${total}`;
+      el.append(count);
+    }
+    // The overall reason already summarizes the chain (tallies + endpoint), so
+    // the pill tooltip is "<Label> — <summary>", not the per-step meaning.
+    const tip = `${oc.label} — ${oc.reason || oc.meaning || ""} · click to pin details`;
+    el.setAttribute("data-tip", tip);
+    el.setAttribute("aria-label", tip);
+    // Reveal-on-demand: the chip is COMPACT (icon only) by default; hovering it
+    // peeks the full badge display (label + tally + per-step badge + tinted
+    // step dots), and clicking pins/unpins that state (pa-conf-on).
+    el.setAttribute("role", "button");
+    el.setAttribute("tabindex", "0");
+    el.setAttribute("aria-pressed", "false");
+    const toggle = () => {
+      const on = this.container.classList.toggle("pa-conf-on");
+      el.setAttribute("aria-pressed", String(on));
+    };
+    el.addEventListener("click", toggle);
+    el.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggle(); }
+    });
+    el.addEventListener("mouseenter", () => this.container.classList.add("pa-conf-peek"));
+    el.addEventListener("mouseleave", () => this.container.classList.remove("pa-conf-peek"));
   }
 
   _updateStepButtons() {
@@ -1196,36 +1296,56 @@ export class ProofAnimator {
     const opEl = meta.querySelector(".pa-op");
     const justEl = meta.querySelector(".pa-just");
     const nextEl = meta.querySelector(".pa-next-pill");
+    const badgeEl = meta.querySelector(".pa-conf-badge");
     const metaRect = meta.getBoundingClientRect();
     const opRect = opEl.getBoundingClientRect();
     const justRect = justEl.getBoundingClientRect();
     const nextRect = nextEl.getBoundingClientRect();
+    // The confidence badge only animates when revealed (peek/pin); hidden in
+    // compact mode it has no box, so there's nothing to fade.
+    const badgeShown = badgeEl && getComputedStyle(badgeEl).display !== "none";
+    const badgeRect = badgeShown ? badgeEl.getBoundingClientRect() : null;
     const nextWasShown = !nextEl.classList.contains("pa-next-hidden");
     this._metaGhosts = this._metaGhosts || [];
     this._metaAnims = this._metaAnims || [];
 
+    // The confidence badge cross-fades SEQUENTIALLY (not with the text): the old
+    // badge fades out fully IN PLACE first, then the new one fades in at its new
+    // spot — so the badge never appears to jump position mid-fade. Deliberately
+    // slow (~2× the text fade) so the verdict change reads clearly.
+    const Dbadge = this._baseDuration;
+
     // 1. Ghost the OLD explanation + justification at their spots and fade out.
-    const ghostOut = (el, rect) => {
+    const ghostOut = (el, rect, duration = this._baseDuration * 0.55) => {
       if (!el.textContent.trim()) return;
       const g = el.cloneNode(true);
       g.classList.add("pa-meta-ghost");
+      // Force absolute inline (beats any selector): the confidence badge carries
+      // a data-tip, and the tooltip rule `.pa-root [data-tip]{position:relative}`
+      // outranks `.pa-meta-ghost{position:absolute}` — a relative ghost would
+      // stay in flow and sink to the bottom of the meta column by the nav.
+      g.style.position = "absolute";
+      g.removeAttribute("data-tip");   // ghosts are decorative — no tooltip
+      g.removeAttribute("aria-label");
       g.style.left = (rect.left - metaRect.left) + "px";
       g.style.top = (rect.top - metaRect.top) + "px";
       g.style.width = Math.ceil(rect.width) + "px";
       meta.appendChild(g);
       this._metaGhosts.push(g);
       const a = this._tween(g, [{ opacity: 1 }, { opacity: 0 }],
-        { duration: this._baseDuration * 0.55, easing: EASE, fill: "forwards" });
+        { duration, easing: EASE, fill: "forwards" });
       a.onfinish = () => g.remove();
       this._metaAnims.push(a);
     };
     ghostOut(opEl, opRect);
     ghostOut(justEl, justRect);
+    if (badgeShown) ghostOut(badgeEl, badgeRect, Dbadge);   // fades out IN PLACE, slow
 
     // 2. The new explanation IS the promoted "Next" title. Put it in the op slot,
     //    hide the (now-promoted) next pill and the old justification, then FLIP the
     //    op up from the Next position into place.
     this._caption(opEl, this._opText(target));
+    this._setConfBadge(target);
     this._caption(justEl, this.data.steps[target].justification || "");
     justEl.style.opacity = "0";
     nextEl.style.opacity = "0";
@@ -1239,6 +1359,17 @@ export class ProofAnimator {
         { duration: this._baseDuration, easing: EASE, fill: "both" });
       a.onfinish = () => { opEl.style.transform = ""; opEl.classList.remove("pa-promoting"); };
       this._metaAnims.push(a);
+    }
+    // The new badge fades in AFTER the old one has fully faded out (delay =
+    // Dbadge) — sequential, so the badge's position only changes once nothing
+    // is visible there. The live badge already reflowed to its new spot but
+    // stays at opacity 0 for the whole fade-out window, so no jump is seen.
+    if (badgeShown) {
+      badgeEl.style.opacity = "0";
+      const ba = this._tween(badgeEl, [{ opacity: 0 }, { opacity: 1 }],
+        { duration: Dbadge, delay: Dbadge, easing: EASE, fill: "both" });
+      ba.onfinish = () => (badgeEl.style.opacity = "");
+      this._metaAnims.push(ba);
     }
 
     // 3. finish(): after the step animation, fade in the new justification first,
@@ -1273,6 +1404,8 @@ export class ProofAnimator {
     if (justEl) justEl.style.opacity = "";
     const nextEl = this.container.querySelector(".pa-next-pill");
     if (nextEl) nextEl.style.opacity = "";
+    const badgeEl = this.container.querySelector(".pa-conf-badge");
+    if (badgeEl) badgeEl.style.opacity = "";
   }
 
   // Render the "Next" pill for the step after idx (hidden on the last step).

--- a/tests/backend/experts/test_grounding.py
+++ b/tests/backend/experts/test_grounding.py
@@ -131,3 +131,15 @@ def test_dataset_carries_source_expressions():
         # WRONG math (True when groundable, None when the walk can't model it).
         applied = apply(ex.context.start, ex.gold_ops)
         assert is_grounded(applied, ex.target_expr) is not False
+
+
+def test_chained_inequality_grounds_as_conjunction():
+    # "a <= g <= b" (an entry-corridor-style bound) parses with a nested
+    # relation; it must ground to the standard conjunction And(a<=g, g<=b).
+    g = SVC.latex_to_graph(r"a \leq x \leq b")
+    got = graph_to_sympy(g)
+    expected = sp.And(a <= x, x <= b)
+    assert sympy_equiv(got, expected)
+    assert is_grounded(g, expected) is True
+    # and a WRONG corridor is rejected, not blessed
+    assert is_grounded(g, sp.And(a <= x, x <= a)) is False

--- a/tests/backend/experts/test_metric.py
+++ b/tests/backend/experts/test_metric.py
@@ -55,3 +55,14 @@ def test_bootstrap_mode_returns_pass_fail():
     # trace set => hard 1.0/0.0
     assert proof_completion_metric(ex, good, trace=[]) == 1.0
     assert proof_completion_metric(ex, bad, trace=[]) == 0.0
+
+
+def test_pm_pseudo_symbol_is_not_convertible():
+    # "x = \pm 3" parses to a graph where ± is an opaque scalar symbol
+    # ("x = 3·±") — not real math. It must not count as a convertible state.
+    from backend.experts.modules.proof_completion.metric import _state_graph
+
+    assert _state_graph(r"x = \pm 3", "algebra") is None
+    assert _state_graph(r"x = \mp 2", "algebra") is None
+    assert _state_graph(r"x = \pm\sqrt{9}", "algebra") is None
+    assert _state_graph(r"x = 3", "algebra") is not None   # control

--- a/tests/backend/experts/test_outputs.py
+++ b/tests/backend/experts/test_outputs.py
@@ -17,7 +17,8 @@ from backend.model.semantic_graph import SemanticGraphNode
 
 
 def _step(_i=1, expr="x^2 = 4"):   # _i: positional index kept for call sites, unused now
-    return DerivationStep(operation="rewrite", expr_latex=expr, justification="valid")
+    return DerivationStep(operation="rewrite", expr_latex=expr, justification="valid",
+                          change_type="rewrite")
 
 
 def _node(nid="x"):
@@ -72,3 +73,19 @@ def test_expert_result_preserves_subclass_fields_on_dump():
     import pytest
     with pytest.raises(ValueError):
         ExpertResult(expert="e", context_id="c", outputs=[traj, traj]).single()
+
+
+def test_change_type_roundtrips_and_is_required():
+    # survives a dump/validate round trip
+    tagged = DerivationStep(operation="take the root", expr_latex="x = 2",
+                            justification="both sides nonneg", change_type="solve")
+    back = DerivationStep.model_validate(tagged.model_dump())
+    assert back.change_type == "solve"
+    # required: a step without a declared change_type is rejected
+    with pytest.raises(ValidationError):
+        DerivationStep.model_validate(
+            {"operation": "rewrite", "expr_latex": "x^2 = 4", "justification": "valid"})
+    # invalid value is rejected
+    with pytest.raises(ValidationError):
+        DerivationStep(operation="o", expr_latex="x", justification="j",
+                       change_type="guess")

--- a/tests/backend/experts/test_step_grounding.py
+++ b/tests/backend/experts/test_step_grounding.py
@@ -1,0 +1,289 @@
+"""Tests for step-to-step grounding (consecutive-consequence confidence tiers)."""
+
+from __future__ import annotations
+
+import time
+
+import sympy as sp
+
+from backend.experts.modules.proof_completion import step_grounding as SG
+from backend.experts.modules.proof_completion.step_grounding import (
+    Tier,
+    classify_pair,
+    ground_steps,
+)
+
+x = sp.Symbol("x")
+
+
+def test_rewrite_chain_all_gold():
+    states = [(x + 1) ** 2, x ** 2 + 2 * x + 1, x * (x + 2) + 1]
+    rep = ground_steps(states, change_types=["rewrite", "rewrite"],
+                       target=x * (x + 2) + 1)
+    assert [p.tier for p in rep.pairs] == [Tier.GOLD, Tier.GOLD]
+    assert all(p.relation == "equivalent" and p.method == "symbolic"
+               for p in rep.pairs)
+    assert rep.endpoint_reached is True
+    assert rep.overall is Tier.GOLD
+
+
+def test_solving_chain_narrows_is_valid():
+    states = [
+        sp.Eq(x ** 2 - 4, 0),
+        sp.Eq(x ** 2, 4),
+        sp.Eq(x, 2),                      # picks one branch — a valid narrowing
+    ]
+    rep = ground_steps(states, change_types=["rewrite", "solve"])
+    assert rep.pairs[0].relation == "equivalent"
+    assert rep.pairs[1].relation == "narrows"
+    assert rep.pairs[1].method == "symbolic"
+    assert rep.pairs[1].tier is Tier.GOLD
+
+
+def test_wrong_middle_step_is_refuted():
+    states = [sp.Eq(x ** 2 - 4, 0), sp.Eq(x ** 2, 4), sp.Eq(x, 7)]
+    rep = ground_steps(states, change_types=["rewrite", "solve"],
+                       target=sp.Eq(x, 7))
+    assert rep.pairs[1].relation == "refuted"
+    assert rep.pairs[1].tier is Tier.RED
+    assert "7" in rep.pairs[1].reason
+    assert rep.overall is Tier.RED
+
+
+def test_undecidable_transcendental_is_plausible():
+    a = sp.sin(x) + sp.cos(x ** 2)
+    b = a + sp.exp(-x ** 2) * sp.sin(x ** 3)
+    pv = classify_pair(a, b)
+    assert pv.relation == "unknown"
+    assert pv.method == "none"
+    assert pv.tier is Tier.BLUE
+
+
+def test_non_convertible_state_is_unchecked():
+    rep = ground_steps([x + 1, None, x + 1])
+    assert rep.steps[1].tier is Tier.GRAY     # the bad state
+    assert rep.pairs[1].tier is Tier.GRAY     # and the transition out of it
+    assert rep.overall is Tier.GRAY
+
+
+def test_fingerprint_refutes_different_roots():
+    # sympy_equiv returns False but cannot label the step wrong by itself;
+    # the landmark comparison (different real roots) provides the refutation.
+    pv = classify_pair((x - 1) * (x - 2), (x - 1) * (x - 3))
+    assert pv.relation == "refuted"
+    assert pv.method == "fingerprint"
+    assert pv.tier is Tier.RED
+
+
+def test_change_type_mislabel_downgrades_one_notch():
+    # A narrowing step declared as a plain rewrite: proven, but mislabeled.
+    pv = classify_pair(sp.Eq(x ** 2, 4), sp.Eq(x, 2), change_type="rewrite")
+    assert pv.relation == "narrows"
+    assert pv.type_consistent is False
+    assert pv.tier is Tier.SILVER
+
+
+def test_timeout_degrades_to_plausible(monkeypatch):
+    def slow_solveset(*args, **kwargs):
+        time.sleep(5)
+        return sp.FiniteSet(0)
+
+    monkeypatch.setattr(SG, "_solveset", slow_solveset)
+    monkeypatch.setattr(SG, "_TIMEOUT_S", 0.3)
+    t0 = time.monotonic()
+    pv = classify_pair(sp.Eq(x ** 2, 4), sp.Eq(x, 1))
+    elapsed = time.monotonic() - t0
+    assert pv.tier is Tier.BLUE               # undecided, not wrong, no hang
+    assert elapsed < 3.0
+
+
+def test_endpoint_gate_caps_overall():
+    states = [(x + 1) ** 2, x ** 2 + 2 * x + 1]
+    rep = ground_steps(states, change_types=["rewrite"], target=x ** 2)
+    assert rep.pairs[0].tier is Tier.GOLD     # the step itself is fine
+    assert rep.endpoint_reached is False
+    assert rep.overall is Tier.BLUE           # but the chain misses the goal
+
+
+def test_no_target_caps_gold_at_verified():
+    rep = ground_steps([(x + 1) ** 2, x ** 2 + 2 * x + 1])
+    assert rep.pairs[0].tier is Tier.GOLD
+    assert rep.endpoint_reached is None
+    assert rep.overall is Tier.SILVER
+
+
+def test_string_states_are_coerced():
+    rep = ground_steps(["(x+1)**2", "x**2 + 2*x + 1"], target="x**2 + 2*x + 1")
+    assert rep.pairs[0].tier is Tier.GOLD
+    assert rep.overall is Tier.GOLD
+
+
+def test_or_branches_count_as_full_solution_set():
+    # x^2 = 4  ->  (x = 2) or (x = -2): equivalent, not narrowing.
+    pv = classify_pair(sp.Eq(x ** 2, 4), sp.Or(sp.Eq(x, 2), sp.Eq(x, -2)),
+                       change_type="solve")
+    assert pv.relation in ("equivalent", "narrows")
+    assert pv.tier is Tier.GOLD
+
+
+def test_divide_both_sides_by_symbol_is_verified():
+    # Residuals proportional by a symbolic factor: conditional on a != 0 -> SILVER.
+    a, b, c = sp.symbols("a b c")
+    pv = classify_pair(sp.Eq(a * x ** 2 + b * x + c, 0),
+                       sp.Eq(x ** 2 + (b / a) * x + c / a, 0),
+                       change_type="rewrite")
+    assert pv.relation == "equivalent"
+    assert pv.method == "scaled"
+    assert pv.tier is Tier.SILVER
+    assert "a" in pv.reason and "0" in pv.reason   # "...wherever a ≠ 0"
+
+
+def test_multiply_both_sides_by_constant_is_proven():
+    # A nonzero NUMERIC factor is an unconditional proof -> GOLD.
+    pv = classify_pair(sp.Eq(x, 3), sp.Eq(2 * x, 6), change_type="rewrite")
+    assert pv.relation == "equivalent"
+    assert pv.method == "symbolic"
+    assert pv.tier is Tier.GOLD
+
+
+def test_sqrt_simplification_is_branch_not_scaled():
+    # sqrt((b^2-4ac)/(4a^2)) == sqrt(b^2-4ac)/(2a) only for a > 0 — the scaled
+    # check must NOT claim proportional residuals; the branch-pair check ranks
+    # it Verified ("equal up to the root branch"), never Proven.
+    a, b, c = sp.symbols("a b c")
+    pv = classify_pair(
+        sp.Eq(x + b / (2 * a), sp.sqrt((b ** 2 - 4 * a * c) / (4 * a ** 2))),
+        sp.Eq(x + b / (2 * a), sp.sqrt(b ** 2 - 4 * a * c) / (2 * a)),
+    )
+    assert pv.method == "branch"
+    assert pv.tier is Tier.SILVER
+
+
+def test_scaling_by_the_unknown_is_not_equivalence():
+    # x = 1  ->  x^2 = x scales the residual by x itself (k = x): that ADDS the
+    # solution x = 0, so the factor must not count as an equivalence.
+    pv = classify_pair(sp.Eq(x, 1), sp.Eq(x ** 2, x))
+    assert pv.method != "scaled"
+    assert pv.tier is not Tier.SILVER
+
+
+def test_substitution_is_plausible_not_refuted():
+    # let u = x+1: the fingerprint must not compare landmarks across DIFFERENT
+    # variables — substitution lands undecided, never refuted.
+    u = sp.Symbol("u")
+    pv = classify_pair(sp.Eq((x + 1) ** 2, 4), sp.Eq(u ** 2, 4),
+                       change_type="substitute")
+    assert pv.relation == "unknown"
+    assert pv.tier is Tier.BLUE
+    assert pv.type_consistent is True
+
+
+def test_approximate_within_tolerance_is_verified():
+    pv = classify_pair(sp.Eq(x, sp.pi), sp.Eq(x, sp.Float("3.14159")),
+                       change_type="approximate")
+    assert pv.relation == "equivalent"
+    assert pv.method == "numeric"
+    assert pv.tier is Tier.SILVER
+
+
+def test_bad_approximation_is_refuted():
+    # "approximate" is not a free pass: pi -> 9 is wrong by any tolerance.
+    pv = classify_pair(sp.Eq(x, sp.pi), sp.Eq(x, 9), change_type="approximate")
+    assert pv.tier is Tier.RED
+
+
+def test_parametric_sqrt_solve_is_verified():
+    # E² = (mc²)² + (pc)²  ->  E = √(...): four free symbols, but solveset
+    # proves it: prev is exactly curr squared (squared-pair, unconditional).
+    E, m, p, c = sp.symbols("E m p c")
+    K = (m * c ** 2) ** 2 + (p * c) ** 2
+    pv = classify_pair(sp.Eq(E ** 2, K), sp.Eq(E, sp.sqrt(K)),
+                       change_type="solve")
+    assert pv.relation == "narrows"
+    assert pv.method == "symbolic"
+    assert pv.tier is Tier.GOLD
+    assert pv.type_consistent is True
+
+
+def test_parametric_narrows_is_verified():
+    # pull c out of the root (E = √(c²·X) -> E = c·√X): NOT a squared pair and
+    # conditional on the sign of c, but solveset proves containment with one
+    # symbol as the unknown and the rest as generic parameters -> SILVER.
+    E, m, p, c = sp.symbols("E m p c")
+    X = m ** 2 * c ** 2 + p ** 2
+    pv = classify_pair(sp.Eq(E, sp.sqrt(c ** 2 * X)), sp.Eq(E, c * sp.sqrt(X)),
+                       change_type="solve")
+    assert pv.relation == "narrows"
+    assert pv.method == "parametric"
+    assert pv.tier is Tier.SILVER
+    assert pv.type_consistent is True
+
+
+def test_multivariate_square_root_is_proven_narrows():
+    # (x + b/2a)² = K/4a²  ->  x + b/2a = √(K/4a²): solveset writes the root
+    # sets in |a|-ambiguous forms (undecidable containment), but prev is exactly
+    # curr squared — an unconditional implication, hence a PROVEN narrowing.
+    a, b, c = sp.symbols("a b c")
+    K = b ** 2 - 4 * a * c
+    pv = classify_pair(
+        sp.Eq((x + b / (2 * a)) ** 2, K / (4 * a ** 2)),
+        sp.Eq(x + b / (2 * a), sp.sqrt(K / (4 * a ** 2))),
+        change_type="solve",
+    )
+    assert pv.relation == "narrows"
+    assert pv.method == "symbolic"
+    assert pv.tier is Tier.GOLD
+
+
+def test_principal_root_simplification_is_verified():
+    # √(K/4a²) -> √K/(2a): true for a > 0, sign-flipped for a < 0 — solveset
+    # returns only ConditionSets, but both equations square to the SAME
+    # statement, so they are equal up to the root branch -> SILVER.
+    a, b, c = sp.symbols("a b c")
+    K = b ** 2 - 4 * a * c
+    pv = classify_pair(
+        sp.Eq(x + b / (2 * a), sp.sqrt(K / (4 * a ** 2))),
+        sp.Eq(x + b / (2 * a), sp.sqrt(K) / (2 * a)),
+        change_type="rewrite",
+    )
+    assert pv.relation == "equivalent"
+    assert pv.method == "branch"
+    assert pv.tier is Tier.SILVER
+    assert pv.type_consistent is True
+
+
+def test_wrong_branch_swap_is_still_refuted():
+    # x = 3 -> x = -3 squares to the same statement too, but the univariate
+    # solution-set check refutes it BEFORE the branch check can bless it.
+    pv = classify_pair(sp.Eq(x, 3), sp.Eq(x, -3))
+    assert pv.relation == "refuted"
+    assert pv.tier is Tier.RED
+
+
+def test_pm_state_is_unchecked_in_animation_build():
+    # End-to-end: a derivation step written with \pm still renders/morphs, but
+    # its confidence tier must be "unchecked" (GRAY) — never a fake verdict
+    # computed from the ± pseudo-symbol.
+    from backend.experts.handlers.proof_animation.animation import build
+    from backend.experts.modules.proof_completion.outputs import (
+        DerivationStep, ProofTrajectory)
+
+    traj = ProofTrajectory(
+        start_latex=r"x^2 = 9",
+        target_latex=r"x = 3",
+        steps=[
+            DerivationStep(operation="take the square root",
+                           expr_latex=r"x = \pm 3",
+                           justification="square root of both sides",
+                           change_type="solve"),
+            DerivationStep(operation="pick the positive root",
+                           expr_latex=r"x = 3",
+                           justification="positive branch",
+                           change_type="solve"),
+        ],
+    )
+    data = build(traj, "algebra", "pm demo")
+    tiers = [s["confidence"]["tier"] for s in data["steps"]]
+    assert tiers[1] == "unchecked"            # the \pm state
+    assert data["steps"][1]["latex"]          # but it still renders
+    assert tiers[0] == "grounded"               # the start is untouched

--- a/tests/proof_animation/proof_animations.json
+++ b/tests/proof_animation/proof_animations.json
@@ -12,12 +12,14 @@
         {
           "operation": "add $c$ to both sides",
           "expr_latex": "a + b = c",
-          "justification": "$c$ crosses the $=$ and flips sign"
+          "justification": "$c$ crosses the $=$ and flips sign",
+          "change_type": "rewrite"
         },
         {
           "operation": "subtract $b$ from both sides",
           "expr_latex": "a = c - b",
-          "justification": "$b$ crosses over, leaving $a$ isolated"
+          "justification": "$b$ crosses over, leaving $a$ isolated",
+          "change_type": "rewrite"
         }
       ]
     }
@@ -35,7 +37,8 @@
         {
           "operation": "expand $(x+1)^2$",
           "expr_latex": "x^2 + 2 x + 1",
-          "justification": "$(x+1)^2 = x^2 + 2x + 1$"
+          "justification": "$(x+1)^2 = x^2 + 2x + 1$",
+          "change_type": "rewrite"
         }
       ]
     }
@@ -53,7 +56,8 @@
         {
           "operation": "factor",
           "expr_latex": "(a - b)(a + b)",
-          "justification": "$a^2 - b^2 = (a-b)(a+b)$"
+          "justification": "$a^2 - b^2 = (a-b)(a+b)$",
+          "change_type": "rewrite"
         }
       ]
     }
@@ -71,27 +75,32 @@
         {
           "operation": "take the square root",
           "expr_latex": "E = \\sqrt{(m c^2)^2 + (p c)^2}",
-          "justification": "solve for $E$ (positive root)"
+          "justification": "solve for $E$ (positive root)",
+          "change_type": "solve"
         },
         {
           "operation": "expand the squares",
           "expr_latex": "E = \\sqrt{m^2 c^4 + p^2 c^2}",
-          "justification": "$(m c^2)^2 = m^2 c^4,\\ (p c)^2 = p^2 c^2$"
+          "justification": "$(m c^2)^2 = m^2 c^4,\\ (p c)^2 = p^2 c^2$",
+          "change_type": "rewrite"
         },
         {
           "operation": "factor out $c^2$",
           "expr_latex": "E = \\sqrt{c^2 \\cdot (m^2 c^2 + p^2)}",
-          "justification": "$c^2$ is common to both terms"
+          "justification": "$c^2$ is common to both terms",
+          "change_type": "rewrite"
         },
         {
           "operation": "pull $c$ out of the root",
           "expr_latex": "E = c \\sqrt{m^2 c^2 + p^2}",
-          "justification": "$\\sqrt{c^2 x} = c \\sqrt{x}$"
+          "justification": "$\\sqrt{c^2 x} = c \\sqrt{x}$",
+          "change_type": "solve"
         },
         {
           "operation": "factor out $m^2 c^2$",
           "expr_latex": "E = m c^2 \\sqrt{1 + \\frac{p^2}{m^2 c^2}}",
-          "justification": "the standard Lorentz-factor form"
+          "justification": "the standard Lorentz-factor form",
+          "change_type": "solve"
         }
       ]
     }
@@ -109,32 +118,38 @@
         {
           "operation": "expand the squares",
           "expr_latex": "c^2 t^2 = c^2 t_0^2 + v^2 t^2",
-          "justification": "$(c t)^2 = c^2 t^2$, etc."
+          "justification": "$(c t)^2 = c^2 t^2$, etc.",
+          "change_type": "rewrite"
         },
         {
           "operation": "collect the $t$ terms",
           "expr_latex": "c^2 t^2 - v^2 t^2 = c^2 t_0^2",
-          "justification": "move $v^2 t^2$ to the left"
+          "justification": "move $v^2 t^2$ to the left",
+          "change_type": "rewrite"
         },
         {
           "operation": "factor out $t^2$",
           "expr_latex": "t^2 \\cdot (c^2 - v^2) = c^2 t_0^2",
-          "justification": "$t^2$ is common on the left"
+          "justification": "$t^2$ is common on the left",
+          "change_type": "rewrite"
         },
         {
           "operation": "divide by $c^2 - v^2$",
           "expr_latex": "t^2 = \\frac{c^2 t_0^2}{c^2 - v^2}",
-          "justification": "isolate $t^2$"
+          "justification": "isolate $t^2$",
+          "change_type": "rewrite"
         },
         {
           "operation": "divide top and bottom by $c^2$",
           "expr_latex": "t^2 = \\frac{t_0^2}{1 - \\frac{v^2}{c^2}}",
-          "justification": "introduce $\\frac{v^2}{c^2}$"
+          "justification": "introduce $\\frac{v^2}{c^2}$",
+          "change_type": "rewrite"
         },
         {
           "operation": "take the square root",
           "expr_latex": "t = \\frac{t_0}{\\sqrt{1 - \\frac{v^2}{c^2}}}",
-          "justification": "moving clocks run slow by $\\gamma$"
+          "justification": "moving clocks run slow by $\\gamma$",
+          "change_type": "solve"
         }
       ]
     }
@@ -152,47 +167,56 @@
         {
           "operation": "Divide both sides by $a$.",
           "expr_latex": "x^{2} + \\frac{b}{a} \\cdot x + \\frac{c}{a} = 0",
-          "justification": "Division property of equality: Dividing both sides of an equation by the same non-zero number maintains the equality."
+          "justification": "Division property of equality: Dividing both sides of an equation by the same non-zero number maintains the equality.",
+          "change_type": "rewrite"
         },
         {
           "operation": "Subtract $\\frac{c}{a}$ from both sides.",
           "expr_latex": "x^{2} + \\frac{b}{a} \\cdot x = - \\frac{c}{a}",
-          "justification": "Subtraction property of equality: Subtracting the same quantity from both sides of an equation maintains the equality."
+          "justification": "Subtraction property of equality: Subtracting the same quantity from both sides of an equation maintains the equality.",
+          "change_type": "rewrite"
         },
         {
           "operation": "Add $\\left(\\frac{b}{2a}\\right)^{2}$ to both sides to complete the square.",
           "expr_latex": "x^{2} + \\frac{b}{a} \\cdot x + \\left(\\frac{b}{2a}\\right)^{2} = - \\frac{c}{a} + \\left(\\frac{b}{2a}\\right)^{2}",
-          "justification": "Addition property of equality: Adding the same quantity to both sides of an equation maintains the equality. This step prepares the left side for factoring as a perfect square."
+          "justification": "Addition property of equality: Adding the same quantity to both sides of an equation maintains the equality. This step prepares the left side for factoring as a perfect square.",
+          "change_type": "rewrite"
         },
         {
           "operation": "Factor the perfect square trinomial on the left side and expand the square on the right side.",
           "expr_latex": "\\left(x + \\frac{b}{2a}\\right)^{2} = - \\frac{c}{a} + \\frac{b^{2}}{4a^{2}}",
-          "justification": "Algebraic identity $(u+v)^2 = u^2 + 2uv + v^2$ for the left side, and exponent rule $(uv)^n = u^n v^n$ for the right side."
+          "justification": "Algebraic identity $(u+v)^2 = u^2 + 2uv + v^2$ for the left side, and exponent rule $(uv)^n = u^n v^n$ for the right side.",
+          "change_type": "rewrite"
         },
         {
           "operation": "Find a common denominator and combine the terms on the right side.",
           "expr_latex": "\\left(x + \\frac{b}{2a}\\right)^{2} = \\frac{- 4 \\cdot a \\cdot c + b^{2}}{4 \\cdot a^{2}}",
-          "justification": "Arithmetic of fractions: To combine fractions, a common denominator $4a^2$ is found, and the numerators are added."
+          "justification": "Arithmetic of fractions: To combine fractions, a common denominator $4a^2$ is found, and the numerators are added.",
+          "change_type": "rewrite"
         },
         {
           "operation": "Take the positive square root of both sides.",
           "expr_latex": "x + \\frac{b}{2a} = \\sqrt{\\frac{- 4 \\cdot a \\cdot c + b^{2}}{4 \\cdot a^{2}}}",
-          "justification": "Square root property of equality: If $u^2 = v$, then $u = \\pm\\sqrt{v}$. We select the positive root as per the instruction."
+          "justification": "Square root property of equality: If $u^2 = v$, then $u = \\pm\\sqrt{v}$. We select the positive root as per the instruction.",
+          "change_type": "solve"
         },
         {
           "operation": "Simplify the square root on the right side.",
           "expr_latex": "x + \\frac{b}{2a} = \\frac{\\sqrt{- 4 \\cdot a \\cdot c + b^{2}}}{2 \\cdot a}",
-          "justification": "Property of square roots: $\\sqrt{\\frac{u}{v}} = \\frac{\\sqrt{u}}{\\sqrt{v}}$ and $\\sqrt{4a^2} = 2a$ (assuming $a$ is positive, or considering the principal root)."
+          "justification": "Property of square roots: $\\sqrt{\\frac{u}{v}} = \\frac{\\sqrt{u}}{\\sqrt{v}}$ and $\\sqrt{4a^2} = 2a$ (assuming $a$ is positive, or considering the principal root).",
+          "change_type": "rewrite"
         },
         {
           "operation": "Subtract $\\frac{b}{2a}$ from both sides.",
           "expr_latex": "x = - \\frac{b}{2a} + \\frac{\\sqrt{- 4 \\cdot a \\cdot c + b^{2}}}{2 \\cdot a}",
-          "justification": "Subtraction property of equality: Subtracting the same quantity from both sides of an equation maintains the equality, isolating $x$."
+          "justification": "Subtraction property of equality: Subtracting the same quantity from both sides of an equation maintains the equality, isolating $x$.",
+          "change_type": "rewrite"
         },
         {
           "operation": "Combine the fractions on the right side.",
           "expr_latex": "x = \\frac{- b + \\sqrt{- 4 \\cdot a \\cdot c + b^{2}}}{2 \\cdot a}",
-          "justification": "Arithmetic of fractions: Since the terms on the right side have a common denominator, their numerators can be combined."
+          "justification": "Arithmetic of fractions: Since the terms on the right side have a common denominator, their numerators can be combined.",
+          "change_type": "rewrite"
         }
       ]
     }


### PR DESCRIPTION
Closes #355.

Reframes #355 from a pass/fail step verifier into a **per-step confidence visualization**: a pure, no-LM helper ranks every derivation transition (and the whole proof) against SymPy and the proof animation shows it as per-step badges, an overall seal, and a tinted step-dot strip. The point is never to fail/stop processing — only to rank and show.

## The gap it closes
Today verification checks per-step *well-formedness* and the *endpoint*, but never that **step n follows from step n−1** — so a well-formed-but-wrong middle step (`x²=4 → x=7`) passed silently. This adds the consecutive-consequence check.

## Verification (all SymPy) — `step_grounding.py` (new pure module)
Per transition, in order: symbolic equivalence → exact narrows (solution-set ⊆) → squared-pair & branch-pair (root steps) → scaled residual (multiply/divide both sides) → parametric narrows (multivariate) → characteristic fingerprint (roots/singularities/limits, **not** sampling) → numeric (approximate). Timeout-guarded; never blocks or raises.

### Five ranked tiers
| Tier | When |
|---|---|
| 🥇 **Grounded** | symbolically proven + type-consistent |
| 🥈 **Verified** | strong CAS evidence (fingerprint / scaled / branch / parametric / numeric), or mislabeled type |
| 🔹 **Plausible** | convertible, not refuted, CAS undecided |
| ○ **Unchecked** | not a single convertible expression |
| ✗ **Refuted** | CAS contradicts it |

Overall = weakest-link + endpoint gate, with a per-tier tally.

## Model + schema
- `DerivationStep` gains a **required** `change_type` (`rewrite`/`solve`/`substitute`/`approximate`/`given`). SymPy is the authority; a mislabel downgrades one tier.
- Signature forbids `\pm`/`\mp` and `\text{…}` in `expr_latex`; `\pm`/`\mp` join the placeholder gate so multivalued/pseudo-symbol states honestly read **Unchecked** (they parse to a junk scalar otherwise).
- Chained inequalities (`a ≤ x ≤ b`) now ground as a conjunction.

## Delivery
- `animation.build` attaches per-step `confidence` + top-level `overall_confidence` (handler/API/agent get it for free); derive CLI prints per-step tiers + an overall line.
- Frontend: reveal-on-demand overall pill (compact → hover-peek → click-pin), opaque top-right foreground badge, and a sequential in-place badge cross-fade on step change (old fades out in place, new fades in after).

## Tests
`tests/backend/experts/test_step_grounding.py` (new) covers every check + refutation, timeout safety, endpoint gate, `change_type` mislabel, `\pm`→Unchecked; plus extensions to `test_metric.py`, `test_outputs.py`, `test_grounding.py`. Full suite: **3403 passed**. Verified end-to-end in the proof-animation preview.

## Follow-up
[#369](https://github.com/ibenian/algebench/issues/369) — first-class `\pm`/`\mp` unary operator + grounding that expands and tests **all** sign combinations (would upgrade root steps from Verified → Grounded). This PR keeps `\pm` honestly Unchecked until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)