### PR TITLE
feat(coach): Quick Intro guided-tour system

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -2,6 +2,13 @@
   "version": "0.0.1",
   "configurations": [
     {
+      "name": "coach-empty",
+      "runtimeExecutable": "./algebench",
+      "runtimeArgs": ["--port", "5743", "--debug", "--server-only"],
+      "port": 5743,
+      "autoPort": false
+    },
+    {
       "name": "ratelimit-verify",
       "runtimeExecutable": "env",
       "runtimeArgs": ["ALGEBENCH_RATELIMIT_CHAT=1/60", "./algebench", "scenes/eigenvalues.json", "--port", "5741", "--server-only"],

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,9 +4,9 @@
     {
       "name": "coach-empty",
       "runtimeExecutable": "./algebench",
-      "runtimeArgs": ["--port", "5743", "--debug", "--server-only"],
+      "runtimeArgs": ["--debug", "--server-only"],
       "port": 5743,
-      "autoPort": false
+      "autoPort": true
     },
     {
       "name": "ratelimit-verify",
@@ -17,8 +17,9 @@
     {
       "name": "artemis-ii",
       "runtimeExecutable": "./algebench",
-      "runtimeArgs": ["scenes/artemis-ii-mission-simulation.json", "--port", "8785", "--debug", "--server-only"],
-      "port": 8785
+      "runtimeArgs": ["scenes/artemis-ii-mission-simulation.json", "--debug", "--server-only"],
+      "port": 8785,
+      "autoPort": true
     },
     {
       "name": "graph-panel-demo",

--- a/agent-tools-reference.md
+++ b/agent-tools-reference.md
@@ -112,6 +112,30 @@ Call **once** per response, after your main action. Keep each prompt under 60 ch
 
 ---
 
+### `control_coach` — Drive the guided tour
+
+```
+control_coach(action="reset")
+control_coach(action="start")
+control_coach(action="goto", step="math-tab")
+control_coach(action="stop")
+```
+
+Controls the onboarding "Coach" overlay (reachable from the **Tour** button, top-right). Use it
+**only to change the tour state** when the user asks — e.g. "reset the tour", "start the tour",
+"take me to the proof step", "turn off the tour", "next tip".
+
+- `action`: `start` (open/resume), `reset` (clear progress and start over), `stop` (dismiss/hide),
+  `goto` (jump to a step — needs `step`), `next` / `prev`, or `status` (no-op).
+- `step`: a step id (e.g. `scenes-panel`, `voice-controls`, `math-tab`, `graph-controls`,
+  `proof-panel`, `viewport-sliders`), a 1-based number, or a fuzzy title.
+
+To **answer questions** about the tour ("where am I?", "what's left?"), read the `coach` object in
+the runtime context (it lists `active`, `currentStepId`, `completed`, `remaining`, and all
+`steps`) — don't call the tool just to report status.
+
+---
+
 ### math.js Expression Reference
 
 Used in `{{expr}}` overlay placeholders (`set_info_overlay`).

--- a/backend/agent_tools.py
+++ b/backend/agent_tools.py
@@ -328,6 +328,43 @@ DERIVE_PROOF_TOOL_DECL = types.FunctionDeclaration(
     ),
 )
 
+CONTROL_COACH_TOOL_DECL = types.FunctionDeclaration(
+    name="control_coach",
+    description=(
+        "Control the guided-tour 'Coach' overlay (the onboarding tour reachable from the Tour "
+        "button at top-right). Use when the user asks to start, reset, stop/hide, resume, or jump "
+        "to a part of the tour — e.g. 'reset the tour', 'start the tour', 'show me the math tab "
+        "step', 'turn off the tour', 'next tip'. The current tour state (active, current step, "
+        "completed steps, all step ids/titles) is provided in the runtime context as `coach`, so "
+        "answer questions about the tour from that context and only call this tool to CHANGE state."
+    ),
+    parameters=types.Schema(
+        type="OBJECT",
+        properties={
+            "action": types.Schema(
+                type="STRING",
+                enum=["start", "reset", "stop", "goto", "next", "prev", "status"],
+                description=(
+                    "What to do: 'start' (open/resume the tour, optionally at a step), "
+                    "'reset' (clear progress and start over from the beginning), "
+                    "'stop' (dismiss/hide the tour), 'goto' (jump to a specific step — requires "
+                    "`step`), 'next'/'prev' (advance/go back one step), 'status' (no-op; read "
+                    "tour state from the `coach` context instead)."
+                ),
+            ),
+            "step": types.Schema(
+                type="STRING",
+                description=(
+                    "For action 'goto' (or optional for 'start'): which step to jump to. Accepts a "
+                    "step id (e.g. 'math-tab', 'proof-panel', 'viewport-sliders'), a 1-based step "
+                    "number, or a fuzzy title match. See the `coach.steps` list in the runtime context."
+                ),
+            ),
+        },
+        required=["action"],
+    ),
+)
+
 ALL_TOOL_DECLS = [
     NAVIGATE_TOOL_DECL,
     SET_CAMERA_TOOL_DECL,
@@ -342,6 +379,7 @@ ALL_TOOL_DECLS = [
     CLEAR_INFO_OVERLAYS_TOOL_DECL,
     NAVIGATE_PROOF_TOOL_DECL,
     DERIVE_PROOF_TOOL_DECL,
+    CONTROL_COACH_TOOL_DECL,
 ]
 
 def _make_tools(*exclude_names):

--- a/backend/server.py
+++ b/backend/server.py
@@ -368,7 +368,10 @@ def _env_bool(name: str, default: bool) -> bool:
     return default
 
 
-DEFAULT_PORT = 8785
+# Honor the PORT env var (used by preview/auto-port harnesses) as the default,
+# falling back to the canonical 8785 for normal CLI use. An explicit --port flag
+# still overrides this.
+DEFAULT_PORT = int(os.environ.get("PORT") or 8785)
 
 index_html_path = static_dir / "index.html"
 style_css_path  = static_dir / "style.css"

--- a/backend/server.py
+++ b/backend/server.py
@@ -370,8 +370,17 @@ def _env_bool(name: str, default: bool) -> bool:
 
 # Honor the PORT env var (used by preview/auto-port harnesses) as the default,
 # falling back to the canonical 8785 for normal CLI use. An explicit --port flag
-# still overrides this.
-DEFAULT_PORT = int(os.environ.get("PORT") or 8785)
+# still overrides this. Parse defensively so a non-numeric PORT can't crash import.
+def _default_port():
+    val = os.environ.get("PORT")
+    if val:
+        try:
+            return int(val)
+        except (ValueError, TypeError):
+            pass
+    return 8785
+
+DEFAULT_PORT = _default_port()
 
 index_html_path = static_dir / "index.html"
 style_css_path  = static_dir / "style.css"
@@ -1780,13 +1789,11 @@ def create_app(initial_scene_path=None, debug=False,
         path = sanitize_path(static_dir / "coach", filename)
         if not path or not path.is_file():
             return Response(status_code=404)
-        suffix = path.suffix
-        if suffix == '.js':
-            media_type = "application/javascript"
-        elif suffix == '.css':
-            media_type = "text/css"
-        else:
-            media_type = "application/octet-stream"
+        # Allowlist only the asset types the Coach actually ships; 404 anything
+        # else so future files under static/coach/ can't be served unintentionally.
+        media_type = {'.js': 'application/javascript', '.css': 'text/css'}.get(path.suffix)
+        if media_type is None:
+            return Response(status_code=404)
         with open(path, 'rb') as f:
             content = f.read()
         return Response(content=content, media_type=media_type,

--- a/backend/server.py
+++ b/backend/server.py
@@ -1174,6 +1174,20 @@ def call_gemini_chat(message, history, context):
                         print(f"   ∴ derive_proof_animation: target={target[:60]!r} "
                               f"start={ (tc_args.get('start_latex') or '')[:40]!r} "
                               f"prompt={ (tc_args.get('prompt') or '')[:40]!r} reason={reason}")
+                elif tc_name == 'control_coach':
+                    # Client-executed: the browser drives the guided-tour Coach overlay.
+                    action = tc_args.get('action', '')
+                    step = tc_args.get('step', '')
+                    tc_result = {
+                        "status": "success",
+                        "action": action,
+                        "step": step,
+                        "message": (f"Tour '{action}' done"
+                                    + (f" (step: {step})" if step else "")
+                                    + ". Briefly confirm to the user; the tour overlay reflects it."),
+                    }
+                    if DEBUG_MODE:
+                        print(f"   🧭 control_coach: action={action!r} step={step!r}")
                 else:
                     tc_result = {"status": "success"}
                 tool_calls.append({
@@ -1757,6 +1771,24 @@ def create_app(initial_scene_path=None, debug=False,
         return Response(content=content, media_type=media_type,
                         headers={"Cache-Control": "no-cache, no-store, must-revalidate"})
 
+    @fastapp.get("/coach/{filename:path}")
+    async def get_coach_file(filename: str):
+        """Serve files from static/coach/ subdirectory (quick-intro Coach)."""
+        path = sanitize_path(static_dir / "coach", filename)
+        if not path or not path.is_file():
+            return Response(status_code=404)
+        suffix = path.suffix
+        if suffix == '.js':
+            media_type = "application/javascript"
+        elif suffix == '.css':
+            media_type = "text/css"
+        else:
+            media_type = "application/octet-stream"
+        with open(path, 'rb') as f:
+            content = f.read()
+        return Response(content=content, media_type=media_type,
+                        headers={"Cache-Control": "no-cache, no-store, must-revalidate"})
+
     # The FLIP animation engine's static assets — a fixed, known set. The request
     # filename is only ever used to LOOK UP a constant (name, media_type); the
     # filesystem path is built from the mapped constant ``name`` literal, so no
@@ -2194,7 +2226,7 @@ def serve_and_open(initial_scene_path=None, port=DEFAULT_PORT, json_output=False
         print(f"\nPress 'q' or Ctrl+C to stop the server")
     else:
         webbrowser.open(url)
-        print(f"Opened AlgeBench in browser")
+        print(f"Opened AlgeBench in browser: {url}")
         print(f"\nDrag & drop JSON files onto the viewport to load scenes")
         print(f"\nPress 'q' or Ctrl+C to stop the server")
 

--- a/static/chat.js
+++ b/static/chat.js
@@ -249,6 +249,15 @@ function buildChatContext() {
     }
     runtime.userViewing = viewing;
 
+    // Guided-tour ("Coach") state so the agent can answer questions about it
+    // and decide whether/how to drive it via the control_coach tool.
+    try {
+        const coachEngine = window.AlgeBenchCoach && window.AlgeBenchCoach.engine;
+        if (coachEngine && typeof coachEngine.status === 'function') {
+            runtime.coach = coachEngine.status();
+        }
+    } catch {}
+
     ctx.runtime = runtime;
     return ctx;
 }
@@ -702,6 +711,14 @@ async function sendChatMessage(text, { silent = false } = {}) {
                     } else {
                         console.warn('derive_proof_animation: graph view not ready to derive');
                     }
+                } else if (tc.name === 'control_coach') {
+                    // Drive the guided-tour "Coach": start/stop/reset/goto/next/prev/status.
+                    const engine = window.AlgeBenchCoach && window.AlgeBenchCoach.engine;
+                    if (engine && typeof engine.control === 'function') {
+                        engine.control(tc.args?.action, { step: tc.args?.step });
+                    } else {
+                        console.warn('control_coach: coach engine not available');
+                    }
                 }
             }
         }
@@ -1001,6 +1018,10 @@ function renderToolCallChip(tc) {
         friendlyText = step === 0
             ? '📐 Proof: showing goal overview'
             : '📐 Proof: step ' + step + (reason ? ' — ' + e(reason) : '');
+    } else if (tc.name === 'control_coach') {
+        const action = tc.args.action || 'status';
+        const step = tc.args.step ? ' → ' + e(tc.args.step) : '';
+        friendlyText = '🧭 Tour: ' + e(action) + step;
     }
 
     const header = document.createElement('div');

--- a/static/coach/coach.css
+++ b/static/coach/coach.css
@@ -1,0 +1,156 @@
+/* ============================================================
+   coach/coach.css — Quick-intro "Coach" player styles.
+   Palette matches the dark purple/blue toolbar in style.css.
+   Injected by coach.js (index.html only adds the script tag).
+   ============================================================ */
+
+/* Toolbar toggle button — reuses .tb-btn look from style.css; this
+   only adds the active-pulse so it stands out as the entry point. */
+#btn-coach { position: relative; }
+#btn-coach .coach-dot {
+    position: absolute; top: -3px; right: -3px;
+    width: 8px; height: 8px; border-radius: 50%;
+    background: #ffcf5a; box-shadow: 0 0 6px #ffcf5a;
+    animation: coach-dot-pulse 1.8s ease-in-out infinite;
+}
+@keyframes coach-dot-pulse {
+    0%, 100% { transform: scale(1);   opacity: 1; }
+    50%      { transform: scale(1.5); opacity: 0.5; }
+}
+
+/* Full-viewport layer — never blocks the page. Children opt back in. */
+#coach-layer {
+    position: fixed; inset: 0;
+    z-index: 99990;
+    pointer-events: none;
+}
+
+/* Spotlight ring — points at a target, never captures clicks. */
+#coach-spotlight {
+    position: fixed;
+    display: none;
+    pointer-events: none;
+    border-radius: 8px;
+    border: 2px solid rgba(140, 150, 255, 0.95);
+    box-shadow:
+        0 0 0 2px rgba(140, 150, 255, 0.35),
+        0 0 18px 4px rgba(120, 130, 255, 0.55);
+    transition: left .25s ease, top .25s ease, width .25s ease, height .25s ease;
+    animation: coach-spot-pulse 1.8s ease-in-out infinite;
+}
+@keyframes coach-spot-pulse {
+    0%, 100% { box-shadow: 0 0 0 2px rgba(140,150,255,0.35), 0 0 18px 4px rgba(120,130,255,0.55); }
+    50%      { box-shadow: 0 0 0 2px rgba(140,150,255,0.20), 0 0 26px 8px rgba(120,130,255,0.30); }
+}
+
+/* Keep hover-reveal targets visible while spotlighted. The ✦ ask buttons are
+   opacity:0 until their parent is hovered, so without this they'd look like an
+   empty (dark) ring when the Coach highlights them. */
+.coach-spotlit { opacity: 1 !important; }
+.ai-ask-btn.coach-spotlit {
+    background: rgba(100, 110, 240, 0.3);
+    color: #c8d4ff;
+    border-color: rgba(160, 180, 255, 0.6);
+    box-shadow: 0 0 6px rgba(120, 140, 255, 0.35);
+}
+
+/* The card — the only interactive piece. */
+#coach-card {
+    position: fixed;
+    display: none;
+    width: 330px;
+    max-width: calc(100vw - 28px);
+    pointer-events: auto;
+    background: linear-gradient(180deg, rgba(28, 28, 48, 0.98), rgba(20, 20, 36, 0.98));
+    border: 1px solid rgba(120, 120, 255, 0.4);
+    border-radius: 12px;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.55);
+    color: #d6d6ee;
+    font-size: 0.9em;
+    line-height: 1.45;
+    overflow: hidden;
+}
+
+.coach-card-head {
+    display: flex; align-items: center; gap: 8px;
+    padding: 12px 14px 8px 14px;
+    cursor: move;
+    user-select: none;
+    touch-action: none;   /* let pointer drag work on touch without scrolling */
+}
+.coach-card-title {
+    flex: 1; font-weight: 600; font-size: 1.02em; color: #fff;
+}
+.coach-card-counter {
+    font-size: 0.78em; color: #9aa0d8; white-space: nowrap;
+}
+.coach-icon-btn {
+    background: transparent; border: none; cursor: pointer;
+    color: #9aa0d8; font-size: 1em; padding: 2px 4px; border-radius: 5px;
+    transition: all .15s;
+}
+.coach-icon-btn:hover { color: #fff; background: rgba(120,120,255,0.2); }
+.coach-tts-toggle.coach-tts-off { opacity: 0.5; }
+
+.coach-card-body { padding: 0 14px 12px 14px; color: #c8c8e6; }
+
+.coach-examples {
+    display: flex; flex-wrap: wrap; gap: 6px;
+    padding: 0 14px 12px 14px;
+}
+.coach-chip {
+    background: rgba(80, 80, 160, 0.3);
+    border: 1px solid rgba(120, 120, 255, 0.3);
+    color: #c0c0e8;
+    border-radius: 14px; padding: 5px 11px;
+    font-size: 0.82em; cursor: pointer; transition: all .15s;
+}
+.coach-chip:hover {
+    background: rgba(90, 90, 210, 0.45);
+    border-color: rgba(150, 150, 255, 0.6);
+    color: #fff;
+}
+
+.coach-prompt-row {
+    display: flex; gap: 6px; padding: 0 14px 12px 14px;
+}
+#coach-prompt-input {
+    flex: 1; min-width: 0;
+    background: rgba(15, 15, 28, 0.9);
+    border: 1px solid rgba(120, 120, 255, 0.3);
+    color: #e6e6f6; border-radius: 8px; padding: 7px 10px;
+    font-size: 0.9em; font-family: inherit;
+}
+#coach-prompt-input:focus {
+    outline: none; border-color: rgba(150, 150, 255, 0.7);
+}
+#coach-prompt-send {
+    background: rgba(70, 130, 220, 0.4);
+    border: 1px solid rgba(120, 160, 255, 0.5);
+    color: #eaf0ff; border-radius: 8px; padding: 7px 12px;
+    cursor: pointer; transition: all .15s;
+}
+#coach-prompt-send:hover { background: rgba(80, 150, 250, 0.6); color: #fff; }
+
+.coach-card-foot {
+    display: flex; align-items: center; gap: 8px;
+    padding: 10px 14px 12px 14px;
+    border-top: 1px solid rgba(120, 120, 255, 0.15);
+}
+.coach-btn {
+    background: rgba(80, 80, 160, 0.3);
+    border: 1px solid rgba(120, 120, 255, 0.3);
+    color: #d0d0ee; border-radius: 7px; padding: 7px 13px;
+    font-size: 0.85em; cursor: pointer; transition: all .15s;
+}
+.coach-btn:hover { background: rgba(90, 90, 210, 0.5); color: #fff; }
+.coach-btn:disabled { opacity: 0.4; cursor: default; }
+.coach-btn-primary {
+    background: rgba(45, 125, 85, 0.55);
+    border-color: rgba(90, 220, 160, 0.6);
+    color: #eafff1;
+}
+.coach-btn-primary:hover { background: rgba(55, 150, 105, 0.7); color: #fff; }
+.coach-foot-spacer { flex: 1; }
+
+.coach-hidden { display: none !important; }

--- a/static/coach/coach.js
+++ b/static/coach/coach.js
@@ -716,7 +716,8 @@ function loadState() {
     // Migrate (bump only — never clear completed; that powers new-step detection)
     const ver = parseInt(_lsGet(LS.version, '0'), 10) || 0;
     if (ver < STEP_VERSION) _lsSet(LS.version, String(STEP_VERSION));
-    S.completed = new Set(_lsJSON(LS.completed, []));
+    const rawCompleted = _lsJSON(LS.completed, []);   // tolerate corrupted (non-array) state
+    S.completed = new Set(Array.isArray(rawCompleted) ? rawCompleted : []);
     S.ttsOn = _lsGet(LS.tts, '1') !== '0';   // default on
     updateTTSIcon();
 }
@@ -894,6 +895,7 @@ function ensureReady() {
     injectCSS();
     buildButton();
     buildLayer();
+    loadState();          // hydrate completed/ttsOn even if controlled before init()/decide()
     setupAudioUnlock();   // defer narration until the first gesture (autoplay policy)
 }
 function init() {

--- a/static/coach/coach.js
+++ b/static/coach/coach.js
@@ -71,6 +71,8 @@ const S = {
     cardMoved: false,   // user dragged the card → don't auto-reposition until next step
     justOpened: false,  // first step after openTour → mention the Tour button once
     spotlitEl: null,    // element currently carrying the .coach-spotlit class
+    userGestured: false,// has the user interacted yet? (browser autoplay gate)
+    pendingNarration: '',// narration deferred until the first gesture
 };
 
 // One-shot tip appended to the first step each time the tour is opened.
@@ -78,13 +80,33 @@ const REOPEN_TIP = ' By the way — you can jump back into this tour anytime: ju
                    'Tour button at the top right.';
 
 // ---- TTS (all optional; no-ops if unavailable or narration is off) ----
+// Browsers block the AudioContext until the user interacts, so a narration
+// fired on page load (first-visit welcome) can't play. We defer it until the
+// first gesture, then flush — see setupAudioUnlock().
 function speak(text) {
     if (!text) return;
     S.lastNarration = text;
     if (!S.ttsOn) return;
+    if (!S.userGestured) { S.pendingNarration = text; return; }   // wait for a gesture
     if (typeof window.algebenchSpeakText === 'function') {
         try { window.algebenchSpeakText(text); } catch {}
     }
+}
+// On the first real user gesture, unlock audio and play any deferred narration.
+function setupAudioUnlock() {
+    const onGesture = () => {
+        if (S.userGestured) return;
+        S.userGestured = true;
+        window.removeEventListener('pointerdown', onGesture, true);
+        window.removeEventListener('keydown', onGesture, true);
+        const t = S.pendingNarration;
+        S.pendingNarration = '';
+        if (t && S.ttsOn && typeof window.algebenchSpeakText === 'function') {
+            try { window.algebenchSpeakText(t); } catch {}
+        }
+    };
+    window.addEventListener('pointerdown', onGesture, true);
+    window.addEventListener('keydown', onGesture, true);
 }
 function stopTTS() {
     if (typeof window.algebenchStopTTS === 'function') {
@@ -856,6 +878,7 @@ function init() {
     injectCSS();
     buildButton();
     buildLayer();
+    setupAudioUnlock();   // defer narration until the first gesture (autoplay policy)
     try { decide(); } catch (e) { console.error('[coach] init failed:', e); }
     updateDot();   // reflect completion state on the Tour button's signal dot
 }

--- a/static/coach/coach.js
+++ b/static/coach/coach.js
@@ -472,11 +472,16 @@ function placeCard(el, position) {
     cardEl.style.top  = top + 'px';
     cardEl.style.visibility = 'visible';
 }
+let _repositionRaf = 0;
 function reposition() {
-    if (!S.active) return;
-    positionSpotlight(S.target);
-    if (S.cardMoved) return;   // honor the user's manual position
-    placeCard(S.target, S.position);
+    if (_repositionRaf) return;   // coalesce bursts of scroll/resize to one rAF
+    _repositionRaf = requestAnimationFrame(() => {
+        _repositionRaf = 0;
+        if (!S.active) return;
+        positionSpotlight(S.target);
+        if (S.cardMoved) return;   // honor the user's manual position
+        placeCard(S.target, S.position);
+    });
 }
 // Auto-place the card and clear any prior manual drag (called on each new step/offer).
 function autoPlace(el, position) {
@@ -540,13 +545,15 @@ function renderOffer({ title, message, primaryLabel, onPrimary, secondaryLabel, 
 }
 
 // ---- Player flow ----
+const _repoOpts = { capture: true, passive: true };
 function attachReposition() {
-    window.addEventListener('resize', reposition, true);
-    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition, _repoOpts);
+    window.addEventListener('scroll', reposition, _repoOpts);
 }
 function detachReposition() {
-    window.removeEventListener('resize', reposition, true);
-    window.removeEventListener('scroll', reposition, true);
+    window.removeEventListener('resize', reposition, _repoOpts);
+    window.removeEventListener('scroll', reposition, _repoOpts);
+    if (_repositionRaf) { cancelAnimationFrame(_repositionRaf); _repositionRaf = 0; }
 }
 function openPlayer() {
     S.active = true;
@@ -564,6 +571,7 @@ function closePlayer() {
     detachReposition();
 }
 function dismiss() {
+    ensureReady();   // may be invoked via the engine before init()
     _lsSet(LS.dismissed, '1');
     log('dismiss (will switch to once-a-day hints)');
     closePlayer();
@@ -680,6 +688,7 @@ async function autoPickLesson() {
 
 // Open the full tour (button / resume / first-time start).
 async function openTour(startId) {
+    ensureReady();   // may be invoked via the engine before init()
     log('openTour', { startId, hasScene: hasScene() });
     _lsSet(LS.dismissed, '0');   // opening = re-engaging; leave daily-hint mode
     if (!hasScene()) {
@@ -761,6 +770,7 @@ function showDailyHint(step) {
 
 function decide() {
     loadState();
+    if (S.active) { log('decide: tour already active → skip auto offer'); return; }
     const pending = pendingSteps();
     log('decide:', {
         firstVisit: _lsGet(LS.firstVisitDone) !== '1',
@@ -834,6 +844,7 @@ function coachStatus() {
 
 // Single entry point for the chat tool. Returns a small result object.
 function coachControl(action, opts = {}) {
+    ensureReady();   // engine may be called (via the chat tool) before init() runs
     action = String(action || '').toLowerCase().trim();
     const step = opts.step;
     log('control_coach', { action, step });
@@ -872,13 +883,22 @@ function coachControl(action, opts = {}) {
 }
 
 // ---- Boot ----
-function init() {
+// Idempotent bootstrap: builds the CSS/button/layer and audio-unlock hook
+// without any auto-offer side effects. Safe to call from engine methods that
+// may run (via the chat tool) before init()'s DOMContentLoaded handler fires.
+let _ready = false;
+function ensureReady() {
+    if (_ready) return;
+    _ready = true;
     initDebug();
-    log('init (debug logging on)');
     injectCSS();
     buildButton();
     buildLayer();
     setupAudioUnlock();   // defer narration until the first gesture (autoplay policy)
+}
+function init() {
+    ensureReady();
+    log('init (debug logging on)');
     try { decide(); } catch (e) { console.error('[coach] init failed:', e); }
     updateDot();   // reflect completion state on the Tour button's signal dot
 }

--- a/static/coach/coach.js
+++ b/static/coach/coach.js
@@ -1,0 +1,884 @@
+// ============================================================
+// coach/coach.js — Quick-intro "Coach" engine.
+//
+// One engine powers BOTH the guided tour and the daily-hint system.
+// It reads steps from the registry (steps self-register via
+// steps/*.js), tracks completion by stable step id in localStorage,
+// renders a non-blocking spotlight + card, narrates via the existing
+// TTS API, and hands the user off into the main chat.
+//
+// Boot: a single <script type="module" src="/coach/coach.js"> tag.
+// This module imports the registry, then the step manifest (which
+// registers all steps), then self-initializes on DOMContentLoaded.
+// No edits to main.js / chat.js are required.
+// ============================================================
+
+import { coach } from './registry.js';
+import './steps/index.js';            // side-effect: registers all steps
+import { loadBuiltinScene } from '/ui.js';
+
+// ---- Persistence (mirrors the graph-view.js _lsGet/_lsSet pattern) ----
+const STEP_VERSION = 1;
+const LS = {
+    version:        'algebench.coach.version',
+    completed:      'algebench.coach.completed',       // JSON array of step ids
+    position:       'algebench.coach.position',        // resume step id
+    dismissed:      'algebench.coach.dismissed',       // '1' | '0'
+    lastHintDate:   'algebench.coach.lastHintDate',    // 'YYYY-MM-DD'
+    firstVisitDone: 'algebench.coach.firstVisitDone',  // '1'
+    tts:            'algebench.coach.tts',             // '1' | '0' (narration on/off; default on)
+    debug:          'algebench.coach.debug',           // '1' | '0' (verbose console logging)
+};
+const _lsGet  = (k, f = null) => { try { return localStorage.getItem(k) ?? f; } catch { return f; } };
+const _lsSet  = (k, v) => { try { localStorage.setItem(k, v); } catch {} };
+const _lsJSON = (k, f) => { try { return JSON.parse(localStorage.getItem(k)) ?? f; } catch { return f; } };
+
+const today = () => new Date().toISOString().slice(0, 10);
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ---- Debug logging ----
+// Enabled by any of: ?coachdebug URL param, localStorage 'algebench.coach.debug'=1,
+// or the server --debug flag (body[data-debug-mode="true"]). Toggle at runtime via
+// window.AlgeBenchCoach.engine.setDebug(true).
+let DEBUG = false;
+function log(...args) {
+    if (!DEBUG) return;
+    try { console.log('%c[coach]', 'color:#8c96ff;font-weight:bold', ...args); } catch {}
+}
+function initDebug() {
+    try {
+        const p = new URLSearchParams(location.search);
+        if (p.has('coachdebug')) {
+            DEBUG = p.get('coachdebug') !== '0';
+            _lsSet(LS.debug, DEBUG ? '1' : '0');
+            return;
+        }
+    } catch {}
+    if (_lsGet(LS.debug) === '1') { DEBUG = true; return; }
+    try { DEBUG = !!(document.body && document.body.dataset && document.body.dataset.debugMode === 'true'); } catch {}
+}
+
+// ---- In-memory state ----
+const S = {
+    completed: new Set(),
+    steps: [],          // relevant steps for the current context
+    idx: 0,
+    active: false,
+    target: null,       // currently spotlighted element
+    position: 'right',  // card anchor for the current step
+    ttsOn: true,        // narration on/off (persisted; default on)
+    lastNarration: '',  // last text shown — so the toggle can replay it
+    cardMoved: false,   // user dragged the card → don't auto-reposition until next step
+    justOpened: false,  // first step after openTour → mention the Tour button once
+    spotlitEl: null,    // element currently carrying the .coach-spotlit class
+};
+
+// One-shot tip appended to the first step each time the tour is opened.
+const REOPEN_TIP = ' By the way — you can jump back into this tour anytime: just click the ' +
+                   'Tour button at the top right.';
+
+// ---- TTS (all optional; no-ops if unavailable or narration is off) ----
+function speak(text) {
+    if (!text) return;
+    S.lastNarration = text;
+    if (!S.ttsOn) return;
+    if (typeof window.algebenchSpeakText === 'function') {
+        try { window.algebenchSpeakText(text); } catch {}
+    }
+}
+function stopTTS() {
+    if (typeof window.algebenchStopTTS === 'function') {
+        try { window.algebenchStopTTS(); } catch {}
+    }
+}
+function updateTTSIcon() {
+    if (!els.ttsToggle) return;
+    els.ttsToggle.textContent = S.ttsOn ? '\u{1F50A}' : '\u{1F507}';   // 🔊 / 🔇
+    els.ttsToggle.title = S.ttsOn ? 'Narration on — click to mute' : 'Narration off — click to enable';
+    els.ttsToggle.classList.toggle('coach-tts-off', !S.ttsOn);
+}
+function toggleTTS() {
+    S.ttsOn = !S.ttsOn;
+    _lsSet(LS.tts, S.ttsOn ? '1' : '0');
+    log('toggle narration →', S.ttsOn ? 'on' : 'off');
+    updateTTSIcon();
+    if (!S.ttsOn) {
+        stopTTS();
+    } else if (S.lastNarration && typeof window.algebenchSpeakText === 'function') {
+        try { window.algebenchSpeakText(S.lastNarration); } catch {}   // replay current
+    }
+}
+
+// ---- Context handed to step.when / step.action ----
+function hasScene() {
+    return !!(window.lessonSpec && window.lessonSpec.scenes && window.lessonSpec.scenes.length);
+}
+function chatAvailable() {
+    const msg = document.getElementById('chat-unavailable-msg');
+    return !(msg && !msg.classList.contains('hidden'));
+}
+function openChatTab() {
+    const panel = document.getElementById('explanation-panel');
+    if (panel && panel.classList.contains('hidden')) {
+        panel.classList.remove('hidden');
+        const handle = document.getElementById('panel-resize-handle');
+        const toggle = document.getElementById('explain-toggle');
+        if (handle) handle.style.display = 'block';
+        if (toggle) { toggle.style.display = 'block'; toggle.classList.add('active'); }
+        setTimeout(() => window.dispatchEvent(new Event('resize')), 50);
+    }
+    document.querySelector('.panel-tab[data-tab="chat"]')?.click();
+}
+function clickDockTab(name) {
+    document.querySelector(`.dock-tab[data-dock-tab="${name}"]`)?.click();
+}
+// Open the chat tab and reveal the proof panel (if a proof is in context).
+function openProofPanel() {
+    openChatTab();
+    const panel = document.getElementById('proof-panel');
+    const toggle = document.getElementById('proof-toggle-btn');
+    if (panel && panel.classList.contains('hidden') && toggle && toggle.style.display !== 'none') {
+        toggle.click();
+    }
+    return !!(panel && !panel.classList.contains('hidden'));
+}
+// Make sure the proof panel is showing an actual step — navigate to the first
+// one only if nothing is selected yet (idx < 0 means the goal / no step).
+function ensureProofStep() {
+    if (typeof window.navigateProof !== 'function') return;
+    const idx = window.proofStepIndex;
+    if (typeof idx !== 'number' || idx < 0) {
+        try { window.navigateProof(0); log('ensureProofStep → navigate to step 0'); } catch {}
+    } else {
+        log(`ensureProofStep: step ${idx} already selected`);
+    }
+}
+// Select the first proof step that has a semantic graph so the Math-tab steps
+// land on a rendered graph, not the "select a step" placeholder. Idempotent:
+// if a graph is already rendered, leave it (re-clicking tears down open
+// node panels / charts).
+function selectFirstGraphStep() {
+    if (document.querySelector('#graph-mermaid-container svg')) return true;
+    const tree = document.getElementById('graph-proof-tree');
+    if (!tree) return false;
+    const steps = [...tree.querySelectorAll('.gp-tree-step')];
+    const node = steps.find((s) => s.querySelector('.gp-tree-step-has-graph')) || steps[0];
+    if (node) { node.click(); return true; }
+    return false;
+}
+// Click the first rendered graph node so its details panel (and the derive
+// button inside it) appear — used by the node-details / derive-button steps.
+// Idempotent: if a node is already selected with its panel open, leave it
+// (re-clicking the same node would toggle the selection off).
+function selectFirstGraphNode() {
+    const host = document.getElementById('graph-info-panel-host');
+    const already = document.querySelector('#graph-mermaid-container .d3sg-node.selected, #graph-mermaid-container .d3sg-node.active');
+    if (already && host && host.innerHTML.trim()) return true;   // panel already open
+    // Prefer an UNselected node so the click opens a panel rather than toggling
+    // a stale selection off.
+    const node = document.querySelector('#graph-mermaid-container .d3sg-nodes .d3sg-node:not(.selected):not(.active)')
+              || document.querySelector('#graph-mermaid-container .d3sg-nodes .d3sg-node');
+    if (node) { node.dispatchEvent(new MouseEvent('click', { bubbles: true })); return true; }
+    return false;
+}
+// Navigate to a scene/step that actually defines sliders, so the slider overlay
+// is visible for the sliders step. No-op if sliders are already showing.
+function gotoSliderStep() {
+    const so = document.getElementById('slider-overlay');
+    if (so && !so.classList.contains('hidden') && so.children.length) return true;
+    const spec = window.lessonSpec;
+    if (!spec || !Array.isArray(spec.scenes) || typeof window.navigateTo !== 'function') return false;
+    for (let si = 0; si < spec.scenes.length; si++) {
+        const sc = spec.scenes[si] || {};
+        if (Array.isArray(sc.sliders) && sc.sliders.length) { window.navigateTo(si, -1); return true; }
+        const steps = sc.steps || [];
+        for (let ti = 0; ti < steps.length; ti++) {
+            if (Array.isArray(steps[ti].sliders) && steps[ti].sliders.length) {
+                window.navigateTo(si, ti); return true;
+            }
+        }
+    }
+    return false;
+}
+// Hand off to the MAIN chat via DOM only (no chat.js edit). Auto-sends.
+function handToChat(text, examples) {
+    openChatTab();
+    if (!chatAvailable()) return false;
+    const input = document.getElementById('chat-input');
+    if (input && text) {
+        input.value = text;
+        input.dispatchEvent(new Event('input'));
+    }
+    document.getElementById('chat-send')?.click();
+    return true;
+}
+function buildCtx() {
+    return { hasScene: hasScene(), chatAvailable: chatAvailable(),
+             openChatTab, clickDockTab, selectFirstGraphStep, selectFirstGraphNode,
+             gotoSliderStep, openProofPanel, ensureProofStep, handToChat, delay, speak };
+}
+
+// ---- Step selection ----
+function safeWhen(step, ctx) {
+    if (typeof step.when !== 'function') return true;
+    try { return !!step.when(ctx); } catch { return true; }
+}
+function relevantSteps() {
+    const ctx = buildCtx();
+    return coach.get().filter((s) => safeWhen(s, ctx));
+}
+// Pending is GLOBAL (across all registered steps), independent of whether a
+// scene is loaded yet — so the entry decision doesn't race the async scene
+// load, and new steps are detected as pending until actually completed.
+// (openTour auto-loads a scene when a pending step needs one.)
+function pendingSteps() {
+    return coach.get().filter((s) => !S.completed.has(s.id));
+}
+function markComplete(id) {
+    if (!id || S.completed.has(id)) return;
+    S.completed.add(id);
+    _lsSet(LS.completed, JSON.stringify([...S.completed]));
+    log(`mark complete: "${id}" (${S.completed.size}/${coach.get().length})`);
+    updateDot();
+}
+// The Tour button's yellow signal means "there's something to see": shown while
+// any step is incomplete (incl. newly-added ones), hidden once all are done.
+function updateDot() {
+    const dot = btnEl && btnEl.querySelector('.coach-dot');
+    if (!dot) return;
+    dot.style.display = pendingSteps().length ? '' : 'none';
+}
+
+// ---- DOM scaffold (built once) ----
+let layerEl, spotlightEl, cardEl, btnEl;
+let els = {};   // named card sub-elements
+
+function injectCSS() {
+    if (document.getElementById('coach-css')) return;
+    const link = document.createElement('link');
+    link.id = 'coach-css';
+    link.rel = 'stylesheet';
+    link.href = '/coach/coach.css';
+    document.head.appendChild(link);
+}
+
+function buildButton() {
+    const toolbar = document.getElementById('toolbar');
+    if (!toolbar || document.getElementById('btn-coach')) return;
+    btnEl = document.createElement('button');
+    btnEl.className = 'tb-btn';
+    btnEl.id = 'btn-coach';
+    btnEl.title = 'Quick guided tour';
+    btnEl.innerHTML = '\u{1F393} Tour<span class="coach-dot"></span>';
+    btnEl.addEventListener('click', () => {
+        if (S.active) dismiss();
+        else openTour();
+    });
+    // Insert before the explain-toggle so it stays the right-most item (mirroring
+    // the scene-dock-toggle on the far left); fall back to append if it's absent.
+    const explainToggle = document.getElementById('explain-toggle');
+    if (explainToggle && explainToggle.parentElement === toolbar) {
+        toolbar.insertBefore(btnEl, explainToggle);
+    } else {
+        toolbar.appendChild(btnEl);
+    }
+}
+
+function buildLayer() {
+    if (document.getElementById('coach-layer')) return;
+    layerEl = document.createElement('div');
+    layerEl.id = 'coach-layer';
+
+    spotlightEl = document.createElement('div');
+    spotlightEl.id = 'coach-spotlight';
+
+    cardEl = document.createElement('div');
+    cardEl.id = 'coach-card';
+    cardEl.innerHTML = `
+        <div class="coach-card-head">
+            <div class="coach-card-title"></div>
+            <span class="coach-card-counter"></span>
+            <button class="coach-icon-btn coach-tts-toggle" title="Narration on — click to mute">\u{1F50A}</button>
+            <button class="coach-icon-btn coach-close" title="Dismiss">✕</button>
+        </div>
+        <div class="coach-card-body"></div>
+        <div class="coach-examples"></div>
+        <div class="coach-prompt-row">
+            <input id="coach-prompt-input" type="text" placeholder="Ask your own question..." />
+            <button id="coach-prompt-send" title="Ask">➜</button>
+        </div>
+        <div class="coach-card-foot">
+            <button class="coach-btn coach-prev">‹ Back</button>
+            <div class="coach-foot-spacer"></div>
+            <button class="coach-btn coach-secondary"></button>
+            <button class="coach-btn coach-btn-primary coach-next">Next ›</button>
+        </div>`;
+
+    layerEl.appendChild(spotlightEl);
+    layerEl.appendChild(cardEl);
+    document.body.appendChild(layerEl);
+
+    els = {
+        head:      cardEl.querySelector('.coach-card-head'),
+        title:     cardEl.querySelector('.coach-card-title'),
+        counter:   cardEl.querySelector('.coach-card-counter'),
+        ttsToggle: cardEl.querySelector('.coach-tts-toggle'),
+        close:     cardEl.querySelector('.coach-close'),
+        body:      cardEl.querySelector('.coach-card-body'),
+        examples:  cardEl.querySelector('.coach-examples'),
+        promptRow: cardEl.querySelector('.coach-prompt-row'),
+        promptInput: cardEl.querySelector('#coach-prompt-input'),
+        promptSend:  cardEl.querySelector('#coach-prompt-send'),
+        foot:      cardEl.querySelector('.coach-card-foot'),
+        prev:      cardEl.querySelector('.coach-prev'),
+        secondary: cardEl.querySelector('.coach-secondary'),
+        next:      cardEl.querySelector('.coach-next'),
+    };
+
+    // close / replay / prompt are stable handlers. Prev/Next/secondary are
+    // assigned per-render via .onclick (renderStep / renderOffer) so step mode
+    // and offer mode never fire each other's handler.
+    els.close.addEventListener('click', () => dismiss());
+    els.ttsToggle.addEventListener('click', () => toggleTTS());
+    updateTTSIcon();
+    const submitPrompt = () => {
+        const v = els.promptInput.value.trim();
+        if (v) engagePrompt(v);
+    };
+    els.promptSend.addEventListener('click', submitPrompt);
+    els.promptInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') { e.preventDefault(); submitPrompt(); }
+    });
+    setupCardDrag();
+}
+
+// Drag the card by its header so it never traps the user behind it.
+// Dimensions are cached on pointerdown and writes are batched in rAF so the
+// card tracks the cursor without per-move layout reflows (no lag).
+function setupCardDrag() {
+    let drag = null;       // { dx, dy, w, h }
+    let raf = 0;
+    let pending = null;    // { left, top }
+    const flush = () => {
+        raf = 0;
+        if (!pending) return;
+        cardEl.style.left = pending.left + 'px';
+        cardEl.style.top  = pending.top + 'px';
+        pending = null;
+    };
+    els.head.addEventListener('pointerdown', (e) => {
+        if (e.target.closest('.coach-icon-btn')) return;   // let close / mute clicks through
+        const r = cardEl.getBoundingClientRect();
+        drag = { dx: e.clientX - r.left, dy: e.clientY - r.top, w: r.width, h: r.height };
+        S.cardMoved = true;
+        try { els.head.setPointerCapture(e.pointerId); } catch {}
+        e.preventDefault();
+        log('card drag start');
+    });
+    els.head.addEventListener('pointermove', (e) => {
+        if (!drag) return;
+        const m = 4;
+        let left = e.clientX - drag.dx;
+        let top  = e.clientY - drag.dy;
+        left = Math.max(m, Math.min(left, window.innerWidth - drag.w - m));
+        top  = Math.max(m, Math.min(top,  window.innerHeight - drag.h - m));
+        pending = { left, top };
+        if (!raf) raf = requestAnimationFrame(flush);
+    });
+    const endDrag = (e) => {
+        if (!drag) return;
+        drag = null;
+        if (raf) { cancelAnimationFrame(raf); raf = 0; }
+        flush();
+        try { els.head.releasePointerCapture(e.pointerId); } catch {}
+        log('card drag end', { left: cardEl.style.left, top: cardEl.style.top });
+    };
+    els.head.addEventListener('pointerup', endDrag);
+    els.head.addEventListener('pointercancel', endDrag);
+}
+
+// ---- Positioning (non-blocking) ----
+function resolveTarget(step) {
+    if (!step) return null;
+    const t = step.target;
+    try {
+        const el = typeof t === 'function' ? t() : (t ? document.querySelector(t) : null);
+        if (el && el.getBoundingClientRect().width > 0) return el;
+        return el || null;
+    } catch { return null; }
+}
+function positionSpotlight(el) {
+    if (!el) { spotlightEl.style.display = 'none'; return; }
+    const r = el.getBoundingClientRect();
+    if (r.width === 0 && r.height === 0) { spotlightEl.style.display = 'none'; return; }
+    spotlightEl.style.display = 'block';
+    spotlightEl.style.left   = (r.left - 6) + 'px';
+    spotlightEl.style.top    = (r.top - 6) + 'px';
+    spotlightEl.style.width  = (r.width + 12) + 'px';
+    spotlightEl.style.height = (r.height + 12) + 'px';
+}
+// Mark the spotlighted element so CSS can keep hover-reveal targets (e.g. the
+// ✦ ask buttons, which are opacity:0 until hovered) visible while highlighted.
+function markSpotlit(el) {
+    if (S.spotlitEl && S.spotlitEl !== el) S.spotlitEl.classList.remove('coach-spotlit');
+    if (el) el.classList.add('coach-spotlit');
+    S.spotlitEl = el || null;
+}
+function placeCard(el, position) {
+    const m = 14;
+    cardEl.style.visibility = 'hidden';
+    cardEl.style.display = 'block';
+    const cw = cardEl.offsetWidth, ch = cardEl.offsetHeight;
+    let left, top;
+    const r = el ? el.getBoundingClientRect() : null;
+    if (!r || position === 'center' || (r.width === 0 && r.height === 0)) {
+        left = (window.innerWidth - cw) / 2;
+        top  = (window.innerHeight - ch) / 2;
+    } else if (position === 'bottom' || position === 'bottom-start') {
+        top = r.bottom + m;
+        left = position === 'bottom-start' ? r.left : r.left + r.width / 2 - cw / 2;
+    } else if (position === 'top') {
+        top = r.top - ch - m; left = r.left + r.width / 2 - cw / 2;
+    } else if (position === 'left') {
+        left = r.left - cw - m; top = r.top + r.height / 2 - ch / 2;
+    } else { // 'right' (default)
+        left = r.right + m; top = r.top + r.height / 2 - ch / 2;
+    }
+    left = Math.max(m, Math.min(left, window.innerWidth - cw - m));
+    top  = Math.max(m, Math.min(top,  window.innerHeight - ch - m));
+    cardEl.style.left = left + 'px';
+    cardEl.style.top  = top + 'px';
+    cardEl.style.visibility = 'visible';
+}
+function reposition() {
+    if (!S.active) return;
+    positionSpotlight(S.target);
+    if (S.cardMoved) return;   // honor the user's manual position
+    placeCard(S.target, S.position);
+}
+// Auto-place the card and clear any prior manual drag (called on each new step/offer).
+function autoPlace(el, position) {
+    S.cardMoved = false;
+    placeCard(el, position);
+}
+
+// ---- Card rendering modes ----
+function show(el, on) { el.classList.toggle('coach-hidden', !on); }
+
+function renderStep(step, idx) {
+    const total = S.steps.length;
+    els.title.textContent = step.title || 'AlgeBench';
+    els.counter.textContent = `${idx + 1} / ${total}`;
+    show(els.counter, true);
+    els.body.textContent = step.narration || '';
+
+    // Example prompt chips
+    els.examples.innerHTML = '';
+    const examples = chatAvailable() ? (step.examplePrompts || []) : [];
+    for (const ex of examples) {
+        const chip = document.createElement('button');
+        chip.className = 'coach-chip';
+        chip.textContent = ex;
+        chip.addEventListener('click', () => engagePrompt(ex));
+        els.examples.appendChild(chip);
+    }
+    show(els.examples, examples.length > 0);
+
+    // Prompt box — only meaningful when chat is available
+    show(els.promptRow, chatAvailable());
+    if (!chatAvailable() && examples.length === 0) {
+        // surface why, once, in the body
+    }
+
+    // Footer nav
+    show(els.foot, true);
+    show(els.prev, true);
+    els.prev.disabled = idx === 0;
+    els.prev.onclick = () => gotoPrev();
+    show(els.secondary, false);
+    els.secondary.onclick = null;
+    els.next.textContent = idx === total - 1 ? 'Done ✓' : 'Next ›';
+    els.next.onclick = () => gotoNext();
+}
+
+function renderOffer({ title, message, primaryLabel, onPrimary, secondaryLabel, onSecondary }) {
+    markSpotlit(null);   // offer cards have no spotlight target
+    els.title.textContent = title;
+    show(els.counter, false);
+    els.body.textContent = message;
+    els.examples.innerHTML = ''; show(els.examples, false);
+    show(els.promptRow, false);
+    show(els.foot, true);
+    show(els.prev, false);
+    show(els.secondary, !!secondaryLabel);
+    els.secondary.textContent = secondaryLabel || '';
+    els.secondary.onclick = onSecondary || null;
+    els.next.textContent = primaryLabel;
+    els.next.onclick = onPrimary;
+}
+
+// ---- Player flow ----
+function attachReposition() {
+    window.addEventListener('resize', reposition, true);
+    window.addEventListener('scroll', reposition, true);
+}
+function detachReposition() {
+    window.removeEventListener('resize', reposition, true);
+    window.removeEventListener('scroll', reposition, true);
+}
+function openPlayer() {
+    S.active = true;
+    btnEl?.classList.add('active');
+    cardEl.style.display = 'block';
+    attachReposition();
+}
+function closePlayer() {
+    stopTTS();
+    S.active = false;
+    btnEl?.classList.remove('active');
+    cardEl.style.display = 'none';
+    spotlightEl.style.display = 'none';
+    markSpotlit(null);
+    detachReposition();
+}
+function dismiss() {
+    _lsSet(LS.dismissed, '1');
+    log('dismiss (will switch to once-a-day hints)');
+    closePlayer();
+}
+
+async function showStep(i) {
+    stopTTS();
+    const step = S.steps[i];
+    if (!step) { finish(); return; }
+    S.idx = i;
+    log(`showStep ${i + 1}/${S.steps.length}: "${step.id}"`);
+
+    // Pre-show action (switch tabs, load lesson, etc.)
+    if (typeof step.action === 'function') {
+        try { await step.action(buildCtx()); }
+        catch (e) { log(`step "${step.id}" action error:`, e); }
+        await delay(120);
+    }
+
+    const el = resolveTarget(step);
+    if (!el && step.optional) {           // skip optional steps with no target
+        log(`step "${step.id}" optional + no target → skip`);
+        markComplete(step.id);
+        if (i < S.steps.length - 1) return showStep(i + 1);
+        return finish();
+    }
+    if (!el) log(`step "${step.id}" target not found → centered card, no spotlight`);
+
+    S.target = el;
+    S.position = step.position || 'right';
+
+    // On the first step after the tour is (re)opened, mention the Tour button.
+    let narration = step.narration || '';
+    if (S.justOpened) {
+        S.justOpened = false;
+        narration += REOPEN_TIP;
+    }
+
+    renderStep(step, i);
+    if (narration !== step.narration) els.body.textContent = narration;   // include the tip
+    positionSpotlight(el);
+    markSpotlit(el);
+    autoPlace(el, S.position);
+    _lsSet(LS.position, step.id);
+    speak(narration);
+}
+
+function gotoNext() {
+    const step = S.steps[S.idx];
+    if (step) markComplete(step.id);
+    if (S.idx >= S.steps.length - 1) { finish(); return; }
+    showStep(S.idx + 1);
+}
+function gotoPrev() {
+    if (S.idx > 0) showStep(S.idx - 1);
+}
+function finish() {
+    // NOTE: no explicit stopTTS() here — speak() interrupts the prior narration
+    // itself. Calling stopTTS() broadcasts a kill that races in and silences the
+    // finish narration before it starts.
+    renderOffer({
+        title: 'You’re all set \u{1F389}',
+        message: 'That’s the tour! Open it again anytime from the Tour button. ' +
+                 'Now explore — drag the 3D view, switch steps, and ask the AI anything.',
+        primaryLabel: 'Done',
+        onPrimary: () => closePlayer(),
+    });
+    spotlightEl.style.display = 'none';
+    autoPlace(null, 'center');
+    speak('That’s the tour! You’re all set. Now explore on your own, and ask the AI whenever you’re curious.');
+}
+
+// Prompt engaged from the player → continue in the MAIN chat.
+function engagePrompt(text) {
+    stopTTS();
+    const step = S.steps[S.idx];
+    const ok = handToChat(text, step?.examplePrompts);
+    log('engagePrompt → main chat', { text, chatAvailable: ok });
+    // Mark chat-related steps complete so they don't re-nag.
+    if (step) markComplete(step.id);
+    markComplete('chat-window');
+    markComplete('ask-math');
+    renderOffer({
+        title: 'This is the main chat',
+        message: ok
+            ? 'I’ve moved your question into the main AI chat on the right — keep the ' +
+              'conversation going there. Ask about any step, symbol, or sub-expression; the AI sees ' +
+              'exactly what’s on your screen.'
+            : 'The AI chat lives on the right. It needs a Gemini API key to answer — once that’s ' +
+              'set you can ask about any step, symbol, or sub-expression.',
+        primaryLabel: 'Got it',
+        onPrimary: () => closePlayer(),
+    });
+    spotlightEl.style.display = 'none';
+    autoPlace(document.getElementById('explanation-panel'), 'left');
+}
+
+// ---- Auto-pick a simple lesson when none is loaded ----
+async function autoPickLesson() {
+    try {
+        const resp = await fetch('/api/scenes', { cache: 'no-store' });
+        const data = await resp.json();
+        const names = data.scenes || [];
+        if (!names.length) return false;
+        // Prefer a lesson that actually has a proof / semantic graph, so the
+        // Math-tab steps land on real content. Lightest graph-having scene first.
+        const prefer = ['artemis-ii-mission-simulation', 'quantum-states',
+                        'atmospheric-entry-physics', 'vector-operations'];
+        const pick = prefer.find((p) => names.includes(p)) || names[0];
+        log('autoPickLesson →', pick);
+        return await loadBuiltinScene(pick);
+    } catch (e) { log('autoPickLesson failed:', e); return false; }
+}
+
+// Open the full tour (button / resume / first-time start).
+async function openTour(startId) {
+    log('openTour', { startId, hasScene: hasScene() });
+    _lsSet(LS.dismissed, '0');   // opening = re-engaging; leave daily-hint mode
+    if (!hasScene()) {
+        await autoPickLesson();
+        await delay(400);   // let the scene render so targets exist
+    }
+    S.steps = relevantSteps();
+    log('openTour relevant steps:', S.steps.map((s) => s.id));
+    if (!S.steps.length) { log('openTour: no relevant steps'); return; }
+    openPlayer();
+    let start = 0;
+    if (startId) {
+        const i = S.steps.findIndex((s) => s.id === startId);
+        if (i >= 0) start = i;
+    } else {
+        const p = S.steps.findIndex((s) => !S.completed.has(s.id));
+        start = p >= 0 ? p : 0;
+    }
+    S.justOpened = true;   // first step will mention the Tour button
+    showStep(start);
+}
+
+// ---- Entry decision logic ----
+function loadState() {
+    // Migrate (bump only — never clear completed; that powers new-step detection)
+    const ver = parseInt(_lsGet(LS.version, '0'), 10) || 0;
+    if (ver < STEP_VERSION) _lsSet(LS.version, String(STEP_VERSION));
+    S.completed = new Set(_lsJSON(LS.completed, []));
+    S.ttsOn = _lsGet(LS.tts, '1') !== '0';   // default on
+    updateTTSIcon();
+}
+
+function showWelcome(firstTime) {
+    openPlayer();
+    spotlightEl.style.display = 'none';
+    const all = coach.get();
+    const doneCount = all.filter((s) => S.completed.has(s.id)).length;
+    if (firstTime) {
+        renderOffer({
+            title: 'Welcome to AlgeBench \u{1F44B}',
+            message: 'I’m your guide. In a quick tour I’ll show you how to browse interactive ' +
+                     'lessons, ask the AI anything, dive into the semantic graph of a proof, and play ' +
+                     'with the 3D viewport. Ready?',
+            primaryLabel: 'Start tour',
+            onPrimary: () => openTour(),
+            secondaryLabel: 'Not now',
+            onSecondary: () => closePlayer(),
+        });
+        speak('Welcome to AlgeBench! I’m your guide. Let me give you a quick tour of what you can do ' +
+              'here — from browsing lessons to asking the AI about the math.');
+    } else {
+        renderOffer({
+            title: 'Welcome back \u{1F44B}',
+            message: `Good to see you again. You’ve explored ${doneCount} of ${all.length} things so ` +
+                     'far — want to pick up where you left off?',
+            primaryLabel: 'Continue',
+            onPrimary: () => openTour(_lsGet(LS.position)),
+            secondaryLabel: 'Not now',
+            onSecondary: () => closePlayer(),
+        });
+        speak('Welcome back! Want to pick up the tour where you left off?');
+    }
+    autoPlace(null, 'center');
+}
+
+function showDailyHint(step) {
+    openPlayer();
+    spotlightEl.style.display = 'none';
+    renderOffer({
+        title: 'A quick tip \u{1F4A1}',
+        message: `There’s more to discover: ${step.title}. Want me to show you?`,
+        primaryLabel: 'Show me',
+        onPrimary: () => openTour(step.id),
+        secondaryLabel: 'Not now',
+        onSecondary: () => closePlayer(),
+    });
+    autoPlace(null, 'center');
+}
+
+function decide() {
+    loadState();
+    const pending = pendingSteps();
+    log('decide:', {
+        firstVisit: _lsGet(LS.firstVisitDone) !== '1',
+        dismissed: _lsGet(LS.dismissed) === '1',
+        completed: [...S.completed],
+        pending: pending.map((s) => s.id),
+        lastHintDate: _lsGet(LS.lastHintDate),
+        today: today(),
+    });
+
+    // First visit — offer the tour; do not auto-dismiss.
+    if (_lsGet(LS.firstVisitDone) !== '1') {
+        _lsSet(LS.firstVisitDone, '1');
+        log('→ first visit: welcome offer');
+        showWelcome(true);
+        return;
+    }
+
+    if (pending.length === 0) { log('→ all steps complete: nothing automatic'); return; }
+
+    if (_lsGet(LS.dismissed) === '1') {
+        // Daily-hint mode: one nudge per calendar day until all steps are done.
+        if (_lsGet(LS.lastHintDate) !== today()) {
+            _lsSet(LS.lastHintDate, today());
+            log('→ daily hint:', pending[0].id);
+            showDailyHint(pending[0]);
+        } else {
+            log('→ dismissed + already hinted today: stay quiet');
+        }
+        return;
+    }
+
+    // Returning, not dismissed, incomplete → welcome back + resume.
+    log('→ returning, not dismissed: welcome back');
+    showWelcome(false);
+}
+
+// ---- Programmatic control surface (used by the chat `control_coach` tool) ----
+
+// Resolve a user-supplied step reference (id, fuzzy title, or 1-based index)
+// to a concrete step id. Returns undefined if nothing matches.
+function resolveStepId(step) {
+    if (step == null || step === '') return undefined;
+    const all = coach.get();
+    const n = Number(step);
+    if (Number.isFinite(n) && String(step).trim() !== '' && !/[a-z]/i.test(String(step))) {
+        const i = Math.max(0, Math.min(all.length - 1, Math.round(n) - 1));   // 1-based
+        return all[i] && all[i].id;
+    }
+    const key = String(step).toLowerCase().trim();
+    let s = all.find((x) => x.id.toLowerCase() === key);
+    if (!s) s = all.find((x) => x.id.toLowerCase().includes(key)
+                              || (x.title || '').toLowerCase().includes(key));
+    return s && s.id;
+}
+
+function coachStatus() {
+    const all = coach.get();
+    return {
+        active: S.active,
+        currentStepId: S.active && S.steps[S.idx] ? S.steps[S.idx].id : null,
+        currentStepNumber: S.active ? S.idx + 1 : null,
+        total: all.length,
+        completed: [...S.completed],
+        remaining: all.filter((s) => !S.completed.has(s.id)).map((s) => s.id),
+        dismissed: _lsGet(LS.dismissed) === '1',
+        narration: S.ttsOn ? 'on' : 'off',
+        steps: all.map((s) => ({ id: s.id, title: s.title })),
+    };
+}
+
+// Single entry point for the chat tool. Returns a small result object.
+function coachControl(action, opts = {}) {
+    action = String(action || '').toLowerCase().trim();
+    const step = opts.step;
+    log('control_coach', { action, step });
+    switch (action) {
+        case 'start': case 'activate': case 'open': case 'resume': case 'show': {
+            const id = resolveStepId(step);
+            openTour(id);
+            return { ok: true, action, status: coachStatus() };
+        }
+        case 'goto': case 'step': case 'jump': {
+            const id = resolveStepId(step);
+            if (!id) return { ok: false, action, error: `No step matches "${step}".`, status: coachStatus() };
+            openTour(id);
+            return { ok: true, action, stepId: id, status: coachStatus() };
+        }
+        case 'next':
+            if (S.active) gotoNext(); else openTour();   // resume if dismissed/closed
+            return { ok: true, action, status: coachStatus() };
+        case 'prev': case 'back':
+            if (S.active) gotoPrev(); else openTour();
+            return { ok: true, action, status: coachStatus() };
+        case 'stop': case 'deactivate': case 'close': case 'dismiss': case 'hide':
+            dismiss();
+            return { ok: true, action, status: coachStatus() };
+        case 'reset': case 'restart': {
+            window.AlgeBenchCoach.engine.reset();
+            _lsSet(LS.dismissed, '0');
+            openTour();   // start over from the first step
+            return { ok: true, action, status: coachStatus() };
+        }
+        case 'status': case 'info': case '':
+            return { ok: true, action: 'status', status: coachStatus() };
+        default:
+            return { ok: false, action, error: `Unknown action "${action}".`, status: coachStatus() };
+    }
+}
+
+// ---- Boot ----
+function init() {
+    initDebug();
+    log('init (debug logging on)');
+    injectCSS();
+    buildButton();
+    buildLayer();
+    try { decide(); } catch (e) { console.error('[coach] init failed:', e); }
+    updateDot();   // reflect completion state on the Tour button's signal dot
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+} else {
+    init();
+}
+
+// Public control surface — used by the chat `control_coach` tool and handy for
+// manual driving from the console.
+window.AlgeBenchCoach.engine = {
+    openTour,
+    dismiss,
+    control: coachControl,     // control_coach tool entry point
+    status: coachStatus,
+    state: () => ({ ...S, completed: [...S.completed] }),
+    setDebug(on) { DEBUG = !!on; _lsSet(LS.debug, on ? '1' : '0'); log('debug logging', on ? 'enabled' : 'disabled'); },
+    reset() {
+        [LS.completed, LS.position, LS.dismissed, LS.lastHintDate, LS.firstVisitDone, LS.version]
+            .forEach((k) => { try { localStorage.removeItem(k); } catch {} });
+        S.completed = new Set();
+        log('reset tour progress');
+    },
+};

--- a/static/coach/registry.js
+++ b/static/coach/registry.js
@@ -1,0 +1,27 @@
+// ============================================================
+// coach/registry.js — the Coach step registry (singleton).
+//
+// Mirrors the window.AlgeBenchDomains pattern in main.js: a tiny
+// self-registering collection that decouples step *definitions*
+// (steps/*.js modules) from the *engine* (coach.js). Features push
+// steps; the engine reads them. Adding a new feature's hint is a new
+// self-registering module + one import line in steps/index.js — no
+// engine, app, or index.html changes.
+// ============================================================
+
+const coach = (window.AlgeBenchCoach = window.AlgeBenchCoach || {
+    _steps: [],
+    // register(step | step[]) — called by steps/*.js modules at import time.
+    register(s) {
+        if (Array.isArray(s)) this._steps.push(...s);
+        else if (s) this._steps.push(s);
+    },
+    // get() — all registered steps, sorted by sparse `order` (default 0).
+    get() {
+        return this._steps
+            .slice()
+            .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+    },
+});
+
+export { coach };

--- a/static/coach/steps/core.js
+++ b/static/coach/steps/core.js
@@ -1,0 +1,296 @@
+// ============================================================
+// coach/steps/core.js — the built-in tour stops.
+//
+// Self-registers via the registry. Each step has a STABLE `id`
+// (drives completion tracking — never rename/reuse). Adding a new
+// feature's hint later is a sibling file + one line in index.js;
+// this file never needs to change for that.
+// ============================================================
+
+import { coach } from '../registry.js';
+
+coach.register([
+    {
+        id: 'scenes-nav',
+        order: 10,
+        group: 'core',
+        target: '#btn-scenes',
+        title: 'Pick a lesson',
+        narration: 'Start here. This menu lists built-in lessons — each one is an interactive ' +
+                   'scene you can step through at your own pace.',
+        position: 'bottom-start',
+    },
+    {
+        id: 'scenes-panel',
+        order: 15,
+        group: 'core',
+        // The left-dock scene/step tree for the loaded lesson.
+        target: () => {
+            const tree = document.getElementById('scene-tree');
+            if (tree && tree.getBoundingClientRect().width > 0) return tree;
+            return document.getElementById('scene-dock') || tree;
+        },
+        title: 'Your map of the lesson',
+        narration: 'This panel is the lesson outline. Each lesson has several scenes, and each scene ' +
+                   'has steps — click any one to jump straight there. It’s how you move around at your own pace.',
+        position: 'right',
+        when: (ctx) => ctx.hasScene,
+        optional: true,
+        action: async (ctx) => { ctx.clickDockTab('scenes'); await ctx.delay(150); },
+    },
+    {
+        id: 'chat-window',
+        order: 20,
+        group: 'core',
+        target: '#explanation-panel',
+        title: 'Ask the AI anything',
+        narration: 'This is the AI chat. It already knows what’s on your screen, so you can ask it ' +
+                   'about the current scene, a step, or what to try next.',
+        position: 'left',
+        examplePrompts: ['What is this scene about?', 'Walk me through this step.'],
+        action: async (ctx) => ctx.openChatTab(),
+    },
+    {
+        id: 'voice-controls',
+        order: 25,
+        group: 'core',
+        target: '#chat-tts-controls',
+        title: 'Give the AI a voice',
+        narration: 'The AI can read its answers aloud. Up here you can pick a character and its voice, ' +
+                   'choose how it speaks — Read for word-for-word, Perform to let the character act it out, ' +
+                   'or Silent for no audio — and set the volume to taste.',
+        position: 'left',
+        when: (ctx) => ctx.chatAvailable,
+        optional: true,
+        action: async (ctx) => { ctx.openChatTab(); await ctx.delay(150); },
+    },
+    {
+        id: 'ask-math',
+        order: 30,
+        group: 'core',
+        target: '#chat-input',
+        title: 'Go as deep as you want',
+        narration: 'You can ask about the math itself — definitions, why a step is valid, or how a ' +
+                   'formula is derived. Type your own question, or tap an example.',
+        position: 'left',
+        examplePrompts: ['Why is this step valid?', 'Explain the math behind this.'],
+        action: async (ctx) => ctx.openChatTab(),
+    },
+    {
+        id: 'ai-ask-buttons',
+        order: 35,
+        group: 'core',
+        // The ✦ "Ask AI" buttons appear on overlays, math, proof steps and graph
+        // nodes. Point at whichever one is currently on screen.
+        target: () => [...document.querySelectorAll('.ai-ask-btn')]
+            .find((b) => { const r = b.getBoundingClientRect(); return r.width > 0 && r.height > 0; }) || null,
+        title: 'The ✦ Ask-AI buttons',
+        narration: 'See the little sparkle buttons dotted around? Each one asks the AI about that exact ' +
+                   'thing — a value, a symbol, a proof step, or a graph node. Click it to send the question ' +
+                   'straight to chat, or hold Command (or Ctrl) and click to edit the question first.',
+        position: 'top',   // sit above the ✦ button so the caption on the left stays visible
+        when: (ctx) => ctx.hasScene,
+        optional: true,
+        action: async (ctx) => { ctx.clickDockTab('scenes'); await ctx.delay(150); },
+    },
+    {
+        id: 'math-tab',
+        order: 38,
+        group: 'core',
+        target: '#graph-proof-tree',
+        title: 'The MATH tab',
+        narration: 'Switch to the MATH tab and you get the full proof for this scene, step by step. ' +
+                   'It’s synchronized — pick a step here and the graph below and the proof panel on the ' +
+                   'right all jump to the same place.',
+        position: 'right',
+        when: (ctx) => ctx.hasScene,
+        optional: true,
+        action: async (ctx) => {
+            ctx.clickDockTab('graph');
+            await ctx.delay(300);
+            ctx.selectFirstGraphStep();
+            await ctx.delay(300);
+        },
+    },
+    {
+        id: 'math-graph',
+        order: 40,
+        group: 'core',
+        target: '#graph-viewport',
+        title: 'The semantic graph',
+        narration: 'Here’s the selected step drawn as a semantic graph — the structure of the math ' +
+                   'laid out visually, not just the symbols.',
+        position: 'left',
+        when: (ctx) => ctx.hasScene,
+        action: async (ctx) => {
+            ctx.clickDockTab('graph');
+            await ctx.delay(300);
+            ctx.selectFirstGraphStep();   // render an actual graph, not the placeholder
+            await ctx.delay(350);
+        },
+    },
+    {
+        id: 'graph-interactive',
+        order: 50,
+        group: 'core',
+        target: () => document.getElementById('graph-mermaid-container')
+                    || document.getElementById('graph-viewport'),
+        title: 'Every piece is clickable',
+        narration: 'The graph is interactive. Hover over any node and a ✦ button appears — click it to ' +
+                   'ask the AI about that exact sub-expression, or hold Command (or Ctrl) and click to ' +
+                   'edit the question first. And clicking a node opens its details, which we’ll look at next.',
+        position: 'left',
+        when: (ctx) => ctx.hasScene,
+        optional: true,
+        action: async (ctx) => {
+            ctx.clickDockTab('graph');
+            await ctx.delay(200);
+            ctx.selectFirstGraphStep();
+            await ctx.delay(300);
+        },
+    },
+    {
+        id: 'node-details',
+        order: 51,
+        group: 'core',
+        target: '#graph-info-panel-host',
+        title: 'Node details',
+        narration: 'Click a node and this panel shows what it is — the expression, a plain-language ' +
+                   'description, and how it connects to the rest of the proof. From here you can ask the ' +
+                   'AI about it or derive it further.',
+        position: 'right',
+        when: (ctx) => ctx.hasScene,
+        optional: true,
+        action: async (ctx) => {
+            ctx.clickDockTab('graph');
+            await ctx.delay(300);
+            ctx.selectFirstGraphStep();
+            await ctx.delay(500);          // let the graph finish rendering
+            ctx.selectFirstGraphNode();    // then open the details panel
+            await ctx.delay(400);
+        },
+    },
+    {
+        id: 'derive-button',
+        order: 52,
+        group: 'core',
+        target: () => document.querySelector('.graph-panel-derive-btn'),
+        title: 'Derive it step by step',
+        narration: 'The Derive button — the stacked-lines icon next to ✦ — derives this expression. ' +
+                   'It builds a verified, step-by-step derivation and docks it right onto the graph, so ' +
+                   'you can watch how the result is reached rather than just being told.',
+        position: 'bottom',
+        when: (ctx) => ctx.hasScene,
+        optional: true,
+        action: async (ctx) => {
+            ctx.clickDockTab('graph');
+            await ctx.delay(300);
+            ctx.selectFirstGraphStep();
+            await ctx.delay(500);          // let the graph finish rendering
+            ctx.selectFirstGraphNode();    // derive button lives in the node panel
+            await ctx.delay(400);
+        },
+    },
+    {
+        id: 'chart-button',
+        order: 53,
+        group: 'core',
+        target: () => [...document.querySelectorAll('.d3sg-chart-btn')]
+            .find((b) => { const r = b.getBoundingClientRect(); return r.width > 0 && r.height > 0; }) || null,
+        title: 'Plot it as a chart',
+        narration: 'Nodes whose expression can be plotted show a small chart button. Click it to open an ' +
+                   'interactive Chart.js plot of that expression — handy for seeing how a function behaves, ' +
+                   'not just its formula.',
+        position: 'right',
+        when: (ctx) => ctx.hasScene,
+        optional: true,
+        action: async (ctx) => {
+            ctx.clickDockTab('graph');
+            await ctx.delay(250);
+            ctx.selectFirstGraphStep();
+            await ctx.delay(350);
+        },
+    },
+    {
+        id: 'graph-controls',
+        order: 54,
+        group: 'core',
+        target: () => document.getElementById('graph-controls-left')
+                    || document.getElementById('graph-viewport'),
+        title: 'Make the graph yours',
+        narration: 'This toolbar controls the graph itself. Switch the renderer between D3 and Mermaid, ' +
+                   'change the theme and how much detail the labels show, flip the layout direction, zoom ' +
+                   'in and out, or dock the graph right beside the 3D view so you can see both at once.',
+        position: 'bottom',
+        when: (ctx) => ctx.hasScene,
+        optional: true,
+        action: async (ctx) => { ctx.clickDockTab('graph'); await ctx.delay(250); },
+    },
+    {
+        id: 'proof-panel',
+        order: 55,
+        group: 'core',
+        target: '#proof-panel',
+        title: 'The proof, in words',
+        narration: 'Over on the right, the proof panel walks the very same steps in plain language and ' +
+                   'equations. Use the arrows at the bottom to step through it — it stays in sync with the ' +
+                   'MATH tab and the graph.',
+        position: 'left',
+        when: (ctx) => ctx.hasScene,
+        optional: true,
+        action: async (ctx) => {
+            ctx.openProofPanel();
+            await ctx.delay(200);
+            ctx.ensureProofStep();   // show a step unless one is already selected
+            await ctx.delay(150);
+        },
+    },
+    {
+        id: 'viewport-3d',
+        order: 60,
+        group: 'core',
+        target: () => document.getElementById('mathbox-container'),
+        title: 'Play with the 3D view',
+        narration: 'This is the 3D viewport, and it’s hands-on. Drag to rotate, scroll to zoom, and ' +
+                   'shift-drag to pan. Everything here is live — the visualization updates as you explore.',
+        position: 'top',
+        when: (ctx) => ctx.hasScene,
+        action: async (ctx) => { ctx.clickDockTab('scenes'); await ctx.delay(150); },
+    },
+    {
+        id: 'camera-views',
+        order: 62,
+        group: 'core',
+        target: '#camera-buttons',
+        title: 'Jump to the best angle',
+        narration: 'These camera buttons snap you to hand-picked viewpoints for the scene — an overview, ' +
+                   'close-ups, or a follow/ride-along view that tracks the motion. Reset returns you to the ' +
+                   'default angle whenever you get lost.',
+        position: 'left',
+        when: (ctx) => ctx.hasScene,
+        optional: true,
+        action: async (ctx) => { ctx.clickDockTab('scenes'); await ctx.delay(200); },
+    },
+    {
+        id: 'viewport-sliders',
+        order: 64,
+        group: 'core',
+        target: () => {
+            const so = document.getElementById('slider-overlay');
+            if (so && !so.classList.contains('hidden') && so.children.length) return so;
+            return document.getElementById('mathbox-container');
+        },
+        title: 'Move the sliders',
+        narration: 'Many steps add sliders. Drag one and the 3D scene, the equations, and the labels all ' +
+                   'update together in real time — it’s the best way to build intuition for how each ' +
+                   'quantity shapes the result.',
+        position: 'top',
+        when: (ctx) => ctx.hasScene,
+        optional: true,
+        action: async (ctx) => {
+            ctx.clickDockTab('scenes');
+            ctx.gotoSliderStep();   // navigate to a step that actually has sliders
+            await ctx.delay(400);
+        },
+    },
+]);

--- a/static/coach/steps/index.js
+++ b/static/coach/steps/index.js
@@ -1,0 +1,10 @@
+// ============================================================
+// coach/steps/index.js — step manifest.
+//
+// The ONE place to list step modules. To add a new feature's hint:
+//   1. create coach/steps/<feature>.js (it calls coach.register(...))
+//   2. add one import line below.
+// No engine / main.js / chat.js / index.html changes needed.
+// ============================================================
+
+import './core.js';

--- a/static/graph-view.js
+++ b/static/graph-view.js
@@ -998,11 +998,17 @@ function _showD3NodeAskBtn(nodeEl) {
     const r = (shape || nodeEl).getBoundingClientRect();
     const btnW = btn.offsetWidth || 24;
     const btnH = btn.offsetHeight || 24;
+    // Sit on the node's right edge, vertically centred and overlapping it — so a
+    // simple rightward move from the node lands on the button with no dead gap.
     btn.style.left = (r.right - btnW / 2) + 'px';
-    btn.style.top = (r.top - btnH / 2) + 'px';
+    btn.style.top = (r.top + r.height / 2 - btnH / 2) + 'px';
     btn.style.opacity = '1';
     btn.style.pointerEvents = 'auto';
 }
+
+// Grace period before the node ask-button hides — long enough to move the
+// cursor from the node onto the button (which cancels the timer on hover).
+const _D3_NODE_ASK_HIDE_DELAY = 600;
 
 function _hideD3NodeAskBtn() {
     if (!_d3NodeAskBtn) return;
@@ -1011,7 +1017,7 @@ function _hideD3NodeAskBtn() {
     _d3NodeAskHideTimer = setTimeout(() => {
         btn.style.opacity = '0';
         btn.style.pointerEvents = 'none';
-    }, 220);
+    }, _D3_NODE_ASK_HIDE_DELAY);
 }
 
 // Derivation ("∴") glyph — a small three-step icon for the Derive button.

--- a/static/index.html
+++ b/static/index.html
@@ -328,6 +328,7 @@
 <script src="/gemini-live-tools/js/voice-character-selector.js"></script>
 <script src="/gemini-live-tools/js/tts-audio-player.js"></script>
 <script src="/chat.js"></script>
+<script type="module" src="/coach/coach.js"></script>
 <div id="json-viewer-overlay" class="hidden">
     <div id="json-viewer-header">
         <span>Scene JSON</span>


### PR DESCRIPTION
## What

Adds a **Quick Intro / guided-tour ("Coach")** system — a non-blocking, interactive overlay that coaches users toward the features most people miss when they just click through scenes and leave.

It teaches: scenes navigation, the AI chat + voice controls, asking about the math, the **semantic graph** (nodes, node details, derive button, chart button, controls), the **3D viewport**, **camera presets**, and **sliders** — 17 steps total.

## Why

Most users never notice the chat, the Built-in Scenes dropdown, or the MATH tab. The Coach guides them through it, doubles as a once-a-day hint system, and auto-surfaces newly added steps.

## How it's built

Self-registering **step registry + engine**, almost entirely in new modules under `static/coach/` (`registry.js`, `coach.js`, `coach.css`, `steps/core.js`, `steps/index.js`). Adding a future feature's hint = one new step module + one import line.

The **only** change to existing front-end markup is a single `<script type="module" src="/coach/coach.js">` tag in `index.html`.

## Highlights

- **Spotlight ring** that never blocks the page; **draggable card** (rAF-batched, no layout thrash).
- **Per-step TTS narration** with a persisted on/off toggle (🔊, default on). Uses the main chat's selected voice (default Joker/Charon).
- **localStorage** state under `algebench.coach.*`: completed step **IDs** (array → new steps auto-detected), resume position, dismissed flag, daily-hint date, first-visit flag, tts + debug flags.
- **Daily-hint mode**; first-time users keep getting nudged until done/dismissed; Tour-button **signal dot** shows only while steps are pending.
- **`control_coach` chat tool**: the AI can start / stop / reset / goto / next / prev the tour and answer questions about it (live status injected into the chat context). Includes backend tool declaration, server passthrough, and `agent-tools-reference.md` docs.
- **Debug logging** gated by `?coachdebug`, `localStorage`, or `--debug`.

## Incidental fixes

- **Toolbar symmetry**: Tour button inserts before `#explain-toggle` so the explain toggle stays right-most (mirrors the left scene-dock toggle).
- **graph-view.js**: the node Ask-AI button is easier to use — centered on the node's right edge, with a longer (600 ms) hide grace period so it doesn't vanish before you reach it.
- **server.py**: print the URL on launch so it's clickable.

## Notes for reviewers

- Existing-code edits are intentionally minimal: `index.html` (1 line), `chat.js` (tool exec + coach status in context), `agent_tools.py` + `server.py` (the `control_coach` tool), `graph-view.js` (ask-button UX), plus a `.claude/launch.json` dev config.
- Verified extensively in the browser preview: all 17 steps land on their targets (sequential + direct-jump via the chat tool), TTS toggle, draggable card, dot show/hide on completion + new steps, finish card speaks, and the dismissed→`next` resume fix. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)