### PR TITLE
sg-report: fix broken D3 button (stub /proof-animation/dock-seq.js)

### DIFF
--- a/scripts/semantic_graph_report.py
+++ b/scripts/semantic_graph_report.py
@@ -208,7 +208,8 @@ def _page_template() -> str:
     <script type="importmap">{{
       "imports": {{
         "/labels.js": "data:text/javascript,export function makeAiAskButton(){{return document.createElement('span')}}",
-        "/expr.js": "data:text/javascript,const m=math.create(math.all);m.import({{binomial:(n,k)=>m.combinations(n,k),erfc:x=>1-m.erf(x),beta:(a,b)=>m.gamma(a)*m.gamma(b)/m.gamma(a%2Bb),conjugate:x=>m.conj(x)}});export function compileExpr(s){{return m.compile(s)}}export function evalExpr(c,t,opts){{const scope=opts%26%26opts.extraScope?{{...opts.extraScope}}:{{}};return c.evaluate(scope)}}"
+        "/expr.js": "data:text/javascript,const m=math.create(math.all);m.import({{binomial:(n,k)=>m.combinations(n,k),erfc:x=>1-m.erf(x),beta:(a,b)=>m.gamma(a)*m.gamma(b)/m.gamma(a%2Bb),conjugate:x=>m.conj(x)}});export function compileExpr(s){{return m.compile(s)}}export function evalExpr(c,t,opts){{const scope=opts%26%26opts.extraScope?{{...opts.extraScope}}:{{}};return c.evaluate(scope)}}",
+        "/proof-animation/dock-seq.js": "data:text/javascript,let n=0;export const nextDockSeq=()=>%2B%2Bn"
       }}
     }}</script>
     <script>


### PR DESCRIPTION
## Problem

The semantic-graph report's **D3** button stopped working — clicking it left the *"Click D3 to render"* placeholder and rendered nothing, with no console error.

## Root cause

`sg-chart.js` began importing `nextDockSeq` from `/proof-animation/dock-seq.js` in #362 (on-the-fly proof derivation animations). The sg-report harness (`semantic_graph_report.py`) injects an importmap that stubs `/labels.js` and `/expr.js` for the standalone page, but it was never updated for the new `dock-seq.js` import. So:

- `import '/proof-animation/dock-seq.js'` → 404
- → `sg-chart.js` fails to load as a module
- → the `Promise.all([import('./d3-semantic-graph.js'), import('./sg-chart.js')])` rejects
- → the `.row-toggle-d3` click handler (attached only in the `.then(...)`) never wires up
- → the D3 button does nothing.

(`d3-semantic-graph.js` itself imports fine; only `sg-chart.js`'s nested `dock-seq` import broke.)

## Fix

Add a one-line data-URL stub to the report's importmap exporting a `nextDockSeq` counter — the static report needs no real cross-manager dock sequencing.

## Verification

Regenerated the report and reloaded in preview: `import('./sg-chart.js')` resolves, clicking **D3** opens the panel and renders the semantic-graph SVG (placeholder gone), console clean. Verified on `algebra.html`.

Independent of #370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)