### PR TITLE
fix(semantic-graph): parse disjunction of equations as Or(Eq, Eq)

### DIFF
--- a/backend/semantic_graph/equation_chain.py
+++ b/backend/semantic_graph/equation_chain.py
@@ -209,6 +209,14 @@ def _has_top_level_relation(latex: str) -> bool:
                     nxt = latex[i + 1] if i + 1 < L else ""
                     if prev in "\\<>=!:" or nxt == "=":
                         continue
+                elif tok.startswith("\\"):
+                    # Command boundary: a backslash relation token must end at a
+                    # non-letter, else `\le` matches `\left`, `\ne` matches `\neg`,
+                    # `\in` matches `\int` / `\infty`. Longer tokens (`\leq`, `\neq`,
+                    # `\geq`) are listed first, so genuine relations still match.
+                    nxt = latex[i + len(tok)] if i + len(tok) < L else ""
+                    if nxt.isalpha():
+                        continue
                 return True
         i += 1
     return False

--- a/backend/semantic_graph/equation_chain.py
+++ b/backend/semantic_graph/equation_chain.py
@@ -20,6 +20,20 @@ _LOGICAL_CONNECTIVE_COMMANDS = (
 
 _CHAIN_RELATION_COMMANDS = ("\\approx", "\\simeq")
 
+# Logical connectives that, when they join RELATIONS (e.g. ``x = 2 \lor x = 3``),
+# must become the ROOT with each relation as a branch — ``Or(Eq, Eq)`` /
+# ``And(...)``. Over plain expressions / propositions / sets they stay with the
+# translator's infix handling; we intercept ONLY when an operand actually
+# contains a relation (so ``(\neg P) \lor (\neg Q)`` and ``dx \wedge dy`` are
+# untouched). ``\lor`` binds looser than ``\land`` binds looser than ``=``.
+_DISJUNCTION_COMMANDS = ("\\lor", "\\vee")
+_CONJUNCTION_COMMANDS = ("\\land", "\\wedge")
+_CONNECTIVE_JOIN = {"disjunction": r" \lor ", "conjunction": r" \land "}
+_RELATION_TOKENS = (
+    "\\leq", "\\geq", "\\neq", "\\le", "\\ge", "\\ne", "\\lt", "\\gt", "\\in",
+    "=", "<", ">",
+)
+
 _preprocessor = LaTeXPreprocessor()
 _postprocessor = GraphPostprocessor()
 
@@ -128,6 +142,142 @@ def _derive_single_expression(latex: str) -> SemanticGraph | None:
     return _postprocessor.postprocess(graph, result)
 
 
+def _split_top_level(latex: str, commands: tuple[str, ...]) -> list[str]:
+    """Split *latex* on top-level occurrences of any command in *commands*.
+
+    Depth-aware over ``{}`` / ``()`` / ``[]``; ignores a command immediately
+    followed by a letter (so ``\\lor`` matches but ``\\lorem`` would not).
+    Returns the trimmed, non-empty parts (one element if nothing split).
+    """
+    parts: list[str] = []
+    buf: list[str] = []
+    depth = 0
+    i = 0
+    L = len(latex)
+    while i < L:
+        c = latex[i]
+        if c in "{([":
+            depth += 1
+            buf.append(c)
+            i += 1
+            continue
+        if c in "}])":
+            depth = max(0, depth - 1)
+            buf.append(c)
+            i += 1
+            continue
+        if depth == 0:
+            matched = ""
+            for cmd in commands:
+                if latex.startswith(cmd, i):
+                    nxt = latex[i + len(cmd)] if i + len(cmd) < L else ""
+                    if not nxt.isalpha():
+                        matched = cmd
+                        break
+            if matched:
+                parts.append("".join(buf).strip())
+                buf = []
+                i += len(matched)
+                continue
+        buf.append(c)
+        i += 1
+    parts.append("".join(buf).strip())
+    return [p for p in parts if p]
+
+
+def _has_top_level_relation(latex: str) -> bool:
+    """True if *latex* contains a relation (``=``, ``<``, ``\\leq``, …) at depth 0."""
+    depth = 0
+    i = 0
+    L = len(latex)
+    while i < L:
+        c = latex[i]
+        if c in "{([":
+            depth += 1
+            i += 1
+            continue
+        if c in "}])":
+            depth = max(0, depth - 1)
+            i += 1
+            continue
+        if depth == 0:
+            for tok in _RELATION_TOKENS:
+                if not latex.startswith(tok, i):
+                    continue
+                if tok == "=":
+                    prev = latex[i - 1] if i > 0 else ""
+                    nxt = latex[i + 1] if i + 1 < L else ""
+                    if prev in "\\<>=!:" or nxt == "=":
+                        continue
+                return True
+        i += 1
+    return False
+
+
+def _merge_under_connective(parts: list[str], op: str) -> SemanticGraph | None:
+    """Parse each *part* as its own relation graph and join under one *op* node.
+
+    Mirrors the equality-chain merge, but the root is a ``disjunction`` /
+    ``conjunction`` operator and each branch is a fully-derived operand graph —
+    so ``x = 2 \\lor x = 3`` becomes ``Or(Eq(x, 2), Eq(x, 3))``. Synthetic ids
+    are namespaced per branch; shared variables (``x``, ``a``, …) intentionally
+    merge across branches.
+    """
+    subgraphs: list[SemanticGraph] = []
+    for part in parts:
+        sub = derive_equation_chain_graph(part)   # full pipeline, recursively
+        if sub is None or not sub.nodes:
+            return None
+        subgraphs.append(sub)
+
+    merged_nodes: dict[str, SemanticGraphNode] = {}
+    merged_edges: list[SemanticGraphEdge] = []
+    roots: list[str] = []
+
+    for si, sub in enumerate(subgraphs):
+        prefix = f"d{si}_"
+
+        def _rename(nid: str, p: str = prefix) -> str:
+            return p + nid if nid.startswith("__") else nid
+
+        for n in sub.nodes:
+            new_id = _rename(n.id)
+            cloned = n.model_copy(update={"id": new_id})
+            if new_id not in merged_nodes:
+                merged_nodes[new_id] = cloned
+            else:
+                existing = merged_nodes[new_id]
+                for field_name in type(n).model_fields:
+                    if field_name == "id":
+                        continue
+                    new_val = getattr(cloned, field_name)
+                    if new_val is not None and getattr(existing, field_name) is None:
+                        setattr(existing, field_name, new_val)
+
+        for e in sub.edges:
+            merged_edges.append(SemanticGraphEdge(
+                from_=_rename(e.from_), to=_rename(e.to)))
+
+        out_set = {e.from_ for e in sub.edges}
+        root_candidates = [n.id for n in sub.nodes if n.id not in out_set]
+        roots.append(_rename(root_candidates[0] if root_candidates
+                             else sub.nodes[0].id))
+
+    conn_id = f"__{op}_1"
+    merged_nodes[conn_id] = SemanticGraphNode(
+        id=conn_id, type="operator", op=op,
+        subexpr=_CONNECTIVE_JOIN[op].join(parts),
+    )
+    for r in roots:
+        merged_edges.append(SemanticGraphEdge(from_=r, to=conn_id))
+
+    return SemanticGraph(
+        nodes=list(merged_nodes.values()),
+        edges=merged_edges,
+        classification=Classification(kind="algebraic"),
+    )
+
+
 def derive_equation_chain_graph(latex: str) -> SemanticGraph | None:
     """Derive a semantic graph for a possibly-chained equation.
 
@@ -145,6 +295,21 @@ def derive_equation_chain_graph(latex: str) -> SemanticGraph | None:
         if graph and early_annotations:
             _postprocessor.inject_annotations(graph, early_annotations)
         return graph
+
+    # Logical connective over RELATIONS: make the connective the root with each
+    # relation as a branch (Or(Eq, Eq) / And(...)). Disjunction is looser than
+    # conjunction, so split `\lor` first; the recursion then handles `\land` and
+    # the `=` inside each branch. Intercept only when an operand truly contains a
+    # relation — otherwise sets/propositions stay with the translator.
+    for _commands, _op in ((_DISJUNCTION_COMMANDS, "disjunction"),
+                           (_CONJUNCTION_COMMANDS, "conjunction")):
+        _parts = _split_top_level(latex, _commands)
+        if len(_parts) >= 2 and any(_has_top_level_relation(p) for p in _parts):
+            graph = _merge_under_connective(_parts, _op)
+            if graph is not None:
+                if early_annotations:
+                    _postprocessor.inject_annotations(graph, early_annotations)
+                return graph
 
     if _has_top_level_statement_comma(latex):
         graph = _derive_single_expression(latex)

--- a/scripts/semantic_graph_report.py
+++ b/scripts/semantic_graph_report.py
@@ -36,6 +36,23 @@ except ImportError:
 
 from backend.semantic_graph.mathjs_converter import latex_to_mathjs
 from backend.semantic_graph.sympy_translator import latex_to_semantic_graph
+from backend.semantic_graph.service import SemanticGraphService
+
+# The report reflects the PRODUCTION renderer — the full service pipeline
+# (preprocess → chain/disjunction handling → translate → postprocess), not the
+# bare translator. So e.g. `x = 2 \lor x = 3` renders as Or(Eq, Eq).
+_SERVICE = SemanticGraphService()
+
+# Report-only showcase (not a test catalog): disjunction of equations, where the
+# connective is the root and each relation is a branch. Format matches the domain
+# catalogs' (test_id, latex, tag, …) so the section builder picks them up.
+_DISJUNCTION_SHOWCASE = [
+    ("disj_two_roots", r"x = 2 \lor x = 3", None),
+    ("disj_two_roots_vee", r"x = 2 \vee x = 3", None),
+    ("disj_quadratic_roots",
+     r"x = \frac{-b + \sqrt{b^2 - 4ac}}{2a} \lor "
+     r"x = \frac{-b - \sqrt{b^2 - 4ac}}{2a}", None),
+]
 from tests.backend.semantic_graph.domains.test_domain_arithmetic import (
     ALL_EXPRESSIONS as ARITHMETIC_EXPRESSIONS,
 )
@@ -125,6 +142,7 @@ def _collect_expressions() -> list[tuple[str, list[tuple[str, str, str | None]]]
         ("Linear Algebra", LINALG_EXPRESSIONS, None),
         ("Complex Analysis", COMPLEX_EXPRESSIONS, None),
         ("Logic & Set Theory", LOGIC_EXPRESSIONS, None),
+        ("Disjunction (roots)", _DISJUNCTION_SHOWCASE, None),
         ("Number Theory", NUMBER_THEORY_EXPRESSIONS, None),
         ("Probability & Statistics", PROBABILITY_EXPRESSIONS, None),
         ("Combinatorics", COMBINATORICS_EXPRESSIONS, None),
@@ -710,7 +728,9 @@ def _render_row(
 
     graph_json = None
     try:
-        graph_obj = latex_to_semantic_graph(latex, domain=domain)
+        graph_obj = _SERVICE.latex_to_graph(latex, domain=domain)
+        if graph_obj is None:
+            raise ValueError("parser returned None")
         graph_dict = graph_obj.model_dump(by_alias=True, exclude_none=True)
         _precompute_chart_scripts(graph_dict)
         mermaid_src = semantic_graph_to_mermaid(graph_dict, theme=theme)

--- a/scripts/semantic_graph_report.py
+++ b/scripts/semantic_graph_report.py
@@ -35,7 +35,6 @@ except ImportError:
     from scripts.graph_to_mermaid import semantic_graph_to_mermaid, load_theme
 
 from backend.semantic_graph.mathjs_converter import latex_to_mathjs
-from backend.semantic_graph.sympy_translator import latex_to_semantic_graph
 from backend.semantic_graph.service import SemanticGraphService
 
 # The report reflects the PRODUCTION renderer — the full service pipeline

--- a/tests/backend/semantic_graph/test_disjunction.py
+++ b/tests/backend/semantic_graph/test_disjunction.py
@@ -1,0 +1,88 @@
+r"""Disjunction of equations/relations in the semantic-graph parser.
+
+``\lor`` / ``\vee`` over **equations** — e.g. quadratic roots
+``x = r_1 \lor x = r_2`` — must parse to a disjunction at the **root** with the
+two equations as its children (``Or(Eq, Eq)``).
+
+Today they don't. The infix-operator rewriter turns ``A \lor B`` into a
+placeholder *function call* ``\Xi_N(A, B)`` for SymPy's ``parse_latex``; since a
+call's arguments can't contain ``=``, relations are made *fences* that the
+rewriter splits on first. So ``x = 2 \lor x = 3`` segments as ``x = [2 \lor x]
+= 3`` and the disjunction gets trapped *inside* the equation — producing an
+``equals``-rooted tree instead of ``Or(Eq, Eq)``.
+
+The ``*_parses`` tests pass today (the parse succeeds and a disjunction node
+exists). The structural tests pin the **correct** shape and are
+``xfail(strict)`` until a dedicated logical-connective-over-relations path lands
+(split on the top-level connective, parse each relation, join under the
+disjunction node — mirroring ``equation_chain`` for ``a = b = c``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.semantic_graph.service import SemanticGraphService
+from tests.backend.semantic_graph.generators.invariants import (
+    assert_universal_invariants,
+    child_ops_of_op,
+)
+
+_SVC = SemanticGraphService()
+
+
+def _graph(latex: str):
+    return _SVC.latex_to_graph(latex)
+
+
+TWO_ROOTS = r"x = 2 \lor x = 3"
+TWO_ROOTS_VEE = r"x = 2 \vee x = 3"
+QUADRATIC = (
+    r"x = \frac{-b + \sqrt{b^2 - 4ac}}{2a} \lor "
+    r"x = \frac{-b - \sqrt{b^2 - 4ac}}{2a}"
+)
+
+
+# --------------------------------------------------------------------------- #
+# Pass today: it parses, stays well-formed, and a disjunction node exists.
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("latex", [TWO_ROOTS, TWO_ROOTS_VEE, QUADRATIC])
+def test_disjunction_parses_and_is_wellformed(latex):
+    g = _graph(latex)
+    assert g is not None, f"failed to parse: {latex!r}"
+    assert_universal_invariants(g, latex=latex)
+    assert "disjunction" in {n.op for n in g.nodes}, (
+        f"no disjunction node for: {latex!r}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The requirement (xfail until the relational-connective path lands):
+# the disjunction must be the ROOT, with two equations as its branches.
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=r"parser traps \lor inside the '=' fence: disjunction is nested "
+           r"under equals instead of Or(Eq, Eq)",
+)
+@pytest.mark.parametrize("latex", [TWO_ROOTS, TWO_ROOTS_VEE])
+def test_disjunction_root_over_two_equations(latex):
+    g = _graph(latex)
+    # both branches feeding the disjunction must themselves be equations
+    assert child_ops_of_op(g, "disjunction") == {"equals"}, (
+        f"disjunction branches should be equations for: {latex!r}"
+    )
+    assert sum(1 for n in g.nodes if n.op == "equals") == 2
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=r"quadratic roots `x = … \lor x = …` hit the same \lor-vs-'=' gap",
+)
+def test_quadratic_roots_is_disjunction_of_equations():
+    g = _graph(QUADRATIC)
+    assert child_ops_of_op(g, "disjunction") == {"equals"}
+    # exactly the two root equations under the disjunction
+    assert sum(1 for n in g.nodes if n.op == "equals") == 2

--- a/tests/backend/semantic_graph/test_disjunction.py
+++ b/tests/backend/semantic_graph/test_disjunction.py
@@ -4,18 +4,12 @@ r"""Disjunction of equations/relations in the semantic-graph parser.
 ``x = r_1 \lor x = r_2`` — must parse to a disjunction at the **root** with the
 two equations as its children (``Or(Eq, Eq)``).
 
-Today they don't. The infix-operator rewriter turns ``A \lor B`` into a
-placeholder *function call* ``\Xi_N(A, B)`` for SymPy's ``parse_latex``; since a
-call's arguments can't contain ``=``, relations are made *fences* that the
-rewriter splits on first. So ``x = 2 \lor x = 3`` segments as ``x = [2 \lor x]
-= 3`` and the disjunction gets trapped *inside* the equation — producing an
-``equals``-rooted tree instead of ``Or(Eq, Eq)``.
-
-The ``*_parses`` tests pass today (the parse succeeds and a disjunction node
-exists). The structural tests pin the **correct** shape and are
-``xfail(strict)`` until a dedicated logical-connective-over-relations path lands
-(split on the top-level connective, parse each relation, join under the
-disjunction node — mirroring ``equation_chain`` for ``a = b = c``).
+This is handled by ``equation_chain._merge_under_connective``: a top-level
+``\lor`` / ``\land`` whose operands contain relations is split, each operand is
+parsed on its own, and the results are joined under a disjunction / conjunction
+node — mirroring how ``a = b = c`` chains are merged under one ``equals`` node.
+(Previously the chain handler split on ``=`` first and trapped the ``\lor``
+inside the middle segment, producing an ``equals``-rooted tree.)
 """
 
 from __future__ import annotations
@@ -58,15 +52,9 @@ def test_disjunction_parses_and_is_wellformed(latex):
 
 
 # --------------------------------------------------------------------------- #
-# The requirement (xfail until the relational-connective path lands):
-# the disjunction must be the ROOT, with two equations as its branches.
+# The requirement: the disjunction is the ROOT, with two equations as branches.
 # --------------------------------------------------------------------------- #
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=r"parser traps \lor inside the '=' fence: disjunction is nested "
-           r"under equals instead of Or(Eq, Eq)",
-)
 @pytest.mark.parametrize("latex", [TWO_ROOTS, TWO_ROOTS_VEE])
 def test_disjunction_root_over_two_equations(latex):
     g = _graph(latex)
@@ -77,10 +65,6 @@ def test_disjunction_root_over_two_equations(latex):
     assert sum(1 for n in g.nodes if n.op == "equals") == 2
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=r"quadratic roots `x = … \lor x = …` hit the same \lor-vs-'=' gap",
-)
 def test_quadratic_roots_is_disjunction_of_equations():
     g = _graph(QUADRATIC)
     assert child_ops_of_op(g, "disjunction") == {"equals"}

--- a/tests/backend/semantic_graph/test_disjunction.py
+++ b/tests/backend/semantic_graph/test_disjunction.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pytest
 
 from backend.semantic_graph.service import SemanticGraphService
+from backend.semantic_graph.equation_chain import _has_top_level_relation
 from tests.backend.semantic_graph.generators.invariants import (
     assert_universal_invariants,
     child_ops_of_op,
@@ -70,3 +71,26 @@ def test_quadratic_roots_is_disjunction_of_equations():
     assert child_ops_of_op(g, "disjunction") == {"equals"}
     # exactly the two root equations under the disjunction
     assert sum(1 for n in g.nodes if n.op == "equals") == 2
+
+
+# --------------------------------------------------------------------------- #
+# Relation detection must respect command boundaries — a backslash relation
+# token (\le, \ne, \in) must NOT match a longer command (\left, \neg, \int,
+# \infty), or the connective interception would fire on ordinary expressions.
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("latex, expected", [
+    (r"x = 2", True),
+    (r"x \leq 3", True),
+    (r"x \geq 3", True),
+    (r"x \neq 3", True),
+    (r"x \in S", True),
+    (r"x < 3", True),
+    (r"\neg P", False),            # \ne must not match \neg
+    (r"\left( x \right)", False),  # \le must not match \left
+    (r"\int f \, dx", False),      # \in must not match \int
+    (r"\infty", False),            # \in must not match \infty
+    (r"a + b", False),
+])
+def test_relation_detection_respects_command_boundary(latex, expected):
+    assert _has_top_level_relation(latex) is expected


### PR DESCRIPTION
## Summary

Parse a **disjunction (or conjunction) of equations** as `Or(Eq, Eq)` — the connective at the root with each relation as a branch — so multi-root answers like the quadratic formula are represented correctly in the semantic graph.

Previously `x = 2 \lor x = 3` parsed wrong: the chain handler split on `=` first, segmenting into `[x, "2 \lor x", 3]` and merging everything under a single `equals` node — trapping the `\lor` *inside* the equation (an `equals`-rooted tree instead of `Or(Eq, Eq)`). The quadratic roots hit the same gap, which is why their final steps showed up as `Unchecked` downstream.

### What changed

- **`backend/semantic_graph/equation_chain.py`** — a top-level logical connective whose operands contain relations is now intercepted *before* the `=` split: each operand is parsed on its own and the results are joined under a `disjunction` / `conjunction` root (mirroring how `a = b = c` chains merge under one `equals`). Precedence: `\lor` looser than `\land` looser than `=`.
- **Guarded to avoid regressions** — it only fires when an operand actually contains a relation. So set operators (`\cup`/`\cap`) and propositional/exterior `\lor`/`\wedge` (e.g. `dx \wedge dy`, `(\neg P) \lor (\neg Q)`) are untouched.
- **`scripts/semantic_graph_report.py`** — the report now renders via the production **service** pipeline (not the bare translator), so it reflects what production actually produces; added a small **"Disjunction (roots)"** showcase (two-roots, `\vee` synonym, quadratic formula).

### Why the report change

The sg report and catalog tests use `latex_to_semantic_graph` (the bare translator), while the fix lives in the service wrapper (`derive_equation_chain_graph`). Pointing the report at the service makes it show the corrected structure and reflect the real renderer (per the `CLAUDE.md` note that the report must reflect the current parser/renderer state). Measured divergence between translator and service across catalogs was ~1/73, so this is low-risk; the regenerated report renders **0 errors**.

## Test plan

- `tests/backend/semantic_graph/test_disjunction.py` (new): parse + well-formedness pass; structural assertions (`Or(Eq, Eq)`: disjunction at root with two `equals` branches) now pass for `x = 2 \lor x = 3`, the `\vee` synonym, and the quadratic roots. (These were `xfail(strict)` against the old parser.)
- Full semantic-graph suite: **3272 passed**, 0 new failures.
- Full test suite: **3604 passed**, 0 failures.
- Regenerated the sg report: 0 errors across all domains; "Disjunction (roots)" renders the `∨`-rooted `Or(Eq, Eq)` graphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>
