### PR TITLE
Proof animation: render captions with an unclosed math delimiter

### DIFF
--- a/static/proof-animation/proof-animation.js
+++ b/static/proof-animation/proof-animation.js
@@ -1075,7 +1075,13 @@ export class ProofAnimator {
   // everything else is plain text.
   _caption(el, text) {
     el.innerHTML = "";
-    const s = String(text);
+    let s = String(text);
+    // Tolerate an UNCLOSED inline-math delimiter: the LM occasionally drops the
+    // trailing `$` (or backtick), e.g. "…and $V_{\text{LEO}} = 7.8 \text{ km/s}".
+    // An odd delimiter count means the tail would render as raw LaTeX, so close
+    // it by appending the missing delimiter — the remainder then renders as math.
+    if ((s.match(/\$/g) || []).length % 2) s += "$";
+    if ((s.match(/`/g) || []).length % 2) s += "`";
     let last = 0, m;
     _CAPTION_RE.lastIndex = 0;
     while ((m = _CAPTION_RE.exec(s)) !== null) {


### PR DESCRIPTION
## Problem

A derivation step's `operation` (or `justification`) occasionally arrives with an **unbalanced `$`** — the LM drops the closing delimiter, e.g.:

> Substitute `$V_{\text{lunar}} = 11 \text{ km/s}$` and `$V_{\text{LEO}} = 7.8 \text{ km/s}`  ← no closing `$`

`_caption` tokenizes on *balanced* `$…$`, so the first segment rendered but the tail showed as **raw LaTeX** in the caption and the Next pill (see the unrendered `$V_{\text{LEO}} = 7.8 \text{ km/s}`).

## Fix

Before tokenizing, balance an odd `$` (or backtick) count by appending the missing closer, so the trailing segment renders as math instead of leaking source. One-liner in `_caption`, no behavior change for already-balanced captions.

## Verification

Injected the exact unbalanced string from the report harness → both math segments now render (`katex` spans = 2, no literal `$`), console clean. Screenshot confirms the caption renders fully.

Pre-existing robustness gap, independent of #370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)