### PR TITLE
ci: serialize gh-pages deploys (fix non-fast-forward race)

### DIFF
--- a/.github/workflows/loc.yml
+++ b/.github/workflows/loc.yml
@@ -11,8 +11,9 @@ permissions:
   contents: write
   pull-requests: write
 
-# Shared with the other report workflows so gh-pages deploys serialize (a shared
-# group can't cancel-in-progress, or one workflow would abort another mid-push).
+# Shared with the other report workflows so gh-pages deploys serialize. Keep
+# cancel-in-progress false: with a shared group, cancelling would abort another
+# workflow's deploy mid-push (we want to queue every deploy, never drop one).
 concurrency:
   group: gh-pages-deploy
   cancel-in-progress: false

--- a/.github/workflows/loc.yml
+++ b/.github/workflows/loc.yml
@@ -11,9 +11,11 @@ permissions:
   contents: write
   pull-requests: write
 
+# Shared with the other report workflows so gh-pages deploys serialize (a shared
+# group can't cancel-in-progress, or one workflow would abort another mid-push).
 concurrency:
-  group: loc-report-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  group: gh-pages-deploy
+  cancel-in-progress: false
 
 jobs:
   loc-report:

--- a/.github/workflows/pages-landing.yml
+++ b/.github/workflows/pages-landing.yml
@@ -10,6 +10,13 @@ on:
 permissions:
   contents: write
 
+# Serialize gh-pages deploys across ALL report workflows (shared group name) so
+# concurrent pushes can't reject each other with a non-fast-forward. Queue, don't
+# cancel — every report deploy must land.
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -7,6 +7,13 @@ on:
 permissions:
   contents: write
 
+# Serialize gh-pages deploys across ALL report workflows (shared group name) so
+# concurrent pushes can't reject each other with a non-fast-forward. Queue, don't
+# cancel — this cleanup pushes to gh-pages too.
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
 jobs:
   cleanup:
     name: Remove PR previews

--- a/.github/workflows/proof-animation.yml
+++ b/.github/workflows/proof-animation.yml
@@ -24,6 +24,13 @@ permissions:
   contents: write
   pull-requests: write
 
+# Serialize gh-pages deploys across ALL report workflows (shared group name) so
+# concurrent pushes can't reject each other with a non-fast-forward. Queue, don't
+# cancel — every report deploy must land.
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
 jobs:
   build-and-deploy:
     name: Generate & deploy proof-animation report

--- a/.github/workflows/semantic-graph.yml
+++ b/.github/workflows/semantic-graph.yml
@@ -24,6 +24,13 @@ permissions:
   contents: write
   pull-requests: write
 
+# Serialize gh-pages deploys across ALL report workflows (shared group name) so
+# concurrent pushes can't reject each other with a non-fast-forward. Queue, don't
+# cancel — every report deploy must land.
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
 jobs:
   build-and-deploy:
     name: Generate & deploy reports


### PR DESCRIPTION
## Summary

Fixes the intermittent **GitHub Pages deploy failure** seen on PRs:

```
! [rejected]  gh-pages -> gh-pages (fetch first)
error: failed to push some refs ... the remote contains work that you do not
have locally. This is usually caused by another repository pushing to the same ref.
```

Five workflows push to `gh-pages` — `semantic-graph`, `proof-animation`, `pages-landing`, `pr-preview-cleanup`, `loc` — but had **no shared lock**, so when more than one runs on the same trigger they race on the `gh-pages` ref and the loser's push is rejected as non-fast-forward. It's luck-of-the-draw which job fails.

## What changed
All five now share one concurrency group so their deploys **queue instead of race**:
```yaml
concurrency:
  group: gh-pages-deploy
  cancel-in-progress: false
```
- A **shared group name** is what serializes runs across different workflows (concurrency groups are global per repo by name).
- **`cancel-in-progress: false`** is required here: with a shared group, `cancel-in-progress: true` would let one workflow abort another mid-push — and we never want to drop a deploy. So they queue.
- `loc.yml`'s old per-ref group (`loc-report-<ref>`, which only serialized loc against itself) is replaced by the shared group.

## Test plan
- YAML validated; each workflow keeps its existing single job.
- Behavioral change is queue-vs-race only — no job logic touched. The next time two report workflows fire together, the second deploy waits for the first instead of failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Authored-By: Claude <81847+claude@users.noreply.github.com>
