### PR TITLE
proof_completion: refinement loop (hard gates + soft critique + feedback)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -24,3 +24,33 @@ GEMINI_API_KEY=
 # through some hosted proxies). Accepts 1/true/yes/on or 0/false/no/off.
 # The CLI launcher sets this explicitly and ignores the env var.
 # ALGEBENCH_TTS_REALTIME=true
+
+# --- Proof-completion expert (refinement loop; issue #372) -----------------
+# The step-by-step derivation expert behind /api/expert/proof_animation.
+# Defaults shown; all optional.
+# Max refinement attempts (1 = single pass, loop disabled):
+# ALGEBENCH_PC_REFINE_ATTEMPTS=2
+# Enable the LLM-as-judge reward signal (adds one LM call per generation):
+# ALGEBENCH_PC_JUDGE=0
+# Wall-clock budget (s) for the refinement loop — don't start a retry past it
+# (the UI aborts derivations at 360s). 0 disables the budget:
+# ALGEBENCH_PC_TIME_BUDGET=240
+# Retry threshold τ — retry while reward < τ:
+# ALGEBENCH_PC_TAU=0.7
+# Reward weights (grounding is weighted to dominate the judge):
+# ALGEBENCH_PC_W_GROUNDING=0.8
+# ALGEBENCH_PC_W_JUDGE=0.2
+# Repo-root-relative path to a compiled artifact to load (confined to the repo;
+# absolute / .. paths are rejected). Empty (default) = uncompiled baseline.
+# Point it at what optimize.py produced:
+# ALGEBENCH_PC_LOAD_ARTIFACT=backend/experts/modules/proof_completion/artifacts/proof_completion.json
+
+# Language model used by the DSPy experts (full litellm model string).
+# ALGEBENCH_LM_MODEL=gemini/gemini-2.5-flash
+# ALGEBENCH_LM_REASONING=low      # thinking budget: low / minimal / disable
+# ALGEBENCH_LM_TEMPERATURE=0      # 0 = deterministic
+
+# --- Logging ---------------------------------------------------------------
+# Console level for backend.* loggers. Default WARNING (DEBUG when --debug is
+# passed); set INFO/DEBUG to see e.g. proof_completion artifact loading.
+# ALGEBENCH_LOG_LEVEL=INFO

--- a/backend/experts/handlers/proof_animation/handler.py
+++ b/backend/experts/handlers/proof_animation/handler.py
@@ -17,6 +17,7 @@ Exposed at ``POST /api/expert/proof_animation``. Requires DSPy configured
 
 from __future__ import annotations
 
+import logging
 from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -28,6 +29,8 @@ from backend.semantic_graph.service import SemanticGraphService
 
 from .animation import build
 from .prompt_endpoints import endpoints_from_prompt
+
+log = logging.getLogger(__name__)
 
 
 class Given(BaseModel):
@@ -134,14 +137,24 @@ def derive_proof_animation(req: DeriveProofRequest) -> dict:
         intent = intent[:_INTENT_MAX].rstrip()
 
     # --- call: run the expert through the canonical invoke boundary -------------
+    log.debug("proof_animation: start=%r target=%r domain=%s (start %s)",
+              start, req.target_latex, domain,
+              "supplied" if req.start_latex else "inferred")
     svc = SemanticGraphService()
     try:
         start_g = svc.latex_to_graph(start, domain=domain)
         target_g = svc.latex_to_graph(req.target_latex, domain=domain)
     except Exception:
+        log.warning("proof_animation: latex_to_graph raised on "
+                    "start=%r / target=%r (domain=%s)",
+                    start, req.target_latex, domain, exc_info=True)
         start_g = target_g = None
     if start_g is None or target_g is None:
         which = "start" if start_g is None else "target"
+        bad = start if start_g is None else req.target_latex
+        log.warning("proof_animation: couldn't parse the %s expression: %r "
+                    "(domain=%s, start %s)", which, bad, domain,
+                    "supplied" if req.start_latex else "inferred")
         return {"error": f"Couldn't parse the {which} expression."}
 
     payload = {"start": start_g, "target": target_g, "domain": domain, "intent": intent}

--- a/backend/experts/modules/proof_completion/README.md
+++ b/backend/experts/modules/proof_completion/README.md
@@ -110,8 +110,10 @@ reward = wellformed_factor · (W_G · grounding_score + W_J · judge_score)
 |---|---|---|
 | `ALGEBENCH_PC_REFINE_ATTEMPTS` | `2` | max attempts `N` (`1` = single pass, loop disabled) |
 | `ALGEBENCH_PC_JUDGE` | `0` (off) | enable the LLM judge (adds one LM call per generation) |
+| `ALGEBENCH_PC_TIME_BUDGET` | `240` (s) | wall-clock budget; don't start a retry past it (`0` = no budget). Guards the client's request timeout (UI aborts at 360s) on long derivations |
 | `ALGEBENCH_PC_TAU` | `0.7` | retry threshold |
 | `ALGEBENCH_PC_W_GROUNDING` / `ALGEBENCH_PC_W_JUDGE` | `0.8` / `0.2` | reward weights |
+| `ALGEBENCH_PC_LOAD_ARTIFACT` | `""` (off) | repo-relative path to a compiled artifact to load (confined via `sanitize_path`; absolute/`..` rejected); empty = baseline; explicit `--program` always loads |
 
 The hard gates (well-formedness, grounding) are deterministic and need **no LM**,
 so with the judge off the only LM call on a passing first attempt is the single

--- a/backend/experts/modules/proof_completion/README.md
+++ b/backend/experts/modules/proof_completion/README.md
@@ -21,6 +21,11 @@ metric.py      the metric + @register_metric
 model.py       context model (GraphTransition)
 graph_ops.py   apply / diff / canonical_equal
 grounding.py   graph -> sympy + equivalence + per-step grounding
+wellformed.py  caption well-formedness checker (balanced $…$ / braces)
+grounding_score.py  tier-graded grounding score (TIER_RANK/4) for the reward
+judge.py       LLM-as-judge signature (pedagogy score + issues; never gates)
+reward.py      the single graded reward + threshold (well-formed · grounding · judge)
+refine.py      the refinement loop engine (ask → score → re-ask with feedback)
 dataset.py     sympy example generator
 domains/       one file per domain (algebra, calculus, rational, equation_solving,
                inequalities, logic), each @register_domain
@@ -68,6 +73,51 @@ shared fields on `GraphOpBase` and behavior provided polymorphically via
    `per_step_groundable` / `score_components`' `step_grounded` measures the
    fraction of the model's step boundaries that are valid math waypoints — the
    "is every intermediate sane?" signal (e.g. `x²+1=0 → x²=−1 → x=√−1`).
+
+## Refinement loop (issue #372)
+
+`module.forward` wraps the prediction in a **refinement loop**: each attempt is
+scored by a single graded `reward(pred, …) ∈ [0,1]` and, if it falls below the
+threshold `τ`, re-asked with the failure issues threaded back as targeted
+feedback (not a blind re-roll). It early-exits the moment an attempt passes, and
+after `N` attempts keeps the **best** one — which still renders, honestly tiered
+by the confidence badges (#370). One pure checker per constraint, each in its own
+file:
+
+```
+reward = wellformed_factor · (W_G · grounding_score + W_J · judge_score)
+```
+
+- **wellformed.py** — near-binary prerequisite: a malformed caption (unbalanced
+  `$`, stray braces) can't render, so it zeroes the reward and the loop retries
+  with the caption issues as feedback (the judge isn't even called). Delegates the
+  `$…$` scanning to the reusable `backend/util/latex.py`, so the chat panel and
+  the caption renderer share one definition of "balanced." Two surfaces: soft
+  `well_formed()` for the loop, hard `assert_well_formed()` for non-generation
+  edges (stored/hand-authored JSON, tests) where no retry exists.
+- **grounding_score.py** — maps the `step_grounding` tiers to `TIER_RANK/4`
+  (Grounded 1.0 · Verified 0.75 · Plausible 0.5 · Unchecked 0.25 · Refuted 0.0),
+  averaged over transitions. Graded, not a hard floor — a `Refuted` step drags the
+  blend down on its own weight (weighted to dominate the judge).
+- **judge.py** — an LLM-as-judge that returns a pedagogy `score` + `issues`. It
+  only nudges the number and supplies feedback; it never decides pass/fail.
+
+### Cost / latency
+
+`τ`, the weights, and `N` are env-tunable:
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `ALGEBENCH_PC_REFINE_ATTEMPTS` | `2` | max attempts `N` (`1` = single pass, loop disabled) |
+| `ALGEBENCH_PC_JUDGE` | `0` (off) | enable the LLM judge (adds one LM call per generation) |
+| `ALGEBENCH_PC_TAU` | `0.7` | retry threshold |
+| `ALGEBENCH_PC_W_GROUNDING` / `ALGEBENCH_PC_W_JUDGE` | `0.8` / `0.2` | reward weights |
+
+The hard gates (well-formedness, grounding) are deterministic and need **no LM**,
+so with the judge off the only LM call on a passing first attempt is the single
+prediction — extra calls happen *only* when an attempt scores below `τ` (early
+exit on pass). Keep `N` small (2–3). The judge, when enabled, is the one extra LM
+call and runs only after the hard prerequisite passes.
 
 ## Pipeline
 

--- a/backend/experts/modules/proof_completion/grounding.py
+++ b/backend/experts/modules/proof_completion/grounding.py
@@ -169,6 +169,28 @@ def _eval_operator(n, op, ins, ev) -> sp.Expr:
         if not wrt:
             raise UngroundableGraph("derivative wrt")
         return sp.Derivative(f, *wrt)
+    if op == "integral":
+        # Mirrors the derivative case: the integrand is the unroled operand; the
+        # integration variable comes from ``with_respect_to`` (else the ``wrt``
+        # edge); optional ``lb``/``ub`` edges make it a definite integral.
+        operands = [c for role, c in ins if role not in ("wrt", "lb", "ub")]
+        if len(operands) != 1:
+            raise UngroundableGraph("integral operand")
+        f = ev(operands[0])
+        if n.with_respect_to:
+            syms = [sp.Symbol(s.strip())
+                    for s in n.with_respect_to.split(",") if s.strip()]
+            var = syms[0] if syms else None
+        else:
+            wrt = [ev(c) for role, c in ins if role == "wrt"]
+            var = wrt[0] if wrt else None
+        if var is None:
+            raise UngroundableGraph("integral wrt")
+        lb = [ev(c) for role, c in ins if role == "lb"]
+        ub = [ev(c) for role, c in ins if role == "ub"]
+        if lb and ub:
+            return sp.Integral(f, (var, lb[0], ub[0]))
+        return sp.Integral(f, var)
     if op in _LOGIC:
         left, right = _binary_operands(op, ins, ev)
         return _LOGIC[op](left, right)

--- a/backend/experts/modules/proof_completion/grounding_score.py
+++ b/backend/experts/modules/proof_completion/grounding_score.py
@@ -22,10 +22,35 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from .grounding import graph_to_sympy
-from .step_grounding import TIER_RANK, ground_steps
+from .step_grounding import TIER_LABEL, TIER_RANK, Tier, ground_steps
 
 # Denominator that turns an ordinal tier rank (0..4) into a [0,1] score.
 _MAX_RANK = max(TIER_RANK.values())  # 4
+
+# How many per-step problems to spell out in the feedback before truncating.
+_MAX_FEEDBACK_STEPS = 8
+
+
+def _detailed_reason(report) -> str:
+    """Summary + the specific steps that aren't verified, so feedback is actionable.
+
+    Lists the actually-actionable failures first — ``refuted`` (wrong) then
+    ``unchecked`` (not a single convertible expression) — then ``plausible``
+    (CAS couldn't decide; not necessarily wrong) to fill out the budget. Each
+    entry is ``step N (tier): reason`` so a retry (and a human reading the log)
+    knows *which* step and *why*, not just the counts.
+    """
+    order = {Tier.RED: 0, Tier.GRAY: 1, Tier.BLUE: 2}   # refuted, unchecked, plausible
+    probs = sorted((p for p in report.pairs if p.tier in order),
+                   key=lambda p: (order[p.tier], p.index))
+    if not probs:
+        return report.reason
+    shown = probs[:_MAX_FEEDBACK_STEPS]
+    detail = "; ".join(
+        f"step {p.index} ({TIER_LABEL[p.tier].lower()}): {p.reason}" for p in shown)
+    more = (f" (+{len(probs) - len(shown)} more)"
+            if len(probs) > len(shown) else "")
+    return f"{report.reason}. Issues — {detail}{more}"
 
 
 @dataclass(frozen=True)
@@ -68,5 +93,5 @@ def grounding_score(start_graph, steps, target_graph, *, domain=None) -> Groundi
         return GroundingScore(0.0, report.reason, report.overall, report)
 
     mean_rank = sum(TIER_RANK[p.tier] for p in report.pairs) / len(report.pairs)
-    return GroundingScore(mean_rank / _MAX_RANK, report.reason,
+    return GroundingScore(mean_rank / _MAX_RANK, _detailed_reason(report),
                           report.overall, report)

--- a/backend/experts/modules/proof_completion/grounding_score.py
+++ b/backend/experts/modules/proof_completion/grounding_score.py
@@ -1,0 +1,72 @@
+"""Tier-graded grounding score for the refinement reward (issue #372 §B).
+
+``step_grounding.py`` ranks each transition into one of five confidence tiers
+but never reduces them to a number. The refinement loop needs exactly that
+number: a graded score in ``[0, 1]`` so a ``Plausible`` derivation scores *mid*
+(not floored) while a ``Refuted`` step drags the blend down on its own weight —
+nothing short-circuits or rejects (that is the threshold's job, in ``reward.py``).
+
+The map is the existing ordinal ``TIER_RANK / 4`` (issue #372 §B):
+
+    Grounded 1.0 · Verified 0.75 · Plausible 0.5 · Unchecked 0.25 · Refuted 0.0
+
+We score the **mean of per-transition tiers** (a finer gradient than the
+weakest-link overall tier, as the issue notes). This module owns the
+latex→state→tier bridge so the reward stays declarative; it reuses
+``metric.states_to_graphs`` (the single source of truth for per-state
+convertibility) and ``grounding.graph_to_sympy`` — no new parsing logic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .grounding import graph_to_sympy
+from .step_grounding import TIER_RANK, ground_steps
+
+# Denominator that turns an ordinal tier rank (0..4) into a [0,1] score.
+_MAX_RANK = max(TIER_RANK.values())  # 4
+
+
+@dataclass(frozen=True)
+class GroundingScore:
+    score: float          # mean per-transition tier, in [0, 1]
+    reason: str           # the step-grounding report's one-liner (feedback text)
+    overall: object       # the report's weakest-link Tier (diagnostics)
+    report: object        # the full StepGroundingReport (diagnostics)
+
+
+def _state_sympy(graph):
+    if graph is None:
+        return None
+    try:
+        return graph_to_sympy(graph)
+    except Exception:
+        return None
+
+
+def grounding_score(start_graph, steps, target_graph, *, domain=None) -> GroundingScore:
+    """Grade a trajectory's step-to-step grounding into a ``[0, 1]`` score.
+
+    ``start_graph`` / ``target_graph`` are the (already parsed) endpoint graphs
+    the expert derived between; ``steps`` is the list of ``DerivationStep`` the
+    model produced. Pure and total — never raises (degrades to a low score).
+
+    An empty derivation scores 0.0 (nothing established).
+    """
+    # local import avoids a module-load cycle (metric imports this is not the
+    # case, but keep the dependency edge one-directional and lazy to be safe).
+    from .metric import states_to_graphs
+
+    graphs, _bad = states_to_graphs(start_graph, list(steps or []), domain)
+    states = [_state_sympy(g) for g in graphs]            # graphs[0] is the start
+    change_types = [getattr(s, "change_type", None) for s in (steps or [])]
+    target_expr = _state_sympy(target_graph)
+
+    report = ground_steps(states, change_types=change_types, target=target_expr)
+    if not report.pairs:
+        return GroundingScore(0.0, report.reason, report.overall, report)
+
+    mean_rank = sum(TIER_RANK[p.tier] for p in report.pairs) / len(report.pairs)
+    return GroundingScore(mean_rank / _MAX_RANK, report.reason,
+                          report.overall, report)

--- a/backend/experts/modules/proof_completion/judge.py
+++ b/backend/experts/modules/proof_completion/judge.py
@@ -1,0 +1,88 @@
+"""LLM-as-judge for the refinement loop (issue #372 §B) — scores, never gates.
+
+The hard gates (well-formedness, grounding) are deterministic. They cannot see
+*pedagogy*: is the derivation clear, are the steps the right size, does the
+justification actually explain the move? That is what this judge adds — a soft,
+graded ``score`` in ``[0, 1]`` **plus** an ``issues`` critique string that is
+threaded back into the next retry. It only nudges the blended reward and supplies
+feedback text; it **never** decides pass/fail — the single threshold ``τ`` does
+(see ``reward.py``). A bad judge score just lowers the number; it cannot, on its
+own, push a well-formed grounded derivation below ``τ`` (the weights ensure it).
+
+One extra LM call, and only when the hard gates pass (the reward short-circuits a
+malformed prediction before calling the judge). Keep it cheap and optional: when
+no LM is configured the reward simply omits the judge term.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import dspy
+
+
+class ProofJudgeSig(dspy.Signature):
+    """Rate the pedagogical quality of a math derivation (you only SCORE it).
+
+    You are given a start expression, a target expression, and a candidate
+    step-by-step derivation between them. Judge it on **clarity** (is each move
+    easy to follow?), **step size** (are steps small enough to be obvious, not
+    giant leaps?), and **rigor** (does each justification actually explain why
+    the move is valid?). You are NOT checking correctness — a separate symbolic
+    checker already does that; assume the math is verified elsewhere.
+
+    Return a single ``score`` in [0, 1] (1.0 = an exemplary teaching derivation,
+    0.0 = confusing or unhelpful) and an ``issues`` string naming concrete,
+    actionable problems (empty string if none). Be terse and specific — the
+    issues are fed back to the author for a targeted retry.
+    """
+
+    start_latex: str = dspy.InputField(desc="the starting expression, as LaTeX")
+    target_latex: str = dspy.InputField(desc="the target expression, as LaTeX")
+    derivation: str = dspy.InputField(desc="the candidate derivation, step by step")
+    score: float = dspy.OutputField(desc="pedagogical quality in [0, 1]")
+    issues: str = dspy.OutputField(desc="concrete, actionable problems (empty if none)")
+
+
+@dataclass(frozen=True)
+class JudgeVerdict:
+    score: float
+    issues: str
+
+
+def render_derivation(steps) -> str:
+    """Flatten derivation steps into the compact text the judge reads."""
+    lines = []
+    for i, s in enumerate(steps or [], start=1):
+        lines.append(f"{i}. [{s.change_type}] {s.operation}")
+        lines.append(f"   => {s.expr_latex}")
+        lines.append(f"   why: {s.justification}")
+    return "\n".join(lines)
+
+
+def _clamp01(x) -> float:
+    try:
+        v = float(x)
+    except (TypeError, ValueError):
+        return 0.0
+    return 0.0 if v < 0 else 1.0 if v > 1 else v
+
+
+class ProofJudge(dspy.Module):
+    """Thin ``Predict(ProofJudgeSig)`` wrapper returning a clamped verdict."""
+
+    def __init__(self):
+        super().__init__()
+        self.rate = dspy.Predict(ProofJudgeSig)
+
+    def __call__(self, *, start_latex: str, target_latex: str, steps) -> JudgeVerdict:
+        try:
+            pred = self.rate(
+                start_latex=start_latex or "",
+                target_latex=target_latex or "",
+                derivation=render_derivation(steps),
+            )
+        except Exception as exc:  # the judge must never break the loop
+            return JudgeVerdict(score=0.0, issues=f"(judge unavailable: {exc})")
+        return JudgeVerdict(score=_clamp01(getattr(pred, "score", 0.0)),
+                            issues=(getattr(pred, "issues", "") or "").strip())

--- a/backend/experts/modules/proof_completion/module.py
+++ b/backend/experts/modules/proof_completion/module.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 
 import dspy
 
 from backend.experts.registry import register_expert
+from backend.util.pathutil import sanitize_path
 from .signature import ProofCompletionSig
 from .model import GraphTransition
 from .grounding import graph_to_latex
@@ -46,12 +48,47 @@ def _env_flag(name: str, default: bool = False) -> bool:
     return val.strip().lower() in ("1", "true", "yes", "on")
 
 
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
 # Refinement defaults. Attempts==1 makes the loop a no-op single pass (extra LM
 # calls happen *only* on a sub-threshold attempt — the happy path costs nothing
 # beyond the one prediction when the judge is off). The judge is opt-in: it adds
 # one LM call per generation, so it stays off unless explicitly enabled.
 _REFINE_ATTEMPTS = _env_int("ALGEBENCH_PC_REFINE_ATTEMPTS", 2)
 _JUDGE_ENABLED = _env_flag("ALGEBENCH_PC_JUDGE", default=False)
+# Wall-clock budget for the whole loop: don't START a retry once this many
+# seconds have elapsed (the first attempt always runs, and a running attempt is
+# never interrupted). Keeps a long, slow, never-passing derivation from blowing
+# the client's request timeout (the proof-animation UI aborts at 360s) — set
+# comfortably below it to leave room for an in-flight attempt + animation build.
+# 0 disables the budget.
+_TIME_BUDGET = _env_float("ALGEBENCH_PC_TIME_BUDGET", 240.0)
+# Compiled-artifact auto-load. ALGEBENCH_PC_LOAD_ARTIFACT holds a *repo-root-
+# relative* path to the compiled program to load; empty (the default) disables it
+# (uncompiled baseline). The path is resolved through ``sanitize_path``, which
+# confines it under the repo root and rejects absolute paths, ``~`` and ``..``
+# escapes. An explicit ``artifact=`` / ``--program`` always wins. The conventional
+# location ``optimize.py`` writes to is ``DEFAULT_ARTIFACT`` (above) — e.g.
+# ALGEBENCH_PC_LOAD_ARTIFACT=backend/experts/modules/proof_completion/artifacts/proof_completion.json
+_ARTIFACT_ENV = os.environ.get("ALGEBENCH_PC_LOAD_ARTIFACT", "").strip()
+_REPO_ROOT = Path(__file__).resolve().parents[4]   # …/proof_completion → repo root
+
+
+def _configured_artifact() -> str | None:
+    """Repo-confined artifact path from the env var, or None (unset or rejected).
+
+    ``sanitize_path`` confines the value under the repo root and rejects
+    absolute paths, ``~``, ``..`` traversal, and unsafe characters.
+    """
+    if not _ARTIFACT_ENV:
+        return None
+    safe = sanitize_path(_REPO_ROOT, _ARTIFACT_ENV)
+    return str(safe) if safe is not None else None
 
 
 def _log_attempt(k: int, n: int, pred, res) -> None:
@@ -96,18 +133,44 @@ class ProofCompletionExpert(dspy.Module):
         self.predict = dspy.ChainOfThought(ProofCompletionSig)
         # explicit artifact wins; else the blessed default if present and allowed;
         # else uncompiled (baseline). load_default=False forces baseline.
-        path = artifact or (DEFAULT_ARTIFACT if load_default else None)
+        # An explicit ``artifact`` wins; otherwise the env-configured path is used
+        # (only when load_default). Empty env → no auto-load (baseline).
+        env_path = _configured_artifact()
+        path = artifact or (env_path if load_default else None)
         if path and os.path.exists(path):
             self.load(path)
             self.loaded_artifact = path
+            log.info("proof_completion: loaded compiled artifact %s", path)
         else:
             self.loaded_artifact = None
+            if artifact and not os.path.exists(artifact):
+                # the caller asked for a specific artifact that isn't there —
+                # surface loudly; it's almost certainly a misconfiguration.
+                log.warning("proof_completion: requested artifact %s not found — "
+                            "running UNCOMPILED baseline", artifact)
+            elif load_default and _ARTIFACT_ENV and env_path is None:
+                # env set but sanitize_path refused it (absolute / ~ / .. / unsafe)
+                log.warning("proof_completion: ALGEBENCH_PC_LOAD_ARTIFACT=%r rejected "
+                            "(must be a safe repo-relative path) — UNCOMPILED baseline",
+                            _ARTIFACT_ENV)
+            elif load_default and env_path:
+                # env resolved to a safe path, but the file isn't there.
+                log.warning("proof_completion: ALGEBENCH_PC_LOAD_ARTIFACT=%r not found "
+                            "(resolved %s) — running UNCOMPILED baseline",
+                            _ARTIFACT_ENV, env_path)
+            elif load_default:
+                log.debug("proof_completion: no artifact configured "
+                          "(ALGEBENCH_PC_LOAD_ARTIFACT empty) — uncompiled baseline")
+            else:
+                log.debug("proof_completion: uncompiled baseline (load_default=False)")
         # Refinement config (constructor args override env; env overrides defaults).
         self.refine_attempts = (refine_attempts if refine_attempts is not None
                                 else _REFINE_ATTEMPTS)
         use_judge = _JUDGE_ENABLED if use_judge is None else use_judge
         # The judge is the only extra-LM signal; build it lazily once, here.
         self.judge = ProofJudge() if use_judge else None
+        log.debug("proof_completion: refine_attempts=%d judge=%s",
+                  self.refine_attempts, bool(self.judge))
 
     def _finalize(self, pred, start_latex: str, target_latex: str):
         """Bind the (code-side) endpoints + model title onto the trajectory.
@@ -153,8 +216,12 @@ class ProofCompletionExpert(dspy.Module):
                           judge=self.judge)
 
         outcome = refine(attempt, evaluate, max_attempts=self.refine_attempts,
+                         time_budget_s=(_TIME_BUDGET or None),
                          on_attempt=_log_attempt)
+        status = ("PASSED" if outcome.passed
+                  else "out of time, kept best" if outcome.out_of_time
+                  else "kept best")
         log.debug("refine done: %d attempt(s), %s (best score %.3f)",
-                  outcome.attempts, "PASSED" if outcome.passed else "kept best",
+                  outcome.attempts, status,
                   getattr(outcome.result, "score", float("nan")))
         return [outcome.prediction.trajectory]  # canonical list[Output]

--- a/backend/experts/modules/proof_completion/module.py
+++ b/backend/experts/modules/proof_completion/module.py
@@ -10,6 +10,7 @@ an artifact and loaded back here.
 
 from __future__ import annotations
 
+import logging
 import os
 
 import dspy
@@ -21,6 +22,8 @@ from .grounding import graph_to_latex
 from .judge import ProofJudge
 from .refine import refine
 from .reward import reward
+
+log = logging.getLogger(__name__)
 
 # The "blessed" compiled program. If this file exists it is loaded by default —
 # so service.invoke and the CLI use the optimized expert without --program.
@@ -49,6 +52,27 @@ def _env_flag(name: str, default: bool = False) -> bool:
 # one LM call per generation, so it stays off unless explicitly enabled.
 _REFINE_ATTEMPTS = _env_int("ALGEBENCH_PC_REFINE_ATTEMPTS", 2)
 _JUDGE_ENABLED = _env_flag("ALGEBENCH_PC_JUDGE", default=False)
+
+
+def _log_attempt(k: int, n: int, pred, res) -> None:
+    """Per-attempt dump for the refinement loop (fires at DEBUG; see ``--debug``).
+
+    Shows the score + breakdown, every step's expression, and the ``issues``
+    string — which is exactly what gets threaded back as feedback if we retry.
+    """
+    if not log.isEnabledFor(logging.DEBUG):
+        return
+    b = res.breakdown
+    log.debug("── refine attempt %d/%d ──  score=%.3f  %s",
+              k + 1, n, res.score, "PASS" if res.passed else "below τ")
+    log.debug("   breakdown: wellformed=%s grounding=%s judge=%s",
+              b.get("wellformed"), b.get("grounding"), b.get("judge"))
+    steps = list(getattr(pred.trajectory, "steps", []) or [])
+    for i, s in enumerate(steps, start=1):
+        log.debug("   step %d [%s]: %s", i, s.change_type, s.expr_latex)
+    if res.issues:
+        verb = "feedback for next attempt" if not res.passed else "notes"
+        log.debug("   %s: %s", verb, res.issues)
 
 
 @register_expert(
@@ -128,5 +152,9 @@ class ProofCompletionExpert(dspy.Module):
                           target_graph=context.target, domain=context.domain,
                           judge=self.judge)
 
-        outcome = refine(attempt, evaluate, max_attempts=self.refine_attempts)
+        outcome = refine(attempt, evaluate, max_attempts=self.refine_attempts,
+                         on_attempt=_log_attempt)
+        log.debug("refine done: %d attempt(s), %s (best score %.3f)",
+                  outcome.attempts, "PASSED" if outcome.passed else "kept best",
+                  getattr(outcome.result, "score", float("nan")))
         return [outcome.prediction.trajectory]  # canonical list[Output]

--- a/backend/experts/modules/proof_completion/module.py
+++ b/backend/experts/modules/proof_completion/module.py
@@ -27,8 +27,9 @@ from .reward import reward
 
 log = logging.getLogger(__name__)
 
-# The "blessed" compiled program. If this file exists it is loaded by default —
-# so service.invoke and the CLI use the optimized expert without --program.
+# The conventional location optimize.py writes the compiled ("blessed") program
+# to. NOTE: this is NOT auto-loaded just by existing — auto-load is opt-in via
+# ALGEBENCH_PC_LOAD_ARTIFACT (see below); point that env var here to use it.
 # (gitignored; produced by proof_completion/optimize.py --out <this path>.)
 DEFAULT_ARTIFACT = os.path.join(os.path.dirname(__file__), "artifacts",
                                 "proof_completion.json")
@@ -214,6 +215,15 @@ class ProofCompletionExpert(dspy.Module):
             return reward(pred.trajectory, start_graph=context.start,
                           target_graph=context.target, domain=context.domain,
                           judge=self.judge)
+
+        # A single attempt cannot retry, so scoring it would be pure overhead (CAS
+        # grounding + an LM call when the judge is on). Short-circuit to the raw
+        # prediction. optimize.py / evaluate.py set refine_attempts=1 precisely to
+        # compile/measure the raw predictor — this keeps that path free of it.
+        if self.refine_attempts <= 1:
+            pred = attempt(0, "")
+            log.debug("refine skipped: single pass (refine_attempts<=1)")
+            return [pred.trajectory]
 
         outcome = refine(attempt, evaluate, max_attempts=self.refine_attempts,
                          time_budget_s=(_TIME_BUDGET or None),

--- a/backend/experts/modules/proof_completion/module.py
+++ b/backend/experts/modules/proof_completion/module.py
@@ -1,6 +1,9 @@
 """ProofCompletionExpert — start graph + target graph → edit trajectory.
 
-A thin ``dspy.Module`` wrapping ``ChainOfThought(ProofCompletionSig)``. The
+A thin ``dspy.Module`` wrapping ``ChainOfThought(ProofCompletionSig)``, wrapped
+in turn by a **refinement loop** (issue #372): each prediction is scored by the
+graded ``reward`` (well-formedness · grounding · optional judge) and, if it falls
+below the threshold, re-asked with the failure issues as targeted feedback. The
 optimizer (MIPROv2/GEPA) compiles *this* module; the compiled state is saved to
 an artifact and loaded back here.
 """
@@ -15,12 +18,37 @@ from backend.experts.registry import register_expert
 from .signature import ProofCompletionSig
 from .model import GraphTransition
 from .grounding import graph_to_latex
+from .judge import ProofJudge
+from .refine import refine
+from .reward import reward
 
 # The "blessed" compiled program. If this file exists it is loaded by default —
 # so service.invoke and the CLI use the optimized expert without --program.
 # (gitignored; produced by proof_completion/optimize.py --out <this path>.)
 DEFAULT_ARTIFACT = os.path.join(os.path.dirname(__file__), "artifacts",
                                 "proof_completion.json")
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    val = os.environ.get(name)
+    if val is None:
+        return default
+    return val.strip().lower() in ("1", "true", "yes", "on")
+
+
+# Refinement defaults. Attempts==1 makes the loop a no-op single pass (extra LM
+# calls happen *only* on a sub-threshold attempt — the happy path costs nothing
+# beyond the one prediction when the judge is off). The judge is opt-in: it adds
+# one LM call per generation, so it stays off unless explicitly enabled.
+_REFINE_ATTEMPTS = _env_int("ALGEBENCH_PC_REFINE_ATTEMPTS", 2)
+_JUDGE_ENABLED = _env_flag("ALGEBENCH_PC_JUDGE", default=False)
 
 
 @register_expert(
@@ -37,7 +65,9 @@ class ProofCompletionExpert(dspy.Module):
     deterministically in code (``latex_to_graph`` + ``diff``).
     """
 
-    def __init__(self, artifact: str | None = None, load_default: bool = True):
+    def __init__(self, artifact: str | None = None, load_default: bool = True,
+                 *, refine_attempts: int | None = None,
+                 use_judge: bool | None = None):
         super().__init__()
         self.predict = dspy.ChainOfThought(ProofCompletionSig)
         # explicit artifact wins; else the blessed default if present and allowed;
@@ -48,6 +78,26 @@ class ProofCompletionExpert(dspy.Module):
             self.loaded_artifact = path
         else:
             self.loaded_artifact = None
+        # Refinement config (constructor args override env; env overrides defaults).
+        self.refine_attempts = (refine_attempts if refine_attempts is not None
+                                else _REFINE_ATTEMPTS)
+        use_judge = _JUDGE_ENABLED if use_judge is None else use_judge
+        # The judge is the only extra-LM signal; build it lazily once, here.
+        self.judge = ProofJudge() if use_judge else None
+
+    def _finalize(self, pred, start_latex: str, target_latex: str):
+        """Bind the (code-side) endpoints + model title onto the trajectory.
+
+        The trajectory must carry its endpoints for it to be self-contained and
+        for the reward's judge to see the start/target — so finalize *before*
+        scoring, not just before returning.
+        """
+        traj = pred.trajectory
+        traj.start_latex = start_latex or None
+        traj.target_latex = target_latex or None
+        # normalise an empty/whitespace title to None so callers can fall back
+        traj.title = (pred.title or "").strip() or None
+        return traj
 
     def forward(self, *, context: GraphTransition, context_id: str,
                 lesson_context: str = "", instruction: str = ""):
@@ -56,19 +106,27 @@ class ProofCompletionExpert(dspy.Module):
         # prompt — they stay code-side for verification + animation.
         start_latex = graph_to_latex(context.start) or ""
         target_latex = graph_to_latex(context.target) or ""
-        pred = self.predict(
-            start_latex=start_latex,
-            target_latex=target_latex,
-            domain=context.domain or "",
-            intent=context.intent or "",
-            lesson_context=lesson_context,
-            instruction=instruction,
-        )
-        traj = pred.trajectory
-        # attach the endpoints so the trajectory is self-contained (not LM output)
-        traj.start_latex = start_latex or None
-        traj.target_latex = target_latex or None
-        # the model-produced display title travels with the trajectory too
-        # (normalise an empty/whitespace title to None so callers can fall back)
-        traj.title = (pred.title or "").strip() or None
-        return [traj]  # the canonical list[Output] (one trajectory)
+
+        def attempt(_k: int, feedback: str):
+            # Thread the previous attempt's failure issues back into the prompt as
+            # an extra instruction — targeted retry, not a blind re-roll.
+            instr = instruction if not feedback else (
+                f"{instruction}\n\n{feedback}" if instruction else feedback)
+            pred = self.predict(
+                start_latex=start_latex,
+                target_latex=target_latex,
+                domain=context.domain or "",
+                intent=context.intent or "",
+                lesson_context=lesson_context,
+                instruction=instr,
+            )
+            self._finalize(pred, start_latex, target_latex)
+            return pred
+
+        def evaluate(pred):
+            return reward(pred.trajectory, start_graph=context.start,
+                          target_graph=context.target, domain=context.domain,
+                          judge=self.judge)
+
+        outcome = refine(attempt, evaluate, max_attempts=self.refine_attempts)
+        return [outcome.prediction.trajectory]  # canonical list[Output]

--- a/backend/experts/modules/proof_completion/refine.py
+++ b/backend/experts/modules/proof_completion/refine.py
@@ -1,0 +1,79 @@
+"""The refinement engine (issue #372 §C, option B2 — hand-rolled loop).
+
+The pinned DSPy (2.6.5) ships **no** retry primitive (``dspy.Refine`` /
+``BestOfN`` were added later; ``dspy.Assert`` / ``Suggest`` were removed), and a
+validation failure there is *reject → one blind re-roll → raise* with the
+``ValidationError`` text discarded. So the model is never told what was wrong.
+
+This module supplies the missing engine, version-proof and dependency-free: ask,
+evaluate, and — crucially — **thread the failure feedback back into the next
+attempt** so retries are targeted, not blind. It early-exits the moment an
+attempt passes; after ``N`` attempts it keeps the **best** one (honestly tiered
+by the confidence badges, per issue #372 §D — refinement raises the ceiling, the
+badges keep the floor honest).
+
+The harness is deliberately decoupled from *how* an attempt is produced and
+scored: it takes an ``attempt`` callable ``(k, feedback) -> prediction`` and an
+``evaluate`` callable ``prediction -> RewardResult`` (anything with ``.score``,
+``.passed``, ``.issues``). Swapping in ``dspy.Refine`` after a dependency bump
+would replace only this loop — the checkers and reward are identical (#372 §C).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+# Prepended to the failure issues when re-asking, so the model reads them as a
+# correction directive rather than as part of the original task.
+FEEDBACK_PREAMBLE = (
+    "Your previous attempt had the problems below. Produce a NEW derivation that "
+    "fixes them — keep what was correct, repair what was flagged:\n"
+)
+
+
+@dataclass
+class RefineOutcome:
+    prediction: object        # the best prediction seen (may still fall short)
+    result: object            # its RewardResult
+    attempts: int             # how many attempts were made
+    passed: bool              # did any attempt clear the threshold?
+
+
+def refine(
+    attempt: Callable[[int, str], object],
+    evaluate: Callable[[object], object],
+    *,
+    max_attempts: int = 2,
+) -> RefineOutcome:
+    """Ask → evaluate → re-ask-with-feedback, keeping the best (never raises here).
+
+    ``attempt(k, feedback)`` produces attempt ``k`` (0-based); ``feedback`` is
+    ``""`` on the first call and the composed issues thereafter. ``evaluate``
+    returns a ``RewardResult``. Early-exits on the first ``passed`` result.
+    Exceptions inside ``attempt``/``evaluate`` end the loop early and return the
+    best-so-far (or re-raise on the very first attempt, where there is nothing to
+    fall back to).
+    """
+    n = max(1, int(max_attempts))
+    best_pred: Optional[object] = None
+    best_res: Optional[object] = None
+    feedback = ""
+    made = 0
+
+    for k in range(n):
+        try:
+            pred = attempt(k, feedback)
+            res = evaluate(pred)
+        except Exception:
+            if best_pred is None:
+                raise            # nothing to fall back to — let the caller see it
+            break
+        made += 1
+        if best_res is None or res.score > best_res.score:
+            best_pred, best_res = pred, res
+        if res.passed:
+            return RefineOutcome(best_pred, best_res, made, True)
+        feedback = FEEDBACK_PREAMBLE + (res.issues or "the derivation scored low")
+
+    return RefineOutcome(best_pred, best_res, made, False)

--- a/backend/experts/modules/proof_completion/refine.py
+++ b/backend/experts/modules/proof_completion/refine.py
@@ -45,6 +45,7 @@ def refine(
     evaluate: Callable[[object], object],
     *,
     max_attempts: int = 2,
+    on_attempt: Optional[Callable[[int, int, object, object], None]] = None,
 ) -> RefineOutcome:
     """Ask → evaluate → re-ask-with-feedback, keeping the best (never raises here).
 
@@ -54,6 +55,10 @@ def refine(
     Exceptions inside ``attempt``/``evaluate`` end the loop early and return the
     best-so-far (or re-raise on the very first attempt, where there is nothing to
     fall back to).
+
+    ``on_attempt(k, n, pred, res)`` — optional observability hook fired after each
+    evaluation (0-based ``k`` of ``n``), so callers can dump per-attempt state
+    (``--debug``) without the loop knowing how to render a prediction.
     """
     n = max(1, int(max_attempts))
     best_pred: Optional[object] = None
@@ -70,6 +75,8 @@ def refine(
                 raise            # nothing to fall back to — let the caller see it
             break
         made += 1
+        if on_attempt is not None:
+            on_attempt(k, n, pred, res)
         if best_res is None or res.score > best_res.score:
             best_pred, best_res = pred, res
         if res.passed:

--- a/backend/experts/modules/proof_completion/refine.py
+++ b/backend/experts/modules/proof_completion/refine.py
@@ -21,6 +21,7 @@ would replace only this loop — the checkers and reward are identical (#372 §C
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from typing import Callable, Optional
 
@@ -38,6 +39,7 @@ class RefineOutcome:
     result: object            # its RewardResult
     attempts: int             # how many attempts were made
     passed: bool              # did any attempt clear the threshold?
+    out_of_time: bool = False  # stopped early because the time budget was spent
 
 
 def refine(
@@ -45,6 +47,7 @@ def refine(
     evaluate: Callable[[object], object],
     *,
     max_attempts: int = 2,
+    time_budget_s: Optional[float] = None,
     on_attempt: Optional[Callable[[int, int, object, object], None]] = None,
 ) -> RefineOutcome:
     """Ask → evaluate → re-ask-with-feedback, keeping the best (never raises here).
@@ -56,6 +59,12 @@ def refine(
     best-so-far (or re-raise on the very first attempt, where there is nothing to
     fall back to).
 
+    ``time_budget_s`` — optional wall-clock budget. A *new* attempt is only
+    started while elapsed time is under it (the first attempt always runs, and a
+    running attempt is never interrupted — scoring is synchronous). This keeps a
+    slow, never-passing derivation (e.g. a long chain that re-scores under the CAS
+    on every attempt) from blowing the caller's request timeout.
+
     ``on_attempt(k, n, pred, res)`` — optional observability hook fired after each
     evaluation (0-based ``k`` of ``n``), so callers can dump per-attempt state
     (``--debug``) without the loop knowing how to render a prediction.
@@ -65,8 +74,14 @@ def refine(
     best_res: Optional[object] = None
     feedback = ""
     made = 0
+    started = time.monotonic()
 
     for k in range(n):
+        if (k > 0 and time_budget_s is not None
+                and time.monotonic() - started >= time_budget_s):
+            # out of time — keep the best so far rather than risk the caller's
+            # request timeout on another full attempt.
+            return RefineOutcome(best_pred, best_res, made, False, out_of_time=True)
         try:
             pred = attempt(k, feedback)
             res = evaluate(pred)

--- a/backend/experts/modules/proof_completion/reward.py
+++ b/backend/experts/modules/proof_completion/reward.py
@@ -28,6 +28,7 @@ from typing import Optional
 
 from .grounding_score import grounding_score
 from .judge import JudgeVerdict
+from .step_grounding import Tier
 from .wellformed import well_formed
 
 
@@ -101,9 +102,20 @@ def reward(
     if jv is not None and jv.issues:
         issues = f"{issues} | judge: {jv.issues}"
 
+    # endpoint_reached / no_refuted are surfaced for observability only. (They
+    # were briefly used for a "good enough" early-accept, but that suppressed the
+    # gold upgrades a retry can find at temperature; the loop now retries while
+    # below τ — chasing a cleaner derivation and fixing malformed captions — with
+    # the time budget guarding the request timeout.)
+    report = gs.report
+    no_refuted = not any(p.tier is Tier.RED for p in getattr(report, "pairs", []))
+    endpoint_reached = getattr(report, "endpoint_reached", None) is True
+
     breakdown = {
         "wellformed": wf.factor,
         "grounding": gs.score,
         "judge": None if jv is None else jv.score,
+        "endpoint_reached": endpoint_reached,
+        "no_refuted": no_refuted,
     }
     return RewardResult(score, issues, score >= tau, breakdown)

--- a/backend/experts/modules/proof_completion/reward.py
+++ b/backend/experts/modules/proof_completion/reward.py
@@ -5,6 +5,13 @@ One function, one number, one threshold. Every signal contributes a score in
 whether to retry. Nothing "rejects" — a bad signal merely scores low.
 
     reward = wellformed_factor * (W_G * grounding_score + W_J * judge_score)
+                                  ──────────────────────────────────────────
+                                                 (W_G + W_J)
+
+The blend is renormalised by ``(W_G + W_J)`` so the score stays in ``[0, 1]``
+regardless of whether the weights sum to 1 (they are env-tunable, so they may
+not). When the judge is absent the judge term drops and grounding alone takes the
+full weight (``score = grounding_score``).
 
 * **wellformed_factor** — a near-binary *prerequisite* (1.0 well-formed, else
   0.0): a malformed caption can't render, so it zeroes the reward and the loop

--- a/backend/experts/modules/proof_completion/reward.py
+++ b/backend/experts/modules/proof_completion/reward.py
@@ -1,0 +1,109 @@
+"""The single graded reward for the refinement loop (issue #372 §B).
+
+One function, one number, one threshold. Every signal contributes a score in
+``[0, 1]``; they blend into one ``reward`` and a single threshold ``τ`` decides
+whether to retry. Nothing "rejects" — a bad signal merely scores low.
+
+    reward = wellformed_factor * (W_G * grounding_score + W_J * judge_score)
+
+* **wellformed_factor** — a near-binary *prerequisite* (1.0 well-formed, else
+  0.0): a malformed caption can't render, so it zeroes the reward and the loop
+  retries with the caption issues as feedback (the judge is not even called).
+* **grounding_score** — tier-graded (``TIER_RANK/4``), weighted to dominate so a
+  ``Refuted`` step can't clear ``τ`` even with a perfect judge.
+* **judge_score** — the LLM judge's pedagogy/clarity score; optional. With no LM
+  configured the judge term is dropped and grounding is renormalised to the full
+  weight, so the reward stays usable offline (and as the optimizer metric).
+
+The reward returns the score **and** an ``issues`` feedback string regardless of
+pass/fail, so the refinement engine can thread targeted feedback into the retry.
+Weights and ``τ`` are tunable via environment variables.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from .grounding_score import grounding_score
+from .judge import JudgeVerdict
+from .wellformed import well_formed
+
+
+def _envf(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+# Grounding dominates the judge so a wrong (Refuted=0) step can't be rescued by a
+# perfect judge score; both are renormalised when the judge is absent.
+W_G = _envf("ALGEBENCH_PC_W_GROUNDING", 0.8)
+W_J = _envf("ALGEBENCH_PC_W_JUDGE", 0.2)
+# Retry while reward < TAU. Tuned so Plausible/Unchecked merely lower the score
+# but a fully-grounded derivation clears it; malformed/Refuted cannot.
+TAU = _envf("ALGEBENCH_PC_TAU", 0.7)
+
+
+@dataclass(frozen=True)
+class RewardResult:
+    score: float
+    issues: str
+    passed: bool
+    breakdown: dict
+
+
+def reward(
+    traj,
+    *,
+    start_graph,
+    target_graph,
+    domain: Optional[str] = None,
+    judge=None,
+    tau: float = TAU,
+) -> RewardResult:
+    """The graded reward for one predicted trajectory (never raises).
+
+    ``judge`` is an optional callable ``(start_latex, target_latex, steps) ->
+    JudgeVerdict``; when None the judge term is omitted and grounding takes the
+    full weight. ``start_graph`` / ``target_graph`` are the parsed endpoint
+    graphs the expert derived between (also used to render the judge's prompt).
+    """
+    wf = well_formed(traj)
+    if not wf.ok:
+        # Prerequisite failed: malformed can't render. Zero the reward and hand
+        # back the caption issues — the judge is not worth calling on a caption
+        # that won't display anyway.
+        return RewardResult(0.0, wf.issues_text, False,
+                            {"wellformed": 0.0, "grounding": None, "judge": None})
+
+    gs = grounding_score(start_graph, list(getattr(traj, "steps", []) or []),
+                         target_graph, domain=domain)
+
+    jv: Optional[JudgeVerdict] = None
+    if judge is not None:
+        jv = judge(
+            start_latex=getattr(traj, "start_latex", None) or "",
+            target_latex=getattr(traj, "target_latex", None) or "",
+            steps=list(getattr(traj, "steps", []) or []),
+        )
+
+    if jv is None:
+        score = gs.score                              # grounding takes full weight
+    else:
+        denom = W_G + W_J or 1.0
+        score = (W_G * gs.score + W_J * jv.score) / denom
+
+    score = wf.factor * score
+    issues = gs.reason
+    if jv is not None and jv.issues:
+        issues = f"{issues} | judge: {jv.issues}"
+
+    breakdown = {
+        "wellformed": wf.factor,
+        "grounding": gs.score,
+        "judge": None if jv is None else jv.score,
+    }
+    return RewardResult(score, issues, score >= tau, breakdown)

--- a/backend/experts/modules/proof_completion/wellformed.py
+++ b/backend/experts/modules/proof_completion/wellformed.py
@@ -69,9 +69,10 @@ def prose_issues(text: str, *, where: str) -> List[str]:
         return issues  # segment-level checks are meaningless once delimiters slip
     for seg in math_segments(text):
         if not seg.content.strip():
-            issues.append(f"{where}: empty math segment '{seg.delimiter}{seg.delimiter}'")
+            issues.append(f"{where}: empty math segment '{seg.delimiter}…{seg.delimiter}'")
         elif not braces_balanced(seg.content):
-            issues.append(f"{where}: unbalanced '{{'…'}}' inside ${seg.content}$")
+            issues.append(f"{where}: unbalanced '{{'…'}}' inside "
+                          f"{seg.delimiter}{seg.content}{seg.delimiter}")
     return issues
 
 

--- a/backend/experts/modules/proof_completion/wellformed.py
+++ b/backend/experts/modules/proof_completion/wellformed.py
@@ -1,0 +1,124 @@
+"""Well-formedness: can every caption in a trajectory actually render?
+
+The motivating defect (issue #372): the LM occasionally emits an ``operation`` /
+``justification`` with an **unbalanced ``$``** — e.g. ``and $V = 7.8 \text{ km/s}``
+with no closing dollar — which leaks raw LaTeX into the rendered caption. A
+malformed caption can't render, so well-formedness is a *prerequisite* the
+refinement reward weights to dominate (see ``reward.py``).
+
+This is a pure, deterministic string check — no sympy, no LM, no network. It
+delegates the delimiter/brace scanning to the reusable :mod:`backend.util.latex`
+(so the same ``$…$`` logic backs the chat panel and caption renderer) and adds
+the proof-step-specific rules on top:
+
+* prose fields (``operation`` / ``justification``) must have **balanced
+  ``$…$``** and balanced braces inside each math segment, with no empty ``$$``;
+* ``expr_latex`` is **math only** — it must contain **no ``$``** (it is already
+  inside a math context) and have balanced braces.
+
+Two surfaces over one checker (see issue #372 §A):
+
+* :func:`well_formed` — the **soft** surface, for the generation loop's reward:
+  returns a graded factor + an ``issues`` critique string (never raises).
+* :func:`assert_well_formed` — the **hard** surface, for non-generation data
+  edges (stored animation JSON, direct construction in tests): raises
+  :class:`MalformedCaption`. *Not* attached as a raising pydantic validator on
+  the generated model — that would fire at parse time, before the reward, and
+  rob the loop of its targeted feedback (issue #372 §A).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+from backend.util.latex import braces_balanced, delimiters_balanced, math_segments
+
+
+class MalformedCaption(ValueError):
+    """A caption/expression is not well-formed (raised at hard data edges)."""
+
+
+@dataclass(frozen=True)
+class WellFormedness:
+    """Verdict for a whole trajectory's captions."""
+
+    ok: bool
+    issues: List[str] = field(default_factory=list)
+
+    @property
+    def factor(self) -> float:
+        """Near-binary prerequisite factor for the reward (1.0 ok, else 0.0)."""
+        return 1.0 if self.ok else 0.0
+
+    @property
+    def issues_text(self) -> str:
+        return "; ".join(self.issues)
+
+
+def prose_issues(text: str, *, where: str) -> List[str]:
+    """Well-formedness problems in a prose caption (``operation``/``justification``).
+
+    ``where`` is a short label woven into the message so feedback is targeted
+    (e.g. ``"step 2 operation"``).
+    """
+    issues: List[str] = []
+    if not delimiters_balanced(text):
+        issues.append(f"{where}: unbalanced '$' — every inline-math segment must "
+                      f"open and close with a matching '$'")
+        return issues  # segment-level checks are meaningless once delimiters slip
+    for seg in math_segments(text):
+        if not seg.content.strip():
+            issues.append(f"{where}: empty math segment '{seg.delimiter}{seg.delimiter}'")
+        elif not braces_balanced(seg.content):
+            issues.append(f"{where}: unbalanced '{{'…'}}' inside ${seg.content}$")
+    return issues
+
+
+def expr_issues(expr_latex: str, *, where: str) -> List[str]:
+    """Well-formedness problems in an ``expr_latex`` (raw math, no delimiters)."""
+    issues: List[str] = []
+    if "$" in expr_latex:
+        issues.append(f"{where}: expr_latex is math-only and must not contain '$'")
+    if not braces_balanced(expr_latex):
+        issues.append(f"{where}: unbalanced '{{'…'}}' in expr_latex")
+    return issues
+
+
+def step_issues(step, *, index: int) -> List[str]:
+    """Every well-formedness problem in one ``DerivationStep`` (1-based ``index``)."""
+    issues: List[str] = []
+    issues += prose_issues(step.operation or "", where=f"step {index} operation")
+    issues += prose_issues(step.justification or "", where=f"step {index} justification")
+    issues += expr_issues(step.expr_latex or "", where=f"step {index} expr_latex")
+    return issues
+
+
+def trajectory_issues(traj) -> List[str]:
+    """Every well-formedness problem across a trajectory's steps (and title)."""
+    issues: List[str] = []
+    title = getattr(traj, "title", None)
+    if title:
+        issues += prose_issues(title, where="title")
+    for i, step in enumerate(getattr(traj, "steps", []) or [], start=1):
+        issues += step_issues(step, index=i)
+    return issues
+
+
+def well_formed(traj) -> WellFormedness:
+    """Soft surface: the trajectory's well-formedness verdict (never raises)."""
+    issues = trajectory_issues(traj)
+    return WellFormedness(ok=not issues, issues=issues)
+
+
+def assert_well_formed(traj) -> None:
+    """Hard surface: raise :class:`MalformedCaption` if any caption is malformed.
+
+    Use at non-generation data edges — loading stored animation JSON, or
+    constructing a trajectory directly in tests/handlers — where there is no
+    retry loop to catch a soft score. Do **not** attach this as a raising
+    pydantic validator on the generated model (see module docstring).
+    """
+    verdict = well_formed(traj)
+    if not verdict.ok:
+        raise MalformedCaption(verdict.issues_text)

--- a/backend/server.py
+++ b/backend/server.py
@@ -12,6 +12,7 @@ import sys
 import json
 import os
 import re
+import logging
 import asyncio
 import webbrowser
 import builtins
@@ -2292,6 +2293,22 @@ Examples:
                         help='Start the server without opening a browser window')
 
     args = parser.parse_args()
+
+    # App logging. uvicorn runs at log_level="error" (quiet) and nothing else
+    # configures the app loggers, so `backend.*` module logs — e.g. whether the
+    # proof_completion expert loaded a compiled artifact or fell back to baseline,
+    # and the per-attempt refinement dump — are otherwise dropped. `--debug` turns
+    # them on (DEBUG); otherwise stay quiet (WARNING). Override with
+    # ALGEBENCH_LOG_LEVEL.
+    _log_level = os.environ.get(
+        "ALGEBENCH_LOG_LEVEL", "DEBUG" if args.debug else "WARNING").upper()
+    _applog = logging.getLogger("backend")
+    if not any(isinstance(h, logging.StreamHandler) for h in _applog.handlers):
+        _h = logging.StreamHandler()
+        _h.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+        _applog.addHandler(_h)
+    _applog.setLevel(getattr(logging, _log_level, logging.INFO))
+    _applog.propagate = False
 
     # Auto-enable buffered mode when flags require it
     if not args.tts_buffered:

--- a/backend/util/latex.py
+++ b/backend/util/latex.py
@@ -1,0 +1,159 @@
+"""Inline-LaTeX delimiter scanning over prose/markdown captions.
+
+Reusable and dependency-free (stdlib only). Captions across AlgeBench mix prose
+with inline math wrapped in ``$…$`` and display math in ``$$…$$`` — the chat
+panel, the proof-animation caption renderer (``static/proof-animation``), and the
+proof-completion expert all need to answer the same low-level questions:
+
+* **where** is the math in a caption (to render only those segments as KaTeX), and
+* **are the delimiters balanced** (an unclosed ``$`` leaks raw LaTeX into prose).
+
+This module is the single source of truth for both. It is deliberately *not*
+inside the proof-completion expert — well-formedness of ``$…$`` is a generic
+string property useful anywhere a caption is produced or consumed.
+
+The scanner honours backslash escapes (``\\$`` is a literal dollar, ``\\{`` a
+literal brace) and treats a maximal run of two dollars as a display delimiter
+(``$$…$$``) and a single dollar as inline (``$…$``). A run of three or more
+dollars, or a delimiter that is opened but never closed, is *unbalanced*.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+
+@dataclass(frozen=True)
+class MathSegment:
+    """One delimited math span found in a caption.
+
+    ``content`` is the text *between* the delimiters (delimiters excluded);
+    ``start``/``end`` are offsets into the original string spanning the whole
+    segment *including* its delimiters, so ``text[start:end]`` round-trips.
+    """
+
+    display: bool          # True for $$…$$, False for $…$
+    content: str           # text between the delimiters
+    start: int             # offset of the opening delimiter
+    end: int               # offset just past the closing delimiter
+
+    @property
+    def delimiter(self) -> str:
+        return "$$" if self.display else "$"
+
+
+def _scan(text: str) -> Tuple[List[MathSegment], bool]:
+    """Scan ``text`` once: return ``(complete_segments, balanced)``.
+
+    ``balanced`` is False if any ``$``/``$$`` delimiter is opened and never
+    closed (the unbalanced-dollar bug), or if a run of three or more dollars is
+    encountered (never a valid delimiter). Escaped ``\\$`` is not a delimiter.
+    """
+    segments: List[MathSegment] = []
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c == "\\":               # escape — skip the escaped char wholesale
+            i += 2
+            continue
+        if c != "$":
+            i += 1
+            continue
+        # how many dollars in this run?
+        run = 1
+        while i + run < n and text[i + run] == "$":
+            run += 1
+        if run >= 3:                # $$$… is never a valid delimiter
+            return segments, False
+        display = run == 2
+        open_start = i
+        j = i + run                 # content begins after the opening delimiter
+        content_start = j
+        closed = False
+        while j < n:
+            if text[j] == "\\":
+                j += 2
+                continue
+            if text[j] == "$":
+                close_run = 1
+                while j + close_run < n and text[j + close_run] == "$":
+                    close_run += 1
+                want = 2 if display else 1
+                if close_run >= want:
+                    seg = MathSegment(display, text[content_start:j],
+                                      open_start, j + want)
+                    segments.append(seg)
+                    i = j + want
+                    closed = True
+                    break
+                # a lone $ inside a $$…$$ block — treat as content, keep scanning
+                j += close_run
+                continue
+            j += 1
+        if not closed:              # opened a delimiter that never closes
+            return segments, False
+    return segments, True
+
+
+def math_segments(text: str) -> List[MathSegment]:
+    """All complete ``$…$`` / ``$$…$$`` segments, in order of appearance.
+
+    Stops at the first unbalanced delimiter (returns what was parsed so far);
+    use :func:`delimiters_balanced` to test for that case.
+    """
+    return _scan(text or "")[0]
+
+
+def delimiters_balanced(text: str) -> bool:
+    """True iff every ``$`` / ``$$`` math delimiter in ``text`` is closed.
+
+    This is the core well-formedness check for the unbalanced-``$`` defect: a
+    caption like ``and $V = 7.8 \\text{ km/s}`` (no closing ``$``) returns False.
+    Prose dollars that are escaped (``\\$5``) do not count as delimiters.
+    """
+    return _scan(text or "")[1]
+
+
+def braces_balanced(text: str) -> bool:
+    """True iff ``{`` / ``}`` are balanced (ignoring escaped ``\\{`` / ``\\}``).
+
+    A useful companion check for inline LaTeX: ``\\frac{a}{b`` (missing ``}``)
+    will not render. Operates on the raw string; callers usually run it on a
+    segment's ``content``.
+    """
+    depth = 0
+    i, n = 0, len(text or "")
+    while i < n:
+        c = text[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth < 0:
+                return False
+        i += 1
+    return depth == 0
+
+
+def strip_math_delimiters(text: str) -> str:
+    """Return ``text`` with the ``$``/``$$`` delimiters removed, content kept.
+
+    Only well-formed segments are unwrapped; an unbalanced tail is left as-is.
+    Handy for plain-text fallbacks (e.g. a TTS summary that should read the math
+    content without the dollar signs).
+    """
+    segs = math_segments(text)
+    if not segs:
+        return text or ""
+    out: List[str] = []
+    cursor = 0
+    for seg in segs:
+        out.append(text[cursor:seg.start])
+        out.append(seg.content)
+        cursor = seg.end
+    out.append(text[cursor:])
+    return "".join(out)

--- a/docs/show-and-tell/grounded-proof-completion.md
+++ b/docs/show-and-tell/grounded-proof-completion.md
@@ -108,7 +108,39 @@ The crucial design choice: **the model emits full expressions, not graph
 edits.** That keeps it doing what LLMs are good at (math in LaTeX) while the code
 side owns everything structural.
 
-> _[screenshot placeholder: the derive CLI output — steps with per‑step glyphs]_
+Here it is end‑to‑end on a product‑rule derivative — a real, unedited CLI run
+against the **uncompiled baseline** with refinement and the LLM‑judge **off**
+(`--attempts 1`, no `--judge`), so you're seeing the raw model + grounding:
+
+```text
+$ ./run.sh scripts/proof_completion_derive.py \
+    "\frac{d}{dx}\left(x^2 \sin x\right)" "2 x \sin x + x^2 \cos x" \
+    --domain calculus --attempts 1
+
+start : \frac{d}{dx}\left(x^2 \sin x\right)
+target: 2 x \sin x + x^2 \cos x
+(model: baseline (uncompiled))
+
+=== derivation (LaTeX): 4 step(s) ===
+   start :   \frac{d}{d x} x^{2} \cdot \sin{\left(x \right)}
+   step 1:  🥇 x^{2} \cdot \frac{d}{d x} \sin{\left(x \right)} + \sin{\left(x \right)} \cdot \frac{d}{d x} x^{2}
+   step 2:  🥇 x^{2} \cdot \frac{d}{d x} \sin{\left(x \right)} + 2 \cdot x \cdot \sin{\left(x \right)}
+   step 3:  🥇 x^{2} \cdot \cos{\left(x \right)} + 2 \cdot x \cdot \sin{\left(x \right)}
+   step 4:  🥇 x^{2} \cdot \cos{\left(x \right)} + 2 \cdot x \cdot \sin{\left(x \right)}
+
+result:
+  steps convertible : 4/4    (each state is a single sympy-convertible expression)
+  math correct      : ✓    (final state reaches the target expression)
+  exact graph       : ✗    (identical structure to the parsed target)
+  step grounding    : 🥇🥇🥇🥇    (each transition follows from the previous state)
+  confidence        : 🥇 Grounded    (4/4 steps verified · endpoint reached)
+```
+
+The model applied the product rule, differentiated each factor, and every
+transition is **symbolically proven** (🥇). Note `exact graph: ✗` while
+`math correct: ✓` — the final tree isn't node‑for‑node identical to the parsed
+target (`a·b` vs `b·a` ordering), but SymPy confirms they're equal, which is why
+the endpoint gate still passes.
 
 ---
 
@@ -155,7 +187,61 @@ claim* — **SymPy is the judge**; a mislabeled step is downgraded one tier.
 > Worth underlining: a wrong middle step like `x^2 = 4 → x = 7` used to slip
 > through (it parses fine). Now it's **Refuted** — SymPy sees `7` isn't a root.
 
-> _[screenshot placeholder: a derivation with a mix of Grounded/Verified/Plausible badges + the tinted step strip]_
+That isn't hypothetical — here's the real run. Even though the model technically
+"reached" the target we asked for, grounding refuses to bless the bad step:
+
+```text
+$ ./run.sh scripts/proof_completion_derive.py "x^2 = 4" "x = 7" --domain algebra --attempts 1
+
+=== derivation (LaTeX): 2 step(s) ===
+   start :   x^{2} = 4
+   step 1:  🥇 x = 2
+   step 2:  ✗ x = 7
+             (refuted: introduces value(s) that do not solve the previous step: 7 — but the step was declared 'rewrite')
+
+result:
+  step grounding    : 🥇✗    (each transition follows from the previous state)
+  confidence        : ✗ Refuted    (1/2 steps verified · 1 refuted · endpoint reached)
+```
+
+`math correct` and the endpoint gate both pass — the chain *did* end at `x = 7` —
+but the overall verdict is **✗ Refuted**, because reaching the requested target
+is not the same as every step being valid. The CAS is the judge.
+
+And here's a longer one with a genuine spread of tiers — deriving the quadratic
+formula. Every step is individually grounded or verified, yet the overall verdict
+is honestly held at **🔹 Plausible** because the `∨`‑form final state isn't the
+exact `±`‑form target we asked for (the endpoint gate, not a weak step):
+
+```text
+$ ./run.sh scripts/proof_completion_derive.py \
+    "a x^2 + b x + c = 0" "x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}" \
+    --domain algebra --attempts 1
+
+=== derivation (LaTeX): 8 step(s) ===
+   start :   a \cdot x^{2} + b \cdot x + c = 0
+   step 1:  🥇 a \cdot x^{2} + b \cdot x = - c
+   step 2:  🥈 x^{2} + \frac{b \cdot x}{a} = - \frac{c}{a}
+   step 3:  🥇 x^{2} + \frac{b \cdot x}{a} + \frac{b^{2}}{4 \cdot a^{2}} = - \frac{c}{a} + \frac{b^{2}}{4 \cdot a^{2}}
+   step 4:  🥇 \left(x + \frac{b}{2 \cdot a}\right)^{2} = - \frac{c}{a} + \frac{b^{2}}{4 \cdot a^{2}}
+   step 5:  🥇 \left(x + \frac{b}{2 \cdot a}\right)^{2} = \frac{- 4 \cdot a \cdot c + b^{2}}{4 \cdot a^{2}}
+   step 6:  🥈 x + \frac{b}{2 \cdot a} = - \frac{\sqrt{- 4 \cdot a \cdot c + b^{2}}}{2 \cdot a} \vee x + \frac{b}{2 \cdot a} = \frac{\sqrt{- 4 \cdot a \cdot c + b^{2}}}{2 \cdot a}
+   step 7:  🥈 x = - \frac{b}{2 \cdot a} - \frac{\sqrt{- 4 \cdot a \cdot c + b^{2}}}{2 \cdot a} \vee x = - \frac{b}{2 \cdot a} + \frac{\sqrt{- 4 \cdot a \cdot c + b^{2}}}{2 \cdot a}
+   step 8:  🥇 x = \frac{- b - \sqrt{- 4 \cdot a \cdot c + b^{2}}}{2 \cdot a} \vee x = \frac{- b + \sqrt{- 4 \cdot a \cdot c + b^{2}}}{2 \cdot a}
+
+result:
+  steps convertible : 8/8    (each state is a single sympy-convertible expression)
+  step grounding    : 🥇🥈🥇🥇🥇🥈🥈🥇    (each transition follows from the previous state)
+  confidence        : 🔹 Plausible    (8/8 steps verified · endpoint NOT reached)
+```
+
+Steps 6–8 carry a **disjunction** (`∨`) — the two roots — and SymPy grounds the
+square‑root branch and the algebra around it (🥇/🥈) rather than punting. That
+disjunction support is recent ([#375](https://github.com/ibenian/algebench/pull/375));
+without it those steps would have shown as **○ Unchecked** ("not a single
+convertible expression").
+
+> _[screenshot placeholder: the same quadratic‑formula derivation animated, with the per‑step badges and tinted step strip]_
 
 ---
 

--- a/docs/show-and-tell/grounded-proof-completion.md
+++ b/docs/show-and-tell/grounded-proof-completion.md
@@ -1,0 +1,302 @@
+# Grounded Proof Completion & Animation — a Show & Tell
+
+AlgeBench can take a *starting* expression and a *target* expression, ask an LLM
+to write the step‑by‑step derivation between them, **verify every step with a
+computer‑algebra system**, rank how confident we are in each step, and then
+**animate** the whole thing as a smooth, morphing transformation on the semantic
+graph — with a confidence badge on each step that never overclaims.
+
+This post is the 10,000‑ft tour. Each numbered section below is really its own
+deep‑dive — **I'll expand each into a standalone post** later.
+
+> _[screenshot placeholder: the proof animation mid‑morph with a GROUNDED badge]_
+
+---
+
+## The big picture
+
+<svg viewBox="0 0 920 430" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, sans-serif">
+  <defs>
+    <marker id="arr" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#7c83ff"/>
+    </marker>
+    <style>
+      .box{rx:10; ry:10; stroke-width:1.5;}
+      .lbl{fill:#e8eaf6; font-size:14px; font-weight:600;}
+      .sub{fill:#aab0d6; font-size:11px;}
+      .edge{stroke:#7c83ff; stroke-width:2; fill:none; marker-end:url(#arr);}
+      .llm{fill:#2a2150; stroke:#8b7cff;}
+      .cas{fill:#14352a; stroke:#4cc38a;}
+      .anim{fill:#3a2a14; stroke:#d4a017;}
+      .io{fill:#1a2740; stroke:#5b9bd5;}
+    </style>
+  </defs>
+
+  <!-- inputs -->
+  <rect class="box io" x="20" y="180" width="150" height="68"/>
+  <text class="lbl" x="95" y="208" text-anchor="middle">User / Agent</text>
+  <text class="sub" x="95" y="226" text-anchor="middle">start → target</text>
+
+  <!-- proof completion -->
+  <rect class="box llm" x="210" y="170" width="180" height="90"/>
+  <text class="lbl" x="300" y="200" text-anchor="middle">Proof Completion</text>
+  <text class="sub" x="300" y="218" text-anchor="middle">DSPy ChainOfThought</text>
+  <text class="sub" x="300" y="234" text-anchor="middle">emits a trajectory</text>
+
+  <!-- grounding -->
+  <rect class="box cas" x="430" y="60" width="200" height="110"/>
+  <text class="lbl" x="530" y="90" text-anchor="middle">Grounding</text>
+  <text class="sub" x="530" y="110" text-anchor="middle">LaTeX → semantic graph</text>
+  <text class="sub" x="530" y="126" text-anchor="middle">graph → SymPy</text>
+  <text class="sub" x="530" y="142" text-anchor="middle">step‑to‑step checks</text>
+  <text class="sub" x="530" y="158" text-anchor="middle">→ 5 confidence tiers</text>
+
+  <!-- animation -->
+  <rect class="box anim" x="430" y="250" width="200" height="110"/>
+  <text class="lbl" x="530" y="280" text-anchor="middle">Animation builder</text>
+  <text class="sub" x="530" y="300" text-anchor="middle">rebase → stable ids</text>
+  <text class="sub" x="530" y="316" text-anchor="middle">annotated LaTeX</text>
+  <text class="sub" x="530" y="332" text-anchor="middle">attach confidence</text>
+
+  <!-- frontend -->
+  <rect class="box io" x="690" y="170" width="200" height="120"/>
+  <text class="lbl" x="790" y="200" text-anchor="middle">Frontend</text>
+  <text class="sub" x="790" y="222" text-anchor="middle">FLIP morph on data‑n</text>
+  <text class="sub" x="790" y="240" text-anchor="middle">per‑step badges</text>
+  <text class="sub" x="790" y="258" text-anchor="middle">overall confidence pill</text>
+
+  <!-- edges -->
+  <path class="edge" d="M170,214 L205,214"/>
+  <path class="edge" d="M392,196 C415,160 415,150 428,125"/>
+  <path class="edge" d="M392,235 C415,270 415,280 428,300"/>
+  <path class="edge" d="M632,120 C665,150 670,165 700,200"/>
+  <path class="edge" d="M632,300 C665,270 670,255 700,225"/>
+</svg>
+
+**One sentence:** an LLM writes the math, a CAS judges it, and a deterministic
+renderer animates it — confidence flows all the way to a badge the user sees.
+
+---
+
+## 1. How proof completion works  ·  _(its own post)_
+
+The model never touches graphs. It's given the **start** and **target** as
+LaTeX and asked to emit a single *trajectory* of steps. Each step is one
+mathematical move plus the **complete expression** you reach after it:
+
+| field | example |
+|---|---|
+| `operation` | "add $\frac{c}{a}$ to both sides" |
+| `expr_latex` | `x^2 + \frac{b}{a}x = -\frac{c}{a}` |
+| `justification` | "addition property of equality" |
+| `change_type` | `rewrite` · `solve` · `substitute` · `approximate` · `given` |
+
+It's a thin DSPy module — `dspy.ChainOfThought(ProofCompletionSig)` — so the
+*prompt itself is optimizable* (MIPROv2/GEPA), and the expert binds the
+start/target LaTeX from the context graphs before inference.
+
+```mermaid
+flowchart LR
+  A[start and target as LaTeX] --> B[ChainOfThought]
+  B --> C[ProofTrajectory]
+  C --> D[step 1 operation expr justification type]
+  C --> E[step 2 ...]
+  C --> F[step n reaches target]
+```
+
+The crucial design choice: **the model emits full expressions, not graph
+edits.** That keeps it doing what LLMs are good at (math in LaTeX) while the code
+side owns everything structural.
+
+> _[screenshot placeholder: the derive CLI output — steps with per‑step glyphs]_
+
+---
+
+## 2. How grounding works — semantic graph + SymPy  ·  _(its own post)_
+
+This is the heart of "grounded." Every state the model wrote is turned into a
+**semantic graph**, the graph is reconstructed into a **SymPy** expression, and
+each *transition* `state[k‑1] → state[k]` is classified by what SymPy can prove.
+
+```mermaid
+flowchart TD
+  L[state LaTeX] --> G[semantic graph]
+  G --> S[graph_to_sympy]
+  S --> R{relation to previous state}
+  R -->|sympy_equiv holds| EQ[equivalent]
+  R -->|solution set is subset| NA[narrows]
+  R -->|landmarks or solutions differ| RF[refuted]
+  R -->|CAS cannot decide| UN[unknown]
+  EQ --> T[tier]
+  NA --> T
+  RF --> T
+  UN --> T
+```
+
+The checks run cheapest‑first and stop at the first that decides: symbolic
+equivalence → exact solution‑set containment → squared/branch pair for roots →
+scaled residual for multiply/divide both sides → parametric narrowing for
+multivariate → a **characteristic fingerprint** (real roots, singularities,
+limits — landmarks, *not* random sampling) → numeric tolerance for declared
+approximations. Each consecutive pair collapses to one of **five tiers**:
+
+| Tier | Icon | Meaning |
+|---|---|---|
+| **Grounded** | 🥇 | symbolically proven to follow from the previous step |
+| **Verified** | 🥈 | strong CAS evidence, short of a full symbolic proof |
+| **Plausible** | 🔹 | valid math, but the CAS couldn't decide this step |
+| **Unchecked** | ○ | not a single convertible expression (e.g. `\pm`, `\dots`) |
+| **Refuted** | ✗ | the CAS shows it does **not** follow |
+
+The overall verdict is the **weakest link** plus an endpoint gate (did the chain
+actually reach the target?). And the model's `change_type` is only an *advisory
+claim* — **SymPy is the judge**; a mislabeled step is downgraded one tier.
+
+> Worth underlining: a wrong middle step like `x^2 = 4 → x = 7` used to slip
+> through (it parses fine). Now it's **Refuted** — SymPy sees `7` isn't a root.
+
+> _[screenshot placeholder: a derivation with a mix of Grounded/Verified/Plausible badges + the tinted step strip]_
+
+---
+
+## 3. How the animation stays stable — rebasing for stable ids  ·  _(its own post)_
+
+A smooth morph needs to know *which glyph is which* across two states — the
+`2` in `c^2` must keep its identity so it glides instead of vanishing and
+reappearing. We get that by **rebasing** every state's graph onto the previous
+one and threading a stable node id through.
+
+<svg viewBox="0 0 900 250" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, sans-serif">
+  <defs>
+    <marker id="arr2" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#d4a017"/>
+    </marker>
+    <style>
+      .n{fill:#1b3a1e; stroke:#66bb6a; stroke-width:1.5;}
+      .nn{fill:#3a2a14; stroke:#d4a017; stroke-width:1.5;}
+      .t{fill:#e8eaf6; font-size:13px; font-weight:600;}
+      .c{fill:#aab0d6; font-size:11px;}
+      .e2{stroke:#7c83ff; stroke-width:2; fill:none;}
+      .keep{stroke:#d4a017; stroke-width:2; fill:none; stroke-dasharray:5 4; marker-end:url(#arr2);}
+    </style>
+  </defs>
+  <text class="t" x="120" y="30" text-anchor="middle">state k‑1</text>
+  <rect class="n" x="60" y="50" width="120" height="36" rx="8"/>
+  <text class="t" x="120" y="73" text-anchor="middle">x · (x+1)</text>
+  <rect class="n" x="40" y="110" width="60" height="32" rx="8"/><text class="c" x="70" y="131" text-anchor="middle">id=a · x</text>
+  <rect class="n" x="120" y="110" width="80" height="32" rx="8"/><text class="c" x="160" y="131" text-anchor="middle">id=b · (x+1)</text>
+
+  <text class="t" x="640" y="30" text-anchor="middle">state k (rebased)</text>
+  <rect class="nn" x="560" y="50" width="160" height="36" rx="8"/>
+  <text class="t" x="640" y="73" text-anchor="middle">x·x + x·1</text>
+  <rect class="n" x="520" y="110" width="60" height="32" rx="8"/><text class="c" x="550" y="131" text-anchor="middle">id=a (kept)</text>
+  <rect class="n" x="600" y="110" width="60" height="32" rx="8"/><text class="c" x="630" y="131" text-anchor="middle">id=b (kept)</text>
+  <rect class="nn" x="680" y="110" width="70" height="32" rx="8"/><text class="c" x="715" y="131" text-anchor="middle">new id</text>
+
+  <path class="keep" d="M105,126 C300,200 360,200 540,126"/>
+  <path class="keep" d="M195,126 C360,210 420,210 610,126"/>
+  <text class="c" x="430" y="225" text-anchor="middle">persisting sub‑expressions keep their id → they MOVE, not delete+insert</text>
+</svg>
+
+The rebase is GumTree‑style: anchor the **largest identical subtrees first** (by
+a downward subtree signature), recursively align their descendants, then a
+content‑only fallback for what changed; genuinely new nodes get a fresh id.
+Render with `to_latex(..., with_ids=True)` and every glyph carries
+`\htmlData{n=<id>}`. The browser engine then runs a **FLIP** animation keyed on
+`data-n`:
+
+```mermaid
+flowchart LR
+  P[ids in both states] -->|MOVE| M[translate and scale]
+  D[id only in old] -->|DELETE| O[ghost fades out]
+  I[id only in new] -->|INSERT| N[fades in last]
+```
+
+So everything that persists interpolates; only genuinely new pieces fade in and
+removed pieces fade out. That's the whole trick behind the Manim‑style morph.
+
+> _[screenshot placeholder: two consecutive states side by side showing the same glyph ids]_
+
+---
+
+## 4. The agent tool that triggers a derivation  ·  _(its own post)_
+
+The chat agent can produce a derivation on demand. The user asks in natural
+language; the agent infers the endpoints and calls a tool that returns a
+**verified** animation, identical to clicking a node's "Derive" button.
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant AI as Chat Agent
+  participant T as derive_proof_animation
+  participant E as ProofCompletionExpert
+  participant V as Grounding
+  U->>AI: derive the quadratic formula
+  AI->>T: start and target LaTeX
+  T->>E: run expert
+  E-->>T: trajectory
+  T->>V: ground every step
+  V-->>T: tiers and overall confidence
+  T-->>AI: verified animation payload
+  AI-->>U: animated derivation with badges
+```
+
+Because the payload carries the confidence tiers, the agent **can't present
+hand‑waving as proof** — an ungrounded step shows up honestly as Unchecked or
+Refuted rather than a confident‑looking wrong answer.
+
+> _[screenshot placeholder: chat asking for a derivation, animation appearing in the panel]_
+
+---
+
+## Where this is going — upcoming improvements
+
+Each of these is a post in its own right too; here's the teaser.
+
+```mermaid
+flowchart TD
+  CORE[Grounded proof completion and animation] --> R[Refinement loop]
+  CORE --> SYNC[Graph ↔ term sync]
+  CORE --> CAS[Grounded symbolic ops on the fly]
+  CORE --> PAGE[Interactive page generation]
+  CORE --> GAME[Gamification]
+```
+
+- **Refinement.** Today we *rank* confidence; next we *raise* it. A retry loop
+  scores each draft with a blended signal — well‑formedness + tier‑graded
+  grounding + a soft LLM‑judge for clarity/pedagogy — and regenerates against a
+  single threshold, feeding the specific failure back to the model. Hard gates
+  set the floor, the judge shapes the gradient.
+
+- **Graph ↔ term sync.** Bidirectional, loop‑safe binding so editing the term
+  updates the semantic graph and vice‑versa — the graph and the algebra stay one
+  object, not two views that can drift.
+
+- **Grounded symbolic operations on the fly.** A conversational CAS: the user
+  *talks* to do math — "simplify this", "multiply both sides by $a$",
+  "substitute $u = x+1$" — and each operation is applied **and grounded** on the
+  live expression. A symbolic‑math bot where every move is CAS‑verified, not
+  guessed.
+
+- **Interactive page generation.** The user plays with equations and proofs,
+  then drops any of them into a beautifully rendered page alongside other content
+  (charts, text), and saves it. Sharing with others follows — gated on auth and
+  share mechanisms.
+
+- **Gamification.** The AI rolls out little games to make the learner an active
+  participant — "what's the next step?", multiple‑choice moves, predict‑before‑
+  reveal — instead of passively watching the animation.
+
+---
+
+### TL;DR
+
+An LLM proposes the math, a semantic‑graph + SymPy pipeline **grounds** every
+step into one of five honest confidence tiers, and a deterministic rebasing
+renderer **animates** the whole derivation with stable ids and per‑step badges —
+all triggerable straight from chat. Ranking confidence was step one; **raising**
+it (refinement), talking math into existence (conversational CAS), and turning it
+into shareable, playable pages are what's next.
+
+> _[screenshot placeholder: hero shot of a fully Grounded derivation, overall pill expanded]_

--- a/docs/show-and-tell/proof-refinement-loop.md
+++ b/docs/show-and-tell/proof-refinement-loop.md
@@ -1,0 +1,394 @@
+# The Refinement Loop — a Show & Tell
+
+When AlgeBench asks an LLM to write a step‑by‑step derivation, the first draft is
+sometimes **broken**: an unbalanced `$` that leaks raw LaTeX into the caption, or
+a step that doesn't actually follow from the one before it. This post is about
+the machinery that **catches a bad draft and re‑asks for a better one** —
+deterministic correctness gates plus an optional taste critic, with the *exact
+reason it failed* handed back to the model so the retry is targeted, not a blind
+re‑roll.
+
+It also covers a side quest: we A/B'd our hand‑written loop against DSPy 3's
+built‑in `Refine`, and the hand‑rolled one won. The "why" turns out to be a neat
+lesson about matching the tool to the task.
+
+> _[screenshot placeholder: a derivation that first came back malformed, then the clean re‑derived version side by side]_
+
+---
+
+## The big picture
+
+One LM draft, scored by a single number, retried only if it falls short — and
+the failure reasons travel back into the next attempt.
+
+<svg viewBox="0 0 940 380" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, sans-serif">
+  <defs>
+    <marker id="arr" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#7c83ff"/>
+    </marker>
+    <marker id="arrG" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#4cc38a"/>
+    </marker>
+    <marker id="arrR" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#e0707a"/>
+    </marker>
+    <style>
+      .lbl{fill:#e8eaf6; font-size:14px; font-weight:600;}
+      .sub{fill:#aab0d6; font-size:11px;}
+      .edge{stroke:#7c83ff; stroke-width:2; fill:none; marker-end:url(#arr);}
+      .pass{stroke:#4cc38a; stroke-width:2; fill:none; marker-end:url(#arrG);}
+      .fail{stroke:#e0707a; stroke-width:2; fill:none; marker-end:url(#arrR); stroke-dasharray:5 4;}
+      .llm{fill:#2a2150; stroke:#8b7cff;}
+      .cas{fill:#14352a; stroke:#4cc38a;}
+      .gate{fill:#3a2a14; stroke:#d4a017;}
+      .io{fill:#1a2740; stroke:#5b9bd5;}
+      .flbl{fill:#e0707a; font-size:11px; font-weight:600;}
+      .plbl{fill:#4cc38a; font-size:11px; font-weight:600;}
+    </style>
+  </defs>
+
+  <!-- generate -->
+  <rect class="llm" rx="10" x="30" y="150" width="170" height="90"/>
+  <text class="lbl" x="115" y="182" text-anchor="middle">Generate</text>
+  <text class="sub" x="115" y="202" text-anchor="middle">ChainOfThought</text>
+  <text class="sub" x="115" y="218" text-anchor="middle">→ a trajectory</text>
+
+  <!-- reward -->
+  <rect class="gate" rx="10" x="270" y="140" width="190" height="110"/>
+  <text class="lbl" x="365" y="170" text-anchor="middle">Reward</text>
+  <text class="sub" x="365" y="190" text-anchor="middle">well‑formed · grounding</text>
+  <text class="sub" x="365" y="206" text-anchor="middle">· (judge) → score ∈ [0,1]</text>
+  <text class="sub" x="365" y="228" text-anchor="middle">+ an issues string</text>
+
+  <!-- threshold -->
+  <polygon class="cas" points="560,195 620,150 680,195 620,240" fill="#14352a" stroke="#4cc38a" stroke-width="1.5"/>
+  <text class="lbl" x="620" y="192" text-anchor="middle">score</text>
+  <text class="lbl" x="620" y="208" text-anchor="middle">≥ τ ?</text>
+
+  <!-- done -->
+  <rect class="io" rx="10" x="760" y="150" width="150" height="90"/>
+  <text class="lbl" x="835" y="182" text-anchor="middle">Done</text>
+  <text class="sub" x="835" y="202" text-anchor="middle">return best</text>
+  <text class="sub" x="835" y="218" text-anchor="middle">trajectory</text>
+
+  <!-- edges -->
+  <path class="edge" d="M200,195 L266,195"/>
+  <path class="edge" d="M460,195 L556,195"/>
+  <path class="pass" d="M680,195 L756,195"/>
+  <text class="plbl" x="718" y="186" text-anchor="middle">pass</text>
+
+  <!-- fail loop back to generate (feedback) -->
+  <path class="fail" d="M620,240 C620,320 250,330 115,330 L115,244"/>
+  <text class="flbl" x="380" y="348" text-anchor="middle">fail &amp; attempts left → re‑ask with the issues as feedback</text>
+</svg>
+
+**One sentence:** generate, score with a single number, and if it's below the
+bar, re‑ask the model *with the exact reasons it failed* — keeping the best
+attempt after a small number of tries.
+
+---
+
+## 1. Why a draft needs refining  ·  _(its own post)_
+
+The model writes math as LaTeX captions. Two failure modes recur:
+
+- **Malformed caption** — an unbalanced `$` (e.g. `…and $V = 7.8 \text{ km/s}`
+  with no closing `$`) leaks raw LaTeX into the rendered text. It can't display.
+- **Ungrounded step** — a step that *parses* fine but doesn't follow from the
+  previous one (`x^2 = 4 → x = 7`). It looks plausible and means the wrong thing.
+
+The pinned DSPy (2.6.5) has **no retry primitive** and its default path is
+*reject → one blind re‑roll → raise*: a validation failure re‑calls the model
+with the **same** inputs and **throws away** the error text. The model is never
+told what was wrong. So we built the engine that DSPy didn't give us.
+
+> _[screenshot placeholder: a caption rendering with a trailing raw `$…` artifact]_
+
+---
+
+## 2. The reward — one number, three signals  ·  _(its own post)_
+
+Every constraint is a pure function returning a score in `[0,1]`. They blend
+into one reward, and a single threshold `τ` decides whether to retry. **Nothing
+rejects** — a bad signal just scores low.
+
+<svg viewBox="0 0 900 340" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, sans-serif">
+  <defs>
+    <marker id="a2" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#7c83ff"/>
+    </marker>
+    <style>
+      .lbl{fill:#e8eaf6; font-size:13px; font-weight:600;}
+      .sub{fill:#aab0d6; font-size:10.5px;}
+      .edge{stroke:#7c83ff; stroke-width:2; fill:none; marker-end:url(#a2);}
+      .det{fill:#14352a; stroke:#4cc38a;}
+      .opt{fill:#2a2150; stroke:#8b7cff;}
+      .comb{fill:#3a2a14; stroke:#d4a017;}
+      .io{fill:#1a2740; stroke:#5b9bd5;}
+      .note{fill:#7c8; font-size:10px;}
+    </style>
+  </defs>
+
+  <!-- well-formedness -->
+  <rect class="det" rx="9" x="20" y="30" width="210" height="64"/>
+  <text class="lbl" x="125" y="56" text-anchor="middle">Well‑formedness</text>
+  <text class="sub" x="125" y="74" text-anchor="middle">balanced $…$ / braces — string check</text>
+
+  <!-- grounding -->
+  <rect class="det" rx="9" x="20" y="118" width="210" height="64"/>
+  <text class="lbl" x="125" y="144" text-anchor="middle">Grounding</text>
+  <text class="sub" x="125" y="162" text-anchor="middle">CAS tiers → TIER_RANK / 4</text>
+
+  <!-- judge -->
+  <rect class="opt" rx="9" x="20" y="206" width="210" height="64"/>
+  <text class="lbl" x="125" y="232" text-anchor="middle">LLM judge  (optional)</text>
+  <text class="sub" x="125" y="250" text-anchor="middle">pedagogy score — never gates</text>
+
+  <!-- combiner -->
+  <rect class="comb" rx="10" x="330" y="110" width="240" height="96"/>
+  <text class="lbl" x="450" y="140" text-anchor="middle">reward =</text>
+  <text class="sub" x="450" y="162" text-anchor="middle">wellformed_factor ×</text>
+  <text class="sub" x="450" y="178" text-anchor="middle">(W_G·grounding + W_J·judge)</text>
+  <text class="note" x="450" y="198" text-anchor="middle">malformed ⇒ factor 0 ⇒ reward 0</text>
+
+  <!-- threshold -->
+  <polygon class="det" points="650,158 705,118 760,158 705,198"/>
+  <text class="lbl" x="705" y="156" text-anchor="middle">≥ τ ?</text>
+
+  <!-- outcome -->
+  <rect class="io" rx="9" x="800" y="126" width="80" height="64"/>
+  <text class="lbl" x="840" y="154" text-anchor="middle">pass /</text>
+  <text class="lbl" x="840" y="172" text-anchor="middle">retry</text>
+
+  <!-- edges -->
+  <path class="edge" d="M230,62 C285,62 285,140 326,150"/>
+  <path class="edge" d="M230,150 L326,158"/>
+  <path class="edge" d="M230,238 C285,238 285,176 326,166"/>
+  <path class="edge" d="M570,158 L646,158"/>
+  <path class="edge" d="M760,158 L796,158"/>
+</svg>
+
+The weighting matters: **grounding dominates the judge** (`W_G=0.8`, `W_J=0.2`),
+and well‑formedness is a near‑binary *prerequisite* — a malformed caption zeroes
+the whole reward before the judge is even called. So a `Refuted` step or a broken
+caption **can't clear `τ` even with a perfect judge**, while a merely `Plausible`
+derivation just scores mid and gets another try.
+
+| tier | score (`TIER_RANK/4`) |
+|---|---|
+| Grounded | 1.00 |
+| Verified | 0.75 |
+| Plausible | 0.50 |
+| Unchecked | 0.25 |
+| Refuted | 0.00 |
+
+---
+
+## 3. One checker per file — soft in the loop, hard at the edges  ·  _(its own post)_
+
+Each constraint is a single pure function, in its own module. The same checker
+has **two surfaces**: a *soft* score for the loop, and a *hard* raise for places
+where there is no retry (hand‑authored JSON, tests).
+
+```
+backend/util/latex.py          reusable $…$ / $$…$$ scanner (no deps)
+  └─ wellformed.py             well_formed() · assert_well_formed()
+  └─ grounding_score.py        tier‑graded grounding via step_grounding
+  └─ judge.py                  LLM‑as‑judge signature (score + issues)
+  └─ reward.py                 blend + threshold τ
+  └─ refine.py                 the loop: ask → score → re‑ask
+```
+
+The `$…$` scanner lives in `backend/util/` on purpose — it's a generic string
+property (the chat panel and caption renderer share the same notion of
+"balanced"), not something that belongs buried in the proof expert.
+
+> _[screenshot placeholder: the unit‑test run — unbalanced `$` rejected, prose‑`$` accepted]_
+
+---
+
+## Watching it work — `--debug`
+
+The derive CLI has a `--debug` flag that dumps every refinement attempt: the
+score, the three reward signals, each step, and the feedback that would be
+threaded into a retry. Here's the **power rule**, `d/dx x² → 2x`:
+
+```text
+./run.sh scripts/proof_completion_derive.py "\frac{d}{dx} x^2" "2x" --debug --attempts 3 --judge
+
+── refine attempt 1/3 ──  score=1.000  PASS
+   breakdown: wellformed=1.0 grounding=1.0 judge=1.0
+   step 1 [rewrite]: 2 \cdot x^{2 - 1}
+   step 2 [rewrite]: 2 \cdot x^{1}
+   step 3 [rewrite]: 2 \cdot x
+   notes: 3/3 steps verified · endpoint reached
+refine done: 1 attempt(s), PASSED (best score 1.000)
+
+=== derivation (LaTeX): 3 step(s) ===
+   start :   \frac{d}{d x} x^{2}
+   step 1:  🥇 2 \cdot x
+   step 2:  🥇 2 \cdot x
+   step 3:  🥇 2 \cdot x
+
+result:
+  steps convertible : 3/3
+  math correct      : ✓    (final state reaches the target expression)
+  exact graph       : ✓    (identical structure to the parsed target)
+  step grounding    : 🥇🥇🥇
+  confidence        : 🥇 Grounded    (3/3 steps verified · endpoint reached)
+```
+
+This is the **happy path** — and it shows three things:
+
+- **All three signals are 1.0**, so the reward is
+  `1.0 × (0.8·1.0 + 0.2·1.0) = 1.0`, which clears `τ=0.7`. The loop **PASSes on
+  attempt 1 and stops** — `refine done: 1 attempt(s)`. No retry, so refinement
+  cost *nothing* beyond the single prediction. (`--judge` is on here, so you can
+  see `judge=1.0`; with it off, that term simply drops out.)
+- **The dump shows the model's *raw* steps** — `2·x^{2-1}`, `2·x^1`, `2·x` — the
+  power rule unfolding pedagogically. The `=== derivation ===` block below shows
+  the **reconstructed, CAS‑verified** view, where all three collapse to `2·x`
+  because SymPy evaluates the exponent arithmetic (`2-1 → 1`, `x¹ → x`). Same
+  value, three teaching steps — which is exactly why every transition is
+  🥇 and the overall confidence is **Grounded**.
+- **Had a signal scored low, you'd see attempt 2, 3…** each re‑asked with the
+  `notes`/issues line as feedback. (Earlier in this post: a `\lor` disjunction
+  target floors `grounding` at 0.5, so the blend lands at 0.6 < τ and the loop
+  retries — the judge being 1.0 can't rescue it.)
+
+`--attempts N` raises the retry cap (handy for watching the loop iterate);
+`--judge` adds the pedagogy signal to the reward.
+
+> _[screenshot placeholder: the `--debug` dump in a terminal, PASS on attempt 1]_
+
+---
+
+## 4. Hand‑rolled vs DSPy Refine — a regime mismatch  ·  _(its own post)_
+
+DSPy 3 ships a built‑in `Refine`. We tested it against our hand‑written loop.
+They share the same skeleton — ask, score, keep the best — but differ in two
+ways that turn out to matter a lot for *this* task.
+
+<svg viewBox="0 0 920 360" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, sans-serif">
+  <defs>
+    <marker id="a3" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#7c83ff"/>
+    </marker>
+    <style>
+      .lbl{fill:#e8eaf6; font-size:13px; font-weight:600;}
+      .sub{fill:#aab0d6; font-size:10.5px;}
+      .edge{stroke:#7c83ff; stroke-width:2; fill:none; marker-end:url(#a3);}
+      .llm{fill:#2a2150; stroke:#8b7cff;}
+      .det{fill:#14352a; stroke:#4cc38a;}
+      .extra{fill:#3a1414; stroke:#e0707a;}
+      .title{fill:#e8eaf6; font-size:14px; font-weight:700;}
+      .good{fill:#4cc38a; font-size:11px; font-weight:600;}
+      .bad{fill:#e0707a; font-size:11px; font-weight:600;}
+    </style>
+  </defs>
+
+  <!-- divider -->
+  <line x1="460" y1="20" x2="460" y2="340" stroke="#39406b" stroke-width="1" stroke-dasharray="4 4"/>
+
+  <!-- LEFT: hand-rolled -->
+  <text class="title" x="220" y="36" text-anchor="middle">Hand‑Rolled Refinement</text>
+  <rect class="llm" rx="9" x="40" y="60" width="150" height="64"/>
+  <text class="lbl" x="115" y="86" text-anchor="middle">Generate</text>
+  <text class="sub" x="115" y="104" text-anchor="middle">temp 0.7</text>
+
+  <rect class="det" rx="9" x="250" y="60" width="160" height="64"/>
+  <text class="lbl" x="330" y="82" text-anchor="middle">Score (deterministic)</text>
+  <text class="sub" x="330" y="100" text-anchor="middle">issues = exact reasons</text>
+
+  <rect class="det" rx="9" x="150" y="200" width="200" height="58"/>
+  <text class="lbl" x="250" y="224" text-anchor="middle">Feedback (free)</text>
+  <text class="sub" x="250" y="242" text-anchor="middle">"step 3 → x=7 is refuted"</text>
+
+  <path class="edge" d="M190,92 L246,92"/>
+  <path class="edge" d="M330,124 L300,196"/>
+  <path class="edge" d="M150,229 C90,229 90,130 110,124"/>
+  <text class="good" x="220" y="290" text-anchor="middle">+1 LM call per retry · exact feedback</text>
+
+  <!-- RIGHT: dspy refine -->
+  <text class="title" x="700" y="36" text-anchor="middle">DSPy Refine</text>
+  <rect class="llm" rx="9" x="520" y="60" width="150" height="64"/>
+  <text class="lbl" x="595" y="86" text-anchor="middle">Generate</text>
+  <text class="sub" x="595" y="104" text-anchor="middle">temp 1.0 (fixed)</text>
+
+  <rect class="det" rx="9" x="730" y="60" width="150" height="64"/>
+  <text class="lbl" x="805" y="86" text-anchor="middle">Score</text>
+  <text class="sub" x="805" y="104" text-anchor="middle">a bare float</text>
+
+  <rect class="extra" rx="9" x="620" y="200" width="220" height="58"/>
+  <text class="lbl" x="730" y="222" text-anchor="middle">OfferFeedback  (extra LM call)</text>
+  <text class="sub" x="730" y="240" text-anchor="middle">guesses blame from reward code</text>
+
+  <path class="edge" d="M670,92 L726,92"/>
+  <path class="edge" d="M805,124 L760,196"/>
+  <path class="edge" d="M620,229 C560,229 560,130 590,124"/>
+  <text class="bad" x="700" y="290" text-anchor="middle">+2 LM calls per retry · reverse‑engineered feedback</text>
+</svg>
+
+Two differences drive the result:
+
+1. **Temperature.** DSPy Refine hard‑codes `temperature=1.0` on every attempt.
+   Ours uses the configured `0.7`. For a task whose "good" output is *narrow*
+   (valid LaTeX that's CAS‑convertible **and** grounded), hotter sampling
+   produces more junk to filter.
+2. **Feedback.** Ours hands the model the **exact** failing step and the CAS's
+   reason. DSPy Refine can only see a **bare float** through its `reward_fn`, so
+   it spends an extra LM call (`OfferFeedback`) trying to *reverse‑engineer* the
+   blame from the reward function's source code. Strictly less signal, more cost.
+
+> Neither approach remembers more than the **last** attempt's hint — each retry
+> is fed a single distilled critique, not a transcript of every prior try. (With
+> our `N=2`, that's moot; it would only bite at `N≥3`.)
+
+---
+
+## 5. The numbers  ·  _(its own post)_
+
+Same 50 eval examples, DSPy 3.2.1, `N=2`, judge off. **No Refinement** is a single
+pass; the other two each get one retry.
+
+| metric | No Refinement | **Hand‑Rolled** | DSPy Refine |
+|---|---|---|---|
+| grounding | 0.941 | **0.975** | 0.939 |
+| pass rate @ τ=0.7 | 0.880 | **0.940** | 0.900 |
+| reaches target | 0.860 | **0.880** | 0.840 |
+| step‑grounded | 0.979 | **0.995** | 0.963 |
+| **LM calls** | 52 | **59** | 71 |
+
+Both loops beat the single pass. Between them, **Hand‑Rolled wins on accuracy and
+costs ~20% fewer LM calls.** DSPy Refine's *only* advantage is fewer lines of our
+code — and claiming it would mean a breaking DSPy 3 upgrade to ship a measurably
+worse pipeline.
+
+| | winner |
+|---|---|
+| accuracy | **Hand‑Rolled** |
+| cost (LM calls) | **Hand‑Rolled** |
+| feedback precision | **Hand‑Rolled** |
+| least code | DSPy Refine |
+| no dependency upgrade | **Hand‑Rolled** |
+
+**The lesson:** `Refine` is built for free‑form tasks where sampling *diversity*
+helps and the reward is a simple property to re‑sample toward. Ours is the
+opposite — narrow structured output, plus we already compute precise feedback its
+interface can't accept. Same idea, different regime; the hand‑rolled loop fits
+ours better.
+
+> _[screenshot placeholder: the A/B comparison table from `compare_refine.py`]_
+
+---
+
+## Where it runs
+
+The loop lives **inside** the expert (`module.forward`), so every path that
+derives a proof gets it for free — the live proof‑animation endpoint, the derive
+CLI, the optimizer's serving calls. The fallback is honest: after `N` tries it
+keeps the best attempt, which **still renders**, tiered truthfully by the
+confidence badges (#370). Refinement raises the *ceiling*; the badges keep the
+*floor* honest.
+
+> _[screenshot placeholder: a derivation in the app with per‑step confidence badges after refinement]_

--- a/scripts/graph_to_mermaid.py
+++ b/scripts/graph_to_mermaid.py
@@ -351,11 +351,10 @@ def _format_label(
                     order = f"^{{{m.group(1)}}}"
             return f"$\\dfrac{{{d}{order}}}{{{d} {wrt}{order}}}$"
         if op in ("integral", "closed_integral") and wrt:
+            # Bounds are separate lb/ub nodes; the stored lower_bound/upper_bound
+            # are those nodes' ids (e.g. __num_2), so don't interpolate them into
+            # the label — the node is just ∫ d⟨var⟩.
             int_cmd = OPERATOR_LATEX.get(op, r"\int")
-            lb = node.get("lower_bound", "")
-            ub = node.get("upper_bound", "")
-            if lb and ub:
-                return f"${int_cmd}_{{{lb}}}^{{{ub}}} d{wrt}$"
             return f"${int_cmd} d{wrt}$"
         if op in ("sum", "product") and wrt:
             agg_cmd = OPERATOR_LATEX.get(op, r"\sum")

--- a/scripts/graph_to_mermaid.py
+++ b/scripts/graph_to_mermaid.py
@@ -310,6 +310,20 @@ def list_themes(theme_dir: Path | None = None) -> list[str]:
 SHOW_FIELDS = {"emoji", "unit", "role", "quantity", "dimension", "label", "description"}
 
 
+def _bound_value(ref: str, nodes_by_id: dict | None) -> str:
+    """Resolve a bound reference to its display value.
+
+    Integral/sum bounds are stored as the bound NODE's id (e.g. ``__num_2``).
+    With a node map, resolve it to that node's value so labels read ∫_0^1 not
+    ∫_{__num_2}. Without a map (or an unknown ref — e.g. a literal like ``a``),
+    return it unchanged.
+    """
+    if ref and nodes_by_id and ref in nodes_by_id:
+        b = nodes_by_id[ref]
+        return b.get("latex") or b.get("label") or b.get("subexpr") or ref
+    return ref
+
+
 def _format_label(
     node: dict[str, str],
     label_mode: str,
@@ -317,6 +331,7 @@ def _format_label(
     arity: int = 0,
     has_condition: bool = False,
     has_assertion: bool = False,
+    nodes_by_id: dict | None = None,
 ) -> str:
     """Format a node label based on the label mode and visible fields.
 
@@ -351,10 +366,12 @@ def _format_label(
                     order = f"^{{{m.group(1)}}}"
             return f"$\\dfrac{{{d}{order}}}{{{d} {wrt}{order}}}$"
         if op in ("integral", "closed_integral") and wrt:
-            # Bounds are separate lb/ub nodes; the stored lower_bound/upper_bound
-            # are those nodes' ids (e.g. __num_2), so don't interpolate them into
-            # the label — the node is just ∫ d⟨var⟩.
             int_cmd = OPERATOR_LATEX.get(op, r"\int")
+            # bounds are stored as node ids (e.g. __num_2) — resolve to values
+            lb = _bound_value(node.get("lower_bound", ""), nodes_by_id)
+            ub = _bound_value(node.get("upper_bound", ""), nodes_by_id)
+            if lb and ub:
+                return f"${int_cmd}_{{{lb}}}^{{{ub}}} d{wrt}$"
             return f"${int_cmd} d{wrt}$"
         if op in ("sum", "product") and wrt:
             agg_cmd = OPERATOR_LATEX.get(op, r"\sum")
@@ -689,6 +706,7 @@ def semantic_graph_to_mermaid(
     # accept the inline ``:::className`` shortcut, so we emit those classes
     # via separate ``class nid className`` statements instead.
     typed_class_assignments: list[tuple[str, str]] = []
+    _nodes_by_id = {n["id"]: n for n in nodes if "id" in n}
     for node in nodes:
         nid = _sanitize_id(node["id"])
         ntype = node.get("type", "scalar")
@@ -707,7 +725,8 @@ def semantic_graph_to_mermaid(
         label = _format_label(node, lm, show=show,
                               arity=in_degree.get(node["id"], 0),
                               has_condition=node["id"] in has_condition_edge,
-                              has_assertion=node["id"] in has_assertion_edge)
+                              has_assertion=node["id"] in has_assertion_edge,
+                              nodes_by_id=_nodes_by_id)
         node_def = _wrap_shape(nid, label, shape)
         # ``operatorVariants`` styling only applies to operator-like nodes.
         # When a matching variant class is available, it takes precedence

--- a/scripts/proof_animation/report.py
+++ b/scripts/proof_animation/report.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from proof_animation.build import build, build_animation, ProofAnimation
 from backend.experts.modules.proof_completion.outputs import ProofTrajectory, DerivationStep
+from backend.experts.modules.proof_completion.wellformed import assert_well_formed
 
 _ROOT = Path(__file__).resolve().parent.parent.parent   # scripts/proof_animation/report.py → repo root
 _ASSETS = _ROOT / "static" / "proof-animation"
@@ -102,6 +103,9 @@ def main() -> int:
     elif args.from_json:
         with open(args.from_json, encoding="utf-8") as fh:
             traj = ProofTrajectory.model_validate_json(fh.read())
+        # Hard edge (issue #372 §A): a hand-authored trajectory has no refinement
+        # loop behind it, so malformed captions are an error here, not a low score.
+        assert_well_formed(traj)
         animations = [build(traj, args.domain, args.title or "derivation")]
     elif args.states:
         traj = ProofTrajectory(

--- a/scripts/proof_completion/compare_refine.py
+++ b/scripts/proof_completion/compare_refine.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""A/B the refinement loop: same examples, refinement OFF vs ON (issue #372).
+
+Runs each eval example twice — ``refine_attempts=1`` (single pass, loop disabled)
+and ``refine_attempts=N`` (ask → score → re-ask-with-feedback) — and reports, for
+each config, the metrics the loop is meant to move: caption **well-formedness**
+rate, **grounding** score, the blended **reward**, and the **pass@τ** rate, next
+to the existing metric components (exact / coverage / step_grounded).
+
+Run with ``ALGEBENCH_LM_TEMPERATURE=0`` (the default here) so the OFF run is byte
+-for-byte the ON run's first attempt: every difference is then attributable to the
+loop, not to sampling noise. Extra LM calls happen only on a sub-τ first attempt.
+
+Usage:
+    ./run.sh scripts/proof_completion/compare_refine.py --data data/proof_completion/eval.jsonl --limit 20
+    ./run.sh scripts/proof_completion/compare_refine.py --data ... --attempts 3 --judge
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+from _pc_env import load_env_local, predict_all
+
+# Deterministic by default so OFF == ON's first attempt (override if you like).
+os.environ.setdefault("ALGEBENCH_LM_TEMPERATURE", "0")
+
+load_env_local()
+
+from backend.experts import init_experts  # noqa: E402
+from backend.experts.modules.proof_completion import ProofCompletionExpert  # noqa: E402
+from backend.experts.modules.proof_completion import dataset as D  # noqa: E402
+from backend.experts.modules.proof_completion.metric import score_components  # noqa: E402
+from backend.experts.modules.proof_completion.reward import TAU, reward  # noqa: E402
+from backend.experts.modules.proof_completion.wellformed import well_formed  # noqa: E402
+
+
+def _traj(pred):
+    """The ProofTrajectory out of a program return (``[traj]``); None on error."""
+    if pred is None:
+        return None
+    if isinstance(pred, (list, tuple)):
+        return pred[0] if pred else None
+    return pred
+
+
+def _row(ex, pred, judge):
+    """Score one prediction: reward components + the existing metric components."""
+    traj = _traj(pred)
+    if traj is None:
+        return {"wellformed": 0.0, "grounding": 0.0, "reward": 0.0, "passed": 0.0,
+                "exact": 0.0, "coverage": 0.0, "step_grounded": 0.0}
+    r = reward(traj, start_graph=ex.context.start, target_graph=ex.context.target,
+               domain=ex.context.domain, judge=judge)
+    c = score_components(ex, pred)
+    return {
+        "wellformed": 1.0 if well_formed(traj).ok else 0.0,
+        "grounding": r.breakdown["grounding"] if r.breakdown["grounding"] is not None else 0.0,
+        "reward": r.score,
+        "passed": 1.0 if r.passed else 0.0,
+        "exact": c["exact"],
+        "coverage": c["coverage"],
+        "step_grounded": c["step_grounded"],
+    }
+
+
+def _agg(rows):
+    keys = ("wellformed", "grounding", "reward", "passed", "exact", "coverage",
+            "step_grounded")
+    return {k: sum(r[k] for r in rows) / len(rows) for k in keys}
+
+
+_LABELS = [
+    ("wellformed", "well-formed rate"),
+    ("grounding", "mean grounding"),
+    ("reward", "mean reward"),
+    ("passed", f"pass@τ ({TAU})"),
+    ("exact", "exact"),
+    ("coverage", "coverage"),
+    ("step_grounded", "step_grounded"),
+]
+
+
+def _print_table(off, on):
+    print(f"\n{'metric':<22}{'OFF (N=1)':>12}{'ON':>12}{'Δ':>10}")
+    print("-" * 56)
+    for key, label in _LABELS:
+        d = on[key] - off[key]
+        arrow = "↑" if d > 1e-9 else ("↓" if d < -1e-9 else " ")
+        print(f"{label:<22}{off[key]:>12.3f}{on[key]:>12.3f}{d:>+9.3f}{arrow}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--data", required=True, help="eval .jsonl")
+    ap.add_argument("--limit", type=int, default=20, help="cap examples (cost guard)")
+    ap.add_argument("--attempts", type=int, default=2, help="N for the ON run")
+    ap.add_argument("--judge", action="store_true",
+                    help="enable the LLM judge in BOTH the loop and the scoring")
+    args = ap.parse_args()
+
+    init_experts()  # configures the DSPy LM + discovers registrations
+    data = D.load_jsonl(args.data)[: args.limit]
+    print(f"comparing on {len(data)} examples  "
+          f"(temp={os.environ.get('ALGEBENCH_LM_TEMPERATURE')}, "
+          f"judge={'on' if args.judge else 'off'}, N={args.attempts})")
+
+    off_prog = ProofCompletionExpert(load_default=False, refine_attempts=1,
+                                     use_judge=args.judge)
+    on_prog = ProofCompletionExpert(load_default=False, refine_attempts=args.attempts,
+                                    use_judge=args.judge)
+    # A shared scoring judge so the reward numbers are comparable across configs.
+    score_judge = on_prog.judge if args.judge else None
+
+    print("\n[1/2] refinement OFF (single pass)…")
+    off_preds = predict_all(off_prog, data, label="off")
+    print("\n[2/2] refinement ON…")
+    on_preds = predict_all(on_prog, data, label="on")
+
+    off_rows = [_row(ex, p, score_judge) for ex, p in zip(data, off_preds)]
+    on_rows = [_row(ex, p, score_judge) for ex, p in zip(data, on_preds)]
+
+    _print_table(_agg(off_rows), _agg(on_rows))
+
+    # per-example movement on the blended reward
+    improved = regressed = same = 0
+    fixed_wf = 0  # malformed under OFF, well-formed under ON
+    for o, n in zip(off_rows, on_rows):
+        d = n["reward"] - o["reward"]
+        if d > 1e-6:
+            improved += 1
+        elif d < -1e-6:
+            regressed += 1
+        else:
+            same += 1
+        if o["wellformed"] < 1.0 and n["wellformed"] == 1.0:
+            fixed_wf += 1
+    print(f"\nreward movement: {improved} improved · {regressed} regressed · "
+          f"{same} unchanged   (of {len(data)})")
+    print(f"malformed captions repaired by the loop: {fixed_wf}")
+
+    # retries: the OFF rows ARE the first attempts, so an example enters the retry
+    # loop iff its first attempt scored below τ. With N=2 that is exactly one
+    # retry each; the resulting extra LM derivation calls are the loop's whole
+    # marginal cost (passing first attempts are temp=0 cache hits).
+    retried = sum(1 for r in off_rows if r["passed"] < 1.0)
+    crossed = sum(1 for o, n in zip(off_rows, on_rows)
+                  if o["passed"] < 1.0 and n["passed"] == 1.0)
+    max_retries = retried * (args.attempts - 1)
+    print(f"\nretries: {retried}/{len(data)} examples fell below τ on the first "
+          f"attempt and entered the loop")
+    if args.attempts == 2:
+        print(f"  → {retried} retry passes (one each); {crossed} of them then crossed τ")
+    else:
+        print(f"  → between {retried} and {max_retries} retry passes "
+              f"(1…{args.attempts - 1} each); {crossed} examples crossed τ")
+    print(f"  extra LM derivation calls ≈ retry passes "
+          f"(first attempts are cache hits at temp=0)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/proof_completion/evaluate.py
+++ b/scripts/proof_completion/evaluate.py
@@ -70,8 +70,10 @@ def main() -> int:
     if args.limit:
         data = data[: args.limit]
 
+    # refine_attempts=1 measures the raw model against the metric; the serving
+    # refinement loop is evaluated separately, not folded into these numbers.
     prog = ProofCompletionExpert(artifact=args.program,
-                                 load_default=not args.baseline)
+                                 load_default=not args.baseline, refine_attempts=1)
     print(f"evaluating {len(data)} examples "
           f"(model: {prog.loaded_artifact or 'baseline (uncompiled)'})")
     preds = predict_all(prog, data, label="eval")

--- a/scripts/proof_completion/optimize.py
+++ b/scripts/proof_completion/optimize.py
@@ -45,7 +45,10 @@ def main() -> int:
         train = train[: args.limit]
     print(f"optimizing on {len(train)} examples with {args.optimizer} (auto={args.auto})")
 
-    student = ProofCompletionExpert(load_default=False)  # compile from baseline
+    # compile from baseline; refine_attempts=1 disables the serving-time
+    # refinement loop so the optimizer compiles the bare predictor (the metric is
+    # the optimization signal, not the reward) without extra per-call LM traffic.
+    student = ProofCompletionExpert(load_default=False, refine_attempts=1)
 
     if args.optimizer == "labeled":
         from dspy.teleprompt import LabeledFewShot

--- a/scripts/proof_completion_derive.py
+++ b/scripts/proof_completion_derive.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 
 from _pc_env import load_env_local
 
@@ -118,6 +119,12 @@ def main() -> int:
     ap.add_argument("--program", default=None, help="optimized artifact to load")
     ap.add_argument("--baseline", action="store_true",
                     help="force the uncompiled model (ignore the default artifact)")
+    ap.add_argument("--attempts", type=int, default=None,
+                    help="max refinement attempts (default: env/2; 1 disables the loop)")
+    ap.add_argument("--judge", action="store_true",
+                    help="enable the LLM-as-judge signal in the refinement reward")
+    ap.add_argument("--debug", action="store_true",
+                    help="log each refinement attempt: score, breakdown, steps, feedback")
     ap.add_argument("--trajectory", action="store_true",
                     help="print the trajectory op(s) at each step")
     ap.add_argument("--explanation", action="store_true",
@@ -127,6 +134,16 @@ def main() -> int:
     ap.add_argument("--json", action="store_true",
                     help="dump the raw model output (the trajectory) as JSON and exit")
     args = ap.parse_args()
+
+    if args.debug:
+        # Isolated DEBUG stream for the refinement loop only — keep dspy/litellm
+        # chatter out of the dump.
+        _h = logging.StreamHandler()
+        _h.setFormatter(logging.Formatter("%(message)s"))
+        _lg = logging.getLogger("backend.experts.modules.proof_completion")
+        _lg.setLevel(logging.DEBUG)
+        _lg.addHandler(_h)
+        _lg.propagate = False
 
     init_experts()  # configure the DSPy LM
     svc = SemanticGraphService()
@@ -145,7 +162,9 @@ def main() -> int:
     ctx = GraphTransition(start=start_g, target=target_g,
                           domain=args.domain, intent=intent)
     prog = ProofCompletionExpert(artifact=args.program,
-                                 load_default=not args.baseline)
+                                 load_default=not args.baseline,
+                                 refine_attempts=args.attempts,
+                                 use_judge=True if args.judge else None)
     if not args.json:
         print(f"(model: {prog.loaded_artifact or 'baseline (uncompiled)'})")
     try:

--- a/scripts/semantic_graph_report.py
+++ b/scripts/semantic_graph_report.py
@@ -105,6 +105,15 @@ from tests.backend.semantic_graph.domains.test_domain_chemistry import (
 # Each domain contributes (section_name, [(test_id, latex), ...]).
 # Expand this list as new domain test files are added.
 
+# Report-only showcase (not a test catalog): bare integral forms, so the
+# integral node structure (integrand + wrt + lb/ub bounds) is easy to eyeball.
+_INTEGRAL_SHOWCASE = [
+    ("integral_indefinite", r"\int x^2 \, dx", None),
+    ("integral_definite", r"\int_0^1 x^2 \, dx", None),
+    ("integral_reciprocal", r"\int_a^b \frac{1}{x} \, dx", None),
+    ("integral_exp_decay", r"\int_0^h e^{-z/H} \, dz", None),
+]
+
 
 def _collect_expressions() -> list[tuple[str, list[tuple[str, str, str | None]]]]:
     # Each section: (display name, catalog, domain hint passed to the parser).
@@ -114,6 +123,7 @@ def _collect_expressions() -> list[tuple[str, list[tuple[str, str, str | None]]]
         ("Arithmetic", ARITHMETIC_EXPRESSIONS, None),
         ("Algebra", ALGEBRA_EXPRESSIONS, None),
         ("Calculus", CALCULUS_EXPRESSIONS, None),
+        ("Integrals (showcase)", _INTEGRAL_SHOWCASE, None),
         ("ODE", ODE_EXPRESSIONS, None),
         ("PDE", PDE_EXPRESSIONS, None),
         ("Structural", STRUCTURAL_EXPRESSIONS, None),
@@ -958,6 +968,12 @@ def generate_site(
     chart_script_dst = outdir / "sg-chart-script.js"
     shutil.copy2(chart_script_src, chart_script_dst)
 
+    # Cache-bust the ES modules on every (re)generation — browsers cache module
+    # imports aggressively, so without this a regenerated report keeps running the
+    # stale JS (won't reflect renderer changes).
+    _d3_ver = int(d3_js_dst.stat().st_mtime)
+    _chart_ver = int(chart_js_dst.stat().st_mtime)
+
     theme = load_theme(graph_theme)
     color_mode = theme.get("mode", "dark")
     colors = THEMES[color_mode]
@@ -974,8 +990,8 @@ def generate_site(
         html, ok, err = _build_report_html(
             [(section_name, expressions)],
             graph_theme=graph_theme, theme=theme, colors=colors,
-            d3_module_url="./d3-semantic-graph.js",
-            chart_module_url="./sg-chart.js",
+            d3_module_url=f"./d3-semantic-graph.js?v={_d3_ver}",
+            chart_module_url=f"./sg-chart.js?v={_chart_ver}",
         )
         (outdir / filename).write_text(html, encoding="utf-8")
         total_ok += ok

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -768,17 +768,28 @@ export class D3SemanticGraphRenderer {
 
         dagre.layout(g);
 
+        // Integral/sum bounds are stored as the bound NODE's id (e.g. "__num_2").
+        // Resolve to that node's value so labels read ∫_0^1, not ∫_{__num_2}.
+        const boundLabel = (ref) => {
+            if (!ref) return '';
+            const b = nodeById[ref];
+            return b ? (b.latex || b.label || b.subexpr || ref) : ref;
+        };
+
         const nodeWrappers = Object.create(null);
         const layoutNodes = [];
         for (const id of g.nodes()) {
             const pos = g.node(id);
+            const src = nodeById[id];
             const wrapper = {
                 data: {
-                    ...nodeById[id],
+                    ...src,
                     _collapsed: this._collapsed.has(id),
                     _childIds: childrenOf[id] || [],
                     _hasConditionEdge: conditionEdgeTargets.has(id),
                     _hasAssertionEdge: assertionEdgeTargets.has(id),
+                    _lowerBoundLabel: boundLabel(src.lower_bound),
+                    _upperBoundLabel: boundLabel(src.upper_bound),
                 },
                 x: pos.x,
                 y: pos.y,
@@ -1472,12 +1483,15 @@ export class D3SemanticGraphRenderer {
             return `\\frac{${d}}{${d}\\cdot}`;
         }
         if (op === 'integral' || op === 'closed_integral') {
-            // Bounds are shown as separate lb/ub nodes (and would otherwise
-            // interpolate raw bound node ids like __num_2 into the label), so the
-            // node itself is just ∫ d⟨var⟩.
             const cmd = OPERATOR_LATEX[op];
             const wrt = data.with_respect_to;
-            return wrt ? `${cmd} d${wrt}` : cmd;
+            const lb = data._lowerBoundLabel || '';   // resolved bound values
+            const ub = data._upperBoundLabel || '';   // (not raw bound node ids)
+            if (wrt) {
+                if (lb && ub) return `${cmd}_{${lb}}^{${ub}} d${wrt}`;
+                return `${cmd} d${wrt}`;
+            }
+            return cmd;
         }
         if (op === 'sum' || op === 'product') {
             const cmd = OPERATOR_LATEX[op];

--- a/static/graph-panel/d3-semantic-graph.js
+++ b/static/graph-panel/d3-semantic-graph.js
@@ -1472,15 +1472,12 @@ export class D3SemanticGraphRenderer {
             return `\\frac{${d}}{${d}\\cdot}`;
         }
         if (op === 'integral' || op === 'closed_integral') {
+            // Bounds are shown as separate lb/ub nodes (and would otherwise
+            // interpolate raw bound node ids like __num_2 into the label), so the
+            // node itself is just ∫ d⟨var⟩.
             const cmd = OPERATOR_LATEX[op];
             const wrt = data.with_respect_to;
-            const lb = data.lower_bound || '';
-            const ub = data.upper_bound || '';
-            if (wrt) {
-                if (lb && ub) return `${cmd}_{${lb}}^{${ub}} d${wrt}`;
-                return `${cmd} d${wrt}`;
-            }
-            return cmd;
+            return wrt ? `${cmd} d${wrt}` : cmd;
         }
         if (op === 'sum' || op === 'product') {
             const cmd = OPERATOR_LATEX[op];

--- a/static/proof-animation/sg-proof.js
+++ b/static/proof-animation/sg-proof.js
@@ -27,10 +27,12 @@ export function clearDeriveCache() {
     _DERIVE_CACHE.clear();
 }
 
-// A derivation is an LM call (sometimes retried server-side); a hard goal can
-// run long, but past this it's almost certainly stuck — fail with a retryable
-// error rather than spin the "Deriving proof…" pill forever.
-const DERIVE_TIMEOUT_MS = 90_000;
+// A derivation is an LM call plus the refinement loop (up to N attempts, each
+// re-scored under the CAS) — a long, multi-step proof legitimately takes a
+// while. Past this it's almost certainly stuck — fail with a retryable error
+// rather than spin the "Deriving proof…" pill forever. Keep this comfortably
+// above the server-side refinement time budget (ALGEBENCH_PC_TIME_BUDGET).
+const DERIVE_TIMEOUT_MS = 360_000;
 
 const GRID_COLS = 8;          // same grid as SgChartManager
 const GRID_ROWS = 8;

--- a/tests/backend/experts/test_grounding.py
+++ b/tests/backend/experts/test_grounding.py
@@ -26,6 +26,8 @@ ROUNDTRIP = [
     (r"a^2 - b^2", a ** 2 - b ** 2),
     (r"(a-b)(a+b)", (a - b) * (a + b)),
     (r"\frac{d}{dx} x^3", sp.Derivative(x ** 3, x)),
+    (r"\int_0^1 x^2 dx", sp.Integral(x ** 2, (x, 0, 1))),   # definite
+    (r"\int x^2 dx", sp.Integral(x ** 2, x)),                # indefinite
     (r"\frac{a}{b}", a / b),
     (r"x^{n}", x ** n),
 ]

--- a/tests/backend/experts/test_grounding_score.py
+++ b/tests/backend/experts/test_grounding_score.py
@@ -1,0 +1,48 @@
+"""Tests for the tier-graded grounding score (issue #372 §B)."""
+
+from __future__ import annotations
+
+from backend.experts.modules.proof_completion import dataset as D
+from backend.experts.modules.proof_completion.grounding_score import grounding_score
+from backend.experts.modules.proof_completion.outputs import DerivationStep
+from backend.semantic_graph.service import SemanticGraphService
+
+_SVC = SemanticGraphService()
+
+
+def _example():
+    exs = D.generate(n=1, seed=11, max_steps=2)
+    assert exs
+    return exs[0]
+
+
+def test_gold_trajectory_scores_high():
+    ex = _example()
+    gs = grounding_score(ex.context.start, ex.gold_steps, ex.context.target,
+                         domain=ex.context.domain)
+    # a correct, gold derivation lands at the top of the tier scale
+    assert gs.score >= 0.75
+    assert 0.0 <= gs.score <= 1.0
+
+
+def test_empty_trajectory_scores_zero():
+    ex = _example()
+    gs = grounding_score(ex.context.start, [], ex.context.target,
+                         domain=ex.context.domain)
+    assert gs.score == 0.0
+
+
+def test_score_is_graded_not_binary():
+    # A refuted middle step should pull the mean down without flooring a chain
+    # that also has a grounded step — i.e. the score lands strictly between 0 and 1.
+    start = _SVC.latex_to_graph("x^2 = 4")
+    target = _SVC.latex_to_graph("x = 2")
+    # step 1: equivalent rewrite (grounded); step 2: a wrong jump (refuted)
+    steps = [
+        DerivationStep(operation="rewrite", expr_latex="x^2 = 4",
+                       justification="same equation", change_type="rewrite"),
+        DerivationStep(operation="wrong", expr_latex="x = 7",
+                       justification="not valid", change_type="solve"),
+    ]
+    gs = grounding_score(start, steps, target)
+    assert 0.0 < gs.score < 1.0

--- a/tests/backend/experts/test_refine.py
+++ b/tests/backend/experts/test_refine.py
@@ -86,3 +86,22 @@ def test_later_exception_falls_back_to_best():
 def test_single_attempt_is_a_no_op_loop():
     out = refine(lambda k, fb: "only", lambda p: _Res(0.2, False), max_attempts=1)
     assert out.attempts == 1 and not out.passed and out.prediction == "only"
+
+
+def test_time_budget_skips_retry():
+    import time as _t
+    seen = []
+
+    def attempt(k, fb):
+        seen.append(k)
+        return f"p{k}"
+
+    def evaluate(p):
+        _t.sleep(0.02)            # push elapsed past the tiny budget
+        return _Res(0.1, False)   # below threshold → would retry if time allowed
+
+    out = refine(attempt, evaluate, max_attempts=5, time_budget_s=0.01)
+    assert seen == [0]            # first attempt runs; no retry started
+    assert out.attempts == 1
+    assert out.out_of_time is True
+    assert out.prediction == "p0"   # best-so-far returned

--- a/tests/backend/experts/test_refine.py
+++ b/tests/backend/experts/test_refine.py
@@ -1,0 +1,88 @@
+"""Tests for the hand-rolled refinement engine (issue #372 §C, B2)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from backend.experts.modules.proof_completion.refine import (
+    FEEDBACK_PREAMBLE,
+    refine,
+)
+
+
+@dataclass
+class _Res:
+    score: float
+    passed: bool
+    issues: str = ""
+
+
+def test_early_exit_on_first_pass():
+    calls = []
+
+    def attempt(k, feedback):
+        calls.append((k, feedback))
+        return "pred"
+
+    out = refine(attempt, lambda p: _Res(1.0, True), max_attempts=3)
+    assert out.passed and out.attempts == 1
+    assert calls == [(0, "")]  # stopped immediately, no retry
+
+
+def test_feedback_is_threaded_into_retry():
+    seen = []
+
+    def attempt(k, feedback):
+        seen.append(feedback)
+        return f"pred{k}"
+
+    # first two attempts fail, third passes
+    scores = iter([_Res(0.1, False, "fix the dollar"),
+                   _Res(0.4, False, "still off"),
+                   _Res(0.9, True)])
+    out = refine(attempt, lambda p: next(scores), max_attempts=3)
+    assert out.passed and out.attempts == 3
+    assert seen[0] == ""                                  # first ask: no feedback
+    assert seen[1].startswith(FEEDBACK_PREAMBLE)
+    assert "fix the dollar" in seen[1]                    # prior issues delivered
+    assert "still off" in seen[2]
+
+
+def test_keeps_best_after_exhausting_attempts():
+    preds = iter(["a", "b", "c"])
+    scores = iter([_Res(0.3, False), _Res(0.6, False), _Res(0.2, False)])
+    out = refine(lambda k, fb: next(preds), lambda p: next(scores), max_attempts=3)
+    assert not out.passed
+    assert out.prediction == "b"          # highest score, even though last
+    assert out.result.score == 0.6
+    assert out.attempts == 3
+
+
+def test_first_attempt_exception_propagates():
+    def attempt(k, feedback):
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        refine(attempt, lambda p: _Res(1.0, True), max_attempts=3)
+
+
+def test_later_exception_falls_back_to_best():
+    preds = iter(["good", "boom"])
+
+    def attempt(k, feedback):
+        return next(preds)
+
+    def evaluate(p):
+        if p == "boom":
+            raise RuntimeError("scoring failed")
+        return _Res(0.5, False)
+
+    out = refine(attempt, evaluate, max_attempts=3)
+    assert out.prediction == "good" and out.attempts == 1
+
+
+def test_single_attempt_is_a_no_op_loop():
+    out = refine(lambda k, fb: "only", lambda p: _Res(0.2, False), max_attempts=1)
+    assert out.attempts == 1 and not out.passed and out.prediction == "only"

--- a/tests/backend/experts/test_reward.py
+++ b/tests/backend/experts/test_reward.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from backend.experts.modules.proof_completion import dataset as D
 from backend.experts.modules.proof_completion.judge import JudgeVerdict
 from backend.experts.modules.proof_completion.outputs import (
@@ -9,8 +11,19 @@ from backend.experts.modules.proof_completion.outputs import (
     ProofTrajectory,
 )
 from backend.experts.modules.proof_completion import reward as R
-from backend.experts.modules.proof_completion.reward import TAU, reward
+from backend.experts.modules.proof_completion.reward import reward
 from backend.experts.modules.proof_completion.step_grounding import Tier
+
+# reward()'s weights/τ are env-tunable at import time (ALGEBENCH_PC_*). Pin them to
+# the documented defaults here and pass ``tau=`` explicitly so these unit tests are
+# independent of whatever a developer has exported.
+TAU = 0.7
+
+
+@pytest.fixture(autouse=True)
+def _pin_reward_weights(monkeypatch):
+    monkeypatch.setattr(R, "W_G", 0.8)
+    monkeypatch.setattr(R, "W_J", 0.2)
 
 
 def _example():
@@ -29,7 +42,7 @@ def _gold_traj(ex):
 def test_gold_passes_threshold_without_judge():
     ex = _example()
     r = reward(_gold_traj(ex), start_graph=ex.context.start,
-               target_graph=ex.context.target, domain=ex.context.domain)
+               target_graph=ex.context.target, domain=ex.context.domain, tau=TAU)
     assert r.score >= TAU and r.passed
     assert r.breakdown["wellformed"] == 1.0
     assert r.breakdown["judge"] is None
@@ -46,7 +59,7 @@ def test_malformed_caption_zeroes_reward_and_skips_judge():
         return JudgeVerdict(score=1.0, issues="")
 
     r = reward(traj, start_graph=ex.context.start, target_graph=ex.context.target,
-               domain=ex.context.domain, judge=spy_judge)
+               domain=ex.context.domain, judge=spy_judge, tau=TAU)
     assert r.score == 0.0 and not r.passed
     assert "unbalanced '$'" in r.issues
     assert calls == []  # judge not called once the prerequisite fails
@@ -56,7 +69,7 @@ def test_judge_alone_cannot_gate_a_grounded_derivation():
     # grounding ~1.0, judge 0.0 -> 0.8*1 + 0.2*0 = 0.8 >= TAU: judge never rejects
     ex = _example()
     r = reward(_gold_traj(ex), start_graph=ex.context.start,
-               target_graph=ex.context.target, domain=ex.context.domain,
+               target_graph=ex.context.target, domain=ex.context.domain, tau=TAU,
                judge=lambda **kw: JudgeVerdict(score=0.0, issues="too terse"))
     assert r.passed
     assert "too terse" in r.issues  # but its feedback still flows back
@@ -94,7 +107,7 @@ def test_below_tau_retries_and_surfaces_endpoint_refuted(monkeypatch):
     # no_refuted are still exposed in the breakdown for observability.
     rep = _FakeReport(True, [Tier.BLUE, Tier.GRAY, Tier.GOLD])
     monkeypatch.setattr(R, "grounding_score", lambda *a, **k: _FakeGS(0.5, rep))
-    r = reward(_wf_traj(), start_graph=None, target_graph=None)
+    r = reward(_wf_traj(), start_graph=None, target_graph=None, tau=TAU)
     assert r.score < TAU and not r.passed
     assert r.breakdown["endpoint_reached"] is True
     assert r.breakdown["no_refuted"] is True
@@ -103,7 +116,7 @@ def test_below_tau_retries_and_surfaces_endpoint_refuted(monkeypatch):
 def test_breakdown_flags_a_refuted_step(monkeypatch):
     rep = _FakeReport(True, [Tier.BLUE, Tier.RED, Tier.GOLD])
     monkeypatch.setattr(R, "grounding_score", lambda *a, **k: _FakeGS(0.5, rep))
-    r = reward(_wf_traj(), start_graph=None, target_graph=None)
+    r = reward(_wf_traj(), start_graph=None, target_graph=None, tau=TAU)
     assert r.breakdown["no_refuted"] is False and not r.passed
 
 
@@ -118,6 +131,6 @@ def test_low_grounding_with_low_judge_fails():
                        justification="introduces a non-solution", change_type="solve"),
     ])
     bad.start_latex, bad.target_latex = "x^2 = 4", "x = 2"
-    r = reward(bad, start_graph=start, target_graph=target,
+    r = reward(bad, start_graph=start, target_graph=target, tau=TAU,
                judge=lambda **kw: JudgeVerdict(score=0.0, issues="bad"))
     assert not r.passed

--- a/tests/backend/experts/test_reward.py
+++ b/tests/backend/experts/test_reward.py
@@ -8,7 +8,9 @@ from backend.experts.modules.proof_completion.outputs import (
     DerivationStep,
     ProofTrajectory,
 )
+from backend.experts.modules.proof_completion import reward as R
 from backend.experts.modules.proof_completion.reward import TAU, reward
+from backend.experts.modules.proof_completion.step_grounding import Tier
 
 
 def _example():
@@ -58,6 +60,51 @@ def test_judge_alone_cannot_gate_a_grounded_derivation():
                judge=lambda **kw: JudgeVerdict(score=0.0, issues="too terse"))
     assert r.passed
     assert "too terse" in r.issues  # but its feedback still flows back
+
+
+class _Pair:
+    def __init__(self, tier):
+        self.tier = tier
+
+
+class _FakeReport:
+    def __init__(self, endpoint_reached, tiers):
+        self.endpoint_reached = endpoint_reached
+        self.pairs = [_Pair(t) for t in tiers]
+
+
+class _FakeGS:
+    def __init__(self, score, report):
+        self.score = score
+        self.reason = "fake"
+        self.overall = None
+        self.report = report
+
+
+def _wf_traj():
+    t = ProofTrajectory(steps=[DerivationStep(
+        operation="op", expr_latex="x = 2", justification="ok", change_type="solve")])
+    t.start_latex, t.target_latex = "s", "t"
+    return t
+
+
+def test_below_tau_retries_and_surfaces_endpoint_refuted(monkeypatch):
+    # The loop retries while below τ (chasing a cleaner derivation / fixing
+    # captions) — there is NO good-enough early-accept. endpoint_reached and
+    # no_refuted are still exposed in the breakdown for observability.
+    rep = _FakeReport(True, [Tier.BLUE, Tier.GRAY, Tier.GOLD])
+    monkeypatch.setattr(R, "grounding_score", lambda *a, **k: _FakeGS(0.5, rep))
+    r = reward(_wf_traj(), start_graph=None, target_graph=None)
+    assert r.score < TAU and not r.passed
+    assert r.breakdown["endpoint_reached"] is True
+    assert r.breakdown["no_refuted"] is True
+
+
+def test_breakdown_flags_a_refuted_step(monkeypatch):
+    rep = _FakeReport(True, [Tier.BLUE, Tier.RED, Tier.GOLD])
+    monkeypatch.setattr(R, "grounding_score", lambda *a, **k: _FakeGS(0.5, rep))
+    r = reward(_wf_traj(), start_graph=None, target_graph=None)
+    assert r.breakdown["no_refuted"] is False and not r.passed
 
 
 def test_low_grounding_with_low_judge_fails():

--- a/tests/backend/experts/test_reward.py
+++ b/tests/backend/experts/test_reward.py
@@ -1,0 +1,76 @@
+"""Tests for the graded refinement reward and threshold (issue #372 §B)."""
+
+from __future__ import annotations
+
+from backend.experts.modules.proof_completion import dataset as D
+from backend.experts.modules.proof_completion.judge import JudgeVerdict
+from backend.experts.modules.proof_completion.outputs import (
+    DerivationStep,
+    ProofTrajectory,
+)
+from backend.experts.modules.proof_completion.reward import TAU, reward
+
+
+def _example():
+    exs = D.generate(n=1, seed=11, max_steps=2)
+    assert exs
+    return exs[0]
+
+
+def _gold_traj(ex):
+    traj = ProofTrajectory(steps=ex.gold_steps)
+    traj.start_latex = "start"
+    traj.target_latex = "target"
+    return traj
+
+
+def test_gold_passes_threshold_without_judge():
+    ex = _example()
+    r = reward(_gold_traj(ex), start_graph=ex.context.start,
+               target_graph=ex.context.target, domain=ex.context.domain)
+    assert r.score >= TAU and r.passed
+    assert r.breakdown["wellformed"] == 1.0
+    assert r.breakdown["judge"] is None
+
+
+def test_malformed_caption_zeroes_reward_and_skips_judge():
+    ex = _example()
+    traj = _gold_traj(ex)
+    traj.steps[0].operation = "and $V = 7.8 km/s"  # unbalanced $
+    calls = []
+
+    def spy_judge(**kw):
+        calls.append(kw)
+        return JudgeVerdict(score=1.0, issues="")
+
+    r = reward(traj, start_graph=ex.context.start, target_graph=ex.context.target,
+               domain=ex.context.domain, judge=spy_judge)
+    assert r.score == 0.0 and not r.passed
+    assert "unbalanced '$'" in r.issues
+    assert calls == []  # judge not called once the prerequisite fails
+
+
+def test_judge_alone_cannot_gate_a_grounded_derivation():
+    # grounding ~1.0, judge 0.0 -> 0.8*1 + 0.2*0 = 0.8 >= TAU: judge never rejects
+    ex = _example()
+    r = reward(_gold_traj(ex), start_graph=ex.context.start,
+               target_graph=ex.context.target, domain=ex.context.domain,
+               judge=lambda **kw: JudgeVerdict(score=0.0, issues="too terse"))
+    assert r.passed
+    assert "too terse" in r.issues  # but its feedback still flows back
+
+
+def test_low_grounding_with_low_judge_fails():
+    # a provably wrong step -> grounding floors (refuted); low judge -> below TAU
+    from backend.semantic_graph.service import SemanticGraphService
+    svc = SemanticGraphService()
+    start = svc.latex_to_graph("x^2 = 4")
+    target = svc.latex_to_graph("x = 2")
+    bad = ProofTrajectory(steps=[
+        DerivationStep(operation="wrong", expr_latex="x = 7",
+                       justification="introduces a non-solution", change_type="solve"),
+    ])
+    bad.start_latex, bad.target_latex = "x^2 = 4", "x = 2"
+    r = reward(bad, start_graph=start, target_graph=target,
+               judge=lambda **kw: JudgeVerdict(score=0.0, issues="bad"))
+    assert not r.passed

--- a/tests/backend/experts/test_wellformed.py
+++ b/tests/backend/experts/test_wellformed.py
@@ -1,0 +1,107 @@
+"""Tests for proof-completion caption well-formedness (issue #372 §A)."""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.experts.modules.proof_completion.outputs import (
+    DerivationStep,
+    ProofTrajectory,
+)
+from backend.experts.modules.proof_completion.wellformed import (
+    MalformedCaption,
+    assert_well_formed,
+    expr_issues,
+    prose_issues,
+    well_formed,
+)
+
+
+def _step(operation="add $4$ to both sides", expr_latex="x^2 = 4",
+          justification="valid since $4 > 0$", change_type="rewrite"):
+    return DerivationStep(operation=operation, expr_latex=expr_latex,
+                          justification=justification, change_type=change_type)
+
+
+def _traj(*steps, title=None):
+    return ProofTrajectory(steps=list(steps), title=title)
+
+
+# --------------------------------------------------------------------------- #
+# prose fields
+# --------------------------------------------------------------------------- #
+
+def test_balanced_prose_has_no_issues():
+    assert prose_issues("add $\\frac{c}{a}$ to both sides", where="op") == []
+
+
+def test_unbalanced_dollar_flagged():
+    issues = prose_issues("and $V = 7.8 \\text{ km/s}", where="step 1 operation")
+    assert len(issues) == 1
+    assert "unbalanced '$'" in issues[0]
+    assert "step 1 operation" in issues[0]
+
+
+def test_prose_dollar_free_is_accepted():
+    # plain prose with no math: trivially well-formed
+    assert prose_issues("move the term across the equals sign", where="op") == []
+
+
+def test_empty_math_segment_flagged():
+    # a balanced but empty display pair $$  $$ — well-delimited, no content
+    issues = prose_issues("see $$  $$ here", where="op")
+    assert any("empty math segment" in m for m in issues)
+
+
+def test_unbalanced_braces_inside_segment_flagged():
+    issues = prose_issues("use $\\frac{a}{b$ here", where="op")
+    assert any("unbalanced" in m for m in issues)
+
+
+# --------------------------------------------------------------------------- #
+# expr_latex (raw math — no delimiters allowed)
+# --------------------------------------------------------------------------- #
+
+def test_clean_expr_has_no_issues():
+    assert expr_issues("x^2 + 2x + 1", where="step 1 expr_latex") == []
+
+
+def test_dollar_in_expr_flagged():
+    issues = expr_issues("$x^2$", where="step 1 expr_latex")
+    assert any("must not contain '$'" in m for m in issues)
+
+
+def test_unbalanced_braces_in_expr_flagged():
+    issues = expr_issues("\\frac{a}{b", where="step 1 expr_latex")
+    assert any("unbalanced" in m for m in issues)
+
+
+# --------------------------------------------------------------------------- #
+# trajectory-level verdict + the two surfaces
+# --------------------------------------------------------------------------- #
+
+def test_well_formed_trajectory_passes():
+    v = well_formed(_traj(_step(), _step(expr_latex="x = 2", change_type="solve")))
+    assert v.ok and v.issues == [] and v.factor == 1.0
+
+
+def test_malformed_trajectory_reports_step_and_field():
+    bad = _step(operation="and $V = 7.8 km/s", expr_latex="x = 2")
+    v = well_formed(_traj(_step(), bad))
+    assert not v.ok and v.factor == 0.0
+    assert any("step 2 operation" in m for m in v.issues)
+
+
+def test_assert_well_formed_raises_on_malformed():
+    bad = _traj(_step(justification="because $a"))
+    with pytest.raises(MalformedCaption):
+        assert_well_formed(bad)
+
+
+def test_assert_well_formed_silent_on_clean():
+    assert_well_formed(_traj(_step()))  # no raise
+
+
+def test_title_is_checked():
+    v = well_formed(_traj(_step(), title="solve $x"))
+    assert not v.ok and any("title" in m for m in v.issues)

--- a/tests/backend/semantic_graph/test_integral.py
+++ b/tests/backend/semantic_graph/test_integral.py
@@ -1,0 +1,68 @@
+r"""Integral parsing in the semantic graph.
+
+The calculus domain suite already exercises integrals inside full equations
+(``integral_power``, ``integral_definite``, the fundamental theorem). This file
+pins the **bare** integral forms and the exact node shape the grounder relies on:
+an ``integral`` operator node carrying the integrand (the unroled operand), the
+integration variable (``with_respect_to`` + a ``wrt`` edge), and — for a definite
+integral — ``lb`` / ``ub`` bound edges with ``lower_bound`` / ``upper_bound``
+attributes. ``graph_to_sympy`` reconstructs exactly this into ``sp.Integral``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.backend.semantic_graph.generators.invariants import (
+    assert_universal_invariants,
+)
+
+
+def _integral_node(graph):
+    return next(n for n in graph.nodes if n.op == "integral")
+
+
+def _roles_into(graph, node_id):
+    return {e.role for e in graph.edges if e.to == node_id}
+
+
+@pytest.mark.parametrize("latex", [
+    r"\int x^2 dx",
+    r"\int x^2 \, dx",
+    r"\int_0^1 x^2 dx",
+    r"\int_a^b f dx",
+])
+def test_integral_parses_and_is_wellformed(parse, latex):
+    g = parse(latex)
+    assert g is not None, f"failed to parse: {latex!r}"
+    assert_universal_invariants(g, latex=latex)
+    assert "integral" in {n.op for n in g.nodes}, f"no integral node for: {latex!r}"
+
+
+def test_indefinite_integral_structure(parse):
+    g = parse(r"\int x^2 dx")
+    node = _integral_node(g)
+    assert node.with_respect_to == "x"
+    roles = _roles_into(g, node.id)
+    assert "wrt" in roles
+    assert "lb" not in roles and "ub" not in roles   # indefinite → no bounds
+
+
+def test_definite_integral_carries_bounds(parse):
+    g = parse(r"\int_0^1 x^2 dx")
+    node = _integral_node(g)
+    assert node.with_respect_to == "x"
+    assert node.lower_bound and node.upper_bound
+    roles = _roles_into(g, node.id)
+    assert {"wrt", "lb", "ub"} <= roles
+
+
+def test_integral_has_an_integrand(parse):
+    # the integrand is the single operand edge with no role (here: x^2 → power)
+    g = parse(r"\int_0^1 x^2 dx")
+    node = _integral_node(g)
+    operands = [e.from_ for e in g.edges
+                if e.to == node.id and e.role not in ("wrt", "lb", "ub")]
+    assert len(operands) == 1
+    integrand = next(n for n in g.nodes if n.id == operands[0])
+    assert integrand.op == "power"   # x^2

--- a/tests/backend/util/test_latex.py
+++ b/tests/backend/util/test_latex.py
@@ -1,0 +1,118 @@
+"""Tests for the reusable inline-LaTeX delimiter scanner."""
+
+from __future__ import annotations
+
+from backend.util.latex import (
+    braces_balanced,
+    delimiters_balanced,
+    math_segments,
+    strip_math_delimiters,
+)
+
+
+# --------------------------------------------------------------------------- #
+# delimiters_balanced — the unbalanced-$ defect (issue #372)
+# --------------------------------------------------------------------------- #
+
+def test_balanced_inline():
+    assert delimiters_balanced("add $x$ to both sides")
+
+
+def test_unbalanced_single_dollar_rejected():
+    # the motivating defect: an opened $ that never closes
+    assert not delimiters_balanced("and $V_{\\text{LEO}} = 7.8 \\text{ km/s}")
+
+
+def test_prose_without_math_is_balanced():
+    assert delimiters_balanced("just plain prose, no math here")
+
+
+def test_escaped_dollar_is_not_a_delimiter():
+    assert delimiters_balanced("it costs \\$5 in total")
+    assert delimiters_balanced("\\$5 and \\$10")  # two escaped, zero delimiters
+
+
+def test_balanced_display_math():
+    assert delimiters_balanced("see $$x^2 + 1$$ above")
+
+
+def test_unbalanced_display_rejected():
+    assert not delimiters_balanced("see $$x^2 + 1$ above")  # opened $$, closed $
+
+
+def test_triple_dollar_is_malformed():
+    assert not delimiters_balanced("weird $$$x$$$")
+
+
+def test_two_inline_segments_balanced():
+    assert delimiters_balanced("$a$ then $b$")
+
+
+def test_odd_number_of_dollars_rejected():
+    assert not delimiters_balanced("$a$ then $b")
+
+
+# --------------------------------------------------------------------------- #
+# math_segments — locating the math
+# --------------------------------------------------------------------------- #
+
+def test_segments_inline_and_display():
+    segs = math_segments("a $x$ and $$y^2$$ end")
+    assert [(s.display, s.content) for s in segs] == [(False, "x"), (True, "y^2")]
+
+
+def test_segment_offsets_round_trip():
+    text = "go $x+1$ now"
+    seg = math_segments(text)[0]
+    assert text[seg.start:seg.end] == "$x+1$"
+    assert seg.content == "x+1"
+
+
+def test_segments_stop_at_unbalanced():
+    # the first segment parses; the dangling $ yields nothing further
+    segs = math_segments("$a$ and $b")
+    assert [s.content for s in segs] == ["a"]
+
+
+def test_delimiter_property():
+    inline, display = math_segments("$a$ $$b$$")
+    assert inline.delimiter == "$" and display.delimiter == "$$"
+
+
+# --------------------------------------------------------------------------- #
+# braces_balanced
+# --------------------------------------------------------------------------- #
+
+def test_braces_balanced():
+    assert braces_balanced("\\frac{a}{b}")
+    assert braces_balanced("no braces at all")
+
+
+def test_braces_unbalanced_missing_close():
+    assert not braces_balanced("\\frac{a}{b")
+
+
+def test_braces_unbalanced_extra_close():
+    assert not braces_balanced("a}b")
+
+
+def test_braces_escaped_ignored():
+    assert braces_balanced("\\{ literal \\}")  # escaped braces are not structural
+
+
+# --------------------------------------------------------------------------- #
+# strip_math_delimiters
+# --------------------------------------------------------------------------- #
+
+def test_strip_removes_delimiters_keeps_content():
+    assert strip_math_delimiters("add $x$ now") == "add x now"
+    assert strip_math_delimiters("a $$y^2$$ b") == "a y^2 b"
+
+
+def test_strip_no_math_is_identity():
+    assert strip_math_delimiters("plain text") == "plain text"
+
+
+def test_strip_leaves_unbalanced_tail():
+    # nothing complete to strip → returns the original
+    assert strip_math_delimiters("dangling $x") == "dangling $x"

--- a/tests/proof_animation/proof_animations.json
+++ b/tests/proof_animation/proof_animations.json
@@ -162,7 +162,7 @@
     "trajectory": {
       "kind": "proof_trajectory",
       "start_latex": "a \\cdot x^{2} + b \\cdot x + c = 0",
-      "target_latex": "x = \\frac{- b + \\sqrt{- 4 \\cdot a \\cdot c + b^{2}}}{2 \\cdot a}",
+      "target_latex": "x = \\frac{- b + \\sqrt{- 4 \\cdot a \\cdot c + b^{2}}}{2 \\cdot a} \\lor x = \\frac{- b - \\sqrt{- 4 \\cdot a \\cdot c + b^{2}}}{2 \\cdot a}",
       "steps": [
         {
           "operation": "Divide both sides by $a$.",
@@ -195,27 +195,21 @@
           "change_type": "rewrite"
         },
         {
-          "operation": "Take the positive square root of both sides.",
-          "expr_latex": "x + \\frac{b}{2a} = \\sqrt{\\frac{- 4 \\cdot a \\cdot c + b^{2}}{4 \\cdot a^{2}}}",
-          "justification": "Square root property of equality: If $u^2 = v$, then $u = \\pm\\sqrt{v}$. We select the positive root as per the instruction.",
+          "operation": "Take the square root of both sides, keeping both branches.",
+          "expr_latex": "x + \\frac{b}{2 \\cdot a} = \\frac{\\sqrt{- 4 \\cdot a \\cdot c + b^{2}}}{2 \\cdot a} \\lor x + \\frac{b}{2 \\cdot a} = - \\frac{\\sqrt{- 4 \\cdot a \\cdot c + b^{2}}}{2 \\cdot a}",
+          "justification": "Square root property of equality: if $u^2 = v$ then $u = \\pm\\sqrt{v}$ — both the positive and negative branches are kept as a disjunction. Also $\\sqrt{4a^2} = 2a$.",
           "change_type": "solve"
         },
         {
-          "operation": "Simplify the square root on the right side.",
-          "expr_latex": "x + \\frac{b}{2a} = \\frac{\\sqrt{- 4 \\cdot a \\cdot c + b^{2}}}{2 \\cdot a}",
-          "justification": "Property of square roots: $\\sqrt{\\frac{u}{v}} = \\frac{\\sqrt{u}}{\\sqrt{v}}$ and $\\sqrt{4a^2} = 2a$ (assuming $a$ is positive, or considering the principal root).",
-          "change_type": "rewrite"
+          "operation": "Subtract $\\frac{b}{2a}$ from both sides in each branch.",
+          "expr_latex": "x = - \\frac{b}{2 \\cdot a} + \\frac{\\sqrt{- 4 \\cdot a \\cdot c + b^{2}}}{2 \\cdot a} \\lor x = - \\frac{b}{2 \\cdot a} - \\frac{\\sqrt{- 4 \\cdot a \\cdot c + b^{2}}}{2 \\cdot a}",
+          "justification": "Subtraction property of equality applied to each branch of the disjunction, isolating $x$.",
+          "change_type": "solve"
         },
         {
-          "operation": "Subtract $\\frac{b}{2a}$ from both sides.",
-          "expr_latex": "x = - \\frac{b}{2a} + \\frac{\\sqrt{- 4 \\cdot a \\cdot c + b^{2}}}{2 \\cdot a}",
-          "justification": "Subtraction property of equality: Subtracting the same quantity from both sides of an equation maintains the equality, isolating $x$.",
-          "change_type": "rewrite"
-        },
-        {
-          "operation": "Combine the fractions on the right side.",
-          "expr_latex": "x = \\frac{- b + \\sqrt{- 4 \\cdot a \\cdot c + b^{2}}}{2 \\cdot a}",
-          "justification": "Arithmetic of fractions: Since the terms on the right side have a common denominator, their numerators can be combined.",
+          "operation": "Combine each numerator over the common denominator $2a$.",
+          "expr_latex": "x = \\frac{- b + \\sqrt{- 4 \\cdot a \\cdot c + b^{2}}}{2 \\cdot a} \\lor x = \\frac{- b - \\sqrt{- 4 \\cdot a \\cdot c + b^{2}}}{2 \\cdot a}",
+          "justification": "Arithmetic of fractions: within each branch the terms share the denominator $2a$, so the numerators combine — giving both quadratic roots.",
           "change_type": "rewrite"
         }
       ]


### PR DESCRIPTION
## Summary

Adds a **refinement loop** to `proof_completion` generation (issue #372): each LM attempt is scored by a single graded reward (hard correctness gates + optional soft critique), and a below-threshold attempt is **re-asked with the exact failure reasons as feedback** — targeted retries, not blind re-rolls. Plus the observability, config, and grounding work that fell out of exercising it on real derivations.

### Refinement loop (#372)
One pure checker per constraint, each in its own file:
- **`backend/util/latex.py`** — reusable `$…$` / `$$…$$` delimiter + brace scanner (shared with the chat/caption conventions), not buried in the expert.
- **`wellformed.py`** — caption well-formedness (balanced `$`, braces, math-only `expr_latex`). Soft `well_formed()` for the loop; hard `assert_well_formed()` at non-generation edges (e.g. hand-authored animation JSON).
- **`grounding_score.py`** — tier-graded grounding (`TIER_RANK/4`), and per-step feedback naming the specific unverified steps.
- **`judge.py`** — optional LLM-as-judge (`score` + `issues`), scores only, never gates.
- **`reward.py`** — `wellformed_factor · (W_G·grounding + W_J·judge)`, one threshold τ.
- **`refine.py`** — hand-rolled engine (no dspy upgrade): ask → score → re-ask with feedback, early-exit on pass, keep best after N, with a wall-clock budget.

`module.forward` runs the loop, so the live `/api/expert/proof_animation` path gets it for free. `optimize.py`/`evaluate.py` pass `refine_attempts=1` to measure the bare model.

### Observability / config / timeout guard
- App logging (`backend.*`): `algebench --debug` → DEBUG, else WARNING; `ALGEBENCH_LOG_LEVEL` override. The handler logs the offending expression when a start/target fails to parse.
- `proof_completion_derive.py` flags: `--debug` (per-attempt dump: score, breakdown, steps, threaded feedback), `--attempts N`, `--judge`.
- `ALGEBENCH_PC_LOAD_ARTIFACT` = repo-relative artifact path (via `sanitize_path`; absolute/`..` rejected); empty (default) = uncompiled baseline.
- `ALGEBENCH_PC_TIME_BUDGET` (default 240s) stops the loop from starting a retry that would blow the request timeout; the proof-animation UI timeout is raised 90s → 360s to fit a multi-attempt loop on long proofs.
- All knobs documented in the expert README + `.env.local.example`.

### Grounding: integral support
`graph_to_sympy` modeled add/multiply/power/derivative/logic but not `integral`, so integral steps (e.g. `∫…dV'` in a physics derivation) were Unchecked. Added the integral case (mirrors derivative): integrand + integration variable + optional `lb`/`ub` bounds → `sp.Integral`. Integral steps now convert (and often verify — `∫₀¹x²dx → 1/3` grounds).

### sg-report
Integral showcase section; integral node labels no longer interpolate raw bound node-ids (`\int_{__num_2}…` → `∫ d⟨var⟩`, bounds shown as their own nodes) in both renderers; and **cache-busting** for the report's bundled ES modules (it was serving stale JS after regeneration).

### Docs
Two WIP show-and-tell articles (SVG diagrams; screenshot placeholders) for the grounded proof-completion pipeline and the refinement loop.

## Test plan
- Full suite green; new tests: latex util, wellformed, grounding_score, reward (incl. blend/threshold + breakdown), refine (early-exit, feedback threading, keep-best, time budget), integral grounding roundtrips, and a semantic-graph integral structure test.
- A/B harness (`scripts/proof_completion/compare_refine.py`, deterministic at temp=0): on the held-out eval set the loop is a strict improvement over a single pass (grounding/exact/pass@τ up, **0 regressions**), paying extra LM calls only on the failing tail.
- Verified the sg-report renders integrals cleanly (0 errors across 21 domains).

## Notes for reviewers
- B2 (hand-rolled loop) was chosen over `dspy.Refine`: it requires dspy 3.x (the project pins `<3.0`, and the litellm/orjson pins are security/build-sensitive). An isolated A/B under dspy 3.2.1 showed the hand-rolled loop matched/beat `Refine` on quality *and* cost (deterministic feedback, no extra reward-model LM calls), so no upgrade was warranted.
- Follow-up tracked in #374 (compile the expert / tune τ,N,weights to beat the loop baseline).

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>
